### PR TITLE
Improve cloning of pure functions

### DIFF
--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -16,7 +16,7 @@ use why3::declaration::{Decl, Module, ValKind::Val};
 
 pub fn default_decl(ctx: &mut TranslationCtx, def_id: DefId, _span: rustc_span::Span) -> Module {
     debug!("generating default declaration for def_id={:?}", def_id);
-    let mut names = CloneMap::new(ctx.tcx, util::item_type(ctx.tcx, def_id));
+    let mut names = CloneMap::new(ctx.tcx, util::item_type(ctx.tcx, def_id).clone_interfaces());
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -36,7 +36,7 @@ pub fn translate_function<'tcx, 'sess>(
     ctx: &mut TranslationCtx<'sess, 'tcx>,
     def_id: DefId,
 ) -> Module {
-    let mut names = CloneMap::new(tcx, ItemType::Program);
+    let mut names = CloneMap::new(tcx, false);
     names.clone_self(def_id);
 
     let gather = GatherInvariants::gather(ctx, &mut names, def_id);

--- a/creusot/src/translation/interface.rs
+++ b/creusot/src/translation/interface.rs
@@ -14,14 +14,14 @@ pub fn interface_for(
     ctx: &mut TranslationCtx<'_, 'tcx>,
     def_id: DefId,
 ) -> (Module, CloneMap<'tcx>) {
-    let mut names = CloneMap::new(ctx.tcx, ItemType::Interface);
+    let mut names = CloneMap::new(ctx.tcx, true);
 
     let mut sig = util::signature_of(ctx, &mut names, def_id);
     sig.contract.variant = Vec::new();
 
     let mut decls: Vec<_> = all_generic_decls_for(ctx.tcx, def_id).collect();
 
-    decls.extend(names.clone().to_clones(ctx));
+    decls.extend(names.to_clones(ctx));
 
     match util::item_type(ctx.tcx, def_id) {
         ItemType::Predicate => {
@@ -35,7 +35,6 @@ pub fn interface_for(
             let mut func_sig = sig.clone();
             func_sig.contract = Contract::new();
             decls.push(Decl::ValDecl(ValKind::Function { sig: func_sig }));
-            decls.push(Decl::ValDecl(ValKind::Val { sig }));
         }
         _ => {
             decls.push(Decl::ValDecl(ValKind::Val { sig }));

--- a/creusot/src/translation/logic.rs
+++ b/creusot/src/translation/logic.rs
@@ -11,7 +11,7 @@ pub fn translate_logic(
     def_id: DefId,
     _span: rustc_span::Span,
 ) -> (Module, CloneMap<'tcx>) {
-    let mut names = CloneMap::new(ctx.tcx, ItemType::Logic);
+    let mut names = CloneMap::new(ctx.tcx, true);
     names.clone_self(def_id);
 
     let sig = crate::util::signature_of(ctx, &mut names, def_id);
@@ -40,7 +40,7 @@ pub fn translate_predicate(
     def_id: DefId,
     _span: rustc_span::Span,
 ) -> (Module, CloneMap<'tcx>) {
-    let mut names = CloneMap::new(ctx.tcx, ItemType::Predicate);
+    let mut names = CloneMap::new(ctx.tcx, true);
     names.clone_self(def_id);
 
     let mut sig = crate::util::signature_of(ctx, &mut names, def_id);

--- a/creusot/src/translation/pure.rs
+++ b/creusot/src/translation/pure.rs
@@ -1,6 +1,6 @@
 use crate::{
     clone_map::CloneMap,
-    ctx::{translate_value_id, ItemType, TranslationCtx},
+    ctx::{translate_value_id, TranslationCtx},
     translation::function::all_generic_decls_for,
 };
 use rustc_hir::def_id::DefId;
@@ -12,14 +12,14 @@ use why3::{
     name::Ident,
 };
 
-use super::{function, specification};
+use super::specification;
 
 pub fn translate_pure(
     ctx: &mut TranslationCtx<'_, 'tcx>,
     def_id: DefId,
     _span: rustc_span::Span,
 ) -> (Module, Module, CloneMap<'tcx>) {
-    let mut names = CloneMap::new(ctx.tcx, ItemType::Logic);
+    let mut names = CloneMap::new(ctx.tcx, true);
     names.clone_self(def_id);
 
     let sig = crate::util::signature_of(ctx, &mut names, def_id);
@@ -109,7 +109,7 @@ fn implementation_module(
 ) -> Module {
     let mut names = names.clone();
     names.clear_graph();
-    names.item_type = ItemType::Program;
+    names.transparent = false;
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -27,7 +27,7 @@ impl<'tcx> TranslationCtx<'_, 'tcx> {
             return;
         }
 
-        let mut names = CloneMap::new(self.tcx, ItemType::Trait);
+        let mut names = CloneMap::new(self.tcx, false);
         names.clone_self(def_id);
 
         // The first predicate is a trait reference so we skip it
@@ -91,7 +91,7 @@ impl<'tcx> TranslationCtx<'_, 'tcx> {
         }
 
         let trait_ref = self.tcx.impl_trait_ref(impl_id).unwrap();
-        let mut names = CloneMap::new(self.tcx, ItemType::Impl);
+        let mut names = CloneMap::new(self.tcx, false);
 
         self.translate_trait(trait_ref.def_id);
 

--- a/creusot/src/translation/ty.rs
+++ b/creusot/src/translation/ty.rs
@@ -198,7 +198,7 @@ pub fn translate_tydecl(ctx: &mut TranslationCtx<'_, '_>, span: Span, did: DefId
     // TODO: allow mutually recursive types
     check_not_mutally_recursive(ctx, did, span);
 
-    let mut names = CloneMap::new(ctx.tcx, ItemType::Type);
+    let mut names = CloneMap::new(ctx.tcx, true);
 
     let adt = ctx.tcx.adt_def(did);
     let gens = ctx.tcx.generics_of(did);

--- a/creusot/tests/should_succeed/pure_function.stdout
+++ b/creusot/tests/should_succeed/pure_function.stdout
@@ -17,14 +17,6 @@ end
 module PureFunction_PureDeclaration_Interface
   use mach.int.Int
   function pure_declaration (x : int) (y : int) : ()
-  val pure_declaration (x : int) (y : int) : ()
-    requires {false}
-    requires {false}
-    requires {false}
-    ensures { true }
-    ensures { true }
-    ensures { true }
-    
 end
 module PureFunction_PureDeclaration
   use mach.int.Int
@@ -60,9 +52,6 @@ module PureFunction_Impl1_Len_Interface
   use prelude.Prelude
   use Type
   function len (self : Type.purefunction_list t) : int
-  val len (self : Type.purefunction_list t) : int
-    ensures { result >= (0 : int) }
-    
 end
 module PureFunction_Impl1_Len
   type t   
@@ -172,7 +161,7 @@ module PureFunction_UsesBothLogicAndProg
   use mach.int.Int
   use Type
   clone PureFunction_Impl1_Len as Len2 with type t = t, axiom .
-  clone PureFunction_UsesLen as UsesLen1 with type t = t, function Len0.len = Len2.len, val Len0.len = Len2.len
+  clone PureFunction_UsesLen as UsesLen1 with type t = t, function Len0.len = Len2.len
   clone Core_Marker_Sized as Sized0 with type self = t
   use prelude.Prelude
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.purefunction_list t


### PR DESCRIPTION
Ensure that the interface of a pure function only contains the
`function` symbol of the function rather than its value which has a
contract. The interface of a pure function is only used in other
interfaces or the bodies of logical functions, thus, we never need the
program symbol in it.

The program symbol can only be used from other program functions which
don't use the interface anyways.

Having the program symbol in the interface meant we were forced to prove the 
refinement each time we wanted to use an interface, which in turn introduced
a whole bunch more symbol sharing issues with the clones.
