### PR TITLE
Improve `inc-some-*` tests

### DIFF
--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -14,140 +14,110 @@ module Type
     | IncSome2List_List_Nil
     
 end
-module IncSome2List_SumList_Interface
+module IncSome2List_Impl1_Sum_Interface
   use mach.int.Int
   use Type
-  function sum_list (l : Type.incsome2list_list) : int
+  function sum (self : Type.incsome2list_list) : int
 end
-module IncSome2List_SumList
+module IncSome2List_Impl1_Sum
   use mach.int.Int
   use Type
   use mach.int.Int32
-  function sum_list (l : Type.incsome2list_list) : int = 
-    match (l) with
-      | Type.IncSome2List_List_Cons a l2 -> a + sum_list l2
+  function sum (self : Type.incsome2list_list) : int = 
+    match (self) with
+      | Type.IncSome2List_List_Cons a l -> a + sum l
       | Type.IncSome2List_List_Nil -> 0
+      end
+end
+module IncSome2List_Impl1_LemmaSumNonneg_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSome2List_Impl1_Sum_Interface as Sum0
+  function lemma_sum_nonneg (self : Type.incsome2list_list) : ()
+end
+module IncSome2List_Impl1_LemmaSumNonneg
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSome2List_Impl1_Sum_Interface as Sum0
+  function lemma_sum_nonneg (self : Type.incsome2list_list) : ()
+  val lemma_sum_nonneg (self : Type.incsome2list_list) : ()
+    ensures { Sum0.sum self >= 0 }
+    ensures { result = lemma_sum_nonneg self }
+    
+  axiom spec : forall self : Type.incsome2list_list . Sum0.sum self >= 0
+  axiom def : forall self : Type.incsome2list_list . lemma_sum_nonneg self = match (self) with
+    | Type.IncSome2List_List_Cons _ l -> lemma_sum_nonneg l
+    | Type.IncSome2List_List_Nil -> ()
+    end
+end
+module IncSome2List_Impl1_LemmaSumNonneg_Impl
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSome2List_Impl1_Sum as Sum0
+  let rec lemma_sum_nonneg (self : Type.incsome2list_list) : ()
+    ensures { Sum0.sum self >= 0 }
+    variant {self}
+    
+   = 
+    match (self) with
+      | Type.IncSome2List_List_Cons _ l -> lemma_sum_nonneg l
+      | Type.IncSome2List_List_Nil -> ()
       end
 end
 module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module IncSome2List_LemmaSumListNonneg_Interface
-  use mach.int.Int
-  use mach.int.Int32
-  use prelude.Prelude
-  use Type
-  clone IncSome2List_SumList_Interface as SumList0
-  val lemma_sum_list_nonneg (l : Type.incsome2list_list) : ()
-    ensures { SumList0.sum_list l >= 0 }
-    
-end
-module IncSome2List_LemmaSumListNonneg
-  use mach.int.Int
-  use mach.int.Int32
-  use prelude.Prelude
-  use Type
-  clone IncSome2List_SumList as SumList0
-  use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2list_list
-  let rec cfg lemma_sum_list_nonneg (l : Type.incsome2list_list) : ()
-    ensures { SumList0.sum_list l >= 0 }
-    
-   = 
-  var _0 : ();
-  var l_1 : Type.incsome2list_list;
-  var _2 : isize;
-  var l_3 : Type.incsome2list_list;
-  var _4 : Type.incsome2list_list;
-  {
-    l_1 <- l;
-    goto BB0
-  }
-  BB0 {
-    switch (l_1)
-      | Type.IncSome2List_List_Cons _ _ -> goto BB1
-      | Type.IncSome2List_List_Nil -> goto BB2
-      | _ -> goto BB3
-      end
-  }
-  BB1 {
-    assume { Resolve2.resolve _2 };
-    goto BB4
-  }
-  BB2 {
-    assume { Resolve1.resolve l_1 };
-    assume { Resolve2.resolve _2 };
-    _0 <- ();
-    goto BB6
-  }
-  BB3 {
-    assume { Resolve1.resolve l_1 };
-    assume { Resolve2.resolve _2 };
-    absurd
-  }
-  BB4 {
-    l_3 <- (let Type.IncSome2List_List_Cons _ a = l_1 in a);
-    assume { Resolve1.resolve l_1 };
-    _4 <- l_3;
-    assume { Resolve3.resolve l_3 };
-    _0 <- lemma_sum_list_nonneg _4;
-    goto BB5
-  }
-  BB5 {
-    goto BB6
-  }
-  BB6 {
-    return _0
-  }
-  
-end
-module IncSome2List_SumListX_Interface
+module IncSome2List_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone IncSome2List_SumList_Interface as SumList0
-  val sum_list_x (l : Type.incsome2list_list) : uint32
-    requires {SumList0.sum_list l <= 1000000}
-    ensures { result = SumList0.sum_list l }
+  clone IncSome2List_Impl1_Sum_Interface as Sum0
+  val sum_x (self : Type.incsome2list_list) : uint32
+    requires {Sum0.sum self <= 1000000}
+    ensures { result = Sum0.sum self }
     
 end
-module IncSome2List_SumListX
+module IncSome2List_Impl1_SumX
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone IncSome2List_SumList as SumList0
+  clone IncSome2List_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.incsome2list_list
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2list_list
-  let rec cfg sum_list_x (l : Type.incsome2list_list) : uint32
-    requires {SumList0.sum_list l <= 1000000}
-    ensures { result = SumList0.sum_list l }
+  let rec cfg sum_x (self : Type.incsome2list_list) : uint32
+    requires {Sum0.sum self <= 1000000}
+    ensures { result = Sum0.sum self }
     
    = 
   var _0 : uint32;
-  var l_1 : Type.incsome2list_list;
+  var self_1 : Type.incsome2list_list;
   var _2 : isize;
   var a_3 : uint32;
