### PR TITLE
Improve handling of integer conversions

### DIFF
--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -44,8 +44,8 @@ module AllZero_Len
   use mach.int.Int32
   function len (l : Type.allzero_list) : int = 
     match (l) with
-      | Type.AllZero_List_Cons _ ls -> Int32.to_int (1 : int32) + len ls
-      | Type.AllZero_List_Nil -> Int32.to_int (0 : int32)
+      | Type.AllZero_List_Cons _ ls -> 1 + len ls
+      | Type.AllZero_List_Nil -> 0
       end
 end
 module AllZero_Get_Interface
@@ -61,9 +61,9 @@ module AllZero_Get
   use mach.int.Int32
   function get (l : Type.allzero_list) (ix : int) : Type.core_option_option uint32 = 
     match (l) with
-      | Type.AllZero_List_Cons x ls -> match (ix = Int32.to_int (0 : int32)) with
+      | Type.AllZero_List_Cons x ls -> match (ix = 0) with
         | True -> Type.Core_Option_Option_Some x
-        | False -> get ls (ix - Int32.to_int (1 : int32))
+        | False -> get ls (ix - 1)
         end
       | Type.AllZero_List_Nil -> Type.Core_Option_Option_None
       end
@@ -93,7 +93,7 @@ module AllZero_AllZero_Interface
   clone AllZero_Len_Interface as Len0
   val all_zero (l : borrowed (Type.allzero_list)) : ()
     ensures { Len0.len ( * l) = Len0.len ( ^ l) }
-    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
     
 end
 module AllZero_AllZero
@@ -112,7 +112,7 @@ module AllZero_AllZero
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = Type.allzero_list
   let rec cfg all_zero (l : borrowed (Type.allzero_list)) : ()
     ensures { Len0.len ( * l) = Len0.len ( ^ l) }
-    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
     
    = 
   var _0 : ();
@@ -136,7 +136,7 @@ module AllZero_AllZero
     goto BB1
   }
   BB1 {
-    invariant zeroed { (forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * loop_l_2) -> Get1.get ( ^ loop_l_2) i = Type.Core_Option_Option_Some (0 : uint32)) -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l_1) -> Get1.get ( ^ l_1) i = Type.Core_Option_Option_Some (0 : uint32)) };
+    invariant zeroed { (forall i : (int) . 0 <= i && i < Len0.len ( * loop_l_2) -> Get1.get ( ^ loop_l_2) i = Type.Core_Option_Option_Some (0 : uint32)) -> (forall i : (int) . 0 <= i && i < Len0.len ( * l_1) -> Get1.get ( ^ l_1) i = Type.Core_Option_Option_Some (0 : uint32)) };
     invariant in_len { Len0.len ( ^ loop_l_2) = Len0.len ( * loop_l_2) -> Len0.len ( ^ l_1) = Len0.len ( * l_1) };
     goto BB2
   }

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -50,8 +50,8 @@ module BinarySearch_LenLogic
   use mach.int.Int32
   function len_logic (l : Type.binarysearch_list t) : int = 
     match (l) with
-      | Type.BinarySearch_List_Cons _ ls -> Int32.to_int (1 : int32) + len_logic ls
-      | Type.BinarySearch_List_Nil -> Int32.to_int (0 : int32)
+      | Type.BinarySearch_List_Cons _ ls -> 1 + len_logic ls
+      | Type.BinarySearch_List_Nil -> 0
       end
 end
 module BinarySearch_Get_Interface
@@ -67,9 +67,9 @@ module BinarySearch_Get
   use mach.int.Int32
   function get (l : Type.binarysearch_list t) (ix : int) : Type.core_option_option t = 
     match (l) with
-      | Type.BinarySearch_List_Cons t ls -> match (ix = Int32.to_int (0 : int32)) with
+      | Type.BinarySearch_List_Cons t ls -> match (ix = 0) with
         | True -> Type.Core_Option_Option_Some t
-        | False -> get ls (ix - Int32.to_int (1 : int32))
+        | False -> get ls (ix - 1)
         end
       | Type.BinarySearch_List_Nil -> Type.Core_Option_Option_None
       end
@@ -97,8 +97,8 @@ module BinarySearch_Impl0_Index_Interface
   clone BinarySearch_Get_Interface as Get1 with type t = t
   clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
   val index (self : Type.binarysearch_list t) (ix : usize) : t
-    requires {UInt64.to_int ix < LenLogic0.len_logic self}
-    ensures { Type.Core_Option_Option_Some result = Get1.get self (UInt64.to_int ix) }
+    requires {ix < LenLogic0.len_logic self}
+    ensures { Type.Core_Option_Option_Some result = Get1.get self ix }
     
 end
 module BinarySearch_Impl0_Index
@@ -119,8 +119,8 @@ module BinarySearch_Impl0_Index
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.binarysearch_list t
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
   let rec cfg index (self : Type.binarysearch_list t) (ix : usize) : t
-    requires {UInt64.to_int ix < LenLogic0.len_logic self}
-    ensures { Type.Core_Option_Option_Some result = Get1.get self (UInt64.to_int ix) }
+    requires {ix < LenLogic0.len_logic self}
+    ensures { Type.Core_Option_Option_Some result = Get1.get self ix }
     
    = 
   var _0 : t;
