### PR TITLE
Properly handle default implementations of trait items

### DIFF
--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -120,6 +120,10 @@ impl CloneInfo<'tcx> {
         self.qname_raw(method_name(tcx, def_id))
     }
 
+    pub fn qname_sym(&self, sym: rustc_span::symbol::Symbol) -> QName {
+        self.qname_raw(sym.to_string().into())
+    }
+
     fn qname_raw(&self, method: Ident) -> QName {
         let module = match &self.kind {
             Kind::Named(name) => vec![name.clone()],

--- a/creusot/src/translation/builtins.rs
+++ b/creusot/src/translation/builtins.rs
@@ -1,21 +1,19 @@
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::{subst::SubstsRef, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::{symbol::sym, Symbol};
-use why3::{
-    mlcfg::{BinOp, Constant, Exp, UnOp},
-    QName,
-};
+use why3::mlcfg::{BinOp, Constant, Exp, UnOp};
 
 use crate::ctx::TranslationCtx;
 
-use super::traits::resolve_opt;
+use super::traits::{resolve_opt, MethodInstance};
 
 pub fn lookup_builtin(
     ctx: &mut TranslationCtx<'_, 'tcx>,
-    mut def_id: DefId,
-    substs: SubstsRef<'tcx>,
+    method: &MethodInstance<'tcx>,
     args: &mut Vec<Exp>,
 ) -> Option<Exp> {
+    let mut def_id = method.def_id;
+    let substs = method.substs;
     if let Some(trait_id) = trait_id_of_method(ctx.tcx, def_id) {
         // We typically implement `From` but call `into`, using the blanket impl of `Into`
         // for any `From` type. So when we see an instance of `into` we check that isn't just

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -261,9 +261,9 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
             traits::resolve_assoc_item_opt(self.tcx, param_env, trait_meth_id, subst);
 
         match resolve_impl {
-            Some((id, subst)) => {
-                self.ctx.translate(id);
-                QVar(self.clone_names.insert(id, subst).qname(self.tcx, id))
+            Some(method) => {
+                self.ctx.translate(method.def_id);
+                QVar(self.clone_names.insert(method.def_id, method.substs).qname_sym(method.ident))
             }
             None => {
                 self.ctx.translate_trait(trait_id);

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -94,7 +94,7 @@ module C01_Impl1
   use mach.int.Int
   use mach.int.UInt32
   clone export C01_Impl1_Inv
-  clone C01_Inv with type self = Type.c01_even, type t = uint32, predicate inv = inv
+  clone export C01_Inv with type self = Type.c01_even, type t = uint32, predicate inv = inv
 end
 module C01_AddsTwo_Interface
   use prelude.Prelude

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -38,20 +38,6 @@ module Core_Cmp_PartialOrd
   val gt (self : self) (other : rhs) : bool
   val ge (self : self) (other : rhs) : bool
 end
-module Core_Tuple_Impl7_PartialCmp_Interface
-  type a   
-  type b   
-  use Type
-  use prelude.Prelude
-  val partial_cmp (self : (a, b)) (other : (a, b)) : Type.core_option_option (Type.core_cmp_ordering)
-end
-module Core_Tuple_Impl7_PartialCmp
-  type a   
-  type b   
-  use Type
-  use prelude.Prelude
-  val partial_cmp (self : (a, b)) (other : (a, b)) : Type.core_option_option (Type.core_cmp_ordering)
-end
 module Core_Tuple_Impl7_Lt_Interface
   type a   
   type b   
@@ -63,53 +49,6 @@ module Core_Tuple_Impl7_Lt
   type b   
   use prelude.Prelude
   val lt (self : (a, b)) (other : (a, b)) : bool
-end
-module Core_Tuple_Impl7_Le_Interface
-  type a   
-  type b   
-  use prelude.Prelude
-  val le (self : (a, b)) (other : (a, b)) : bool
-end
-module Core_Tuple_Impl7_Le
-  type a   
-  type b   
-  use prelude.Prelude
-  val le (self : (a, b)) (other : (a, b)) : bool
-end
-module Core_Tuple_Impl7_Ge_Interface
-  type a   
-  type b   
-  use prelude.Prelude
-  val ge (self : (a, b)) (other : (a, b)) : bool
-end
-module Core_Tuple_Impl7_Ge
-  type a   
-  type b   
-  use prelude.Prelude
-  val ge (self : (a, b)) (other : (a, b)) : bool
-end
-module Core_Tuple_Impl7_Gt_Interface
-  type a   
-  type b   
-  use prelude.Prelude
-  val gt (self : (a, b)) (other : (a, b)) : bool
-end
-module Core_Tuple_Impl7_Gt
-  type a   
-  type b   
-  use prelude.Prelude
-  val gt (self : (a, b)) (other : (a, b)) : bool
-end
-module Core_Tuple_Impl7
-  type a   
-  type b   
-  clone export Core_Tuple_Impl7_Gt_Interface with type a = a, type b = b
-  clone export Core_Tuple_Impl7_Ge_Interface with type a = a, type b = b
-  clone export Core_Tuple_Impl7_Le_Interface with type a = a, type b = b
-  clone export Core_Tuple_Impl7_Lt_Interface with type a = a, type b = b
-  clone export Core_Tuple_Impl7_PartialCmp_Interface with type a = a, type b = b
-  clone Core_Cmp_PartialOrd with type self = (a, b), type rhs = (a, b), val partial_cmp = partial_cmp, val lt = lt,
-  val le = le, val ge = ge, val gt = gt
 end
 module ConstrainedTypes_UsesConcreteInstance_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/drop_pair.stdout
+++ b/creusot/tests/should_succeed/drop_pair.stdout
@@ -57,7 +57,7 @@ module CreusotContracts_Builtins_Impl12
   type t   
   use prelude.Prelude
   clone export CreusotContracts_Builtins_Impl12_Resolve with type t = t
-  clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
+  clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
 end
 module DropPair_DropPair2_Interface
   use prelude.Prelude

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -367,7 +367,7 @@ module CreusotContracts_Builtins_Impl12
   type t   
   use prelude.Prelude
   clone export CreusotContracts_Builtins_Impl12_Resolve with type t = t
-  clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
+  clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
 end
 module IncSome2List_IncSome2List_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -484,7 +484,7 @@ module CreusotContracts_Builtins_Impl12
   type t   
   use prelude.Prelude
   clone export CreusotContracts_Builtins_Impl12_Resolve with type t = t
-  clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
+  clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
 end
 module IncSome2Tree_IncSome2Tree_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -378,5 +378,5 @@ end
 module ListIndexMut_Impl0
   use Type
   clone export ListIndexMut_Impl0_Resolve
-  clone CreusotContracts_Builtins_Resolve with type self = Type.listindexmut_list, predicate resolve = resolve
+  clone export CreusotContracts_Builtins_Resolve with type self = Type.listindexmut_list, predicate resolve = resolve
 end

--- a/creusot/tests/should_succeed/modules.stdout
+++ b/creusot/tests/should_succeed/modules.stdout
@@ -96,5 +96,6 @@ end
 module Modules_Nested_Impl0
   use Type
   clone export Modules_Nested_Impl0_Resolve
-  clone CreusotContracts_Builtins_Resolve with type self = Type.modules_nested_nested, predicate resolve = resolve
+  clone export CreusotContracts_Builtins_Resolve with type self = Type.modules_nested_nested,
+  predicate resolve = resolve
 end

--- a/creusot/tests/should_succeed/pure_function.stdout
+++ b/creusot/tests/should_succeed/pure_function.stdout
@@ -196,5 +196,5 @@ end
 module PureFunction_Impl0
   type t   
   use Type
-  clone CreusotContracts_WellFounded with type self = Type.purefunction_list t
+  clone export CreusotContracts_WellFounded with type self = Type.purefunction_list t
 end

--- a/creusot/tests/should_succeed/trait_impl.stdout
+++ b/creusot/tests/should_succeed/trait_impl.stdout
@@ -90,12 +90,12 @@ module TraitImpl_Impl0
   type t2   
   type t1   
   clone export TraitImpl_Impl0_X_Interface with type b = b, type t2 = t2, type t1 = t1
-  clone TraitImpl_T with type self = (t1, t2), type b = b, val x = x
+  clone export TraitImpl_T with type self = (t1, t2), type b = b, val x = x
 end
 module TraitImpl_Impl1
   type b   
   use mach.int.Int
   use mach.int.UInt32
   clone export TraitImpl_Impl1_X_Interface with type b = b
-  clone TraitImpl_T with type self = uint32, type b = b, val x = x
+  clone export TraitImpl_T with type self = uint32, type b = b, val x = x
 end

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -101,7 +101,7 @@ module C03_Impl0
   use mach.int.Int
   use mach.int.Int32
   clone export C03_Impl0_F_Interface
-  clone C03_A with type self = int32, val f = f
+  clone export C03_A with type self = int32, val f = f
 end
 module C03_B
   type self   
@@ -115,7 +115,7 @@ module C03_Impl1
   use mach.int.Int
   use mach.int.UInt32
   clone export C03_Impl1_G_Interface
-  clone C03_B with type self = uint32, val g = g
+  clone export C03_B with type self = uint32, val g = g
 end
 module C03_C
   type self   
@@ -127,5 +127,5 @@ module C03_Impl2
   use mach.int.Int
   use mach.int.UInt32
   clone export C03_Impl2_H_Interface
-  clone C03_C with type self = uint32, type t = g, val h = h
+  clone export C03_C with type self = uint32, type t = g, val h = h
 end

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -80,14 +80,6 @@ module C07_Test
   }
   
 end
-module C07_Impl0
-  use mach.int.Int
-  use mach.int.Int32
-  clone export C07_Impl0_Ix_Interface
-  type tgt  = 
-    ()
-  clone C07_Ix with type self = int32, type tgt = tgt, val ix = ix
-end
 module C07_Test2_Interface
   use prelude.Prelude
   use mach.int.Int
@@ -117,4 +109,12 @@ module C07_Test2
     return _0
   }
   
+end
+module C07_Impl0
+  use mach.int.Int
+  use mach.int.Int32
+  clone export C07_Impl0_Ix_Interface
+  type tgt  = 
+    ()
+  clone export C07_Ix with type self = int32, type tgt = tgt, val ix = ix
 end

--- a/creusot/tests/should_succeed/traits/10.stdout
+++ b/creusot/tests/should_succeed/traits/10.stdout
@@ -34,5 +34,5 @@ module C10_Impl0
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t1
   clone export C10_Impl0_Resolve with type t1 = t1, type t2 = t2, predicate Resolve0.resolve = Resolve1.resolve,
   predicate Resolve1.resolve = Resolve2.resolve
-  clone CreusotContracts_Builtins_Resolve with type self = (t1, t2), predicate resolve = resolve
+  clone export CreusotContracts_Builtins_Resolve with type self = (t1, t2), predicate resolve = resolve
 end

--- a/creusot/tests/should_succeed/traits/12_default_method.rs
+++ b/creusot/tests/should_succeed/traits/12_default_method.rs
@@ -1,0 +1,24 @@
+#![feature(register_tool, rustc_attrs)]
+#![register_tool(creusot)]
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
+
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+trait T {
+    fn default(&self) -> u32 {
+        0
+    }
+
+    logic! { fn logic_default(self) -> bool {
+      true
+    }}
+}
+
+impl T for u32 {}
+
+#[ensures(x.logic_default())]
+fn should_use_impl(x: u32) {
+    x.default();
+}

--- a/creusot/tests/should_succeed/traits/12_default_method.stdout
+++ b/creusot/tests/should_succeed/traits/12_default_method.stdout
@@ -1,0 +1,69 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C12DefaultMethod_T
+  type self   
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Prelude
+  val default (self : self) : uint32
+  function logic_default (self : self) : bool
+end
+module C12DefaultMethod_Impl0
+  use mach.int.Int
+  use mach.int.UInt32
+  clone export C12DefaultMethod_T with type self = uint32
+end
+module CreusotContracts_Builtins_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module C12DefaultMethod_ShouldUseImpl_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  clone C12DefaultMethod_Impl0 as T0
+  val should_use_impl (x : uint32) : ()
+    ensures { T0.logic_default x }
+    
+end
+module C12DefaultMethod_ShouldUseImpl
+  use mach.int.Int
+  use mach.int.UInt32
+  clone C12DefaultMethod_Impl0 as T0
+  use prelude.Prelude
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = uint32
+  let rec cfg should_use_impl (x : uint32) : ()
+    ensures { T0.logic_default x }
+    
+   = 
+  var _0 : ();
+  var x_1 : uint32;
+  var _2 : uint32;
+  var _3 : uint32;
+  {
+    x_1 <- x;
+    goto BB0
+  }
+  BB0 {
+    _3 <- x_1;
+    assume { Resolve1.resolve x_1 };
+    _2 <- T0.default _3;
+    goto BB1
+  }
+  BB1 {
+    assume { Resolve2.resolve _3 };
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -510,5 +510,5 @@ end
 module C01_Impl0
   type t   
   use Type
-  clone CreusotContracts_WellFounded with type self = Type.c01_list t
+  clone export CreusotContracts_WellFounded with type self = Type.c01_list t
 end


### PR DESCRIPTION
Addresses an issue found in #121 where a default implementation of a trait method broke specialization.

The issue arises when we attempt to specialize a trait method to the specific version belonging to an instance. When that method is actually a default implementation, there is no specialized version at all!
Everything in rustc refers us to the generic implementation that comes from the trait definition, effectively _unspecializing_ the method call. In other words:

```rust

trait T {
  fn func(&self) { () }
}

impl T for u32 {}
```

To `rustc` there is no method `func` for the instance of `T` of `u32`! My solution is semi-hacky: the idea is that if we are dealing with a default method call, we actually use the `DefId` of the impl rather than the method. 