-  var l2_4 : Type.incsome2list_list;
+  var l_4 : Type.incsome2list_list;
   var _5 : uint32;
   var _6 : uint32;
   var _7 : Type.incsome2list_list;
   {
-    l_1 <- l;
+    self_1 <- self;
     goto BB0
   }
   BB0 {
-    switch (l_1)
+    switch (self_1)
       | Type.IncSome2List_List_Cons _ _ -> goto BB1
       | Type.IncSome2List_List_Nil -> goto BB2
       | _ -> goto BB3
@@ -158,26 +128,26 @@ module IncSome2List_SumListX
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve l_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     _0 <- (0 : uint32);
     goto BB6
   }
   BB3 {
-    assume { Resolve1.resolve l_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     absurd
   }
   BB4 {
-    a_3 <- (let Type.IncSome2List_List_Cons a _ = l_1 in a);
-    l2_4 <- (let Type.IncSome2List_List_Cons _ a = l_1 in a);
-    assume { Resolve1.resolve l_1 };
+    a_3 <- (let Type.IncSome2List_List_Cons a _ = self_1 in a);
+    l_4 <- (let Type.IncSome2List_List_Cons _ a = self_1 in a);
+    assume { Resolve1.resolve self_1 };
     assume { Resolve3.resolve _5 };
     _5 <- a_3;
     assume { Resolve4.resolve a_3 };
-    _7 <- l2_4;
-    assume { Resolve5.resolve l2_4 };
-    _6 <- sum_list_x _7;
+    _7 <- l_4;
+    assume { Resolve5.resolve l_4 };
+    _6 <- sum_x _7;
     goto BB5
   }
   BB5 {
@@ -208,24 +178,24 @@ module Rand_Random
   type t   
   val random () : t
 end
-module IncSome2List_TakeSomeRestList_Interface
+module IncSome2List_Impl1_TakeSomeRest_Interface
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
   use Type
-  clone IncSome2List_SumList_Interface as SumList0
-  val take_some_rest_list (ml : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
-    ensures { SumList0.sum_list ( * (let (_, a) = result in a)) <= SumList0.sum_list ( * ml) }
-    ensures {  * (let (a, _) = result in a) <= SumList0.sum_list ( * ml) }
-    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) =  ^ (let (a, _) = result in a) + SumList0.sum_list ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - SumList0.sum_list ( * (let (_, a) = result in a)) }
+  clone IncSome2List_Impl1_Sum_Interface as Sum0
+  val take_some_rest (self : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
+    ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
+    ensures {  * (let (a, _) = result in a) <= Sum0.sum ( * self) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ (let (a, _) = result in a) + Sum0.sum ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     
 end
-module IncSome2List_TakeSomeRestList
+module IncSome2List_Impl1_TakeSomeRest
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
   use Type
-  clone IncSome2List_SumList as SumList0
+  clone IncSome2List_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve9 with type t = Type.incsome2list_list
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve8 with type t = uint32
@@ -235,18 +205,18 @@ module IncSome2List_TakeSomeRestList
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsome2list_list
-  clone IncSome2List_LemmaSumListNonneg_Interface as LemmaSumListNonneg4 with function SumList0.sum_list = SumList0.sum_list
-  let rec cfg take_some_rest_list (ml : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
-    ensures { SumList0.sum_list ( * (let (_, a) = result in a)) <= SumList0.sum_list ( * ml) }
-    ensures {  * (let (a, _) = result in a) <= SumList0.sum_list ( * ml) }
-    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) =  ^ (let (a, _) = result in a) + SumList0.sum_list ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - SumList0.sum_list ( * (let (_, a) = result in a)) }
+  clone IncSome2List_Impl1_LemmaSumNonneg as LemmaSumNonneg4 with function Sum0.sum = Sum0.sum, axiom .
+  let rec cfg take_some_rest (self : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
+    ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
+    ensures {  * (let (a, _) = result in a) <= Sum0.sum ( * self) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ (let (a, _) = result in a) + Sum0.sum ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     
    = 
   var _0 : (borrowed uint32, borrowed (Type.incsome2list_list));
-  var ml_1 : borrowed (Type.incsome2list_list);
+  var self_1 : borrowed (Type.incsome2list_list);
   var _2 : isize;
   var ma_3 : borrowed uint32;
-  var ml2_4 : borrowed (Type.incsome2list_list);
+  var ml_4 : borrowed (Type.incsome2list_list);
   var _5 : ();
   var _6 : Type.incsome2list_list;
   var _7 : bool;
@@ -256,11 +226,11 @@ module IncSome2List_TakeSomeRestList
   var _11 : ();
   var _12 : ();
   {
-    ml_1 <- ml;
+    self_1 <- self;
     goto BB0
   }
   BB0 {
-    switch ( * ml_1)
+    switch ( * self_1)
       | Type.IncSome2List_List_Cons _ _ -> goto BB1
       | Type.IncSome2List_List_Nil -> goto BB2
       | _ -> goto BB3
@@ -271,23 +241,23 @@ module IncSome2List_TakeSomeRestList
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve ml_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     goto BB11
   }
   BB3 {
-    assume { Resolve1.resolve ml_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     absurd
   }
   BB4 {
-    ma_3 <- borrow_mut (let Type.IncSome2List_List_Cons a _ =  * ml_1 in a);
-    ml_1 <- { ml_1 with current = (let Type.IncSome2List_List_Cons a b =  * ml_1 in Type.IncSome2List_List_Cons ( ^ ma_3) b) };
-    ml2_4 <- borrow_mut (let Type.IncSome2List_List_Cons _ a =  * ml_1 in a);
-    ml_1 <- { ml_1 with current = (let Type.IncSome2List_List_Cons a b =  * ml_1 in Type.IncSome2List_List_Cons a ( ^ ml2_4)) };
-    assume { Resolve1.resolve ml_1 };
-    _6 <-  * ml2_4;
-    _5 <- LemmaSumListNonneg4.lemma_sum_list_nonneg _6;
+    ma_3 <- borrow_mut (let Type.IncSome2List_List_Cons a _ =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSome2List_List_Cons a b =  * self_1 in Type.IncSome2List_List_Cons ( ^ ma_3) b) };
+    ml_4 <- borrow_mut (let Type.IncSome2List_List_Cons _ a =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSome2List_List_Cons a b =  * self_1 in Type.IncSome2List_List_Cons a ( ^ ml_4)) };
+    assume { Resolve1.resolve self_1 };
+    _6 <-  * ml_4;
+    _5 <- LemmaSumNonneg4.lemma_sum_nonneg _6;
     goto BB5
   }
   BB5 {
@@ -307,19 +277,19 @@ module IncSome2List_TakeSomeRestList
     _8 <- borrow_mut ( * ma_3);
     ma_3 <- { ma_3 with current = ( ^ _8) };
     assume { Resolve8.resolve ma_3 };
-    _9 <- borrow_mut ( * ml2_4);
-    ml2_4 <- { ml2_4 with current = ( ^ _9) };
-    assume { Resolve9.resolve ml2_4 };
+    _9 <- borrow_mut ( * ml_4);
+    ml_4 <- { ml_4 with current = ( ^ _9) };
+    assume { Resolve9.resolve ml_4 };
     _0 <- (_8, _9);
     goto BB10
   }
   BB8 {
     assume { Resolve8.resolve ma_3 };
     assume { Resolve7.resolve _7 };
-    _10 <- borrow_mut ( * ml2_4);
-    ml2_4 <- { ml2_4 with current = ( ^ _10) };
-    assume { Resolve9.resolve ml2_4 };
-    _0 <- take_some_rest_list _10;
+    _10 <- borrow_mut ( * ml_4);
+    ml_4 <- { ml_4 with current = ( ^ _10) };
+    assume { Resolve9.resolve ml_4 };
+    _0 <- take_some_rest _10;
     goto BB9
   }
   BB9 {
@@ -374,9 +344,9 @@ module IncSome2List_IncSome2List_Interface
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone IncSome2List_SumList_Interface as SumList0
+  clone IncSome2List_Impl1_Sum_Interface as Sum0
   val inc_some_2_list (l : Type.incsome2list_list) (j : uint32) (k : uint32) : ()
-    requires {SumList0.sum_list l + j + k <= 1000000}
+    requires {Sum0.sum l + j + k <= 1000000}
     
 end
 module IncSome2List_IncSome2List
@@ -384,25 +354,24 @@ module IncSome2List_IncSome2List
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone IncSome2List_SumList as SumList0
+  clone IncSome2List_Impl1_Sum as Sum0
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve11 with type self = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Resolve as Resolve10 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic9
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = uint32
-  clone CreusotContracts_Builtins_Impl12 as Resolve13 with type t = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Impl12 as Resolve12 with type t = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve6 with type t1 = borrowed uint32,
-  type t2 = borrowed (Type.incsome2list_list), predicate Resolve0.resolve = Resolve12.resolve,
-  predicate Resolve1.resolve = Resolve13.resolve
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = uint32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2list_list
-  clone IncSome2List_TakeSomeRestList_Interface as TakeSomeRestList4 with function SumList0.sum_list = SumList0.sum_list
-  clone IncSome2List_SumListX_Interface as SumListX2 with function SumList0.sum_list = SumList0.sum_list
+  clone CreusotContracts_Builtins_Resolve as Resolve10 with type self = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic8
+  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
+  clone CreusotContracts_Builtins_Impl12 as Resolve12 with type t = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Impl12 as Resolve11 with type t = uint32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve5 with type t1 = borrowed uint32,
+  type t2 = borrowed (Type.incsome2list_list), predicate Resolve0.resolve = Resolve11.resolve,
+  predicate Resolve1.resolve = Resolve12.resolve
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = uint32
+  clone IncSome2List_Impl1_TakeSomeRest_Interface as TakeSomeRest2 with function Sum0.sum = Sum0.sum
+  clone IncSome2List_Impl1_SumX_Interface as SumX1 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_2_list (l : Type.incsome2list_list) (j : uint32) (k : uint32) : ()
-    requires {SumList0.sum_list l + j + k <= 1000000}
+    requires {Sum0.sum l + j + k <= 1000000}
     
    = 
   var _0 : ();
@@ -411,29 +380,26 @@ module IncSome2List_IncSome2List
   var k_3 : uint32;
   var sum0_4 : uint32;
   var _5 : Type.incsome2list_list;
-  var _6 : Type.incsome2list_list;
-  var ma_7 : borrowed uint32;
-  var ml_8 : borrowed (Type.incsome2list_list);
-  var _9 : (borrowed uint32, borrowed (Type.incsome2list_list));
-  var _10 : borrowed (Type.incsome2list_list);
-  var _11 : borrowed (Type.incsome2list_list);
-  var mb_12 : borrowed uint32;
-  var _13 : (borrowed uint32, borrowed (Type.incsome2list_list));
-  var _14 : borrowed (Type.incsome2list_list);
-  var _15 : uint32;
-  var _16 : uint32;
-  var _17 : ();
-  var _18 : bool;
-  var _19 : bool;
+  var ma_6 : borrowed uint32;
+  var ml_7 : borrowed (Type.incsome2list_list);
+  var _8 : (borrowed uint32, borrowed (Type.incsome2list_list));
+  var _9 : borrowed (Type.incsome2list_list);
+  var mb_10 : borrowed uint32;
+  var _11 : (borrowed uint32, borrowed (Type.incsome2list_list));
+  var _12 : borrowed (Type.incsome2list_list);
+  var _13 : uint32;
+  var _14 : uint32;
+  var _15 : ();
+  var _16 : bool;
+  var _17 : bool;
+  var _18 : uint32;
+  var _19 : Type.incsome2list_list;
   var _20 : uint32;
-  var _21 : Type.incsome2list_list;
-  var _22 : Type.incsome2list_list;
+  var _21 : uint32;
+  var _22 : uint32;
   var _23 : uint32;
   var _24 : uint32;
-  var _25 : uint32;
-  var _26 : uint32;
-  var _27 : uint32;
-  var _28 : ();
+  var _25 : ();
   {
     l_1 <- l;
     j_2 <- j;
@@ -441,87 +407,87 @@ module IncSome2List_IncSome2List
     goto BB0
   }
   BB0 {
-    _6 <- l_1;
-    _5 <- _6;
-    assume { Resolve1.resolve _6 };
-    sum0_4 <- SumListX2.sum_list_x _5;
+    _5 <- l_1;
+    sum0_4 <- SumX1.sum_x _5;
     goto BB1
   }
   BB1 {
-    _11 <- borrow_mut l_1;
-    l_1 <-  ^ _11;
-    _10 <- borrow_mut ( * _11);
-    _11 <- { _11 with current = ( ^ _10) };
-    assume { Resolve3.resolve _11 };
-    _9 <- TakeSomeRestList4.take_some_rest_list _10;
+    _9 <- borrow_mut l_1;
+    l_1 <-  ^ _9;
+    _8 <- TakeSomeRest2.take_some_rest _9;
     goto BB2
   }
   BB2 {
-    assume { Resolve5.resolve ma_7 };
-    ma_7 <- (let (a, _) = _9 in a);
-    assume { Resolve3.resolve ml_8 };
-    ml_8 <- (let (_, a) = _9 in a);
-    assume { Resolve6.resolve _9 };
-    _14 <- borrow_mut ( * ml_8);
-    ml_8 <- { ml_8 with current = ( ^ _14) };
-    assume { Resolve3.resolve ml_8 };
-    _13 <- TakeSomeRestList4.take_some_rest_list _14;
+    assume { Resolve3.resolve ma_6 };
+    ma_6 <- (let (a, _) = _8 in a);
+    assume { Resolve4.resolve ml_7 };
+    ml_7 <- (let (_, a) = _8 in a);
+    assume { Resolve5.resolve _8 };
+    _12 <- borrow_mut ( * ml_7);
+    ml_7 <- { ml_7 with current = ( ^ _12) };
+    assume { Resolve4.resolve ml_7 };
+    _11 <- TakeSomeRest2.take_some_rest _12;
     goto BB3
   }
   BB3 {
-    assume { Resolve5.resolve mb_12 };
-    mb_12 <- (let (a, _) = _13 in a);
+    assume { Resolve3.resolve mb_10 };
+    mb_10 <- (let (a, _) = _11 in a);
+    assume { Resolve5.resolve _11 };
     assume { Resolve6.resolve _13 };
-    assume { Resolve7.resolve _15 };
-    _15 <- j_2;
-    ma_7 <- { ma_7 with current = ( * ma_7 + _15) };
-    assume { Resolve5.resolve ma_7 };
-    assume { Resolve7.resolve _15 };
-    assume { Resolve7.resolve _16 };
-    _16 <- k_3;
-    mb_12 <- { mb_12 with current = ( * mb_12 + _16) };
-    assume { Resolve5.resolve mb_12 };
-    assume { Resolve7.resolve _16 };
-    _22 <- l_1;
-    _21 <- _22;
-    assume { Resolve1.resolve _22 };
-    _20 <- SumListX2.sum_list_x _21;
+    _13 <- j_2;
+    ma_6 <- { ma_6 with current = ( * ma_6 + _13) };
+    assume { Resolve3.resolve ma_6 };
+    assume { Resolve6.resolve _13 };
+    assume { Resolve6.resolve _14 };
+    _14 <- k_3;
+    mb_10 <- { mb_10 with current = ( * mb_10 + _14) };
+    assume { Resolve3.resolve mb_10 };
+    assume { Resolve6.resolve _14 };
+    _19 <- l_1;
+    _18 <- SumX1.sum_x _19;
     goto BB4
   }
   BB4 {
-    assume { Resolve7.resolve _25 };
-    _25 <- sum0_4;
-    assume { Resolve7.resolve sum0_4 };
-    assume { Resolve7.resolve _26 };
-    _26 <- j_2;
-    assume { Resolve7.resolve j_2 };
-    _24 <- _25 + _26;
-    assume { Resolve7.resolve _27 };
-    _27 <- k_3;
-    assume { Resolve7.resolve k_3 };
-    _23 <- _24 + _27;
-    _19 <- _20 = _23;
-    _18 <- not _19;
-    switch (_18)
+    assume { Resolve6.resolve _22 };
+    _22 <- sum0_4;
+    assume { Resolve6.resolve sum0_4 };
+    assume { Resolve6.resolve _23 };
+    _23 <- j_2;
+    assume { Resolve6.resolve j_2 };
+    _21 <- _22 + _23;
+    assume { Resolve6.resolve _24 };
+    _24 <- k_3;
+    assume { Resolve6.resolve k_3 };
+    _20 <- _21 + _24;
+    _17 <- _18 = _20;
+    _16 <- not _17;
+    switch (_16)
       | False -> goto BB6
       | True -> goto BB5
       | _ -> goto BB5
       end
   }
   BB5 {
-    assume { Resolve8.resolve _18 };
+    assume { Resolve7.resolve _16 };
     absurd
   }
   BB6 {
-    assume { Resolve8.resolve _18 };
-    _17 <- ();
-    assume { Resolve10.resolve _17 };
+    assume { Resolve7.resolve _16 };
+    _15 <- ();
+    assume { Resolve9.resolve _15 };
     _0 <- ();
     goto BB7
   }
   BB7 {
-    assume { Resolve11.resolve l_1 };
+    assume { Resolve10.resolve l_1 };
     return _0
   }
   
+end
+module CreusotContracts_WellFounded
+  type self   
+end
+module IncSome2List_Impl0
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.incsome2list_list
 end

--- a/creusot/tests/should_succeed/inc_some_2_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_2_tree.rs
@@ -10,68 +10,73 @@ enum Tree {
     Leaf,
 }
 use Tree::*;
+impl WellFounded for Tree {}
 
-logic! {
-    fn sum_tree(t: Tree) -> Int {
-        match t {
-            Node(tl, a, tr) => sum_tree(*tl) + Int::from(a) + sum_tree(*tr),
+impl Tree {
+    logic! {
+        fn sum(self) -> Int {
+            match self {
+                Node(tl, a, tr) => tl.sum() + Int::from(a) + tr.sum(),
+                Leaf => 0,
+            }
+        }
+    }
+
+    // TODO: Make this ghost
+    #[pure]
+    #[variant(*self)]
+    #[ensures(self.sum() >= 0)]
+    fn lemma_sum_nonneg(&self) {
+        match self {
+            Node(tl, _, tr) => {
+                tl.lemma_sum_nonneg();
+                tr.lemma_sum_nonneg();
+            }
+            Leaf => (),
+        }
+    }
+
+    #[requires(self.sum() <= 1_000_000)]
+    #[ensures(Int::from(result) == self.sum())]
+    fn sum_x(&self) -> u32 {
+        match self {
+            Node(tl, a, tr) => {
+                tl.lemma_sum_nonneg();
+                tr.lemma_sum_nonneg();
+                tl.sum_x() + *a + tr.sum_x()
+            }
             Leaf => 0,
         }
     }
-}
 
-// TODO: Make this ghost
-#[ensures(sum_tree(*t) >= 0)]
-fn lemma_sum_tree_nonneg(t: &Tree) {
-    match t {
-        Node(tl, _, tr) => {
-            lemma_sum_tree_nonneg(tl);
-            lemma_sum_tree_nonneg(tr);
-        }
-        Leaf => (),
-    }
-}
-
-#[requires(sum_tree(*t) <= 1_000_000)]
-#[ensures(Int::from(result) == sum_tree(*t))]
-fn sum_tree_x(t: &Tree) -> u32 {
-    match t {
-        Node(tl, a, tr) => {
-            lemma_sum_tree_nonneg(tl);
-            lemma_sum_tree_nonneg(tr);
-            sum_tree_x(tl) + *a + sum_tree_x(tr)
-        }
-        Leaf => 0,
-    }
-}
-
-#[ensures(sum_tree(^mt) - sum_tree(*mt) ==
-    Int::from(^result.0) + sum_tree(^result.1) - Int::from(*result.0) - sum_tree(*result.1))]
-#[ensures(Int::from(*result.0) <= sum_tree(*mt))]
-#[ensures(sum_tree(*result.1) <= sum_tree(*mt))]
-fn take_some_rest_tree(mt: &mut Tree) -> (&mut u32, &mut Tree) {
-    match mt {
-        Node(mtl, ma, mtr) => {
-            lemma_sum_tree_nonneg(mtl);
-            lemma_sum_tree_nonneg(mtr);
-            if rand::random() {
-                (ma, if rand::random() { mtl } else { mtr })
-            } else if rand::random() {
-                take_some_rest_tree(mtl)
-            } else {
-                take_some_rest_tree(mtr)
+    #[ensures((^self).sum() - self.sum() ==
+        Int::from(^result.0) + (^result.1).sum() - Int::from(*result.0) - (*result.1).sum())]
+    #[ensures(Int::from(*result.0) <= self.sum())]
+    #[ensures(result.1.sum() <= self.sum())]
+    fn take_some_rest(&mut self) -> (&mut u32, &mut Tree) {
+        match self {
+            Node(mtl, ma, mtr) => {
+                mtl.lemma_sum_nonneg();
+                mtr.lemma_sum_nonneg();
+                if rand::random() {
+                    (ma, if rand::random() { mtl } else { mtr })
+                } else if rand::random() {
+                    mtl.take_some_rest()
+                } else {
+                    mtr.take_some_rest()
+                }
             }
+            Leaf => loop {},
         }
-        Leaf => loop {},
     }
 }
 
-#[requires(sum_tree(t) + Int::from(j) + Int::from(k) <= 1_000_000)]
+#[requires(t.sum() + Int::from(j) + Int::from(k) <= 1_000_000)]
 fn inc_some_2_tree(mut t: Tree, j: u32, k: u32) {
-    let sum0 = sum_tree_x(&t);
-    let (ma, mt) = take_some_rest_tree(&mut t);
-    let (mb, _) = take_some_rest_tree(mt);
+    let sum0 = t.sum_x();
+    let (ma, mt) = t.take_some_rest();
+    let (mb, _) = mt.take_some_rest();
     *ma += j;
     *mb += k;
-    assert!(sum_tree_x(&t) == sum0 + j + k);
+    assert!(t.sum_x() == sum0 + j + k);
 }

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -14,143 +14,99 @@ module Type
     | IncSome2Tree_Tree_Leaf
     
 end
-module IncSome2Tree_SumTree_Interface
+module IncSome2Tree_Impl1_Sum_Interface
   use mach.int.Int
   use Type
-  function sum_tree (t : Type.incsome2tree_tree) : int
+  function sum (self : Type.incsome2tree_tree) : int
 end
-module IncSome2Tree_SumTree
+module IncSome2Tree_Impl1_Sum
   use mach.int.Int
   use Type
   use mach.int.Int32
-  function sum_tree (t : Type.incsome2tree_tree) : int = 
-    match (t) with
-      | Type.IncSome2Tree_Tree_Node tl a tr -> sum_tree tl + a + sum_tree tr
+  function sum (self : Type.incsome2tree_tree) : int = 
+    match (self) with
+      | Type.IncSome2Tree_Tree_Node tl a tr -> sum tl + a + sum tr
       | Type.IncSome2Tree_Tree_Leaf -> 0
+      end
+end
+module IncSome2Tree_Impl1_LemmaSumNonneg_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSome2Tree_Impl1_Sum_Interface as Sum0
+  function lemma_sum_nonneg (self : Type.incsome2tree_tree) : ()
+end
+module IncSome2Tree_Impl1_LemmaSumNonneg
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSome2Tree_Impl1_Sum_Interface as Sum0
+  function lemma_sum_nonneg (self : Type.incsome2tree_tree) : ()
+  val lemma_sum_nonneg (self : Type.incsome2tree_tree) : ()
+    ensures { Sum0.sum self >= 0 }
+    ensures { result = lemma_sum_nonneg self }
+    
+  axiom spec : forall self : Type.incsome2tree_tree . Sum0.sum self >= 0
+  axiom def : forall self : Type.incsome2tree_tree . lemma_sum_nonneg self = match (self) with
+    | Type.IncSome2Tree_Tree_Node tl _ tr -> let _ = lemma_sum_nonneg tl in let _ = lemma_sum_nonneg tr in ()
+    | Type.IncSome2Tree_Tree_Leaf -> ()
+    end
+end
+module IncSome2Tree_Impl1_LemmaSumNonneg_Impl
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSome2Tree_Impl1_Sum as Sum0
+  let rec lemma_sum_nonneg (self : Type.incsome2tree_tree) : ()
+    ensures { Sum0.sum self >= 0 }
+    variant {self}
+    
+   = 
+    match (self) with
+      | Type.IncSome2Tree_Tree_Node tl _ tr -> let _ = lemma_sum_nonneg tl in let _ = lemma_sum_nonneg tr in ()
+      | Type.IncSome2Tree_Tree_Leaf -> ()
       end
 end
 module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module IncSome2Tree_LemmaSumTreeNonneg_Interface
-  use mach.int.Int
-  use mach.int.Int32
-  use prelude.Prelude
-  use Type
-  clone IncSome2Tree_SumTree_Interface as SumTree0
-  val lemma_sum_tree_nonneg (t : Type.incsome2tree_tree) : ()
-    ensures { SumTree0.sum_tree t >= 0 }
-    
-end
-module IncSome2Tree_LemmaSumTreeNonneg
-  use mach.int.Int
-  use mach.int.Int32
-  use prelude.Prelude
-  use Type
-  clone IncSome2Tree_SumTree as SumTree0
-  use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2tree_tree
-  let rec cfg lemma_sum_tree_nonneg (t : Type.incsome2tree_tree) : ()
-    ensures { SumTree0.sum_tree t >= 0 }
-    
-   = 
-  var _0 : ();
-  var t_1 : Type.incsome2tree_tree;
-  var _2 : isize;
-  var tl_3 : Type.incsome2tree_tree;
-  var tr_4 : Type.incsome2tree_tree;
-  var _5 : ();
-  var _6 : Type.incsome2tree_tree;
-  var _7 : ();
-  var _8 : Type.incsome2tree_tree;
-  {
-    t_1 <- t;
-    goto BB0
-  }
-  BB0 {
-    switch (t_1)
-      | Type.IncSome2Tree_Tree_Node _ _ _ -> goto BB1
-      | Type.IncSome2Tree_Tree_Leaf -> goto BB2
-      | _ -> goto BB3
-      end
-  }
-  BB1 {
-    assume { Resolve2.resolve _2 };
-    goto BB4
-  }
-  BB2 {
-    assume { Resolve1.resolve t_1 };
-    assume { Resolve2.resolve _2 };
-    _0 <- ();
-    goto BB7
-  }
-  BB3 {
-    assume { Resolve1.resolve t_1 };
-    assume { Resolve2.resolve _2 };
-    absurd
-  }
-  BB4 {
-    tl_3 <- (let Type.IncSome2Tree_Tree_Node a _ _ = t_1 in a);
-    tr_4 <- (let Type.IncSome2Tree_Tree_Node _ _ a = t_1 in a);
-    assume { Resolve1.resolve t_1 };
-    _6 <- tl_3;
-    assume { Resolve3.resolve tl_3 };
-    _5 <- lemma_sum_tree_nonneg _6;
-    goto BB5
-  }
-  BB5 {
-    assume { Resolve1.resolve _6 };
-    _8 <- tr_4;
-    assume { Resolve3.resolve tr_4 };
-    _7 <- lemma_sum_tree_nonneg _8;
-    goto BB6
-  }
-  BB6 {
-    assume { Resolve1.resolve _8 };
-    _0 <- ();
-    goto BB7
-  }
-  BB7 {
-    return _0
-  }
-  
-end
-module IncSome2Tree_SumTreeX_Interface
+module IncSome2Tree_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone IncSome2Tree_SumTree_Interface as SumTree0
-  val sum_tree_x (t : Type.incsome2tree_tree) : uint32
-    requires {SumTree0.sum_tree t <= 1000000}
-    ensures { result = SumTree0.sum_tree t }
+  clone IncSome2Tree_Impl1_Sum_Interface as Sum0
+  val sum_x (self : Type.incsome2tree_tree) : uint32
+    requires {Sum0.sum self <= 1000000}
+    ensures { result = Sum0.sum self }
     
 end
-module IncSome2Tree_SumTreeX
+module IncSome2Tree_Impl1_SumX
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone IncSome2Tree_SumTree as SumTree0
+  clone IncSome2Tree_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.incsome2tree_tree
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2tree_tree
-  clone IncSome2Tree_LemmaSumTreeNonneg_Interface as LemmaSumTreeNonneg3 with function SumTree0.sum_tree = SumTree0.sum_tree
-  let rec cfg sum_tree_x (t : Type.incsome2tree_tree) : uint32
-    requires {SumTree0.sum_tree t <= 1000000}
-    ensures { result = SumTree0.sum_tree t }
+  clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg3 with function Sum0.sum = Sum0.sum, axiom .
+  let rec cfg sum_x (self : Type.incsome2tree_tree) : uint32
+    requires {Sum0.sum self <= 1000000}
+    ensures { result = Sum0.sum self }
     
    = 
   var _0 : uint32;
-  var t_1 : Type.incsome2tree_tree;
+  var self_1 : Type.incsome2tree_tree;
   var _2 : isize;
   var tl_3 : Type.incsome2tree_tree;
   var a_4 : uint32;
@@ -166,11 +122,11 @@ module IncSome2Tree_SumTreeX
   var _14 : uint32;
   var _15 : Type.incsome2tree_tree;
   {
-    t_1 <- t;
+    self_1 <- self;
     goto BB0
   }
   BB0 {
-    switch (t_1)
+    switch (self_1)
       | Type.IncSome2Tree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSome2Tree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
@@ -181,36 +137,36 @@ module IncSome2Tree_SumTreeX
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve t_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     _0 <- (0 : uint32);
     goto BB9
   }
   BB3 {
-    assume { Resolve1.resolve t_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     absurd
   }
   BB4 {
-    tl_3 <- (let Type.IncSome2Tree_Tree_Node a _ _ = t_1 in a);
-    a_4 <- (let Type.IncSome2Tree_Tree_Node _ a _ = t_1 in a);
-    tr_5 <- (let Type.IncSome2Tree_Tree_Node _ _ a = t_1 in a);
-    assume { Resolve1.resolve t_1 };
+    tl_3 <- (let Type.IncSome2Tree_Tree_Node a _ _ = self_1 in a);
+    a_4 <- (let Type.IncSome2Tree_Tree_Node _ a _ = self_1 in a);
+    tr_5 <- (let Type.IncSome2Tree_Tree_Node _ _ a = self_1 in a);
+    assume { Resolve1.resolve self_1 };
     _7 <- tl_3;
-    _6 <- LemmaSumTreeNonneg3.lemma_sum_tree_nonneg _7;
+    _6 <- LemmaSumNonneg3.lemma_sum_nonneg _7;
     goto BB5
   }
   BB5 {
     assume { Resolve1.resolve _7 };
     _9 <- tr_5;
-    _8 <- LemmaSumTreeNonneg3.lemma_sum_tree_nonneg _9;
+    _8 <- LemmaSumNonneg3.lemma_sum_nonneg _9;
     goto BB6
   }
   BB6 {
     assume { Resolve1.resolve _9 };
     _12 <- tl_3;
     assume { Resolve4.resolve tl_3 };
-    _11 <- sum_tree_x _12;
+    _11 <- sum_x _12;
     goto BB7
   }
   BB7 {
@@ -220,7 +176,7 @@ module IncSome2Tree_SumTreeX
     _10 <- _11 + _13;
     _15 <- tr_5;
     assume { Resolve4.resolve tr_5 };
-    _14 <- sum_tree_x _15;
+    _14 <- sum_x _15;
     goto BB8
   }
   BB8 {
@@ -251,24 +207,24 @@ module Rand_Random
   type t   
   val random () : t
 end
-module IncSome2Tree_TakeSomeRestTree_Interface
+module IncSome2Tree_Impl1_TakeSomeRest_Interface
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
   use Type
-  clone IncSome2Tree_SumTree_Interface as SumTree0
-  val take_some_rest_tree (mt : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
-    ensures { SumTree0.sum_tree ( * (let (_, a) = result in a)) <= SumTree0.sum_tree ( * mt) }
-    ensures {  * (let (a, _) = result in a) <= SumTree0.sum_tree ( * mt) }
-    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) =  ^ (let (a, _) = result in a) + SumTree0.sum_tree ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - SumTree0.sum_tree ( * (let (_, a) = result in a)) }
+  clone IncSome2Tree_Impl1_Sum_Interface as Sum0
+  val take_some_rest (self : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
+    ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
+    ensures {  * (let (a, _) = result in a) <= Sum0.sum ( * self) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ (let (a, _) = result in a) + Sum0.sum ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     
 end
-module IncSome2Tree_TakeSomeRestTree
+module IncSome2Tree_Impl1_TakeSomeRest
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
   use Type
-  clone IncSome2Tree_SumTree as SumTree0
+  clone IncSome2Tree_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve9 with type t = Type.incsome2tree_tree
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve8 with type t = uint32
@@ -278,15 +234,15 @@ module IncSome2Tree_TakeSomeRestTree
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsome2tree_tree
-  clone IncSome2Tree_LemmaSumTreeNonneg_Interface as LemmaSumTreeNonneg4 with function SumTree0.sum_tree = SumTree0.sum_tree
-  let rec cfg take_some_rest_tree (mt : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
-    ensures { SumTree0.sum_tree ( * (let (_, a) = result in a)) <= SumTree0.sum_tree ( * mt) }
-    ensures {  * (let (a, _) = result in a) <= SumTree0.sum_tree ( * mt) }
-    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) =  ^ (let (a, _) = result in a) + SumTree0.sum_tree ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - SumTree0.sum_tree ( * (let (_, a) = result in a)) }
+  clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg4 with function Sum0.sum = Sum0.sum, axiom .
+  let rec cfg take_some_rest (self : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
+    ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
+    ensures {  * (let (a, _) = result in a) <= Sum0.sum ( * self) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ (let (a, _) = result in a) + Sum0.sum ( ^ (let (_, a) = result in a)) -  * (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     
    = 
   var _0 : (borrowed uint32, borrowed (Type.incsome2tree_tree));
-  var mt_1 : borrowed (Type.incsome2tree_tree);
+  var self_1 : borrowed (Type.incsome2tree_tree);
   var _2 : isize;
   var mtl_3 : borrowed (Type.incsome2tree_tree);
   var ma_4 : borrowed uint32;
@@ -307,11 +263,11 @@ module IncSome2Tree_TakeSomeRestTree
   var _19 : ();
   var _20 : ();
   {
-    mt_1 <- mt;
+    self_1 <- self;
     goto BB0
   }
   BB0 {
-    switch ( * mt_1)
+    switch ( * self_1)
       | Type.IncSome2Tree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSome2Tree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
@@ -322,31 +278,31 @@ module IncSome2Tree_TakeSomeRestTree
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve mt_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     goto BB21
   }
   BB3 {
-    assume { Resolve1.resolve mt_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     absurd
   }
   BB4 {
-    mtl_3 <- borrow_mut (let Type.IncSome2Tree_Tree_Node a _ _ =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * mt_1 in Type.IncSome2Tree_Tree_Node ( ^ mtl_3) b c) };
-    ma_4 <- borrow_mut (let Type.IncSome2Tree_Tree_Node _ a _ =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * mt_1 in Type.IncSome2Tree_Tree_Node a ( ^ ma_4) c) };
-    mtr_5 <- borrow_mut (let Type.IncSome2Tree_Tree_Node _ _ a =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * mt_1 in Type.IncSome2Tree_Tree_Node a b ( ^ mtr_5)) };
-    assume { Resolve1.resolve mt_1 };
+    mtl_3 <- borrow_mut (let Type.IncSome2Tree_Tree_Node a _ _ =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * self_1 in Type.IncSome2Tree_Tree_Node ( ^ mtl_3) b c) };
+    ma_4 <- borrow_mut (let Type.IncSome2Tree_Tree_Node _ a _ =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * self_1 in Type.IncSome2Tree_Tree_Node a ( ^ ma_4) c) };
+    mtr_5 <- borrow_mut (let Type.IncSome2Tree_Tree_Node _ _ a =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * self_1 in Type.IncSome2Tree_Tree_Node a b ( ^ mtr_5)) };
+    assume { Resolve1.resolve self_1 };
     _7 <-  * mtl_3;
-    _6 <- LemmaSumTreeNonneg4.lemma_sum_tree_nonneg _7;
+    _6 <- LemmaSumNonneg4.lemma_sum_nonneg _7;
     goto BB5
   }
   BB5 {
     assume { Resolve5.resolve _7 };
     _9 <-  * mtr_5;
-    _8 <- LemmaSumTreeNonneg4.lemma_sum_tree_nonneg _9;
+    _8 <- LemmaSumNonneg4.lemma_sum_nonneg _9;
     goto BB6
   }
   BB6 {
@@ -421,7 +377,7 @@ module IncSome2Tree_TakeSomeRestTree
     _17 <- borrow_mut ( * mtl_3);
     mtl_3 <- { mtl_3 with current = ( ^ _17) };
     assume { Resolve9.resolve mtl_3 };
-    _0 <- take_some_rest_tree _17;
+    _0 <- take_some_rest _17;
     goto BB16
   }
   BB16 {
@@ -433,7 +389,7 @@ module IncSome2Tree_TakeSomeRestTree
     _18 <- borrow_mut ( * mtr_5);
     mtr_5 <- { mtr_5 with current = ( ^ _18) };
     assume { Resolve9.resolve mtr_5 };
-    _0 <- take_some_rest_tree _18;
+    _0 <- take_some_rest _18;
     goto BB18
   }
   BB18 {
@@ -491,9 +447,9 @@ module IncSome2Tree_IncSome2Tree_Interface
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone IncSome2Tree_SumTree_Interface as SumTree0
+  clone IncSome2Tree_Impl1_Sum_Interface as Sum0
   val inc_some_2_tree (t : Type.incsome2tree_tree) (j : uint32) (k : uint32) : ()
-    requires {SumTree0.sum_tree t + j + k <= 1000000}
+    requires {Sum0.sum t + j + k <= 1000000}
     
 end
 module IncSome2Tree_IncSome2Tree
@@ -501,25 +457,24 @@ module IncSome2Tree_IncSome2Tree
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone IncSome2Tree_SumTree as SumTree0
+  clone IncSome2Tree_Impl1_Sum as Sum0
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve11 with type self = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve10 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic9
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = uint32
-  clone CreusotContracts_Builtins_Impl12 as Resolve13 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Impl12 as Resolve12 with type t = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve6 with type t1 = borrowed uint32,
-  type t2 = borrowed (Type.incsome2tree_tree), predicate Resolve0.resolve = Resolve12.resolve,
-  predicate Resolve1.resolve = Resolve13.resolve
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = uint32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2tree_tree
-  clone IncSome2Tree_TakeSomeRestTree_Interface as TakeSomeRestTree4 with function SumTree0.sum_tree = SumTree0.sum_tree
-  clone IncSome2Tree_SumTreeX_Interface as SumTreeX2 with function SumTree0.sum_tree = SumTree0.sum_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve10 with type self = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic8
+  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
+  clone CreusotContracts_Builtins_Impl12 as Resolve12 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Impl12 as Resolve11 with type t = uint32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve5 with type t1 = borrowed uint32,
+  type t2 = borrowed (Type.incsome2tree_tree), predicate Resolve0.resolve = Resolve11.resolve,
+  predicate Resolve1.resolve = Resolve12.resolve
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = uint32
+  clone IncSome2Tree_Impl1_TakeSomeRest_Interface as TakeSomeRest2 with function Sum0.sum = Sum0.sum
+  clone IncSome2Tree_Impl1_SumX_Interface as SumX1 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_2_tree (t : Type.incsome2tree_tree) (j : uint32) (k : uint32) : ()
-    requires {SumTree0.sum_tree t + j + k <= 1000000}
+    requires {Sum0.sum t + j + k <= 1000000}
     
    = 
   var _0 : ();
@@ -528,29 +483,26 @@ module IncSome2Tree_IncSome2Tree
   var k_3 : uint32;
   var sum0_4 : uint32;
   var _5 : Type.incsome2tree_tree;
-  var _6 : Type.incsome2tree_tree;
-  var ma_7 : borrowed uint32;
-  var mt_8 : borrowed (Type.incsome2tree_tree);
-  var _9 : (borrowed uint32, borrowed (Type.incsome2tree_tree));
-  var _10 : borrowed (Type.incsome2tree_tree);
-  var _11 : borrowed (Type.incsome2tree_tree);
-  var mb_12 : borrowed uint32;
-  var _13 : (borrowed uint32, borrowed (Type.incsome2tree_tree));
-  var _14 : borrowed (Type.incsome2tree_tree);
-  var _15 : uint32;
-  var _16 : uint32;
-  var _17 : ();
-  var _18 : bool;
-  var _19 : bool;
+  var ma_6 : borrowed uint32;
+  var mt_7 : borrowed (Type.incsome2tree_tree);
+  var _8 : (borrowed uint32, borrowed (Type.incsome2tree_tree));
+  var _9 : borrowed (Type.incsome2tree_tree);
+  var mb_10 : borrowed uint32;
+  var _11 : (borrowed uint32, borrowed (Type.incsome2tree_tree));
+  var _12 : borrowed (Type.incsome2tree_tree);
+  var _13 : uint32;
+  var _14 : uint32;
+  var _15 : ();
+  var _16 : bool;
+  var _17 : bool;
+  var _18 : uint32;
+  var _19 : Type.incsome2tree_tree;
   var _20 : uint32;
-  var _21 : Type.incsome2tree_tree;
-  var _22 : Type.incsome2tree_tree;
+  var _21 : uint32;
+  var _22 : uint32;
   var _23 : uint32;
   var _24 : uint32;
-  var _25 : uint32;
-  var _26 : uint32;
-  var _27 : uint32;
-  var _28 : ();
+  var _25 : ();
   {
     t_1 <- t;
     j_2 <- j;
@@ -558,87 +510,87 @@ module IncSome2Tree_IncSome2Tree
     goto BB0
   }
   BB0 {
-    _6 <- t_1;
-    _5 <- _6;
-    assume { Resolve1.resolve _6 };
-    sum0_4 <- SumTreeX2.sum_tree_x _5;
+    _5 <- t_1;
+    sum0_4 <- SumX1.sum_x _5;
     goto BB1
   }
   BB1 {
-    _11 <- borrow_mut t_1;
-    t_1 <-  ^ _11;
-    _10 <- borrow_mut ( * _11);
-    _11 <- { _11 with current = ( ^ _10) };
-    assume { Resolve3.resolve _11 };
-    _9 <- TakeSomeRestTree4.take_some_rest_tree _10;
+    _9 <- borrow_mut t_1;
+    t_1 <-  ^ _9;
+    _8 <- TakeSomeRest2.take_some_rest _9;
     goto BB2
   }
   BB2 {
-    assume { Resolve5.resolve ma_7 };
-    ma_7 <- (let (a, _) = _9 in a);
-    assume { Resolve3.resolve mt_8 };
-    mt_8 <- (let (_, a) = _9 in a);
-    assume { Resolve6.resolve _9 };
-    _14 <- borrow_mut ( * mt_8);
-    mt_8 <- { mt_8 with current = ( ^ _14) };
-    assume { Resolve3.resolve mt_8 };
-    _13 <- TakeSomeRestTree4.take_some_rest_tree _14;
+    assume { Resolve3.resolve ma_6 };
+    ma_6 <- (let (a, _) = _8 in a);
+    assume { Resolve4.resolve mt_7 };
+    mt_7 <- (let (_, a) = _8 in a);
+    assume { Resolve5.resolve _8 };
+    _12 <- borrow_mut ( * mt_7);
+    mt_7 <- { mt_7 with current = ( ^ _12) };
+    assume { Resolve4.resolve mt_7 };
+    _11 <- TakeSomeRest2.take_some_rest _12;
     goto BB3
   }
   BB3 {
-    assume { Resolve5.resolve mb_12 };
-    mb_12 <- (let (a, _) = _13 in a);
+    assume { Resolve3.resolve mb_10 };
+    mb_10 <- (let (a, _) = _11 in a);
+    assume { Resolve5.resolve _11 };
     assume { Resolve6.resolve _13 };
-    assume { Resolve7.resolve _15 };
-    _15 <- j_2;
-    ma_7 <- { ma_7 with current = ( * ma_7 + _15) };
-    assume { Resolve5.resolve ma_7 };
-    assume { Resolve7.resolve _15 };
-    assume { Resolve7.resolve _16 };
-    _16 <- k_3;
-    mb_12 <- { mb_12 with current = ( * mb_12 + _16) };
-    assume { Resolve5.resolve mb_12 };
-    assume { Resolve7.resolve _16 };
-    _22 <- t_1;
-    _21 <- _22;
-    assume { Resolve1.resolve _22 };
-    _20 <- SumTreeX2.sum_tree_x _21;
+    _13 <- j_2;
+    ma_6 <- { ma_6 with current = ( * ma_6 + _13) };
+    assume { Resolve3.resolve ma_6 };
+    assume { Resolve6.resolve _13 };
+    assume { Resolve6.resolve _14 };
+    _14 <- k_3;
+    mb_10 <- { mb_10 with current = ( * mb_10 + _14) };
+    assume { Resolve3.resolve mb_10 };
+    assume { Resolve6.resolve _14 };
+    _19 <- t_1;
+    _18 <- SumX1.sum_x _19;
     goto BB4
   }
   BB4 {
-    assume { Resolve7.resolve _25 };
-    _25 <- sum0_4;
-    assume { Resolve7.resolve sum0_4 };
-    assume { Resolve7.resolve _26 };
-    _26 <- j_2;
-    assume { Resolve7.resolve j_2 };
-    _24 <- _25 + _26;
-    assume { Resolve7.resolve _27 };
-    _27 <- k_3;
-    assume { Resolve7.resolve k_3 };
-    _23 <- _24 + _27;
-    _19 <- _20 = _23;
-    _18 <- not _19;
-    switch (_18)
+    assume { Resolve6.resolve _22 };
+    _22 <- sum0_4;
+    assume { Resolve6.resolve sum0_4 };
+    assume { Resolve6.resolve _23 };
+    _23 <- j_2;
+    assume { Resolve6.resolve j_2 };
+    _21 <- _22 + _23;
+    assume { Resolve6.resolve _24 };
+    _24 <- k_3;
+    assume { Resolve6.resolve k_3 };
+    _20 <- _21 + _24;
+    _17 <- _18 = _20;
+    _16 <- not _17;
+    switch (_16)
       | False -> goto BB6
       | True -> goto BB5
       | _ -> goto BB5
       end
   }
   BB5 {
-    assume { Resolve8.resolve _18 };
+    assume { Resolve7.resolve _16 };
     absurd
   }
   BB6 {
-    assume { Resolve8.resolve _18 };
-    _17 <- ();
-    assume { Resolve10.resolve _17 };
+    assume { Resolve7.resolve _16 };
+    _15 <- ();
+    assume { Resolve9.resolve _15 };
     _0 <- ();
     goto BB7
   }
   BB7 {
-    assume { Resolve11.resolve t_1 };
+    assume { Resolve10.resolve t_1 };
     return _0
   }
   
+end
+module CreusotContracts_WellFounded
+  type self   
+end
+module IncSome2Tree_Impl0
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.incsome2tree_tree
 end

--- a/creusot/tests/should_succeed/inc_some_list.rs
+++ b/creusot/tests/should_succeed/inc_some_list.rs
@@ -10,54 +10,59 @@ enum List {
     Nil,
 }
 use List::*;
+impl WellFounded for List {}
 
-logic! {
-    fn sum_list(l: List) -> Int {
-        match l {
-            Cons(a, l2) => Int::from(a) + sum_list(*l2),
+impl List {
+    logic! {
+        fn sum(self) -> Int {
+            match self {
+                Cons(a, l) => Int::from(a) + l.sum(),
+                Nil => 0,
+            }
+        }
+    }
+
+    // TODO: Make this ghost
+    #[pure]
+    #[variant(*self)]
+    #[ensures(self.sum() >= 0)]
+    fn lemma_sum_nonneg(&self) {
+        match self {
+            Cons(_, l) => l.lemma_sum_nonneg(),
+            Nil => (),
+        }
+    }
+
+    #[requires(self.sum() <= 1_000_000)]
+    #[ensures(Int::from(result) == self.sum())]
+    fn sum_x(&self) -> u32 {
+        match self {
+            Cons(a, l) => *a + l.sum_x(),
             Nil => 0,
         }
     }
-}
 
-// TODO: Make this ghost
-#[ensures(sum_list(*l) >= 0)]
-fn lemma_sum_list_nonneg(l: &List) {
-    match l {
-        Cons(_, l) => lemma_sum_list_nonneg(l),
-        Nil => (),
-    }
-}
-
-#[requires(sum_list(*l) <= 1_000_000)]
-#[ensures(Int::from(result) == sum_list(*l))]
-fn sum_list_x(l: &List) -> u32 {
-    match l {
-        Cons(a, l2) => *a + sum_list_x(l2),
-        Nil => 0,
-    }
-}
-
-#[ensures(sum_list(^ml) - sum_list(*ml) == Int::from(^result) - Int::from(*result))]
-#[ensures(Int::from(*result) <= sum_list(*ml))]
-fn take_some_list(ml: &mut List) -> &mut u32 {
-    match ml {
-        Cons(ma, ml2) => {
-            lemma_sum_list_nonneg(ml2);
-            if rand::random() {
-                ma
-            } else {
-                take_some_list(ml2)
+    #[ensures((^self).sum() - self.sum() == Int::from(^result) - Int::from(*result))]
+    #[ensures(Int::from(*result) <= self.sum())]
+    fn take_some(&mut self) -> &mut u32 {
+        match self {
+            Cons(ma, ml) => {
+                ml.lemma_sum_nonneg();
+                if rand::random() {
+                    ma
+                } else {
+                    ml.take_some()
+                }
             }
+            Nil => loop {},
         }
-        Nil => loop {},
     }
 }
 
-#[requires(sum_list(l) + Int::from(k) <= 1_000_000)]
+#[requires(l.sum() + Int::from(k) <= 1_000_000)]
 fn inc_some_list(mut l: List, k: u32) {
-    let sum0 = sum_list_x(&l);
-    let ma = take_some_list(&mut l);
+    let sum0 = l.sum_x();
+    let ma = l.take_some();
     *ma += k;
-    assert!(sum_list_x(&l) == sum0 + k);
+    assert!(l.sum_x() == sum0 + k);
 }

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -14,140 +14,110 @@ module Type
     | IncSomeList_List_Nil
     
 end
-module IncSomeList_SumList_Interface
+module IncSomeList_Impl1_Sum_Interface
   use mach.int.Int
   use Type
-  function sum_list (l : Type.incsomelist_list) : int
+  function sum (self : Type.incsomelist_list) : int
 end
-module IncSomeList_SumList
+module IncSomeList_Impl1_Sum
   use mach.int.Int
   use Type
   use mach.int.Int32
-  function sum_list (l : Type.incsomelist_list) : int = 
-    match (l) with
-      | Type.IncSomeList_List_Cons a l2 -> a + sum_list l2
+  function sum (self : Type.incsomelist_list) : int = 
+    match (self) with
+      | Type.IncSomeList_List_Cons a l -> a + sum l
       | Type.IncSomeList_List_Nil -> 0
+      end
+end
+module IncSomeList_Impl1_LemmaSumNonneg_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSomeList_Impl1_Sum_Interface as Sum0
+  function lemma_sum_nonneg (self : Type.incsomelist_list) : ()
+end
+module IncSomeList_Impl1_LemmaSumNonneg
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSomeList_Impl1_Sum_Interface as Sum0
+  function lemma_sum_nonneg (self : Type.incsomelist_list) : ()
+  val lemma_sum_nonneg (self : Type.incsomelist_list) : ()
+    ensures { Sum0.sum self >= 0 }
+    ensures { result = lemma_sum_nonneg self }
+    
+  axiom spec : forall self : Type.incsomelist_list . Sum0.sum self >= 0
+  axiom def : forall self : Type.incsomelist_list . lemma_sum_nonneg self = match (self) with
+    | Type.IncSomeList_List_Cons _ l -> lemma_sum_nonneg l
+    | Type.IncSomeList_List_Nil -> ()
+    end
+end
+module IncSomeList_Impl1_LemmaSumNonneg_Impl
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSomeList_Impl1_Sum as Sum0
+  let rec lemma_sum_nonneg (self : Type.incsomelist_list) : ()
+    ensures { Sum0.sum self >= 0 }
+    variant {self}
+    
+   = 
+    match (self) with
+      | Type.IncSomeList_List_Cons _ l -> lemma_sum_nonneg l
+      | Type.IncSomeList_List_Nil -> ()
       end
 end
 module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module IncSomeList_LemmaSumListNonneg_Interface
-  use mach.int.Int
-  use mach.int.Int32
-  use prelude.Prelude
-  use Type
-  clone IncSomeList_SumList_Interface as SumList0
-  val lemma_sum_list_nonneg (l : Type.incsomelist_list) : ()
-    ensures { SumList0.sum_list l >= 0 }
-    
-end
-module IncSomeList_LemmaSumListNonneg
-  use mach.int.Int
-  use mach.int.Int32
-  use prelude.Prelude
-  use Type
-  clone IncSomeList_SumList as SumList0
-  use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsomelist_list
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsomelist_list
-  let rec cfg lemma_sum_list_nonneg (l : Type.incsomelist_list) : ()
-    ensures { SumList0.sum_list l >= 0 }
-    
-   = 
-  var _0 : ();
-  var l_1 : Type.incsomelist_list;
-  var _2 : isize;
-  var l_3 : Type.incsomelist_list;
-  var _4 : Type.incsomelist_list;
-  {
-    l_1 <- l;
-    goto BB0
-  }
-  BB0 {
-    switch (l_1)
-      | Type.IncSomeList_List_Cons _ _ -> goto BB1
-      | Type.IncSomeList_List_Nil -> goto BB2
-      | _ -> goto BB3
-      end
-  }
-  BB1 {
-    assume { Resolve2.resolve _2 };
-    goto BB4
-  }
-  BB2 {
-    assume { Resolve1.resolve l_1 };
-    assume { Resolve2.resolve _2 };
-    _0 <- ();
-    goto BB6
-  }
-  BB3 {
-    assume { Resolve1.resolve l_1 };
-    assume { Resolve2.resolve _2 };
-    absurd
-  }
-  BB4 {
-    l_3 <- (let Type.IncSomeList_List_Cons _ a = l_1 in a);
-    assume { Resolve1.resolve l_1 };
-    _4 <- l_3;
-    assume { Resolve3.resolve l_3 };
-    _0 <- lemma_sum_list_nonneg _4;
-    goto BB5
-  }
-  BB5 {
-    goto BB6
-  }
-  BB6 {
-    return _0
-  }
-  
-end
-module IncSomeList_SumListX_Interface
+module IncSomeList_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone IncSomeList_SumList_Interface as SumList0
-  val sum_list_x (l : Type.incsomelist_list) : uint32
-    requires {SumList0.sum_list l <= 1000000}
-    ensures { result = SumList0.sum_list l }
+  clone IncSomeList_Impl1_Sum_Interface as Sum0
+  val sum_x (self : Type.incsomelist_list) : uint32
+    requires {Sum0.sum self <= 1000000}
+    ensures { result = Sum0.sum self }
     
 end
-module IncSomeList_SumListX
+module IncSomeList_Impl1_SumX
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone IncSomeList_SumList as SumList0
+  clone IncSomeList_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.incsomelist_list
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsomelist_list
-  let rec cfg sum_list_x (l : Type.incsomelist_list) : uint32
-    requires {SumList0.sum_list l <= 1000000}
-    ensures { result = SumList0.sum_list l }
+  let rec cfg sum_x (self : Type.incsomelist_list) : uint32
+    requires {Sum0.sum self <= 1000000}
+    ensures { result = Sum0.sum self }
     
    = 
   var _0 : uint32;
-  var l_1 : Type.incsomelist_list;
+  var self_1 : Type.incsomelist_list;
   var _2 : isize;
   var a_3 : uint32;
-  var l2_4 : Type.incsomelist_list;
+  var l_4 : Type.incsomelist_list;
   var _5 : uint32;
   var _6 : uint32;
   var _7 : Type.incsomelist_list;
   {
-    l_1 <- l;
+    self_1 <- self;
     goto BB0
   }
   BB0 {
-    switch (l_1)
+    switch (self_1)
       | Type.IncSomeList_List_Cons _ _ -> goto BB1
       | Type.IncSomeList_List_Nil -> goto BB2
       | _ -> goto BB3
@@ -158,26 +128,26 @@ module IncSomeList_SumListX
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve l_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     _0 <- (0 : uint32);
     goto BB6
   }
   BB3 {
-    assume { Resolve1.resolve l_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     absurd
   }
   BB4 {
-    a_3 <- (let Type.IncSomeList_List_Cons a _ = l_1 in a);
-    l2_4 <- (let Type.IncSomeList_List_Cons _ a = l_1 in a);
-    assume { Resolve1.resolve l_1 };
+    a_3 <- (let Type.IncSomeList_List_Cons a _ = self_1 in a);
+    l_4 <- (let Type.IncSomeList_List_Cons _ a = self_1 in a);
+    assume { Resolve1.resolve self_1 };
     assume { Resolve3.resolve _5 };
     _5 <- a_3;
     assume { Resolve4.resolve a_3 };
-    _7 <- l2_4;
-    assume { Resolve5.resolve l2_4 };
-    _6 <- sum_list_x _7;
+    _7 <- l_4;
+    assume { Resolve5.resolve l_4 };
+    _6 <- sum_x _7;
     goto BB5
   }
   BB5 {
@@ -208,23 +178,23 @@ module Rand_Random
   type t   
   val random () : t
 end
-module IncSomeList_TakeSomeList_Interface
+module IncSomeList_Impl1_TakeSome_Interface
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
   use Type
-  clone IncSomeList_SumList_Interface as SumList0
-  val take_some_list (ml : borrowed (Type.incsomelist_list)) : borrowed uint32
-    ensures {  * result <= SumList0.sum_list ( * ml) }
-    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) =  ^ result -  * result }
+  clone IncSomeList_Impl1_Sum_Interface as Sum0
+  val take_some (self : borrowed (Type.incsomelist_list)) : borrowed uint32
+    ensures {  * result <= Sum0.sum ( * self) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result -  * result }
     
 end
-module IncSomeList_TakeSomeList
+module IncSomeList_Impl1_TakeSome
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
   use Type
-  clone IncSomeList_SumList as SumList0
+  clone IncSomeList_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve9 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
@@ -234,19 +204,19 @@ module IncSomeList_TakeSomeList
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsomelist_list
-  clone IncSomeList_LemmaSumListNonneg_Interface as LemmaSumListNonneg4 with function SumList0.sum_list = SumList0.sum_list
-  let rec cfg take_some_list (ml : borrowed (Type.incsomelist_list)) : borrowed uint32
-    ensures {  * result <= SumList0.sum_list ( * ml) }
-    ensures { SumList0.sum_list ( ^ ml) - SumList0.sum_list ( * ml) =  ^ result -  * result }
+  clone IncSomeList_Impl1_LemmaSumNonneg as LemmaSumNonneg4 with function Sum0.sum = Sum0.sum, axiom .
+  let rec cfg take_some (self : borrowed (Type.incsomelist_list)) : borrowed uint32
+    ensures {  * result <= Sum0.sum ( * self) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result -  * result }
     
    = 
   var _0 : borrowed uint32;
-  var ml_1 : borrowed (Type.incsomelist_list);
+  var self_1 : borrowed (Type.incsomelist_list);
   var _2 : borrowed uint32;
   var _3 : borrowed uint32;
   var _4 : isize;
   var ma_5 : borrowed uint32;
-  var ml2_6 : borrowed (Type.incsomelist_list);
+  var ml_6 : borrowed (Type.incsomelist_list);
   var _7 : borrowed uint32;
   var _8 : ();
   var _9 : Type.incsomelist_list;
@@ -258,11 +228,11 @@ module IncSomeList_TakeSomeList
   var _15 : ();
   var _16 : ();
   {
-    ml_1 <- ml;
+    self_1 <- self;
     goto BB0
   }
   BB0 {
-    switch ( * ml_1)
+    switch ( * self_1)
       | Type.IncSomeList_List_Cons _ _ -> goto BB1
       | Type.IncSomeList_List_Nil -> goto BB2
       | _ -> goto BB3
@@ -273,23 +243,23 @@ module IncSomeList_TakeSomeList
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve ml_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _4 };
     goto BB11
   }
   BB3 {
-    assume { Resolve1.resolve ml_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _4 };
     absurd
   }
   BB4 {
-    ma_5 <- borrow_mut (let Type.IncSomeList_List_Cons a _ =  * ml_1 in a);
-    ml_1 <- { ml_1 with current = (let Type.IncSomeList_List_Cons a b =  * ml_1 in Type.IncSomeList_List_Cons ( ^ ma_5) b) };
-    ml2_6 <- borrow_mut (let Type.IncSomeList_List_Cons _ a =  * ml_1 in a);
-    ml_1 <- { ml_1 with current = (let Type.IncSomeList_List_Cons a b =  * ml_1 in Type.IncSomeList_List_Cons a ( ^ ml2_6)) };
-    assume { Resolve1.resolve ml_1 };
-    _9 <-  * ml2_6;
-    _8 <- LemmaSumListNonneg4.lemma_sum_list_nonneg _9;
+    ma_5 <- borrow_mut (let Type.IncSomeList_List_Cons a _ =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSomeList_List_Cons a b =  * self_1 in Type.IncSomeList_List_Cons ( ^ ma_5) b) };
+    ml_6 <- borrow_mut (let Type.IncSomeList_List_Cons _ a =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSomeList_List_Cons a b =  * self_1 in Type.IncSomeList_List_Cons a ( ^ ml_6)) };
+    assume { Resolve1.resolve self_1 };
+    _9 <-  * ml_6;
+    _8 <- LemmaSumNonneg4.lemma_sum_nonneg _9;
     goto BB5
   }
   BB5 {
@@ -305,7 +275,7 @@ module IncSomeList_TakeSomeList
       end
   }
   BB7 {
-    assume { Resolve7.resolve ml2_6 };
+    assume { Resolve7.resolve ml_6 };
     assume { Resolve8.resolve _11 };
     _12 <- borrow_mut ( * ma_5);
     ma_5 <- { ma_5 with current = ( ^ _12) };
@@ -318,10 +288,10 @@ module IncSomeList_TakeSomeList
   BB8 {
     assume { Resolve9.resolve ma_5 };
     assume { Resolve8.resolve _11 };
-    _14 <- borrow_mut ( * ml2_6);
-    ml2_6 <- { ml2_6 with current = ( ^ _14) };
-    assume { Resolve7.resolve ml2_6 };
-    _13 <- take_some_list _14;
+    _14 <- borrow_mut ( * ml_6);
+    ml_6 <- { ml_6 with current = ( ^ _14) };
+    assume { Resolve7.resolve ml_6 };
+    _13 <- take_some _14;
     goto BB9
   }
   BB9 {
@@ -372,9 +342,9 @@ module IncSomeList_IncSomeList_Interface
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone IncSomeList_SumList_Interface as SumList0
+  clone IncSomeList_Impl1_Sum_Interface as Sum0
   val inc_some_list (l : Type.incsomelist_list) (k : uint32) : ()
-    requires {SumList0.sum_list l + k <= 1000000}
+    requires {Sum0.sum l + k <= 1000000}
     
 end
 module IncSomeList_IncSomeList
@@ -382,20 +352,18 @@ module IncSomeList_IncSomeList
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone IncSomeList_SumList as SumList0
+  clone IncSomeList_Impl1_Sum as Sum0
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve10 with type self = Type.incsomelist_list
-  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic8
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = uint32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = Type.incsomelist_list
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsomelist_list
-  clone IncSomeList_TakeSomeList_Interface as TakeSomeList4 with function SumList0.sum_list = SumList0.sum_list
-  clone IncSomeList_SumListX_Interface as SumListX2 with function SumList0.sum_list = SumList0.sum_list
+  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = Type.incsomelist_list
+  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic6
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
+  clone IncSomeList_Impl1_TakeSome_Interface as TakeSome2 with function Sum0.sum = Sum0.sum
+  clone IncSomeList_Impl1_SumX_Interface as SumX1 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_list (l : Type.incsomelist_list) (k : uint32) : ()
-    requires {SumList0.sum_list l + k <= 1000000}
+    requires {Sum0.sum l + k <= 1000000}
     
    = 
   var _0 : ();
@@ -403,84 +371,81 @@ module IncSomeList_IncSomeList
   var k_2 : uint32;
   var sum0_3 : uint32;
   var _4 : Type.incsomelist_list;
-  var _5 : Type.incsomelist_list;
-  var ma_6 : borrowed uint32;
-  var _7 : borrowed (Type.incsomelist_list);
-  var _8 : borrowed (Type.incsomelist_list);
-  var _9 : uint32;
-  var _10 : ();
-  var _11 : bool;
-  var _12 : bool;
+  var ma_5 : borrowed uint32;
+  var _6 : borrowed (Type.incsomelist_list);
+  var _7 : uint32;
+  var _8 : ();
+  var _9 : bool;
+  var _10 : bool;
+  var _11 : uint32;
+  var _12 : Type.incsomelist_list;
   var _13 : uint32;
-  var _14 : Type.incsomelist_list;
-  var _15 : Type.incsomelist_list;
-  var _16 : uint32;
-  var _17 : uint32;
-  var _18 : uint32;
-  var _19 : ();
+  var _14 : uint32;
+  var _15 : uint32;
+  var _16 : ();
   {
     l_1 <- l;
     k_2 <- k;
     goto BB0
   }
   BB0 {
-    _5 <- l_1;
-    _4 <- _5;
-    assume { Resolve1.resolve _5 };
-    sum0_3 <- SumListX2.sum_list_x _4;
+    _4 <- l_1;
+    sum0_3 <- SumX1.sum_x _4;
     goto BB1
   }
   BB1 {
-    _8 <- borrow_mut l_1;
-    l_1 <-  ^ _8;
-    _7 <- borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _7) };
-    assume { Resolve3.resolve _8 };
-    ma_6 <- TakeSomeList4.take_some_list _7;
+    _6 <- borrow_mut l_1;
+    l_1 <-  ^ _6;
+    ma_5 <- TakeSome2.take_some _6;
     goto BB2
   }
   BB2 {
-    assume { Resolve5.resolve _9 };
-    _9 <- k_2;
-    ma_6 <- { ma_6 with current = ( * ma_6 + _9) };
-    assume { Resolve6.resolve ma_6 };
-    assume { Resolve5.resolve _9 };
-    _15 <- l_1;
-    _14 <- _15;
-    assume { Resolve1.resolve _15 };
-    _13 <- SumListX2.sum_list_x _14;
+    assume { Resolve3.resolve _7 };
+    _7 <- k_2;
+    ma_5 <- { ma_5 with current = ( * ma_5 + _7) };
+    assume { Resolve4.resolve ma_5 };
+    assume { Resolve3.resolve _7 };
+    _12 <- l_1;
+    _11 <- SumX1.sum_x _12;
     goto BB3
   }
   BB3 {
-    assume { Resolve5.resolve _17 };
-    _17 <- sum0_3;
-    assume { Resolve5.resolve sum0_3 };
-    assume { Resolve5.resolve _18 };
-    _18 <- k_2;
-    assume { Resolve5.resolve k_2 };
-    _16 <- _17 + _18;
-    _12 <- _13 = _16;
-    _11 <- not _12;
-    switch (_11)
+    assume { Resolve3.resolve _14 };
+    _14 <- sum0_3;
+    assume { Resolve3.resolve sum0_3 };
+    assume { Resolve3.resolve _15 };
+    _15 <- k_2;
+    assume { Resolve3.resolve k_2 };
+    _13 <- _14 + _15;
+    _10 <- _11 = _13;
+    _9 <- not _10;
+    switch (_9)
       | False -> goto BB5
       | True -> goto BB4
       | _ -> goto BB4
       end
   }
   BB4 {
-    assume { Resolve7.resolve _11 };
+    assume { Resolve5.resolve _9 };
     absurd
   }
   BB5 {
-    assume { Resolve7.resolve _11 };
-    _10 <- ();
-    assume { Resolve9.resolve _10 };
+    assume { Resolve5.resolve _9 };
+    _8 <- ();
+    assume { Resolve7.resolve _8 };
     _0 <- ();
     goto BB6
   }
   BB6 {
-    assume { Resolve10.resolve l_1 };
+    assume { Resolve8.resolve l_1 };
     return _0
   }
   
+end
+module CreusotContracts_WellFounded
+  type self   
+end
+module IncSomeList_Impl0
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.incsomelist_list
 end

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -14,143 +14,99 @@ module Type
     | IncSomeTree_Tree_Leaf
     
 end
-module IncSomeTree_SumTree_Interface
+module IncSomeTree_Impl1_Sum_Interface
   use mach.int.Int
   use Type
-  function sum_tree (t : Type.incsometree_tree) : int
+  function sum (self : Type.incsometree_tree) : int
 end
-module IncSomeTree_SumTree
+module IncSomeTree_Impl1_Sum
   use mach.int.Int
   use Type
   use mach.int.Int32
-  function sum_tree (t : Type.incsometree_tree) : int = 
-    match (t) with
-      | Type.IncSomeTree_Tree_Node tl a tr -> sum_tree tl + a + sum_tree tr
+  function sum (self : Type.incsometree_tree) : int = 
+    match (self) with
+      | Type.IncSomeTree_Tree_Node tl a tr -> sum tl + a + sum tr
       | Type.IncSomeTree_Tree_Leaf -> 0
+      end
+end
+module IncSomeTree_Impl1_LemmaSumNonneg_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSomeTree_Impl1_Sum_Interface as Sum0
+  function lemma_sum_nonneg (self : Type.incsometree_tree) : ()
+end
+module IncSomeTree_Impl1_LemmaSumNonneg
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSomeTree_Impl1_Sum_Interface as Sum0
+  function lemma_sum_nonneg (self : Type.incsometree_tree) : ()
+  val lemma_sum_nonneg (self : Type.incsometree_tree) : ()
+    ensures { Sum0.sum self >= 0 }
+    ensures { result = lemma_sum_nonneg self }
+    
+  axiom spec : forall self : Type.incsometree_tree . Sum0.sum self >= 0
+  axiom def : forall self : Type.incsometree_tree . lemma_sum_nonneg self = match (self) with
+    | Type.IncSomeTree_Tree_Node tl _ tr -> let _ = lemma_sum_nonneg tl in let _ = lemma_sum_nonneg tr in ()
+    | Type.IncSomeTree_Tree_Leaf -> ()
+    end
+end
+module IncSomeTree_Impl1_LemmaSumNonneg_Impl
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone IncSomeTree_Impl1_Sum as Sum0
+  let rec lemma_sum_nonneg (self : Type.incsometree_tree) : ()
+    ensures { Sum0.sum self >= 0 }
+    variant {self}
+    
+   = 
+    match (self) with
+      | Type.IncSomeTree_Tree_Node tl _ tr -> let _ = lemma_sum_nonneg tl in let _ = lemma_sum_nonneg tr in ()
+      | Type.IncSomeTree_Tree_Leaf -> ()
       end
 end
 module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module IncSomeTree_LemmaSumTreeNonneg_Interface
-  use mach.int.Int
-  use mach.int.Int32
-  use prelude.Prelude
-  use Type
-  clone IncSomeTree_SumTree_Interface as SumTree0
-  val lemma_sum_tree_nonneg (t : Type.incsometree_tree) : ()
-    ensures { SumTree0.sum_tree t >= 0 }
-    
-end
-module IncSomeTree_LemmaSumTreeNonneg
-  use mach.int.Int
-  use mach.int.Int32
-  use prelude.Prelude
-  use Type
-  clone IncSomeTree_SumTree as SumTree0
-  use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsometree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsometree_tree
-  let rec cfg lemma_sum_tree_nonneg (t : Type.incsometree_tree) : ()
-    ensures { SumTree0.sum_tree t >= 0 }
-    
-   = 
-  var _0 : ();
-  var t_1 : Type.incsometree_tree;
-  var _2 : isize;
-  var tl_3 : Type.incsometree_tree;
-  var tr_4 : Type.incsometree_tree;
-  var _5 : ();
-  var _6 : Type.incsometree_tree;
-  var _7 : ();
-  var _8 : Type.incsometree_tree;
-  {
-    t_1 <- t;
-    goto BB0
-  }
-  BB0 {
-    switch (t_1)
-      | Type.IncSomeTree_Tree_Node _ _ _ -> goto BB1
-      | Type.IncSomeTree_Tree_Leaf -> goto BB2
-      | _ -> goto BB3
-      end
-  }
-  BB1 {
-    assume { Resolve2.resolve _2 };
-    goto BB4
-  }
-  BB2 {
-    assume { Resolve1.resolve t_1 };
-    assume { Resolve2.resolve _2 };
-    _0 <- ();
-    goto BB7
-  }
-  BB3 {
-    assume { Resolve1.resolve t_1 };
-    assume { Resolve2.resolve _2 };
-    absurd
-  }
-  BB4 {
-    tl_3 <- (let Type.IncSomeTree_Tree_Node a _ _ = t_1 in a);
-    tr_4 <- (let Type.IncSomeTree_Tree_Node _ _ a = t_1 in a);
-    assume { Resolve1.resolve t_1 };
-    _6 <- tl_3;
-    assume { Resolve3.resolve tl_3 };
-    _5 <- lemma_sum_tree_nonneg _6;
-    goto BB5
-  }
-  BB5 {
-    assume { Resolve1.resolve _6 };
-    _8 <- tr_4;
-    assume { Resolve3.resolve tr_4 };
-    _7 <- lemma_sum_tree_nonneg _8;
-    goto BB6
-  }
-  BB6 {
-    assume { Resolve1.resolve _8 };
-    _0 <- ();
-    goto BB7
-  }
-  BB7 {
-    return _0
-  }
-  
-end
-module IncSomeTree_SumTreeX_Interface
+module IncSomeTree_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone IncSomeTree_SumTree_Interface as SumTree0
-  val sum_tree_x (t : Type.incsometree_tree) : uint32
-    requires {SumTree0.sum_tree t <= 1000000}
-    ensures { result = SumTree0.sum_tree t }
+  clone IncSomeTree_Impl1_Sum_Interface as Sum0
+  val sum_x (self : Type.incsometree_tree) : uint32
+    requires {Sum0.sum self <= 1000000}
+    ensures { result = Sum0.sum self }
     
 end
-module IncSomeTree_SumTreeX
+module IncSomeTree_Impl1_SumX
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone IncSomeTree_SumTree as SumTree0
+  clone IncSomeTree_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.incsometree_tree
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsometree_tree
-  clone IncSomeTree_LemmaSumTreeNonneg_Interface as LemmaSumTreeNonneg3 with function SumTree0.sum_tree = SumTree0.sum_tree
-  let rec cfg sum_tree_x (t : Type.incsometree_tree) : uint32
-    requires {SumTree0.sum_tree t <= 1000000}
-    ensures { result = SumTree0.sum_tree t }
+  clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg3 with function Sum0.sum = Sum0.sum, axiom .
+  let rec cfg sum_x (self : Type.incsometree_tree) : uint32
+    requires {Sum0.sum self <= 1000000}
+    ensures { result = Sum0.sum self }
     
    = 
   var _0 : uint32;
-  var t_1 : Type.incsometree_tree;
+  var self_1 : Type.incsometree_tree;
   var _2 : isize;
   var tl_3 : Type.incsometree_tree;
   var a_4 : uint32;
@@ -166,11 +122,11 @@ module IncSomeTree_SumTreeX
   var _14 : uint32;
   var _15 : Type.incsometree_tree;
   {
-    t_1 <- t;
+    self_1 <- self;
     goto BB0
   }
   BB0 {
-    switch (t_1)
+    switch (self_1)
       | Type.IncSomeTree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSomeTree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
@@ -181,36 +137,36 @@ module IncSomeTree_SumTreeX
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve t_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     _0 <- (0 : uint32);
     goto BB9
   }
   BB3 {
-    assume { Resolve1.resolve t_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _2 };
     absurd
   }
   BB4 {
-    tl_3 <- (let Type.IncSomeTree_Tree_Node a _ _ = t_1 in a);
-    a_4 <- (let Type.IncSomeTree_Tree_Node _ a _ = t_1 in a);
-    tr_5 <- (let Type.IncSomeTree_Tree_Node _ _ a = t_1 in a);
-    assume { Resolve1.resolve t_1 };
+    tl_3 <- (let Type.IncSomeTree_Tree_Node a _ _ = self_1 in a);
+    a_4 <- (let Type.IncSomeTree_Tree_Node _ a _ = self_1 in a);
+    tr_5 <- (let Type.IncSomeTree_Tree_Node _ _ a = self_1 in a);
+    assume { Resolve1.resolve self_1 };
     _7 <- tl_3;
-    _6 <- LemmaSumTreeNonneg3.lemma_sum_tree_nonneg _7;
+    _6 <- LemmaSumNonneg3.lemma_sum_nonneg _7;
     goto BB5
   }
   BB5 {
     assume { Resolve1.resolve _7 };
     _9 <- tr_5;
-    _8 <- LemmaSumTreeNonneg3.lemma_sum_tree_nonneg _9;
+    _8 <- LemmaSumNonneg3.lemma_sum_nonneg _9;
     goto BB6
   }
   BB6 {
     assume { Resolve1.resolve _9 };
     _12 <- tl_3;
     assume { Resolve4.resolve tl_3 };
-    _11 <- sum_tree_x _12;
+    _11 <- sum_x _12;
     goto BB7
   }
   BB7 {
@@ -220,7 +176,7 @@ module IncSomeTree_SumTreeX
     _10 <- _11 + _13;
     _15 <- tr_5;
     assume { Resolve4.resolve tr_5 };
-    _14 <- sum_tree_x _15;
+    _14 <- sum_x _15;
     goto BB8
   }
   BB8 {
@@ -251,23 +207,23 @@ module Rand_Random
   type t   
   val random () : t
 end
-module IncSomeTree_TakeSomeTree_Interface
+module IncSomeTree_Impl1_TakeSome_Interface
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
   use Type
-  clone IncSomeTree_SumTree_Interface as SumTree0
-  val take_some_tree (mt : borrowed (Type.incsometree_tree)) : borrowed uint32
-    ensures {  * result <= SumTree0.sum_tree ( * mt) }
-    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) =  ^ result -  * result }
+  clone IncSomeTree_Impl1_Sum_Interface as Sum0
+  val take_some (self : borrowed (Type.incsometree_tree)) : borrowed uint32
+    ensures {  * result <= Sum0.sum ( * self) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result -  * result }
     
 end
-module IncSomeTree_TakeSomeTree
+module IncSomeTree_Impl1_TakeSome
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
   use Type
-  clone IncSomeTree_SumTree as SumTree0
+  clone IncSomeTree_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve9 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
@@ -277,14 +233,14 @@ module IncSomeTree_TakeSomeTree
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsometree_tree
-  clone IncSomeTree_LemmaSumTreeNonneg_Interface as LemmaSumTreeNonneg4 with function SumTree0.sum_tree = SumTree0.sum_tree
-  let rec cfg take_some_tree (mt : borrowed (Type.incsometree_tree)) : borrowed uint32
-    ensures {  * result <= SumTree0.sum_tree ( * mt) }
-    ensures { SumTree0.sum_tree ( ^ mt) - SumTree0.sum_tree ( * mt) =  ^ result -  * result }
+  clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg4 with function Sum0.sum = Sum0.sum, axiom .
+  let rec cfg take_some (self : borrowed (Type.incsometree_tree)) : borrowed uint32
+    ensures {  * result <= Sum0.sum ( * self) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result -  * result }
     
    = 
   var _0 : borrowed uint32;
-  var mt_1 : borrowed (Type.incsometree_tree);
+  var self_1 : borrowed (Type.incsometree_tree);
   var _2 : borrowed uint32;
   var _3 : borrowed uint32;
   var _4 : isize;
@@ -308,11 +264,11 @@ module IncSomeTree_TakeSomeTree
   var _22 : ();
   var _23 : ();
   {
-    mt_1 <- mt;
+    self_1 <- self;
     goto BB0
   }
   BB0 {
-    switch ( * mt_1)
+    switch ( * self_1)
       | Type.IncSomeTree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSomeTree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
@@ -323,31 +279,31 @@ module IncSomeTree_TakeSomeTree
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve mt_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _4 };
     goto BB17
   }
   BB3 {
-    assume { Resolve1.resolve mt_1 };
+    assume { Resolve1.resolve self_1 };
     assume { Resolve2.resolve _4 };
     absurd
   }
   BB4 {
-    mtl_5 <- borrow_mut (let Type.IncSomeTree_Tree_Node a _ _ =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * mt_1 in Type.IncSomeTree_Tree_Node ( ^ mtl_5) b c) };
-    ma_6 <- borrow_mut (let Type.IncSomeTree_Tree_Node _ a _ =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * mt_1 in Type.IncSomeTree_Tree_Node a ( ^ ma_6) c) };
-    mtr_7 <- borrow_mut (let Type.IncSomeTree_Tree_Node _ _ a =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * mt_1 in Type.IncSomeTree_Tree_Node a b ( ^ mtr_7)) };
-    assume { Resolve1.resolve mt_1 };
+    mtl_5 <- borrow_mut (let Type.IncSomeTree_Tree_Node a _ _ =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * self_1 in Type.IncSomeTree_Tree_Node ( ^ mtl_5) b c) };
+    ma_6 <- borrow_mut (let Type.IncSomeTree_Tree_Node _ a _ =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * self_1 in Type.IncSomeTree_Tree_Node a ( ^ ma_6) c) };
+    mtr_7 <- borrow_mut (let Type.IncSomeTree_Tree_Node _ _ a =  * self_1 in a);
+    self_1 <- { self_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * self_1 in Type.IncSomeTree_Tree_Node a b ( ^ mtr_7)) };
+    assume { Resolve1.resolve self_1 };
     _10 <-  * mtl_5;
-    _9 <- LemmaSumTreeNonneg4.lemma_sum_tree_nonneg _10;
+    _9 <- LemmaSumNonneg4.lemma_sum_nonneg _10;
     goto BB5
   }
   BB5 {
     assume { Resolve5.resolve _10 };
     _12 <-  * mtr_7;
-    _11 <- LemmaSumTreeNonneg4.lemma_sum_tree_nonneg _12;
+    _11 <- LemmaSumNonneg4.lemma_sum_nonneg _12;
     goto BB6
   }
   BB6 {
@@ -393,7 +349,7 @@ module IncSomeTree_TakeSomeTree
     _19 <- borrow_mut ( * mtl_5);
     mtl_5 <- { mtl_5 with current = ( ^ _19) };
     assume { Resolve7.resolve mtl_5 };
-    _18 <- take_some_tree _19;
+    _18 <- take_some _19;
     goto BB12
   }
   BB12 {
@@ -411,7 +367,7 @@ module IncSomeTree_TakeSomeTree
     _21 <- borrow_mut ( * mtr_7);
     mtr_7 <- { mtr_7 with current = ( ^ _21) };
     assume { Resolve7.resolve mtr_7 };
-    _20 <- take_some_tree _21;
+    _20 <- take_some _21;
     goto BB14
   }
   BB14 {
@@ -465,9 +421,9 @@ module IncSomeTree_IncSomeTree_Interface
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone IncSomeTree_SumTree_Interface as SumTree0
+  clone IncSomeTree_Impl1_Sum_Interface as Sum0
   val inc_some_tree (t : Type.incsometree_tree) (k : uint32) : ()
-    requires {SumTree0.sum_tree t + k <= 1000000}
+    requires {Sum0.sum t + k <= 1000000}
     
 end
 module IncSomeTree_IncSomeTree
@@ -475,20 +431,18 @@ module IncSomeTree_IncSomeTree
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone IncSomeTree_SumTree as SumTree0
+  clone IncSomeTree_Impl1_Sum as Sum0
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve10 with type self = Type.incsometree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic8
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = uint32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = Type.incsometree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsometree_tree
-  clone IncSomeTree_TakeSomeTree_Interface as TakeSomeTree4 with function SumTree0.sum_tree = SumTree0.sum_tree
-  clone IncSomeTree_SumTreeX_Interface as SumTreeX2 with function SumTree0.sum_tree = SumTree0.sum_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = Type.incsometree_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic6
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
+  clone IncSomeTree_Impl1_TakeSome_Interface as TakeSome2 with function Sum0.sum = Sum0.sum
+  clone IncSomeTree_Impl1_SumX_Interface as SumX1 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_tree (t : Type.incsometree_tree) (k : uint32) : ()
-    requires {SumTree0.sum_tree t + k <= 1000000}
+    requires {Sum0.sum t + k <= 1000000}
     
    = 
   var _0 : ();
@@ -496,84 +450,81 @@ module IncSomeTree_IncSomeTree
   var k_2 : uint32;
   var sum0_3 : uint32;
   var _4 : Type.incsometree_tree;
-  var _5 : Type.incsometree_tree;
-  var ma_6 : borrowed uint32;
-  var _7 : borrowed (Type.incsometree_tree);
-  var _8 : borrowed (Type.incsometree_tree);
-  var _9 : uint32;
-  var _10 : ();
-  var _11 : bool;
-  var _12 : bool;
+  var ma_5 : borrowed uint32;
+  var _6 : borrowed (Type.incsometree_tree);
+  var _7 : uint32;
+  var _8 : ();
+  var _9 : bool;
+  var _10 : bool;
+  var _11 : uint32;
+  var _12 : Type.incsometree_tree;
   var _13 : uint32;
-  var _14 : Type.incsometree_tree;
-  var _15 : Type.incsometree_tree;
-  var _16 : uint32;
-  var _17 : uint32;
-  var _18 : uint32;
-  var _19 : ();
+  var _14 : uint32;
+  var _15 : uint32;
+  var _16 : ();
   {
     t_1 <- t;
     k_2 <- k;
     goto BB0
   }
   BB0 {
-    _5 <- t_1;
-    _4 <- _5;
-    assume { Resolve1.resolve _5 };
-    sum0_3 <- SumTreeX2.sum_tree_x _4;
+    _4 <- t_1;
+    sum0_3 <- SumX1.sum_x _4;
     goto BB1
   }
   BB1 {
-    _8 <- borrow_mut t_1;
-    t_1 <-  ^ _8;
-    _7 <- borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _7) };
-    assume { Resolve3.resolve _8 };
-    ma_6 <- TakeSomeTree4.take_some_tree _7;
+    _6 <- borrow_mut t_1;
+    t_1 <-  ^ _6;
+    ma_5 <- TakeSome2.take_some _6;
     goto BB2
   }
   BB2 {
-    assume { Resolve5.resolve _9 };
-    _9 <- k_2;
-    ma_6 <- { ma_6 with current = ( * ma_6 + _9) };
-    assume { Resolve6.resolve ma_6 };
-    assume { Resolve5.resolve _9 };
-    _15 <- t_1;
-    _14 <- _15;
-    assume { Resolve1.resolve _15 };
-    _13 <- SumTreeX2.sum_tree_x _14;
+    assume { Resolve3.resolve _7 };
+    _7 <- k_2;
+    ma_5 <- { ma_5 with current = ( * ma_5 + _7) };
+    assume { Resolve4.resolve ma_5 };
+    assume { Resolve3.resolve _7 };
+    _12 <- t_1;
+    _11 <- SumX1.sum_x _12;
     goto BB3
   }
   BB3 {
-    assume { Resolve5.resolve _17 };
-    _17 <- sum0_3;
-    assume { Resolve5.resolve sum0_3 };
-    assume { Resolve5.resolve _18 };
-    _18 <- k_2;
-    assume { Resolve5.resolve k_2 };
-    _16 <- _17 + _18;
-    _12 <- _13 = _16;
-    _11 <- not _12;
-    switch (_11)
+    assume { Resolve3.resolve _14 };
+    _14 <- sum0_3;
+    assume { Resolve3.resolve sum0_3 };
+    assume { Resolve3.resolve _15 };
+    _15 <- k_2;
+    assume { Resolve3.resolve k_2 };
+    _13 <- _14 + _15;
+    _10 <- _11 = _13;
+    _9 <- not _10;
+    switch (_9)
       | False -> goto BB5
       | True -> goto BB4
       | _ -> goto BB4
       end
   }
   BB4 {
-    assume { Resolve7.resolve _11 };
+    assume { Resolve5.resolve _9 };
     absurd
   }
   BB5 {
-    assume { Resolve7.resolve _11 };
-    _10 <- ();
-    assume { Resolve9.resolve _10 };
+    assume { Resolve5.resolve _9 };
+    _8 <- ();
+    assume { Resolve7.resolve _8 };
     _0 <- ();
     goto BB6
   }
   BB6 {
-    assume { Resolve10.resolve t_1 };
+    assume { Resolve8.resolve t_1 };
     return _0
   }
   
+end
+module CreusotContracts_WellFounded
+  type self   
+end
+module IncSomeTree_Impl0
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.incsometree_tree
 end


### PR DESCRIPTION
This improves `inc-some-*` tests.
It makes functions on `List` and `Tree` `Impl`'d methods to make code more concise.
Also, it marks lemma functions with `#[pure]`, performing termination checking.
In order to make `#[pure]` work, I augmented `lower_expr` and `lower_stmt` for a couple of missed cases.