@@ -157,8 +157,8 @@ module BinarySearch_Impl0_Index
     goto BB1
   }
   BB1 {
-    invariant ix_valid { UInt64.to_int ix_2 < LenLogic0.len_logic l_4 };
-    invariant res_get { Get1.get self_1 (UInt64.to_int orig_ix_3) = Get1.get l_4 (UInt64.to_int ix_2) };
+    invariant ix_valid { ix_2 < LenLogic0.len_logic l_4 };
+    invariant res_get { Get1.get self_1 orig_ix_3 = Get1.get l_4 ix_2 };
     goto BB2
   }
   BB2 {
@@ -225,8 +225,8 @@ module BinarySearch_Impl0_Len_Interface
   use Type
   clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
   val len (self : Type.binarysearch_list t) : usize
-    requires {LenLogic0.len_logic self <= Int32.to_int (1000000 : int32)}
-    ensures { UInt64.to_int result = LenLogic0.len_logic self }
+    requires {LenLogic0.len_logic self <= 1000000}
+    ensures { result = LenLogic0.len_logic self }
     ensures { result >= (0 : usize) }
     
 end
@@ -245,8 +245,8 @@ module BinarySearch_Impl0_Len
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.binarysearch_list t
   let rec cfg len (self : Type.binarysearch_list t) : usize
-    requires {LenLogic0.len_logic self <= Int32.to_int (1000000 : int32)}
-    ensures { UInt64.to_int result = LenLogic0.len_logic self }
+    requires {LenLogic0.len_logic self <= 1000000}
+    ensures { result = LenLogic0.len_logic self }
     ensures { result >= (0 : usize) }
     
    = 
@@ -274,7 +274,7 @@ module BinarySearch_Impl0_Len
     goto BB1
   }
   BB1 {
-    invariant len_valid { UInt64.to_int len_2 + LenLogic0.len_logic l_3 = LenLogic0.len_logic self_1 };
+    invariant len_valid { len_2 + LenLogic0.len_logic l_3 = LenLogic0.len_logic self_1 };
     goto BB2
   }
   BB2 {
@@ -359,10 +359,10 @@ module BinarySearch_BinarySearch_Interface
   clone BinarySearch_IsSorted_Interface as IsSorted0
   val binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
     requires {IsSorted0.is_sorted arr}
-    requires {LenLogic1.len_logic arr <= Int32.to_int (1000000 : int32)}
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic1.len_logic arr -> elem < GetDefault2.get_default arr i (0 : uint32)) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < UInt64.to_int x -> GetDefault2.get_default arr i (0 : uint32) < elem) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get3.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some elem }
+    requires {LenLogic1.len_logic arr <= 1000000}
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . x < i && i < LenLogic1.len_logic arr -> elem < GetDefault2.get_default arr i (0 : uint32)) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < x -> GetDefault2.get_default arr i (0 : uint32) < elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get3.get arr x = Type.Core_Option_Option_Some elem }
     
 end
 module BinarySearch_BinarySearch
@@ -388,10 +388,10 @@ module BinarySearch_BinarySearch
   function LenLogic0.len_logic = LenLogic0.len_logic
   let rec cfg binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
     requires {IsSorted2.is_sorted arr}
-    requires {LenLogic0.len_logic arr <= Int32.to_int (1000000 : int32)}
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic0.len_logic arr -> elem < GetDefault1.get_default arr i (0 : uint32)) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < UInt64.to_int x -> GetDefault1.get_default arr i (0 : uint32) < elem) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get3.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some elem }
+    requires {LenLogic0.len_logic arr <= 1000000}
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . x < i && i < LenLogic0.len_logic arr -> elem < GetDefault1.get_default arr i (0 : uint32)) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < x -> GetDefault1.get_default arr i (0 : uint32) < elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get3.get arr x = Type.Core_Option_Option_Some elem }
     
    = 
   var _0 : Type.core_result_result usize usize;
@@ -478,8 +478,8 @@ module BinarySearch_BinarySearch
     goto BB5
   }
   BB5 {
-    invariant size_valid { UInt64.to_int size_8 + UInt64.to_int base_10 <= LenLogic0.len_logic arr_1 };
-    invariant in_interval { GetDefault1.get_default arr_1 (UInt64.to_int base_10) (0 : uint32) <= elem_2 && elem_2 <= GetDefault1.get_default arr_1 (UInt64.to_int base_10 + UInt64.to_int size_8) (0 : uint32) };
+    invariant size_valid { size_8 + base_10 <= LenLogic0.len_logic arr_1 };
+    invariant in_interval { GetDefault1.get_default arr_1 base_10 (0 : uint32) <= elem_2 && elem_2 <= GetDefault1.get_default arr_1 (base_10 + size_8) (0 : uint32) };
     invariant size_pos { size_8 > (0 : usize) };
     goto BB6
   }

--- a/creusot/tests/should_succeed/clones/03.stdout
+++ b/creusot/tests/should_succeed/clones/03.stdout
@@ -63,7 +63,7 @@ module C03_Prog2_Interface
   use mach.int.Int32
   clone C03_Omg_Interface as Omg0 with type t = int
   val prog2 () : ()
-    ensures { Omg0.omg (Int32.to_int (0 : int32)) }
+    ensures { Omg0.omg 0 }
     
 end
 module C03_Prog2
@@ -73,7 +73,7 @@ module C03_Prog2
   clone C03_Omg as Omg2 with type t = int32
   clone C03_Prog_Interface as Prog1 with type t = int32, function Omg0.omg = Omg2.omg
   let rec cfg prog2 () : ()
-    ensures { Omg0.omg (Int32.to_int (0 : int32)) }
+    ensures { Omg0.omg 0 }
     
    = 
   var _0 : ();
@@ -96,7 +96,7 @@ module C03_Prog3_Interface
   use mach.int.Int32
   clone C03_Omg_Interface as Omg0 with type t = (int, int)
   val prog3 () : ()
-    ensures { Omg0.omg (Int32.to_int (0 : int32), Int32.to_int (0 : int32)) }
+    ensures { Omg0.omg (0, 0) }
     
 end
 module C03_Prog3
@@ -104,7 +104,7 @@ module C03_Prog3
   use mach.int.Int32
   clone C03_Omg as Omg0 with type t = (int, int)
   let rec cfg prog3 () : ()
-    ensures { Omg0.omg (Int32.to_int (0 : int32), Int32.to_int (0 : int32)) }
+    ensures { Omg0.omg (0, 0) }
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -25,8 +25,8 @@ module IncSome2List_SumList
   use mach.int.Int32
   function sum_list (l : Type.incsome2list_list) : int = 
     match (l) with
-      | Type.IncSome2List_List_Cons a l2 -> UInt32.to_int a + sum_list l2
-      | Type.IncSome2List_List_Nil -> Int32.to_int (0 : int32)
+      | Type.IncSome2List_List_Cons a l2 -> a + sum_list l2
+      | Type.IncSome2List_List_Nil -> 0
       end
 end
 module CreusotContracts_Builtins_Resolve
@@ -40,7 +40,7 @@ module IncSome2List_LemmaSumListNonneg_Interface
   use Type
   clone IncSome2List_SumList_Interface as SumList0
   val lemma_sum_list_nonneg (l : Type.incsome2list_list) : ()
-    ensures { SumList0.sum_list l >= Int32.to_int (0 : int32) }
+    ensures { SumList0.sum_list l >= 0 }
     
 end
 module IncSome2List_LemmaSumListNonneg
@@ -54,7 +54,7 @@ module IncSome2List_LemmaSumListNonneg
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2list_list
   let rec cfg lemma_sum_list_nonneg (l : Type.incsome2list_list) : ()
-    ensures { SumList0.sum_list l >= Int32.to_int (0 : int32) }
+    ensures { SumList0.sum_list l >= 0 }
     
    = 
   var _0 : ();
@@ -112,8 +112,8 @@ module IncSome2List_SumListX_Interface
   use Type
   clone IncSome2List_SumList_Interface as SumList0
   val sum_list_x (l : Type.incsome2list_list) : uint32
-    requires {SumList0.sum_list l <= Int32.to_int (1000000 : int32)}
-    ensures { UInt32.to_int result = SumList0.sum_list l }
+    requires {SumList0.sum_list l <= 1000000}
+    ensures { result = SumList0.sum_list l }
     
 end
 module IncSome2List_SumListX
@@ -130,8 +130,8 @@ module IncSome2List_SumListX
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2list_list
   let rec cfg sum_list_x (l : Type.incsome2list_list) : uint32
-    requires {SumList0.sum_list l <= Int32.to_int (1000000 : int32)}
-    ensures { UInt32.to_int result = SumList0.sum_list l }
+    requires {SumList0.sum_list l <= 1000000}
+    ensures { result = SumList0.sum_list l }
     
    = 
   var _0 : uint32;
@@ -216,8 +216,8 @@ module IncSome2List_TakeSomeRestList_Interface
   clone IncSome2List_SumList_Interface as SumList0
   val take_some_rest_list (ml : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
     ensures { SumList0.sum_list ( * (let (_, a) = result in a)) <= SumList0.sum_list ( * ml) }
-    ensures { UInt32.to_int ( * (let (a, _) = result in a)) <= SumList0.sum_list ( * ml) }
-    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) = UInt32.to_int ( ^ (let (a, _) = result in a)) + SumList0.sum_list ( ^ (let (_, a) = result in a)) - UInt32.to_int ( * (let (a, _) = result in a)) - SumList0.sum_list ( * (let (_, a) = result in a)) }
+    ensures {  * (let (a, _) = result in a) <= SumList0.sum_list ( * ml) }
+    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) =  ^ (let (a, _) = result in a) + SumList0.sum_list ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - SumList0.sum_list ( * (let (_, a) = result in a)) }
     
 end
 module IncSome2List_TakeSomeRestList
@@ -238,8 +238,8 @@ module IncSome2List_TakeSomeRestList
   clone IncSome2List_LemmaSumListNonneg_Interface as LemmaSumListNonneg4 with function SumList0.sum_list = SumList0.sum_list
   let rec cfg take_some_rest_list (ml : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
     ensures { SumList0.sum_list ( * (let (_, a) = result in a)) <= SumList0.sum_list ( * ml) }
-    ensures { UInt32.to_int ( * (let (a, _) = result in a)) <= SumList0.sum_list ( * ml) }
-    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) = UInt32.to_int ( ^ (let (a, _) = result in a)) + SumList0.sum_list ( ^ (let (_, a) = result in a)) - UInt32.to_int ( * (let (a, _) = result in a)) - SumList0.sum_list ( * (let (_, a) = result in a)) }
+    ensures {  * (let (a, _) = result in a) <= SumList0.sum_list ( * ml) }
+    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) =  ^ (let (a, _) = result in a) + SumList0.sum_list ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - SumList0.sum_list ( * (let (_, a) = result in a)) }
     
    = 
   var _0 : (borrowed uint32, borrowed (Type.incsome2list_list));
@@ -376,7 +376,7 @@ module IncSome2List_IncSome2List_Interface
   use mach.int.UInt32
   clone IncSome2List_SumList_Interface as SumList0
   val inc_some_2_list (l : Type.incsome2list_list) (j : uint32) (k : uint32) : ()
-    requires {SumList0.sum_list l + UInt32.to_int j + UInt32.to_int k <= Int32.to_int (1000000 : int32)}
+    requires {SumList0.sum_list l + j + k <= 1000000}
     
 end
 module IncSome2List_IncSome2List
@@ -402,7 +402,7 @@ module IncSome2List_IncSome2List
   clone IncSome2List_TakeSomeRestList_Interface as TakeSomeRestList4 with function SumList0.sum_list = SumList0.sum_list
   clone IncSome2List_SumListX_Interface as SumListX2 with function SumList0.sum_list = SumList0.sum_list
   let rec cfg inc_some_2_list (l : Type.incsome2list_list) (j : uint32) (k : uint32) : ()
-    requires {SumList0.sum_list l + UInt32.to_int j + UInt32.to_int k <= Int32.to_int (1000000 : int32)}
+    requires {SumList0.sum_list l + j + k <= 1000000}
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -25,8 +25,8 @@ module IncSome2Tree_SumTree
   use mach.int.Int32
   function sum_tree (t : Type.incsome2tree_tree) : int = 
     match (t) with
-      | Type.IncSome2Tree_Tree_Node tl a tr -> sum_tree tl + UInt32.to_int a + sum_tree tr
-      | Type.IncSome2Tree_Tree_Leaf -> Int32.to_int (0 : int32)
+      | Type.IncSome2Tree_Tree_Node tl a tr -> sum_tree tl + a + sum_tree tr
+      | Type.IncSome2Tree_Tree_Leaf -> 0
       end
 end
 module CreusotContracts_Builtins_Resolve
@@ -40,7 +40,7 @@ module IncSome2Tree_LemmaSumTreeNonneg_Interface
   use Type
   clone IncSome2Tree_SumTree_Interface as SumTree0
   val lemma_sum_tree_nonneg (t : Type.incsome2tree_tree) : ()
-    ensures { SumTree0.sum_tree t >= Int32.to_int (0 : int32) }
+    ensures { SumTree0.sum_tree t >= 0 }
     
 end
 module IncSome2Tree_LemmaSumTreeNonneg
@@ -54,7 +54,7 @@ module IncSome2Tree_LemmaSumTreeNonneg
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2tree_tree
   let rec cfg lemma_sum_tree_nonneg (t : Type.incsome2tree_tree) : ()
-    ensures { SumTree0.sum_tree t >= Int32.to_int (0 : int32) }
+    ensures { SumTree0.sum_tree t >= 0 }
     
    = 
   var _0 : ();
@@ -126,8 +126,8 @@ module IncSome2Tree_SumTreeX_Interface
   use Type
   clone IncSome2Tree_SumTree_Interface as SumTree0
   val sum_tree_x (t : Type.incsome2tree_tree) : uint32
-    requires {SumTree0.sum_tree t <= Int32.to_int (1000000 : int32)}
-    ensures { UInt32.to_int result = SumTree0.sum_tree t }
+    requires {SumTree0.sum_tree t <= 1000000}
+    ensures { result = SumTree0.sum_tree t }
     
 end
 module IncSome2Tree_SumTreeX
@@ -145,8 +145,8 @@ module IncSome2Tree_SumTreeX
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2tree_tree
   clone IncSome2Tree_LemmaSumTreeNonneg_Interface as LemmaSumTreeNonneg3 with function SumTree0.sum_tree = SumTree0.sum_tree
   let rec cfg sum_tree_x (t : Type.incsome2tree_tree) : uint32
-    requires {SumTree0.sum_tree t <= Int32.to_int (1000000 : int32)}
-    ensures { UInt32.to_int result = SumTree0.sum_tree t }
+    requires {SumTree0.sum_tree t <= 1000000}
+    ensures { result = SumTree0.sum_tree t }
     
    = 
   var _0 : uint32;
@@ -259,8 +259,8 @@ module IncSome2Tree_TakeSomeRestTree_Interface
   clone IncSome2Tree_SumTree_Interface as SumTree0
   val take_some_rest_tree (mt : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
     ensures { SumTree0.sum_tree ( * (let (_, a) = result in a)) <= SumTree0.sum_tree ( * mt) }
-    ensures { UInt32.to_int ( * (let (a, _) = result in a)) <= SumTree0.sum_tree ( * mt) }
-    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) = UInt32.to_int ( ^ (let (a, _) = result in a)) + SumTree0.sum_tree ( ^ (let (_, a) = result in a)) - UInt32.to_int ( * (let (a, _) = result in a)) - SumTree0.sum_tree ( * (let (_, a) = result in a)) }
+    ensures {  * (let (a, _) = result in a) <= SumTree0.sum_tree ( * mt) }
+    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) =  ^ (let (a, _) = result in a) + SumTree0.sum_tree ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - SumTree0.sum_tree ( * (let (_, a) = result in a)) }
     
 end
 module IncSome2Tree_TakeSomeRestTree
@@ -281,8 +281,8 @@ module IncSome2Tree_TakeSomeRestTree
   clone IncSome2Tree_LemmaSumTreeNonneg_Interface as LemmaSumTreeNonneg4 with function SumTree0.sum_tree = SumTree0.sum_tree
   let rec cfg take_some_rest_tree (mt : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
     ensures { SumTree0.sum_tree ( * (let (_, a) = result in a)) <= SumTree0.sum_tree ( * mt) }
-    ensures { UInt32.to_int ( * (let (a, _) = result in a)) <= SumTree0.sum_tree ( * mt) }
-    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) = UInt32.to_int ( ^ (let (a, _) = result in a)) + SumTree0.sum_tree ( ^ (let (_, a) = result in a)) - UInt32.to_int ( * (let (a, _) = result in a)) - SumTree0.sum_tree ( * (let (_, a) = result in a)) }
+    ensures {  * (let (a, _) = result in a) <= SumTree0.sum_tree ( * mt) }
+    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) =  ^ (let (a, _) = result in a) + SumTree0.sum_tree ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - SumTree0.sum_tree ( * (let (_, a) = result in a)) }
     
    = 
   var _0 : (borrowed uint32, borrowed (Type.incsome2tree_tree));
@@ -493,7 +493,7 @@ module IncSome2Tree_IncSome2Tree_Interface
   use mach.int.UInt32
   clone IncSome2Tree_SumTree_Interface as SumTree0
   val inc_some_2_tree (t : Type.incsome2tree_tree) (j : uint32) (k : uint32) : ()
-    requires {SumTree0.sum_tree t + UInt32.to_int j + UInt32.to_int k <= Int32.to_int (1000000 : int32)}
+    requires {SumTree0.sum_tree t + j + k <= 1000000}
     
 end
 module IncSome2Tree_IncSome2Tree
@@ -519,7 +519,7 @@ module IncSome2Tree_IncSome2Tree
   clone IncSome2Tree_TakeSomeRestTree_Interface as TakeSomeRestTree4 with function SumTree0.sum_tree = SumTree0.sum_tree
   clone IncSome2Tree_SumTreeX_Interface as SumTreeX2 with function SumTree0.sum_tree = SumTree0.sum_tree
   let rec cfg inc_some_2_tree (t : Type.incsome2tree_tree) (j : uint32) (k : uint32) : ()
-    requires {SumTree0.sum_tree t + UInt32.to_int j + UInt32.to_int k <= Int32.to_int (1000000 : int32)}
+    requires {SumTree0.sum_tree t + j + k <= 1000000}
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -25,8 +25,8 @@ module IncSomeList_SumList
   use mach.int.Int32
   function sum_list (l : Type.incsomelist_list) : int = 
     match (l) with
-      | Type.IncSomeList_List_Cons a l2 -> UInt32.to_int a + sum_list l2
-      | Type.IncSomeList_List_Nil -> Int32.to_int (0 : int32)
+      | Type.IncSomeList_List_Cons a l2 -> a + sum_list l2
+      | Type.IncSomeList_List_Nil -> 0
       end
 end
 module CreusotContracts_Builtins_Resolve
@@ -40,7 +40,7 @@ module IncSomeList_LemmaSumListNonneg_Interface
   use Type
   clone IncSomeList_SumList_Interface as SumList0
   val lemma_sum_list_nonneg (l : Type.incsomelist_list) : ()
-    ensures { SumList0.sum_list l >= Int32.to_int (0 : int32) }
+    ensures { SumList0.sum_list l >= 0 }
     
 end
 module IncSomeList_LemmaSumListNonneg
@@ -54,7 +54,7 @@ module IncSomeList_LemmaSumListNonneg
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsomelist_list
   let rec cfg lemma_sum_list_nonneg (l : Type.incsomelist_list) : ()
-    ensures { SumList0.sum_list l >= Int32.to_int (0 : int32) }
+    ensures { SumList0.sum_list l >= 0 }
     
    = 
   var _0 : ();
@@ -112,8 +112,8 @@ module IncSomeList_SumListX_Interface
   use Type
   clone IncSomeList_SumList_Interface as SumList0
   val sum_list_x (l : Type.incsomelist_list) : uint32
-    requires {SumList0.sum_list l <= Int32.to_int (1000000 : int32)}
-    ensures { UInt32.to_int result = SumList0.sum_list l }
+    requires {SumList0.sum_list l <= 1000000}
+    ensures { result = SumList0.sum_list l }
     
 end
 module IncSomeList_SumListX
@@ -130,8 +130,8 @@ module IncSomeList_SumListX
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsomelist_list
   let rec cfg sum_list_x (l : Type.incsomelist_list) : uint32
-    requires {SumList0.sum_list l <= Int32.to_int (1000000 : int32)}
-    ensures { UInt32.to_int result = SumList0.sum_list l }
+    requires {SumList0.sum_list l <= 1000000}
+    ensures { result = SumList0.sum_list l }
     
    = 
   var _0 : uint32;
@@ -215,8 +215,8 @@ module IncSomeList_TakeSomeList_Interface
   use Type
   clone IncSomeList_SumList_Interface as SumList0
   val take_some_list (ml : borrowed (Type.incsomelist_list)) : borrowed uint32
-    ensures { UInt32.to_int ( * result) <= SumList0.sum_list ( * ml) }
-    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) = UInt32.to_int ( ^ result) - UInt32.to_int ( * result) }
+    ensures {  * result <= SumList0.sum_list ( * ml) }
+    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) =  ^ result -  * result }
     
 end
 module IncSomeList_TakeSomeList
@@ -236,8 +236,8 @@ module IncSomeList_TakeSomeList
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsomelist_list
   clone IncSomeList_LemmaSumListNonneg_Interface as LemmaSumListNonneg4 with function SumList0.sum_list = SumList0.sum_list
   let rec cfg take_some_list (ml : borrowed (Type.incsomelist_list)) : borrowed uint32
-    ensures { UInt32.to_int ( * result) <= SumList0.sum_list ( * ml) }
-    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) = UInt32.to_int ( ^ result) - UInt32.to_int ( * result) }
+    ensures {  * result <= SumList0.sum_list ( * ml) }
+    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) =  ^ result -  * result }
     
    = 
   var _0 : borrowed uint32;
@@ -374,7 +374,7 @@ module IncSomeList_IncSomeList_Interface
   use mach.int.UInt32
   clone IncSomeList_SumList_Interface as SumList0
   val inc_some_list (l : Type.incsomelist_list) (k : uint32) : ()
-    requires {SumList0.sum_list l + UInt32.to_int k <= Int32.to_int (1000000 : int32)}
+    requires {SumList0.sum_list l + k <= 1000000}
     
 end
 module IncSomeList_IncSomeList
@@ -395,7 +395,7 @@ module IncSomeList_IncSomeList
   clone IncSomeList_TakeSomeList_Interface as TakeSomeList4 with function SumList0.sum_list = SumList0.sum_list
   clone IncSomeList_SumListX_Interface as SumListX2 with function SumList0.sum_list = SumList0.sum_list
   let rec cfg inc_some_list (l : Type.incsomelist_list) (k : uint32) : ()
-    requires {SumList0.sum_list l + UInt32.to_int k <= Int32.to_int (1000000 : int32)}
+    requires {SumList0.sum_list l + k <= 1000000}
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -25,8 +25,8 @@ module IncSomeTree_SumTree
   use mach.int.Int32
   function sum_tree (t : Type.incsometree_tree) : int = 
     match (t) with
-      | Type.IncSomeTree_Tree_Node tl a tr -> sum_tree tl + UInt32.to_int a + sum_tree tr
-      | Type.IncSomeTree_Tree_Leaf -> Int32.to_int (0 : int32)
+      | Type.IncSomeTree_Tree_Node tl a tr -> sum_tree tl + a + sum_tree tr
+      | Type.IncSomeTree_Tree_Leaf -> 0
       end
 end
 module CreusotContracts_Builtins_Resolve
@@ -40,7 +40,7 @@ module IncSomeTree_LemmaSumTreeNonneg_Interface
   use Type
   clone IncSomeTree_SumTree_Interface as SumTree0
   val lemma_sum_tree_nonneg (t : Type.incsometree_tree) : ()
-    ensures { SumTree0.sum_tree t >= Int32.to_int (0 : int32) }
+    ensures { SumTree0.sum_tree t >= 0 }
     
 end
 module IncSomeTree_LemmaSumTreeNonneg
@@ -54,7 +54,7 @@ module IncSomeTree_LemmaSumTreeNonneg
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsometree_tree
   let rec cfg lemma_sum_tree_nonneg (t : Type.incsometree_tree) : ()
-    ensures { SumTree0.sum_tree t >= Int32.to_int (0 : int32) }
+    ensures { SumTree0.sum_tree t >= 0 }
     
    = 
   var _0 : ();
@@ -126,8 +126,8 @@ module IncSomeTree_SumTreeX_Interface
   use Type
   clone IncSomeTree_SumTree_Interface as SumTree0
   val sum_tree_x (t : Type.incsometree_tree) : uint32
-    requires {SumTree0.sum_tree t <= Int32.to_int (1000000 : int32)}
-    ensures { UInt32.to_int result = SumTree0.sum_tree t }
+    requires {SumTree0.sum_tree t <= 1000000}
+    ensures { result = SumTree0.sum_tree t }
     
 end
 module IncSomeTree_SumTreeX
@@ -145,8 +145,8 @@ module IncSomeTree_SumTreeX
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsometree_tree
   clone IncSomeTree_LemmaSumTreeNonneg_Interface as LemmaSumTreeNonneg3 with function SumTree0.sum_tree = SumTree0.sum_tree
   let rec cfg sum_tree_x (t : Type.incsometree_tree) : uint32
-    requires {SumTree0.sum_tree t <= Int32.to_int (1000000 : int32)}
-    ensures { UInt32.to_int result = SumTree0.sum_tree t }
+    requires {SumTree0.sum_tree t <= 1000000}
+    ensures { result = SumTree0.sum_tree t }
     
    = 
   var _0 : uint32;
@@ -258,8 +258,8 @@ module IncSomeTree_TakeSomeTree_Interface
   use Type
   clone IncSomeTree_SumTree_Interface as SumTree0
   val take_some_tree (mt : borrowed (Type.incsometree_tree)) : borrowed uint32
-    ensures { UInt32.to_int ( * result) <= SumTree0.sum_tree ( * mt) }
-    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) = UInt32.to_int ( ^ result) - UInt32.to_int ( * result) }
+    ensures {  * result <= SumTree0.sum_tree ( * mt) }
+    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) =  ^ result -  * result }
     
 end
 module IncSomeTree_TakeSomeTree
@@ -279,8 +279,8 @@ module IncSomeTree_TakeSomeTree
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsometree_tree
   clone IncSomeTree_LemmaSumTreeNonneg_Interface as LemmaSumTreeNonneg4 with function SumTree0.sum_tree = SumTree0.sum_tree
   let rec cfg take_some_tree (mt : borrowed (Type.incsometree_tree)) : borrowed uint32
-    ensures { UInt32.to_int ( * result) <= SumTree0.sum_tree ( * mt) }
-    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) = UInt32.to_int ( ^ result) - UInt32.to_int ( * result) }
+    ensures {  * result <= SumTree0.sum_tree ( * mt) }
+    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) =  ^ result -  * result }
     
    = 
   var _0 : borrowed uint32;
@@ -467,7 +467,7 @@ module IncSomeTree_IncSomeTree_Interface
   use mach.int.UInt32
   clone IncSomeTree_SumTree_Interface as SumTree0
   val inc_some_tree (t : Type.incsometree_tree) (k : uint32) : ()
-    requires {SumTree0.sum_tree t + UInt32.to_int k <= Int32.to_int (1000000 : int32)}
+    requires {SumTree0.sum_tree t + k <= 1000000}
     
 end
 module IncSomeTree_IncSomeTree
@@ -488,7 +488,7 @@ module IncSomeTree_IncSomeTree
   clone IncSomeTree_TakeSomeTree_Interface as TakeSomeTree4 with function SumTree0.sum_tree = SumTree0.sum_tree
   clone IncSomeTree_SumTreeX_Interface as SumTreeX2 with function SumTree0.sum_tree = SumTree0.sum_tree
   let rec cfg inc_some_tree (t : Type.incsometree_tree) (k : uint32) : ()
-    requires {SumTree0.sum_tree t + UInt32.to_int k <= Int32.to_int (1000000 : int32)}
+    requires {SumTree0.sum_tree t + k <= 1000000}
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -42,9 +42,9 @@ module ListIndexMut_Len
   use Type
   use mach.int.Int32
   function len (l : Type.listindexmut_list) : int = 
-    let Type.ListIndexMut_List _ ls = l in Int32.to_int (1 : int32) + match (ls) with
+    let Type.ListIndexMut_List _ ls = l in 1 + match (ls) with
       | Type.ListIndexMut_Option_Some ls -> len ls
-      | Type.ListIndexMut_Option_None -> Int32.to_int (0 : int32)
+      | Type.ListIndexMut_Option_None -> 0
       end
 end
 module ListIndexMut_Get_Interface
@@ -59,10 +59,10 @@ module ListIndexMut_Get
   use mach.int.UInt32
   use mach.int.Int32
   function get (l : Type.listindexmut_list) (ix : int) : Type.listindexmut_option uint32 = 
-    let Type.ListIndexMut_List i ls = l in match (ix > Int32.to_int (0 : int32)) with
+    let Type.ListIndexMut_List i ls = l in match (ix > 0) with
       | False -> Type.ListIndexMut_Option_Some i
       | True -> match (ls) with
-        | Type.ListIndexMut_Option_Some ls -> get ls (ix - Int32.to_int (1 : int32))
+        | Type.ListIndexMut_Option_Some ls -> get ls (ix - 1)
         | Type.ListIndexMut_Option_None -> Type.ListIndexMut_Option_None
         end
       end
@@ -87,11 +87,11 @@ module ListIndexMut_IndexMut_Interface
   clone ListIndexMut_Get_Interface as Get1
   clone ListIndexMut_Len_Interface as Len0
   val index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
-    requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
-    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * param_l) && i <> UInt64.to_int param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
+    requires {param_ix < Len0.len ( * param_l)}
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
     ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get1.get ( ^ param_l) (UInt64.to_int param_ix) }
-    ensures { Type.ListIndexMut_Option_Some ( * result) = Get1.get ( * param_l) (UInt64.to_int param_ix) }
+    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get1.get ( ^ param_l) param_ix }
+    ensures { Type.ListIndexMut_Option_Some ( * result) = Get1.get ( * param_l) param_ix }
     
 end
 module ListIndexMut_IndexMut
@@ -113,11 +113,11 @@ module ListIndexMut_IndexMut
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = usize
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = Type.listindexmut_list
   let rec cfg index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
-    requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
-    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * param_l) && i <> UInt64.to_int param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
+    requires {param_ix < Len0.len ( * param_l)}
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
     ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get1.get ( ^ param_l) (UInt64.to_int param_ix) }
-    ensures { Type.ListIndexMut_Option_Some ( * result) = Get1.get ( * param_l) (UInt64.to_int param_ix) }
+    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get1.get ( ^ param_l) param_ix }
+    ensures { Type.ListIndexMut_Option_Some ( * result) = Get1.get ( * param_l) param_ix }
     
    = 
   var _0 : borrowed uint32;
@@ -153,11 +153,11 @@ module ListIndexMut_IndexMut
     goto BB1
   }
   BB1 {
-    invariant valid_ix { (0 : usize) <= ix_5 && UInt64.to_int ix_5 < Len0.len ( * l_4) };
-    invariant get_target_now { Get1.get ( * l_4) (UInt64.to_int ix_5) = Get1.get ( * param_l_1) (UInt64.to_int param_ix_2) };
-    invariant get_target_fin { Get1.get ( ^ l_4) (UInt64.to_int ix_5) = Get1.get ( ^ param_l_1) (UInt64.to_int param_ix_2) };
+    invariant valid_ix { (0 : usize) <= ix_5 && ix_5 < Len0.len ( * l_4) };
+    invariant get_target_now { Get1.get ( * l_4) ix_5 = Get1.get ( * param_l_1) param_ix_2 };
+    invariant get_target_fin { Get1.get ( ^ l_4) ix_5 = Get1.get ( ^ param_l_1) param_ix_2 };
     invariant len { Len0.len ( ^ l_4) = Len0.len ( * l_4) -> Len0.len ( ^ param_l_1) = Len0.len ( * param_l_1) };
-    invariant untouched { (forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l_4) && i <> UInt64.to_int ix_5 -> Get1.get ( ^ l_4) i = Get1.get ( * l_4) i) -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * param_l_1) && i <> UInt64.to_int param_ix_2 -> Get1.get ( ^ param_l_1) i = Get1.get ( * param_l_1) i) };
+    invariant untouched { (forall i : (int) . 0 <= i && i < Len0.len ( * l_4) && i <> ix_5 -> Get1.get ( ^ l_4) i = Get1.get ( * l_4) i) -> (forall i : (int) . 0 <= i && i < Len0.len ( * param_l_1) && i <> param_ix_2 -> Get1.get ( ^ param_l_1) i = Get1.get ( * param_l_1) i) };
     goto BB2
   }
   BB2 {
@@ -238,10 +238,10 @@ module ListIndexMut_Write_Interface
   clone ListIndexMut_Get_Interface as Get1
   clone ListIndexMut_Len_Interface as Len0
   val write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
-    requires {UInt64.to_int ix < Len0.len ( * l)}
-    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) && i <> UInt64.to_int ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
+    requires {ix < Len0.len ( * l)}
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
     ensures { Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { Type.ListIndexMut_Option_Some v = Get1.get ( ^ l) (UInt64.to_int ix) }
+    ensures { Type.ListIndexMut_Option_Some v = Get1.get ( ^ l) ix }
     
 end
 module ListIndexMut_Write
@@ -259,10 +259,10 @@ module ListIndexMut_Write
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
   clone ListIndexMut_IndexMut_Interface as IndexMut5 with function Len0.len = Len0.len, function Get1.get = Get1.get
   let rec cfg write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
-    requires {UInt64.to_int ix < Len0.len ( * l)}
-    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) && i <> UInt64.to_int ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
+    requires {ix < Len0.len ( * l)}
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
     ensures { Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { Type.ListIndexMut_Option_Some v = Get1.get ( ^ l) (UInt64.to_int ix) }
+    ensures { Type.ListIndexMut_Option_Some v = Get1.get ( ^ l) ix }
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/logic_functions.stdout
+++ b/creusot/tests/should_succeed/logic_functions.stdout
@@ -76,6 +76,6 @@ module LogicFunctions_DerefPat
   function deref_pat (o : Type.core_option_option int) : int = 
     match (o) with
       | Type.Core_Option_Option_Some a -> a
-      | Type.Core_Option_Option_None -> Int32.to_int (0 : int32)
+      | Type.Core_Option_Option_None -> 0
       end
 end

--- a/creusot/tests/should_succeed/syntax/04_assoc_prec.stdout
+++ b/creusot/tests/should_succeed/syntax/04_assoc_prec.stdout
@@ -20,8 +20,8 @@ module C04AssocPrec_RespectPrec_Interface
   use mach.int.UInt32
   val respect_prec (x : (uint32, uint32)) : ()
     ensures { (let (a, _) = x in a) = (let (_, a) = x in a) }
-    ensures { div (Int32.to_int (5 : int32) * Int32.to_int (3 : int32)) (Int32.to_int (2 : int32)) <> Int32.to_int (4 : int32) * (Int32.to_int (40 : int32) + Int32.to_int (1 : int32)) }
-    ensures { Int32.to_int (5 : int32) = Int32.to_int (3 : int32) -> Int32.to_int (2 : int32) + Int32.to_int (1 : int32) = Int32.to_int (3 : int32) }
+    ensures { div (5 * 3) 2 <> 4 * (40 + 1) }
+    ensures { 5 = 3 -> 2 + 1 = 3 }
     
 end
 module C04AssocPrec_RespectPrec
@@ -31,8 +31,8 @@ module C04AssocPrec_RespectPrec
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = (uint32, uint32)
   let rec cfg respect_prec (x : (uint32, uint32)) : ()
     ensures { (let (a, _) = x in a) = (let (_, a) = x in a) }
-    ensures { div (Int32.to_int (5 : int32) * Int32.to_int (3 : int32)) (Int32.to_int (2 : int32)) <> Int32.to_int (4 : int32) * (Int32.to_int (40 : int32) + Int32.to_int (1 : int32)) }
-    ensures { Int32.to_int (5 : int32) = Int32.to_int (3 : int32) -> Int32.to_int (2 : int32) + Int32.to_int (1 : int32) = Int32.to_int (3 : int32) }
+    ensures { div (5 * 3) 2 <> 4 * (40 + 1) }
+    ensures { 5 = 3 -> 2 + 1 = 3 }
     
    = 
   var _0 : ();
@@ -53,7 +53,7 @@ module C04AssocPrec_RespectAssoc_Interface
   use mach.int.UInt32
   use mach.int.Int32
   val respect_assoc () : ()
-    ensures { UInt32.to_int (0 : uint32) + UInt32.to_int (1 : uint32) = Int32.to_int (0 : int32) }
+    ensures { 0 + 1 = 0 }
     
 end
 module C04AssocPrec_RespectAssoc
@@ -61,7 +61,7 @@ module C04AssocPrec_RespectAssoc
   use mach.int.UInt32
   use mach.int.Int32
   let rec cfg respect_assoc () : ()
-    ensures { UInt32.to_int (0 : uint32) + UInt32.to_int (1 : uint32) = Int32.to_int (0 : int32) }
+    ensures { 0 + 1 = 0 }
     
    = 
   var _0 : ();


### PR DESCRIPTION
Instead of doing `Int32.to_int (x : int32)` we just do `x` which allows Why3 to directly interpret as an `int`. 
This might help why3 in some edge cases by removing unnecessary conversions but mostly it just makes it easier for me to understand whats going on in proof tasks.


Also adds handling for `Box::new`
