### PR TITLE
Make the suffix added to clone names unique to each base name

### DIFF
--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -89,11 +89,11 @@ module AllZero_AllZero_Interface
   use Type
   use mach.int.UInt32
   use prelude.Prelude
-  clone AllZero_Get_Interface as Get1
+  clone AllZero_Get_Interface as Get0
   clone AllZero_Len_Interface as Len0
   val all_zero (l : borrowed (Type.allzero_list)) : ()
     ensures { Len0.len ( * l) = Len0.len ( ^ l) }
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) -> Get0.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
     
 end
 module AllZero_AllZero
@@ -102,17 +102,17 @@ module AllZero_AllZero
   use Type
   use mach.int.UInt32
   use prelude.Prelude
-  clone AllZero_Get as Get1
+  clone AllZero_Get as Get0
   clone AllZero_Len as Len0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = ()
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = Type.allzero_list
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = Type.allzero_list
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = ()
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = Type.allzero_list
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.allzero_list
   let rec cfg all_zero (l : borrowed (Type.allzero_list)) : ()
     ensures { Len0.len ( * l) = Len0.len ( ^ l) }
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) -> Get0.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
     
    = 
   var _0 : ();
@@ -131,12 +131,12 @@ module AllZero_AllZero
     goto BB0
   }
   BB0 {
-    assume { Resolve2.resolve loop_l_2 };
+    assume { Resolve0.resolve loop_l_2 };
     loop_l_2 <- l_1;
     goto BB1
   }
   BB1 {
-    invariant zeroed { (forall i : (int) . 0 <= i && i < Len0.len ( * loop_l_2) -> Get1.get ( ^ loop_l_2) i = Type.Core_Option_Option_Some (0 : uint32)) -> (forall i : (int) . 0 <= i && i < Len0.len ( * l_1) -> Get1.get ( ^ l_1) i = Type.Core_Option_Option_Some (0 : uint32)) };
+    invariant zeroed { (forall i : (int) . 0 <= i && i < Len0.len ( * loop_l_2) -> Get0.get ( ^ loop_l_2) i = Type.Core_Option_Option_Some (0 : uint32)) -> (forall i : (int) . 0 <= i && i < Len0.len ( * l_1) -> Get0.get ( ^ l_1) i = Type.Core_Option_Option_Some (0 : uint32)) };
     invariant in_len { Len0.len ( ^ loop_l_2) = Len0.len ( * loop_l_2) -> Len0.len ( ^ l_1) = Len0.len ( * l_1) };
     goto BB2
   }
@@ -147,7 +147,7 @@ module AllZero_AllZero
       end
   }
   BB3 {
-    assume { Resolve3.resolve _6 };
+    assume { Resolve1.resolve _6 };
     goto BB4
   }
   BB4 {
@@ -155,21 +155,21 @@ module AllZero_AllZero
     loop_l_2 <- { loop_l_2 with current = (let Type.AllZero_List_Cons a b =  * loop_l_2 in Type.AllZero_List_Cons ( ^ value_7) b) };
     next_8 <- borrow_mut (let Type.AllZero_List_Cons _ a =  * loop_l_2 in a);
     loop_l_2 <- { loop_l_2 with current = (let Type.AllZero_List_Cons a b =  * loop_l_2 in Type.AllZero_List_Cons a ( ^ next_8)) };
-    assume { Resolve2.resolve loop_l_2 };
+    assume { Resolve0.resolve loop_l_2 };
     value_7 <- { value_7 with current = (0 : uint32) };
-    assume { Resolve4.resolve value_7 };
+    assume { Resolve2.resolve value_7 };
     _9 <- borrow_mut ( * next_8);
     next_8 <- { next_8 with current = ( ^ _9) };
-    assume { Resolve5.resolve next_8 };
-    assume { Resolve2.resolve loop_l_2 };
+    assume { Resolve3.resolve next_8 };
+    assume { Resolve0.resolve loop_l_2 };
     loop_l_2 <- _9;
     _5 <- ();
-    assume { Resolve6.resolve _5 };
+    assume { Resolve4.resolve _5 };
     goto BB1
   }
   BB5 {
-    assume { Resolve2.resolve loop_l_2 };
-    assume { Resolve3.resolve _6 };
+    assume { Resolve0.resolve loop_l_2 };
+    assume { Resolve1.resolve _6 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -94,11 +94,11 @@ module BinarySearch_Impl0_Index_Interface
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt64
-  clone BinarySearch_Get_Interface as Get1 with type t = t
+  clone BinarySearch_Get_Interface as Get0 with type t = t
   clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
   val index (self : Type.binarysearch_list t) (ix : usize) : t
     requires {ix < LenLogic0.len_logic self}
-    ensures { Type.Core_Option_Option_Some result = Get1.get self ix }
+    ensures { Type.Core_Option_Option_Some result = Get0.get self ix }
     
 end
 module BinarySearch_Impl0_Index
@@ -107,20 +107,20 @@ module BinarySearch_Impl0_Index
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt64
-  clone BinarySearch_Get as Get1 with type t = t
+  clone BinarySearch_Get as Get0 with type t = t
   clone BinarySearch_LenLogic as LenLogic0 with type t = t
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = t
-  clone Std_Process_Abort_Interface as Abort6
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
+  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = Type.binarysearch_list t
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = t
+  clone Std_Process_Abort_Interface as Abort0
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.binarysearch_list t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = usize
   let rec cfg index (self : Type.binarysearch_list t) (ix : usize) : t
     requires {ix < LenLogic0.len_logic self}
-    ensures { Type.Core_Option_Option_Some result = Get1.get self ix }
+    ensures { Type.Core_Option_Option_Some result = Get0.get self ix }
     
    = 
   var _0 : t;
@@ -148,17 +148,17 @@ module BinarySearch_Impl0_Index
     goto BB0
   }
   BB0 {
-    assume { Resolve2.resolve orig_ix_3 };
+    assume { Resolve0.resolve orig_ix_3 };
     orig_ix_3 <- ix_2;
-    assume { Resolve2.resolve orig_ix_3 };
-    assume { Resolve3.resolve l_4 };
+    assume { Resolve0.resolve orig_ix_3 };
+    assume { Resolve1.resolve l_4 };
     l_4 <- self_1;
-    assume { Resolve3.resolve self_1 };
+    assume { Resolve1.resolve self_1 };
     goto BB1
   }
   BB1 {
     invariant ix_valid { ix_2 < LenLogic0.len_logic l_4 };
-    invariant res_get { Get1.get self_1 orig_ix_3 = Get1.get l_4 ix_2 };
+    invariant res_get { Get0.get self_1 orig_ix_3 = Get0.get l_4 ix_2 };
     goto BB2
   }
   BB2 {
@@ -168,14 +168,14 @@ module BinarySearch_Impl0_Index
       end
   }
   BB3 {
-    assume { Resolve4.resolve _9 };
+    assume { Resolve2.resolve _9 };
     goto BB4
   }
   BB4 {
     t_10 <- (let Type.BinarySearch_List_Cons a _ = l_4 in a);
     ls_11 <- (let Type.BinarySearch_List_Cons _ a = l_4 in a);
-    assume { Resolve3.resolve l_4 };
-    assume { Resolve2.resolve _13 };
+    assume { Resolve1.resolve l_4 };
+    assume { Resolve0.resolve _13 };
     _13 <- ix_2;
     _12 <- _13 > (0 : usize);
     switch (_12)
@@ -185,33 +185,33 @@ module BinarySearch_Impl0_Index
       end
   }
   BB5 {
-    assume { Resolve7.resolve t_10 };
-    assume { Resolve8.resolve _12 };
+    assume { Resolve4.resolve t_10 };
+    assume { Resolve5.resolve _12 };
     _15 <- ls_11;
-    assume { Resolve9.resolve ls_11 };
+    assume { Resolve6.resolve ls_11 };
     _14 <- _15;
-    assume { Resolve9.resolve _15 };
-    assume { Resolve3.resolve l_4 };
+    assume { Resolve6.resolve _15 };
+    assume { Resolve1.resolve l_4 };
     l_4 <- _14;
     ix_2 <- ix_2 - (1 : usize);
     _8 <- ();
-    assume { Resolve5.resolve _8 };
+    assume { Resolve3.resolve _8 };
     goto BB1
   }
   BB6 {
-    assume { Resolve2.resolve ix_2 };
-    assume { Resolve9.resolve ls_11 };
-    assume { Resolve8.resolve _12 };
+    assume { Resolve0.resolve ix_2 };
+    assume { Resolve6.resolve ls_11 };
+    assume { Resolve5.resolve _12 };
     _0 <- t_10;
-    assume { Resolve7.resolve t_10 };
+    assume { Resolve4.resolve t_10 };
     return _0
   }
   BB7 {
-    assume { Resolve2.resolve ix_2 };
-    assume { Resolve3.resolve l_4 };
-    assume { Resolve4.resolve _9 };
+    assume { Resolve0.resolve ix_2 };
+    assume { Resolve1.resolve l_4 };
+    assume { Resolve2.resolve _9 };
     _5 <- ();
-    assume { Resolve5.resolve _5 };
+    assume { Resolve3.resolve _5 };
     absurd
   }
   
@@ -239,11 +239,11 @@ module BinarySearch_Impl0_Len
   use Type
   clone BinarySearch_LenLogic as LenLogic0 with type t = t
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = usize
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.binarysearch_list t
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.binarysearch_list t
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = usize
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.binarysearch_list t
   let rec cfg len (self : Type.binarysearch_list t) : usize
     requires {LenLogic0.len_logic self <= 1000000}
     ensures { result = LenLogic0.len_logic self }
@@ -268,9 +268,9 @@ module BinarySearch_Impl0_Len
   }
   BB0 {
     len_2 <- (0 : usize);
-    assume { Resolve1.resolve l_3 };
+    assume { Resolve0.resolve l_3 };
     l_3 <- self_1;
-    assume { Resolve1.resolve self_1 };
+    assume { Resolve0.resolve self_1 };
     goto BB1
   }
   BB1 {
@@ -284,29 +284,29 @@ module BinarySearch_Impl0_Len
       end
   }
   BB3 {
-    assume { Resolve2.resolve _7 };
+    assume { Resolve1.resolve _7 };
     goto BB4
   }
   BB4 {
     ls_8 <- (let Type.BinarySearch_List_Cons _ a = l_3 in a);
-    assume { Resolve1.resolve l_3 };
+    assume { Resolve0.resolve l_3 };
     len_2 <- len_2 + (1 : usize);
     _9 <- ls_8;
-    assume { Resolve5.resolve ls_8 };
-    assume { Resolve1.resolve l_3 };
+    assume { Resolve4.resolve ls_8 };
+    assume { Resolve0.resolve l_3 };
     l_3 <- _9;
     _6 <- ();
-    assume { Resolve3.resolve _6 };
+    assume { Resolve2.resolve _6 };
     goto BB1
   }
   BB5 {
-    assume { Resolve1.resolve l_3 };
-    assume { Resolve2.resolve _7 };
+    assume { Resolve0.resolve l_3 };
+    assume { Resolve1.resolve _7 };
     _4 <- ();
-    assume { Resolve3.resolve _4 };
-    assume { Resolve4.resolve _0 };
+    assume { Resolve2.resolve _4 };
+    assume { Resolve3.resolve _0 };
     _0 <- len_2;
-    assume { Resolve4.resolve len_2 };
+    assume { Resolve3.resolve len_2 };
     return _0
   }
   
@@ -353,16 +353,16 @@ module BinarySearch_BinarySearch_Interface
   use mach.int.UInt64
   use Type
   use mach.int.UInt32
-  clone BinarySearch_Get_Interface as Get3 with type t = uint32
-  clone BinarySearch_GetDefault_Interface as GetDefault2 with type t = uint32
-  clone BinarySearch_LenLogic_Interface as LenLogic1 with type t = uint32
+  clone BinarySearch_Get_Interface as Get0 with type t = uint32
+  clone BinarySearch_GetDefault_Interface as GetDefault0 with type t = uint32
+  clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = uint32
   clone BinarySearch_IsSorted_Interface as IsSorted0
   val binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
     requires {IsSorted0.is_sorted arr}
-    requires {LenLogic1.len_logic arr <= 1000000}
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . x < i && i < LenLogic1.len_logic arr -> elem < GetDefault2.get_default arr i (0 : uint32)) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < x -> GetDefault2.get_default arr i (0 : uint32) < elem) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get3.get arr x = Type.Core_Option_Option_Some elem }
+    requires {LenLogic0.len_logic arr <= 1000000}
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . x < i && i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr i (0 : uint32)) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < x -> GetDefault0.get_default arr i (0 : uint32) < elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get0.get arr x = Type.Core_Option_Option_Some elem }
     
 end
 module BinarySearch_BinarySearch
@@ -372,26 +372,26 @@ module BinarySearch_BinarySearch
   use mach.int.UInt64
   use mach.int.Int32
   use Type
-  clone BinarySearch_Get as Get3 with type t = uint32
-  clone BinarySearch_IsSorted as IsSorted2 with function Get0.get = Get3.get
-  clone BinarySearch_GetDefault as GetDefault1 with type t = uint32, function Get0.get = Get3.get
+  clone BinarySearch_Get as Get0 with type t = uint32
+  clone BinarySearch_IsSorted as IsSorted0 with function Get0.get = Get0.get
+  clone BinarySearch_GetDefault as GetDefault0 with type t = uint32, function Get0.get = Get0.get
   clone BinarySearch_LenLogic as LenLogic0 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve11 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = usize
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.binarysearch_list uint32
-  clone BinarySearch_Impl0_Index_Interface as Index10 with type t = uint32,
-  function LenLogic0.len_logic = LenLogic0.len_logic, function Get1.get = Get3.get
-  clone BinarySearch_Impl0_Len_Interface as Len4 with type t = uint32,
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = usize
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.binarysearch_list uint32
+  clone BinarySearch_Impl0_Index_Interface as Index0 with type t = uint32,
+  function LenLogic0.len_logic = LenLogic0.len_logic, function Get0.get = Get0.get
+  clone BinarySearch_Impl0_Len_Interface as Len0 with type t = uint32,
   function LenLogic0.len_logic = LenLogic0.len_logic
   let rec cfg binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
-    requires {IsSorted2.is_sorted arr}
+    requires {IsSorted0.is_sorted arr}
     requires {LenLogic0.len_logic arr <= 1000000}
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . x < i && i < LenLogic0.len_logic arr -> elem < GetDefault1.get_default arr i (0 : uint32)) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < x -> GetDefault1.get_default arr i (0 : uint32) < elem) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get3.get arr x = Type.Core_Option_Option_Some elem }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . x < i && i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr i (0 : uint32)) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < x -> GetDefault0.get_default arr i (0 : uint32) < elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get0.get arr x = Type.Core_Option_Option_Some elem }
     
    = 
   var _0 : Type.core_result_result usize usize;
@@ -447,7 +447,7 @@ module BinarySearch_BinarySearch
   }
   BB0 {
     _6 <- arr_1;
-    _5 <- Len4.len _6;
+    _5 <- Len0.len _6;
     goto BB1
   }
   BB1 {
@@ -459,18 +459,18 @@ module BinarySearch_BinarySearch
       end
   }
   BB2 {
-    assume { Resolve5.resolve arr_1 };
-    assume { Resolve6.resolve elem_2 };
-    assume { Resolve7.resolve _4 };
+    assume { Resolve0.resolve arr_1 };
+    assume { Resolve1.resolve elem_2 };
+    assume { Resolve2.resolve _4 };
     _0 <- Type.Core_Result_Result_Err (0 : usize);
     goto BB21
   }
   BB3 {
-    assume { Resolve7.resolve _4 };
+    assume { Resolve2.resolve _4 };
     _3 <- ();
-    assume { Resolve8.resolve _3 };
+    assume { Resolve3.resolve _3 };
     _9 <- arr_1;
-    size_8 <- Len4.len _9;
+    size_8 <- Len0.len _9;
     goto BB4
   }
   BB4 {
@@ -479,12 +479,12 @@ module BinarySearch_BinarySearch
   }
   BB5 {
     invariant size_valid { size_8 + base_10 <= LenLogic0.len_logic arr_1 };
-    invariant in_interval { GetDefault1.get_default arr_1 base_10 (0 : uint32) <= elem_2 && elem_2 <= GetDefault1.get_default arr_1 (base_10 + size_8) (0 : uint32) };
+    invariant in_interval { GetDefault0.get_default arr_1 base_10 (0 : uint32) <= elem_2 && elem_2 <= GetDefault0.get_default arr_1 (base_10 + size_8) (0 : uint32) };
     invariant size_pos { size_8 > (0 : usize) };
     goto BB6
   }
   BB6 {
-    assume { Resolve9.resolve _17 };
+    assume { Resolve4.resolve _17 };
     _17 <- size_8;
     _16 <- _17 > (1 : usize);
     switch (_16)
@@ -494,32 +494,32 @@ module BinarySearch_BinarySearch
       end
   }
   BB7 {
-    assume { Resolve7.resolve _16 };
-    assume { Resolve9.resolve _19 };
+    assume { Resolve2.resolve _16 };
+    assume { Resolve4.resolve _19 };
     _19 <- size_8;
     _20 <- (2 : usize) = (0 : usize);
     assert { not _20 };
     goto BB8
   }
   BB8 {
-    assume { Resolve7.resolve _20 };
+    assume { Resolve2.resolve _20 };
     half_18 <- _19 / (2 : usize);
-    assume { Resolve9.resolve _22 };
+    assume { Resolve4.resolve _22 };
     _22 <- base_10;
-    assume { Resolve9.resolve _23 };
+    assume { Resolve4.resolve _23 };
     _23 <- half_18;
     mid_21 <- _22 + _23;
     _28 <- arr_1;
-    assume { Resolve9.resolve _29 };
+    assume { Resolve4.resolve _29 };
     _29 <- mid_21;
-    _27 <- Index10.index _28 _29;
+    _27 <- Index0.index _28 _29;
     goto BB9
   }
   BB9 {
-    assume { Resolve6.resolve _26 };
+    assume { Resolve1.resolve _26 };
     _26 <- _27;
-    assume { Resolve11.resolve _27 };
-    assume { Resolve6.resolve _30 };
+    assume { Resolve5.resolve _27 };
+    assume { Resolve1.resolve _30 };
     _30 <- elem_2;
     _25 <- _26 > _30;
     switch (_25)
@@ -529,52 +529,52 @@ module BinarySearch_BinarySearch
       end
   }
   BB10 {
-    assume { Resolve9.resolve mid_21 };
-    assume { Resolve7.resolve _25 };
-    assume { Resolve9.resolve _24 };
+    assume { Resolve4.resolve mid_21 };
+    assume { Resolve2.resolve _25 };
+    assume { Resolve4.resolve _24 };
     _24 <- base_10;
-    assume { Resolve9.resolve base_10 };
+    assume { Resolve4.resolve base_10 };
     goto BB12
   }
   BB11 {
-    assume { Resolve9.resolve base_10 };
-    assume { Resolve7.resolve _25 };
-    assume { Resolve9.resolve _24 };
+    assume { Resolve4.resolve base_10 };
+    assume { Resolve2.resolve _25 };
+    assume { Resolve4.resolve _24 };
     _24 <- mid_21;
-    assume { Resolve9.resolve mid_21 };
+    assume { Resolve4.resolve mid_21 };
     goto BB12
   }
   BB12 {
-    assume { Resolve9.resolve base_10 };
+    assume { Resolve4.resolve base_10 };
     base_10 <- _24;
-    assume { Resolve9.resolve _31 };
+    assume { Resolve4.resolve _31 };
     _31 <- half_18;
-    assume { Resolve9.resolve half_18 };
+    assume { Resolve4.resolve half_18 };
     size_8 <- size_8 - _31;
-    assume { Resolve9.resolve _31 };
+    assume { Resolve4.resolve _31 };
     _15 <- ();
-    assume { Resolve8.resolve _15 };
+    assume { Resolve3.resolve _15 };
     goto BB5
   }
   BB13 {
-    assume { Resolve9.resolve size_8 };
-    assume { Resolve7.resolve _16 };
+    assume { Resolve4.resolve size_8 };
+    assume { Resolve2.resolve _16 };
     _11 <- ();
-    assume { Resolve8.resolve _11 };
+    assume { Resolve3.resolve _11 };
     _37 <- arr_1;
-    assume { Resolve5.resolve arr_1 };
-    assume { Resolve9.resolve _38 };
+    assume { Resolve0.resolve arr_1 };
+    assume { Resolve4.resolve _38 };
     _38 <- base_10;
-    _36 <- Index10.index _37 _38;
+    _36 <- Index0.index _37 _38;
     goto BB14
   }
   BB14 {
-    assume { Resolve6.resolve cmp_35 };
+    assume { Resolve1.resolve cmp_35 };
     cmp_35 <- _36;
-    assume { Resolve11.resolve _36 };
-    assume { Resolve6.resolve _40 };
+    assume { Resolve5.resolve _36 };
+    assume { Resolve1.resolve _40 };
     _40 <- cmp_35;
-    assume { Resolve6.resolve _41 };
+    assume { Resolve1.resolve _41 };
     _41 <- elem_2;
     _39 <- _40 = _41;
     switch (_39)
@@ -584,23 +584,23 @@ module BinarySearch_BinarySearch
       end
   }
   BB15 {
-    assume { Resolve6.resolve elem_2 };
-    assume { Resolve6.resolve cmp_35 };
-    assume { Resolve7.resolve _39 };
-    assume { Resolve9.resolve _42 };
+    assume { Resolve1.resolve elem_2 };
+    assume { Resolve1.resolve cmp_35 };
+    assume { Resolve2.resolve _39 };
+    assume { Resolve4.resolve _42 };
     _42 <- base_10;
-    assume { Resolve9.resolve base_10 };
+    assume { Resolve4.resolve base_10 };
     _0 <- Type.Core_Result_Result_Ok _42;
     goto BB20
   }
   BB16 {
-    assume { Resolve7.resolve _39 };
-    assume { Resolve6.resolve _44 };
+    assume { Resolve2.resolve _39 };
+    assume { Resolve1.resolve _44 };
     _44 <- cmp_35;
-    assume { Resolve6.resolve cmp_35 };
-    assume { Resolve6.resolve _45 };
+    assume { Resolve1.resolve cmp_35 };
+    assume { Resolve1.resolve _45 };
     _45 <- elem_2;
-    assume { Resolve6.resolve elem_2 };
+    assume { Resolve1.resolve elem_2 };
     _43 <- _44 < _45;
     switch (_43)
       | False -> goto BB18
@@ -609,19 +609,19 @@ module BinarySearch_BinarySearch
       end
   }
   BB17 {
-    assume { Resolve7.resolve _43 };
-    assume { Resolve9.resolve _47 };
+    assume { Resolve2.resolve _43 };
+    assume { Resolve4.resolve _47 };
     _47 <- base_10;
-    assume { Resolve9.resolve base_10 };
+    assume { Resolve4.resolve base_10 };
     _46 <- _47 + (1 : usize);
     _0 <- Type.Core_Result_Result_Err _46;
     goto BB19
   }
   BB18 {
-    assume { Resolve7.resolve _43 };
-    assume { Resolve9.resolve _48 };
+    assume { Resolve2.resolve _43 };
+    assume { Resolve4.resolve _48 };
     _48 <- base_10;
-    assume { Resolve9.resolve base_10 };
+    assume { Resolve4.resolve base_10 };
     _0 <- Type.Core_Result_Result_Err _48;
     goto BB19
   }

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -108,12 +108,12 @@ module C01_AddsTwo
   use Type
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.c01_cell uint32 (Type.c01_even)
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = uint32
-  clone C01_Impl1 as Inv5
-  clone C01_Impl0_Set_Interface as Set4 with type t = uint32, type i = Type.c01_even, predicate Inv0.inv = Inv5.inv
-  clone C01_Impl0_Get_Interface as Get0 with type t = uint32, type i = Type.c01_even, predicate Inv0.inv = Inv5.inv
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = Type.c01_cell uint32 (Type.c01_even)
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
+  clone C01_Impl1 as Inv0
+  clone C01_Impl0_Set_Interface as Set0 with type t = uint32, type i = Type.c01_even, predicate Inv0.inv = Inv0.inv
+  clone C01_Impl0_Get_Interface as Get0 with type t = uint32, type i = Type.c01_even, predicate Inv0.inv = Inv0.inv
   let rec cfg adds_two (c : Type.c01_cell uint32 (Type.c01_even)) : () = 
   var _0 : ();
   var c_1 : Type.c01_cell uint32 (Type.c01_even);
@@ -137,7 +137,7 @@ module C01_AddsTwo
     goto BB1
   }
   BB1 {
-    assume { Resolve1.resolve _5 };
+    assume { Resolve0.resolve _5 };
     _5 <- v_2;
     _4 <- _5 < (100000 : uint32);
     switch (_4)
@@ -147,32 +147,32 @@ module C01_AddsTwo
       end
   }
   BB2 {
-    assume { Resolve2.resolve _4 };
+    assume { Resolve1.resolve _4 };
     _7 <- c_1;
-    assume { Resolve3.resolve c_1 };
-    assume { Resolve1.resolve _9 };
+    assume { Resolve2.resolve c_1 };
+    assume { Resolve0.resolve _9 };
     _9 <- v_2;
-    assume { Resolve1.resolve v_2 };
+    assume { Resolve0.resolve v_2 };
     _8 <- _9 + (2 : uint32);
-    _6 <- Set4.set _7 _8;
+    _6 <- Set0.set _7 _8;
     goto BB3
   }
   BB3 {
-    assume { Resolve3.resolve _7 };
-    assume { Resolve1.resolve _8 };
+    assume { Resolve2.resolve _7 };
+    assume { Resolve0.resolve _8 };
     _0 <- ();
     goto BB6
   }
   BB4 {
-    assume { Resolve1.resolve v_2 };
-    assume { Resolve2.resolve _4 };
+    assume { Resolve0.resolve v_2 };
+    assume { Resolve1.resolve _4 };
     _11 <- c_1;
-    assume { Resolve3.resolve c_1 };
-    _10 <- Set4.set _11 (0 : uint32);
+    assume { Resolve2.resolve c_1 };
+    _10 <- Set0.set _11 (0 : uint32);
     goto BB5
   }
   BB5 {
-    assume { Resolve3.resolve _11 };
+    assume { Resolve2.resolve _11 };
     _0 <- ();
     goto BB6
   }

--- a/creusot/tests/should_succeed/clones/02.stdout
+++ b/creusot/tests/should_succeed/clones/02.stdout
@@ -26,19 +26,19 @@ module C02_UsesSimple
     Simple0.simple ()
 end
 module C02_Program_Interface
-  clone C02_Simple_Interface as Simple1
+  clone C02_Simple_Interface as Simple0
   clone C02_UsesSimple_Interface as UsesSimple0
   val program () : ()
     requires {UsesSimple0.uses_simple ()}
-    ensures { Simple1.simple () }
+    ensures { Simple0.simple () }
     
 end
 module C02_Program
-  clone C02_Simple as Simple1
-  clone C02_UsesSimple as UsesSimple0 with function Simple0.simple = Simple1.simple
+  clone C02_Simple as Simple0
+  clone C02_UsesSimple as UsesSimple0 with function Simple0.simple = Simple0.simple
   let rec cfg program () : ()
     requires {UsesSimple0.uses_simple ()}
-    ensures { Simple1.simple () }
+    ensures { Simple0.simple () }
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/clones/03.stdout
+++ b/creusot/tests/should_succeed/clones/03.stdout
@@ -35,11 +35,11 @@ module C03_Prog_Interface
 end
 module C03_Prog
   type t   
-  clone C03_Omg as Omg1 with type t = t
+  clone C03_Omg as Omg0 with type t = t
   clone Core_Marker_Sized as Sized0 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t
   let rec cfg prog (x : t) : ()
-    ensures { Omg1.omg x }
+    ensures { Omg0.omg x }
     
    = 
   var _0 : ();
@@ -53,7 +53,7 @@ module C03_Prog
     goto BB1
   }
   BB1 {
-    assume { Resolve2.resolve x_1 };
+    assume { Resolve0.resolve x_1 };
     return _0
   }
   
@@ -70,8 +70,8 @@ module C03_Prog2
   use mach.int.Int
   use mach.int.Int32
   clone C03_Omg as Omg0 with type t = int
-  clone C03_Omg as Omg2 with type t = int32
-  clone C03_Prog_Interface as Prog1 with type t = int32, function Omg0.omg = Omg2.omg
+  clone C03_Omg as Omg1 with type t = int32
+  clone C03_Prog_Interface as Prog0 with type t = int32, function Omg0.omg = Omg1.omg
   let rec cfg prog2 () : ()
     ensures { Omg0.omg 0 }
     
@@ -82,7 +82,7 @@ module C03_Prog2
     goto BB0
   }
   BB0 {
-    _1 <- Prog1.prog (0 : int32);
+    _1 <- Prog0.prog (0 : int32);
     goto BB1
   }
   BB1 {

--- a/creusot/tests/should_succeed/clones/04.stdout
+++ b/creusot/tests/should_succeed/clones/04.stdout
@@ -60,10 +60,10 @@ end
 module C04_F
   use mach.int.Int
   use mach.int.UInt32
-  clone C04_A as A2
-  clone C04_B as B1 with function A0.a = A2.a
-  clone C04_C as C0 with function B0.b = B1.b
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
+  clone C04_A as A0
+  clone C04_B as B0 with function A0.a = A0.a
+  clone C04_C as C0 with function B0.b = B0.b
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg f (x : uint32) : ()
     requires {C0.c x}
     
@@ -76,7 +76,7 @@ module C04_F
   }
   BB0 {
     _0 <- ();
-    assume { Resolve3.resolve x_1 };
+    assume { Resolve0.resolve x_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/inc_max.stdout
+++ b/creusot/tests/should_succeed/inc_max.stdout
@@ -129,11 +129,11 @@ module IncMax_IncMax
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic4
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
-  clone IncMax_TakeMax_Interface as TakeMax1
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic0
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = uint32
+  clone IncMax_TakeMax_Interface as TakeMax0
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max (a : uint32) (b : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32)}
@@ -169,18 +169,18 @@ module IncMax_IncMax
     _6 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
     assume { Resolve0.resolve _7 };
-    mc_3 <- TakeMax1.take_max _4 _6;
+    mc_3 <- TakeMax0.take_max _4 _6;
     goto BB1
   }
   BB1 {
     mc_3 <- { mc_3 with current = ( * mc_3 + (1 : uint32)) };
     assume { Resolve0.resolve mc_3 };
-    assume { Resolve2.resolve _11 };
+    assume { Resolve1.resolve _11 };
     _11 <- a_1;
-    assume { Resolve2.resolve a_1 };
-    assume { Resolve2.resolve _12 };
+    assume { Resolve1.resolve a_1 };
+    assume { Resolve1.resolve _12 };
     _12 <- b_2;
-    assume { Resolve2.resolve b_2 };
+    assume { Resolve1.resolve b_2 };
     _10 <- _11 <> _12;
     _9 <- not _10;
     switch (_9)
@@ -190,13 +190,13 @@ module IncMax_IncMax
       end
   }
   BB2 {
-    assume { Resolve3.resolve _9 };
+    assume { Resolve2.resolve _9 };
     absurd
   }
   BB3 {
-    assume { Resolve3.resolve _9 };
+    assume { Resolve2.resolve _9 };
     _8 <- ();
-    assume { Resolve5.resolve _8 };
+    assume { Resolve3.resolve _8 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -49,9 +49,9 @@ end
 module IncMax3_IncMax3
   use prelude.Prelude
   use mach.int.Int
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = int
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = ()
-  clone IncMax3_Swap_Interface as Swap3
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = int
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone IncMax3_Swap_Interface as Swap0
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = borrowed int
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = int
@@ -120,20 +120,20 @@ module IncMax3_IncMax3
     _11 <- borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _11) };
     assume { Resolve2.resolve _12 };
-    _8 <- Swap3.swap _9 _11;
+    _8 <- Swap0.swap _9 _11;
     goto BB2
   }
   BB2 {
     assume { Resolve2.resolve _9 };
     assume { Resolve2.resolve _11 };
     _4 <- ();
-    assume { Resolve4.resolve _4 };
+    assume { Resolve3.resolve _4 };
     goto BB4
   }
   BB3 {
     assume { Resolve1.resolve _5 };
     _4 <- ();
-    assume { Resolve4.resolve _4 };
+    assume { Resolve3.resolve _4 };
     goto BB4
   }
   BB4 {
@@ -157,25 +157,25 @@ module IncMax3_IncMax3
     assume { Resolve2.resolve _19 };
     _21 <- borrow_mut mc_3;
     mc_3 <-  ^ _21;
-    assume { Resolve5.resolve mc_3 };
+    assume { Resolve4.resolve mc_3 };
     _20 <- borrow_mut ( * _21);
     _21 <- { _21 with current = ( ^ _20) };
     assume { Resolve2.resolve _21 };
-    _17 <- Swap3.swap _18 _20;
+    _17 <- Swap0.swap _18 _20;
     goto BB6
   }
   BB6 {
     assume { Resolve2.resolve _18 };
     assume { Resolve2.resolve _20 };
     _13 <- ();
-    assume { Resolve4.resolve _13 };
+    assume { Resolve3.resolve _13 };
     goto BB8
   }
   BB7 {
-    assume { Resolve5.resolve mc_3 };
+    assume { Resolve4.resolve mc_3 };
     assume { Resolve1.resolve _14 };
     _13 <- ();
-    assume { Resolve4.resolve _13 };
+    assume { Resolve3.resolve _13 };
     goto BB8
   }
   BB8 {
@@ -202,27 +202,27 @@ module IncMax3_IncMax3
     _29 <- borrow_mut ( * _30);
     _30 <- { _30 with current = ( ^ _29) };
     assume { Resolve2.resolve _30 };
-    _26 <- Swap3.swap _27 _29;
+    _26 <- Swap0.swap _27 _29;
     goto BB10
   }
   BB10 {
     assume { Resolve2.resolve _27 };
     assume { Resolve2.resolve _29 };
     _22 <- ();
-    assume { Resolve4.resolve _22 };
+    assume { Resolve3.resolve _22 };
     goto BB12
   }
   BB11 {
     assume { Resolve1.resolve _23 };
     _22 <- ();
-    assume { Resolve4.resolve _22 };
+    assume { Resolve3.resolve _22 };
     goto BB12
   }
   BB12 {
     ma_1 <- { ma_1 with current = ( * ma_1 + (2 : int)) };
-    assume { Resolve5.resolve ma_1 };
+    assume { Resolve4.resolve ma_1 };
     mb_2 <- { mb_2 with current = ( * mb_2 + (1 : int)) };
-    assume { Resolve5.resolve mb_2 };
+    assume { Resolve4.resolve mb_2 };
     _0 <- ();
     return _0
   }
@@ -247,11 +247,11 @@ end
 module IncMax3_TestIncMax3
   use mach.int.Int
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic4
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = int
-  clone IncMax3_IncMax3_Interface as IncMax31
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic0
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = int
+  clone IncMax3_IncMax3_Interface as IncMax30
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = int
   let rec cfg test_inc_max_3 (a : int) (b : int) (c : int) : () = 
   var _0 : ();
@@ -301,16 +301,16 @@ module IncMax3_TestIncMax3
     _9 <- borrow_mut ( * _10);
     _10 <- { _10 with current = ( ^ _9) };
     assume { Resolve0.resolve _10 };
-    _4 <- IncMax31.inc_max_3 _5 _7 _9;
+    _4 <- IncMax30.inc_max_3 _5 _7 _9;
     goto BB1
   }
   BB1 {
     assume { Resolve0.resolve _5 };
     assume { Resolve0.resolve _7 };
     assume { Resolve0.resolve _9 };
-    assume { Resolve2.resolve _16 };
+    assume { Resolve1.resolve _16 };
     _16 <- a_1;
-    assume { Resolve2.resolve _17 };
+    assume { Resolve1.resolve _17 };
     _17 <- b_2;
     _15 <- _16 <> _17;
     switch (_15)
@@ -320,22 +320,22 @@ module IncMax3_TestIncMax3
       end
   }
   BB2 {
-    assume { Resolve2.resolve a_1 };
-    assume { Resolve2.resolve c_3 };
-    assume { Resolve3.resolve _14 };
+    assume { Resolve1.resolve a_1 };
+    assume { Resolve1.resolve c_3 };
+    assume { Resolve2.resolve _14 };
     _13 <- false;
     goto BB4
   }
   BB3 {
-    assume { Resolve3.resolve _14 };
-    assume { Resolve2.resolve _22 };
+    assume { Resolve2.resolve _14 };
+    assume { Resolve1.resolve _22 };
     _22 <- c_3;
-    assume { Resolve2.resolve c_3 };
-    assume { Resolve2.resolve _23 };
+    assume { Resolve1.resolve c_3 };
+    assume { Resolve1.resolve _23 };
     _23 <- a_1;
-    assume { Resolve2.resolve a_1 };
+    assume { Resolve1.resolve a_1 };
     _21 <- _22 <> _23;
-    assume { Resolve3.resolve _13 };
+    assume { Resolve2.resolve _13 };
     _13 <- _21;
     goto BB4
   }
@@ -348,20 +348,20 @@ module IncMax3_TestIncMax3
       end
   }
   BB5 {
-    assume { Resolve2.resolve b_2 };
-    assume { Resolve3.resolve _15 };
+    assume { Resolve1.resolve b_2 };
+    assume { Resolve2.resolve _15 };
     _14 <- false;
     goto BB7
   }
   BB6 {
-    assume { Resolve3.resolve _15 };
-    assume { Resolve2.resolve _19 };
+    assume { Resolve2.resolve _15 };
+    assume { Resolve1.resolve _19 };
     _19 <- b_2;
-    assume { Resolve2.resolve b_2 };
-    assume { Resolve2.resolve _20 };
+    assume { Resolve1.resolve b_2 };
+    assume { Resolve1.resolve _20 };
     _20 <- c_3;
     _18 <- _19 <> _20;
-    assume { Resolve3.resolve _14 };
+    assume { Resolve2.resolve _14 };
     _14 <- _18;
     goto BB7
   }
@@ -373,13 +373,13 @@ module IncMax3_TestIncMax3
       end
   }
   BB8 {
-    assume { Resolve3.resolve _12 };
+    assume { Resolve2.resolve _12 };
     absurd
   }
   BB9 {
-    assume { Resolve3.resolve _12 };
+    assume { Resolve2.resolve _12 };
     _11 <- ();
-    assume { Resolve5.resolve _11 };
+    assume { Resolve3.resolve _11 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/inc_max_many.stdout
+++ b/creusot/tests/should_succeed/inc_max_many.stdout
@@ -129,11 +129,11 @@ module IncMaxMany_IncMaxMany
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic4
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
-  clone IncMaxMany_TakeMax_Interface as TakeMax1
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic0
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = uint32
+  clone IncMaxMany_TakeMax_Interface as TakeMax0
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max_many (a : uint32) (b : uint32) (k : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && k <= (1000000 : uint32)}
@@ -180,20 +180,20 @@ module IncMaxMany_IncMaxMany
     _7 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     assume { Resolve0.resolve _8 };
-    mc_4 <- TakeMax1.take_max _5 _7;
+    mc_4 <- TakeMax0.take_max _5 _7;
     goto BB1
   }
   BB1 {
-    assume { Resolve2.resolve _9 };
+    assume { Resolve1.resolve _9 };
     _9 <- k_3;
     mc_4 <- { mc_4 with current = ( * mc_4 + _9) };
     assume { Resolve0.resolve mc_4 };
-    assume { Resolve2.resolve _9 };
-    assume { Resolve2.resolve _14 };
+    assume { Resolve1.resolve _9 };
+    assume { Resolve1.resolve _14 };
     _14 <- a_1;
-    assume { Resolve2.resolve _16 };
+    assume { Resolve1.resolve _16 };
     _16 <- b_2;
-    assume { Resolve2.resolve _17 };
+    assume { Resolve1.resolve _17 };
     _17 <- k_3;
     _15 <- _16 + _17;
     _13 <- _14 >= _15;
@@ -204,27 +204,27 @@ module IncMaxMany_IncMaxMany
       end
   }
   BB2 {
-    assume { Resolve2.resolve a_1 };
-    assume { Resolve2.resolve b_2 };
-    assume { Resolve2.resolve k_3 };
-    assume { Resolve3.resolve _13 };
+    assume { Resolve1.resolve a_1 };
+    assume { Resolve1.resolve b_2 };
+    assume { Resolve1.resolve k_3 };
+    assume { Resolve2.resolve _13 };
     _12 <- true;
     goto BB4
   }
   BB3 {
-    assume { Resolve3.resolve _13 };
-    assume { Resolve2.resolve _19 };
+    assume { Resolve2.resolve _13 };
+    assume { Resolve1.resolve _19 };
     _19 <- b_2;
-    assume { Resolve2.resolve b_2 };
-    assume { Resolve2.resolve _21 };
+    assume { Resolve1.resolve b_2 };
+    assume { Resolve1.resolve _21 };
     _21 <- a_1;
-    assume { Resolve2.resolve a_1 };
-    assume { Resolve2.resolve _22 };
+    assume { Resolve1.resolve a_1 };
+    assume { Resolve1.resolve _22 };
     _22 <- k_3;
-    assume { Resolve2.resolve k_3 };
+    assume { Resolve1.resolve k_3 };
     _20 <- _21 + _22;
     _18 <- _19 >= _20;
-    assume { Resolve3.resolve _12 };
+    assume { Resolve2.resolve _12 };
     _12 <- _18;
     goto BB4
   }
@@ -237,13 +237,13 @@ module IncMaxMany_IncMaxMany
       end
   }
   BB5 {
-    assume { Resolve3.resolve _11 };
+    assume { Resolve2.resolve _11 };
     absurd
   }
   BB6 {
-    assume { Resolve3.resolve _11 };
+    assume { Resolve2.resolve _11 };
     _10 <- ();
-    assume { Resolve5.resolve _10 };
+    assume { Resolve3.resolve _10 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -129,9 +129,9 @@ module IncMaxRepeat_IncMaxRepeat
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone Core_Panicking_Panic_Interface as Panic5
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = ()
-  clone IncMaxRepeat_TakeMax_Interface as TakeMax3
+  clone Core_Panicking_Panic_Interface as Panic0
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone IncMaxRepeat_TakeMax_Interface as TakeMax0
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
@@ -211,7 +211,7 @@ module IncMaxRepeat_IncMaxRepeat
     _16 <- borrow_mut ( * _17);
     _17 <- { _17 with current = ( ^ _16) };
     assume { Resolve2.resolve _17 };
-    mc_13 <- TakeMax3.take_max _14 _16;
+    mc_13 <- TakeMax0.take_max _14 _16;
     goto BB4
   }
   BB4 {
@@ -219,14 +219,14 @@ module IncMaxRepeat_IncMaxRepeat
     assume { Resolve2.resolve mc_13 };
     i_4 <- i_4 + (1 : uint32);
     _9 <- ();
-    assume { Resolve4.resolve _9 };
+    assume { Resolve3.resolve _9 };
     goto BB1
   }
   BB5 {
     assume { Resolve0.resolve n_3 };
     assume { Resolve1.resolve _10 };
     _5 <- ();
-    assume { Resolve4.resolve _5 };
+    assume { Resolve3.resolve _5 };
     assume { Resolve0.resolve _25 };
     _25 <- a_1;
     assume { Resolve0.resolve _27 };
@@ -281,7 +281,7 @@ module IncMaxRepeat_IncMaxRepeat
   BB10 {
     assume { Resolve1.resolve _22 };
     _21 <- ();
-    assume { Resolve4.resolve _21 };
+    assume { Resolve3.resolve _21 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -94,11 +94,11 @@ module IncSome2List_Impl1_SumX
   use Type
   clone IncSome2List_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.incsome2list_list
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.incsome2list_list
   let rec cfg sum_x (self : Type.incsome2list_list) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { result = Sum0.sum self }
@@ -124,29 +124,29 @@ module IncSome2List_Impl1_SumX
       end
   }
   BB1 {
-    assume { Resolve2.resolve _2 };
+    assume { Resolve1.resolve _2 };
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     _0 <- (0 : uint32);
     goto BB6
   }
   BB3 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     absurd
   }
   BB4 {
     a_3 <- (let Type.IncSome2List_List_Cons a _ = self_1 in a);
     l_4 <- (let Type.IncSome2List_List_Cons _ a = self_1 in a);
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve3.resolve _5 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve2.resolve _5 };
     _5 <- a_3;
-    assume { Resolve4.resolve a_3 };
+    assume { Resolve3.resolve a_3 };
     _7 <- l_4;
-    assume { Resolve5.resolve l_4 };
+    assume { Resolve4.resolve l_4 };
     _6 <- sum_x _7;
     goto BB5
   }
@@ -197,15 +197,15 @@ module IncSome2List_Impl1_TakeSomeRest
   use Type
   clone IncSome2List_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve9 with type t = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve8 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
-  clone Rand_Random_Interface as Random6 with type t = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsome2list_list
-  clone IncSome2List_Impl1_LemmaSumNonneg as LemmaSumNonneg4 with function Sum0.sum = Sum0.sum, axiom .
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
+  clone Rand_Random_Interface as Random0 with type t = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.incsome2list_list
+  clone IncSome2List_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some_rest (self : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     ensures {  * (let (a, _) = result in a) <= Sum0.sum ( * self) }
@@ -237,17 +237,17 @@ module IncSome2List_Impl1_TakeSomeRest
       end
   }
   BB1 {
-    assume { Resolve2.resolve _2 };
+    assume { Resolve1.resolve _2 };
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     goto BB11
   }
   BB3 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     absurd
   }
   BB4 {
@@ -255,14 +255,14 @@ module IncSome2List_Impl1_TakeSomeRest
     self_1 <- { self_1 with current = (let Type.IncSome2List_List_Cons a b =  * self_1 in Type.IncSome2List_List_Cons ( ^ ma_3) b) };
     ml_4 <- borrow_mut (let Type.IncSome2List_List_Cons _ a =  * self_1 in a);
     self_1 <- { self_1 with current = (let Type.IncSome2List_List_Cons a b =  * self_1 in Type.IncSome2List_List_Cons a ( ^ ml_4)) };
-    assume { Resolve1.resolve self_1 };
+    assume { Resolve0.resolve self_1 };
     _6 <-  * ml_4;
-    _5 <- LemmaSumNonneg4.lemma_sum_nonneg _6;
+    _5 <- LemmaSumNonneg0.lemma_sum_nonneg _6;
     goto BB5
   }
   BB5 {
-    assume { Resolve5.resolve _6 };
-    _7 <- Random6.random ();
+    assume { Resolve3.resolve _6 };
+    _7 <- Random0.random ();
     goto BB6
   }
   BB6 {
@@ -273,22 +273,22 @@ module IncSome2List_Impl1_TakeSomeRest
       end
   }
   BB7 {
-    assume { Resolve7.resolve _7 };
+    assume { Resolve4.resolve _7 };
     _8 <- borrow_mut ( * ma_3);
     ma_3 <- { ma_3 with current = ( ^ _8) };
-    assume { Resolve8.resolve ma_3 };
+    assume { Resolve5.resolve ma_3 };
     _9 <- borrow_mut ( * ml_4);
     ml_4 <- { ml_4 with current = ( ^ _9) };
-    assume { Resolve9.resolve ml_4 };
+    assume { Resolve6.resolve ml_4 };
     _0 <- (_8, _9);
     goto BB10
   }
   BB8 {
-    assume { Resolve8.resolve ma_3 };
-    assume { Resolve7.resolve _7 };
+    assume { Resolve5.resolve ma_3 };
+    assume { Resolve4.resolve _7 };
     _10 <- borrow_mut ( * ml_4);
     ml_4 <- { ml_4 with current = ( ^ _10) };
-    assume { Resolve9.resolve ml_4 };
+    assume { Resolve6.resolve ml_4 };
     _0 <- take_some_rest _10;
     goto BB9
   }
@@ -303,7 +303,7 @@ module IncSome2List_Impl1_TakeSomeRest
   }
   BB12 {
     _12 <- ();
-    assume { Resolve3.resolve _12 };
+    assume { Resolve2.resolve _12 };
     goto BB11
   }
   
@@ -356,20 +356,20 @@ module IncSome2List_IncSome2List
   use mach.int.UInt32
   clone IncSome2List_Impl1_Sum as Sum0
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve10 with type self = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic8
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
-  clone CreusotContracts_Builtins_Impl12 as Resolve12 with type t = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Impl12 as Resolve11 with type t = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve5 with type t1 = borrowed uint32,
-  type t2 = borrowed (Type.incsome2list_list), predicate Resolve0.resolve = Resolve11.resolve,
-  predicate Resolve1.resolve = Resolve12.resolve
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = uint32
-  clone IncSome2List_Impl1_TakeSomeRest_Interface as TakeSomeRest2 with function Sum0.sum = Sum0.sum
-  clone IncSome2List_Impl1_SumX_Interface as SumX1 with function Sum0.sum = Sum0.sum
+  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic0
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
+  clone CreusotContracts_Builtins_Impl12 as Resolve8 with type t = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Impl12 as Resolve7 with type t = uint32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t1 = borrowed uint32,
+  type t2 = borrowed (Type.incsome2list_list), predicate Resolve0.resolve = Resolve7.resolve,
+  predicate Resolve1.resolve = Resolve8.resolve
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
+  clone IncSome2List_Impl1_TakeSomeRest_Interface as TakeSomeRest0 with function Sum0.sum = Sum0.sum
+  clone IncSome2List_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_2_list (l : Type.incsome2list_list) (j : uint32) (k : uint32) : ()
     requires {Sum0.sum l + j + k <= 1000000}
     
@@ -408,56 +408,56 @@ module IncSome2List_IncSome2List
   }
   BB0 {
     _5 <- l_1;
-    sum0_4 <- SumX1.sum_x _5;
+    sum0_4 <- SumX0.sum_x _5;
     goto BB1
   }
   BB1 {
     _9 <- borrow_mut l_1;
     l_1 <-  ^ _9;
-    _8 <- TakeSomeRest2.take_some_rest _9;
+    _8 <- TakeSomeRest0.take_some_rest _9;
     goto BB2
   }
   BB2 {
-    assume { Resolve3.resolve ma_6 };
+    assume { Resolve0.resolve ma_6 };
     ma_6 <- (let (a, _) = _8 in a);
-    assume { Resolve4.resolve ml_7 };
+    assume { Resolve1.resolve ml_7 };
     ml_7 <- (let (_, a) = _8 in a);
-    assume { Resolve5.resolve _8 };
+    assume { Resolve2.resolve _8 };
     _12 <- borrow_mut ( * ml_7);
     ml_7 <- { ml_7 with current = ( ^ _12) };
-    assume { Resolve4.resolve ml_7 };
-    _11 <- TakeSomeRest2.take_some_rest _12;
+    assume { Resolve1.resolve ml_7 };
+    _11 <- TakeSomeRest0.take_some_rest _12;
     goto BB3
   }
   BB3 {
-    assume { Resolve3.resolve mb_10 };
+    assume { Resolve0.resolve mb_10 };
     mb_10 <- (let (a, _) = _11 in a);
-    assume { Resolve5.resolve _11 };
-    assume { Resolve6.resolve _13 };
+    assume { Resolve2.resolve _11 };
+    assume { Resolve3.resolve _13 };
     _13 <- j_2;
     ma_6 <- { ma_6 with current = ( * ma_6 + _13) };
-    assume { Resolve3.resolve ma_6 };
-    assume { Resolve6.resolve _13 };
-    assume { Resolve6.resolve _14 };
+    assume { Resolve0.resolve ma_6 };
+    assume { Resolve3.resolve _13 };
+    assume { Resolve3.resolve _14 };
     _14 <- k_3;
     mb_10 <- { mb_10 with current = ( * mb_10 + _14) };
-    assume { Resolve3.resolve mb_10 };
-    assume { Resolve6.resolve _14 };
+    assume { Resolve0.resolve mb_10 };
+    assume { Resolve3.resolve _14 };
     _19 <- l_1;
-    _18 <- SumX1.sum_x _19;
+    _18 <- SumX0.sum_x _19;
     goto BB4
   }
   BB4 {
-    assume { Resolve6.resolve _22 };
+    assume { Resolve3.resolve _22 };
     _22 <- sum0_4;
-    assume { Resolve6.resolve sum0_4 };
-    assume { Resolve6.resolve _23 };
+    assume { Resolve3.resolve sum0_4 };
+    assume { Resolve3.resolve _23 };
     _23 <- j_2;
-    assume { Resolve6.resolve j_2 };
+    assume { Resolve3.resolve j_2 };
     _21 <- _22 + _23;
-    assume { Resolve6.resolve _24 };
+    assume { Resolve3.resolve _24 };
     _24 <- k_3;
-    assume { Resolve6.resolve k_3 };
+    assume { Resolve3.resolve k_3 };
     _20 <- _21 + _24;
     _17 <- _18 = _20;
     _16 <- not _17;
@@ -468,18 +468,18 @@ module IncSome2List_IncSome2List
       end
   }
   BB5 {
-    assume { Resolve7.resolve _16 };
+    assume { Resolve4.resolve _16 };
     absurd
   }
   BB6 {
-    assume { Resolve7.resolve _16 };
+    assume { Resolve4.resolve _16 };
     _15 <- ();
-    assume { Resolve9.resolve _15 };
+    assume { Resolve5.resolve _15 };
     _0 <- ();
     goto BB7
   }
   BB7 {
-    assume { Resolve10.resolve l_1 };
+    assume { Resolve6.resolve l_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -94,12 +94,12 @@ module IncSome2Tree_Impl1_SumX
   use Type
   clone IncSome2Tree_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsome2tree_tree
-  clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg3 with function Sum0.sum = Sum0.sum, axiom .
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.incsome2tree_tree
+  clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg sum_x (self : Type.incsome2tree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { result = Sum0.sum self }
@@ -133,49 +133,49 @@ module IncSome2Tree_Impl1_SumX
       end
   }
   BB1 {
-    assume { Resolve2.resolve _2 };
+    assume { Resolve1.resolve _2 };
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     _0 <- (0 : uint32);
     goto BB9
   }
   BB3 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     absurd
   }
   BB4 {
     tl_3 <- (let Type.IncSome2Tree_Tree_Node a _ _ = self_1 in a);
     a_4 <- (let Type.IncSome2Tree_Tree_Node _ a _ = self_1 in a);
     tr_5 <- (let Type.IncSome2Tree_Tree_Node _ _ a = self_1 in a);
-    assume { Resolve1.resolve self_1 };
+    assume { Resolve0.resolve self_1 };
     _7 <- tl_3;
-    _6 <- LemmaSumNonneg3.lemma_sum_nonneg _7;
+    _6 <- LemmaSumNonneg0.lemma_sum_nonneg _7;
     goto BB5
   }
   BB5 {
-    assume { Resolve1.resolve _7 };
+    assume { Resolve0.resolve _7 };
     _9 <- tr_5;
-    _8 <- LemmaSumNonneg3.lemma_sum_nonneg _9;
+    _8 <- LemmaSumNonneg0.lemma_sum_nonneg _9;
     goto BB6
   }
   BB6 {
-    assume { Resolve1.resolve _9 };
+    assume { Resolve0.resolve _9 };
     _12 <- tl_3;
-    assume { Resolve4.resolve tl_3 };
+    assume { Resolve2.resolve tl_3 };
     _11 <- sum_x _12;
     goto BB7
   }
   BB7 {
-    assume { Resolve5.resolve _13 };
+    assume { Resolve3.resolve _13 };
     _13 <- a_4;
-    assume { Resolve6.resolve a_4 };
+    assume { Resolve4.resolve a_4 };
     _10 <- _11 + _13;
     _15 <- tr_5;
-    assume { Resolve4.resolve tr_5 };
+    assume { Resolve2.resolve tr_5 };
     _14 <- sum_x _15;
     goto BB8
   }
@@ -226,15 +226,15 @@ module IncSome2Tree_Impl1_TakeSomeRest
   use Type
   clone IncSome2Tree_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve9 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve8 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
-  clone Rand_Random_Interface as Random6 with type t = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsome2tree_tree
-  clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg4 with function Sum0.sum = Sum0.sum, axiom .
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
+  clone Rand_Random_Interface as Random0 with type t = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.incsome2tree_tree
+  clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some_rest (self : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     ensures {  * (let (a, _) = result in a) <= Sum0.sum ( * self) }
@@ -274,17 +274,17 @@ module IncSome2Tree_Impl1_TakeSomeRest
       end
   }
   BB1 {
-    assume { Resolve2.resolve _2 };
+    assume { Resolve1.resolve _2 };
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     goto BB21
   }
   BB3 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     absurd
   }
   BB4 {
@@ -294,20 +294,20 @@ module IncSome2Tree_Impl1_TakeSomeRest
     self_1 <- { self_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * self_1 in Type.IncSome2Tree_Tree_Node a ( ^ ma_4) c) };
     mtr_5 <- borrow_mut (let Type.IncSome2Tree_Tree_Node _ _ a =  * self_1 in a);
     self_1 <- { self_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * self_1 in Type.IncSome2Tree_Tree_Node a b ( ^ mtr_5)) };
-    assume { Resolve1.resolve self_1 };
+    assume { Resolve0.resolve self_1 };
     _7 <-  * mtl_3;
-    _6 <- LemmaSumNonneg4.lemma_sum_nonneg _7;
+    _6 <- LemmaSumNonneg0.lemma_sum_nonneg _7;
     goto BB5
   }
   BB5 {
-    assume { Resolve5.resolve _7 };
+    assume { Resolve3.resolve _7 };
     _9 <-  * mtr_5;
-    _8 <- LemmaSumNonneg4.lemma_sum_nonneg _9;
+    _8 <- LemmaSumNonneg0.lemma_sum_nonneg _9;
     goto BB6
   }
   BB6 {
-    assume { Resolve5.resolve _9 };
-    _10 <- Random6.random ();
+    assume { Resolve3.resolve _9 };
+    _10 <- Random0.random ();
     goto BB7
   }
   BB7 {
@@ -318,11 +318,11 @@ module IncSome2Tree_Impl1_TakeSomeRest
       end
   }
   BB8 {
-    assume { Resolve7.resolve _10 };
+    assume { Resolve4.resolve _10 };
     _11 <- borrow_mut ( * ma_4);
     ma_4 <- { ma_4 with current = ( ^ _11) };
-    assume { Resolve8.resolve ma_4 };
-    _14 <- Random6.random ();
+    assume { Resolve5.resolve ma_4 };
+    _14 <- Random0.random ();
     goto BB9
   }
   BB9 {
@@ -333,35 +333,35 @@ module IncSome2Tree_Impl1_TakeSomeRest
       end
   }
   BB10 {
-    assume { Resolve9.resolve mtr_5 };
-    assume { Resolve7.resolve _14 };
+    assume { Resolve6.resolve mtr_5 };
+    assume { Resolve4.resolve _14 };
     _15 <- borrow_mut ( * mtl_3);
     mtl_3 <- { mtl_3 with current = ( ^ _15) };
-    assume { Resolve9.resolve mtl_3 };
+    assume { Resolve6.resolve mtl_3 };
     _13 <- borrow_mut ( * _15);
     _15 <- { _15 with current = ( ^ _13) };
-    assume { Resolve1.resolve _15 };
+    assume { Resolve0.resolve _15 };
     goto BB12
   }
   BB11 {
-    assume { Resolve9.resolve mtl_3 };
-    assume { Resolve7.resolve _14 };
+    assume { Resolve6.resolve mtl_3 };
+    assume { Resolve4.resolve _14 };
     _13 <- borrow_mut ( * mtr_5);
     mtr_5 <- { mtr_5 with current = ( ^ _13) };
-    assume { Resolve9.resolve mtr_5 };
+    assume { Resolve6.resolve mtr_5 };
     goto BB12
   }
   BB12 {
     _12 <- borrow_mut ( * _13);
     _13 <- { _13 with current = ( ^ _12) };
-    assume { Resolve1.resolve _13 };
+    assume { Resolve0.resolve _13 };
     _0 <- (_11, _12);
     goto BB20
   }
   BB13 {
-    assume { Resolve8.resolve ma_4 };
-    assume { Resolve7.resolve _10 };
-    _16 <- Random6.random ();
+    assume { Resolve5.resolve ma_4 };
+    assume { Resolve4.resolve _10 };
+    _16 <- Random0.random ();
     goto BB14
   }
   BB14 {
@@ -372,11 +372,11 @@ module IncSome2Tree_Impl1_TakeSomeRest
       end
   }
   BB15 {
-    assume { Resolve9.resolve mtr_5 };
-    assume { Resolve7.resolve _16 };
+    assume { Resolve6.resolve mtr_5 };
+    assume { Resolve4.resolve _16 };
     _17 <- borrow_mut ( * mtl_3);
     mtl_3 <- { mtl_3 with current = ( ^ _17) };
-    assume { Resolve9.resolve mtl_3 };
+    assume { Resolve6.resolve mtl_3 };
     _0 <- take_some_rest _17;
     goto BB16
   }
@@ -384,11 +384,11 @@ module IncSome2Tree_Impl1_TakeSomeRest
     goto BB19
   }
   BB17 {
-    assume { Resolve9.resolve mtl_3 };
-    assume { Resolve7.resolve _16 };
+    assume { Resolve6.resolve mtl_3 };
+    assume { Resolve4.resolve _16 };
     _18 <- borrow_mut ( * mtr_5);
     mtr_5 <- { mtr_5 with current = ( ^ _18) };
-    assume { Resolve9.resolve mtr_5 };
+    assume { Resolve6.resolve mtr_5 };
     _0 <- take_some_rest _18;
     goto BB18
   }
@@ -406,7 +406,7 @@ module IncSome2Tree_Impl1_TakeSomeRest
   }
   BB22 {
     _20 <- ();
-    assume { Resolve3.resolve _20 };
+    assume { Resolve2.resolve _20 };
     goto BB21
   }
   
@@ -459,20 +459,20 @@ module IncSome2Tree_IncSome2Tree
   use mach.int.UInt32
   clone IncSome2Tree_Impl1_Sum as Sum0
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve10 with type self = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic8
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
-  clone CreusotContracts_Builtins_Impl12 as Resolve12 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Impl12 as Resolve11 with type t = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve5 with type t1 = borrowed uint32,
-  type t2 = borrowed (Type.incsome2tree_tree), predicate Resolve0.resolve = Resolve11.resolve,
-  predicate Resolve1.resolve = Resolve12.resolve
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = uint32
-  clone IncSome2Tree_Impl1_TakeSomeRest_Interface as TakeSomeRest2 with function Sum0.sum = Sum0.sum
-  clone IncSome2Tree_Impl1_SumX_Interface as SumX1 with function Sum0.sum = Sum0.sum
+  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic0
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
+  clone CreusotContracts_Builtins_Impl12 as Resolve8 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Impl12 as Resolve7 with type t = uint32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t1 = borrowed uint32,
+  type t2 = borrowed (Type.incsome2tree_tree), predicate Resolve0.resolve = Resolve7.resolve,
+  predicate Resolve1.resolve = Resolve8.resolve
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
+  clone IncSome2Tree_Impl1_TakeSomeRest_Interface as TakeSomeRest0 with function Sum0.sum = Sum0.sum
+  clone IncSome2Tree_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_2_tree (t : Type.incsome2tree_tree) (j : uint32) (k : uint32) : ()
     requires {Sum0.sum t + j + k <= 1000000}
     
@@ -511,56 +511,56 @@ module IncSome2Tree_IncSome2Tree
   }
   BB0 {
     _5 <- t_1;
-    sum0_4 <- SumX1.sum_x _5;
+    sum0_4 <- SumX0.sum_x _5;
     goto BB1
   }
   BB1 {
     _9 <- borrow_mut t_1;
     t_1 <-  ^ _9;
-    _8 <- TakeSomeRest2.take_some_rest _9;
+    _8 <- TakeSomeRest0.take_some_rest _9;
     goto BB2
   }
   BB2 {
-    assume { Resolve3.resolve ma_6 };
+    assume { Resolve0.resolve ma_6 };
     ma_6 <- (let (a, _) = _8 in a);
-    assume { Resolve4.resolve mt_7 };
+    assume { Resolve1.resolve mt_7 };
     mt_7 <- (let (_, a) = _8 in a);
-    assume { Resolve5.resolve _8 };
+    assume { Resolve2.resolve _8 };
     _12 <- borrow_mut ( * mt_7);
     mt_7 <- { mt_7 with current = ( ^ _12) };
-    assume { Resolve4.resolve mt_7 };
-    _11 <- TakeSomeRest2.take_some_rest _12;
+    assume { Resolve1.resolve mt_7 };
+    _11 <- TakeSomeRest0.take_some_rest _12;
     goto BB3
   }
   BB3 {
-    assume { Resolve3.resolve mb_10 };
+    assume { Resolve0.resolve mb_10 };
     mb_10 <- (let (a, _) = _11 in a);
-    assume { Resolve5.resolve _11 };
-    assume { Resolve6.resolve _13 };
+    assume { Resolve2.resolve _11 };
+    assume { Resolve3.resolve _13 };
     _13 <- j_2;
     ma_6 <- { ma_6 with current = ( * ma_6 + _13) };
-    assume { Resolve3.resolve ma_6 };
-    assume { Resolve6.resolve _13 };
-    assume { Resolve6.resolve _14 };
+    assume { Resolve0.resolve ma_6 };
+    assume { Resolve3.resolve _13 };
+    assume { Resolve3.resolve _14 };
     _14 <- k_3;
     mb_10 <- { mb_10 with current = ( * mb_10 + _14) };
-    assume { Resolve3.resolve mb_10 };
-    assume { Resolve6.resolve _14 };
+    assume { Resolve0.resolve mb_10 };
+    assume { Resolve3.resolve _14 };
     _19 <- t_1;
-    _18 <- SumX1.sum_x _19;
+    _18 <- SumX0.sum_x _19;
     goto BB4
   }
   BB4 {
-    assume { Resolve6.resolve _22 };
+    assume { Resolve3.resolve _22 };
     _22 <- sum0_4;
-    assume { Resolve6.resolve sum0_4 };
-    assume { Resolve6.resolve _23 };
+    assume { Resolve3.resolve sum0_4 };
+    assume { Resolve3.resolve _23 };
     _23 <- j_2;
-    assume { Resolve6.resolve j_2 };
+    assume { Resolve3.resolve j_2 };
     _21 <- _22 + _23;
-    assume { Resolve6.resolve _24 };
+    assume { Resolve3.resolve _24 };
     _24 <- k_3;
-    assume { Resolve6.resolve k_3 };
+    assume { Resolve3.resolve k_3 };
     _20 <- _21 + _24;
     _17 <- _18 = _20;
     _16 <- not _17;
@@ -571,18 +571,18 @@ module IncSome2Tree_IncSome2Tree
       end
   }
   BB5 {
-    assume { Resolve7.resolve _16 };
+    assume { Resolve4.resolve _16 };
     absurd
   }
   BB6 {
-    assume { Resolve7.resolve _16 };
+    assume { Resolve4.resolve _16 };
     _15 <- ();
-    assume { Resolve9.resolve _15 };
+    assume { Resolve5.resolve _15 };
     _0 <- ();
     goto BB7
   }
   BB7 {
-    assume { Resolve10.resolve t_1 };
+    assume { Resolve6.resolve t_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -94,11 +94,11 @@ module IncSomeList_Impl1_SumX
   use Type
   clone IncSomeList_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.incsomelist_list
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.incsomelist_list
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsomelist_list
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.incsomelist_list
   let rec cfg sum_x (self : Type.incsomelist_list) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { result = Sum0.sum self }
@@ -124,29 +124,29 @@ module IncSomeList_Impl1_SumX
       end
   }
   BB1 {
-    assume { Resolve2.resolve _2 };
+    assume { Resolve1.resolve _2 };
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     _0 <- (0 : uint32);
     goto BB6
   }
   BB3 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     absurd
   }
   BB4 {
     a_3 <- (let Type.IncSomeList_List_Cons a _ = self_1 in a);
     l_4 <- (let Type.IncSomeList_List_Cons _ a = self_1 in a);
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve3.resolve _5 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve2.resolve _5 };
     _5 <- a_3;
-    assume { Resolve4.resolve a_3 };
+    assume { Resolve3.resolve a_3 };
     _7 <- l_4;
-    assume { Resolve5.resolve l_4 };
+    assume { Resolve4.resolve l_4 };
     _6 <- sum_x _7;
     goto BB5
   }
@@ -196,15 +196,15 @@ module IncSomeList_Impl1_TakeSome
   use Type
   clone IncSomeList_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve9 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve7 with type t = Type.incsomelist_list
-  clone Rand_Random_Interface as Random6 with type t = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.incsomelist_list
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsomelist_list
-  clone IncSomeList_Impl1_LemmaSumNonneg as LemmaSumNonneg4 with function Sum0.sum = Sum0.sum, axiom .
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.incsomelist_list
+  clone Rand_Random_Interface as Random0 with type t = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsomelist_list
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.incsomelist_list
+  clone IncSomeList_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some (self : borrowed (Type.incsomelist_list)) : borrowed uint32
     ensures {  * result <= Sum0.sum ( * self) }
     ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result -  * result }
@@ -239,17 +239,17 @@ module IncSomeList_Impl1_TakeSome
       end
   }
   BB1 {
-    assume { Resolve2.resolve _4 };
+    assume { Resolve1.resolve _4 };
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _4 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _4 };
     goto BB11
   }
   BB3 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _4 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _4 };
     absurd
   }
   BB4 {
@@ -257,14 +257,14 @@ module IncSomeList_Impl1_TakeSome
     self_1 <- { self_1 with current = (let Type.IncSomeList_List_Cons a b =  * self_1 in Type.IncSomeList_List_Cons ( ^ ma_5) b) };
     ml_6 <- borrow_mut (let Type.IncSomeList_List_Cons _ a =  * self_1 in a);
     self_1 <- { self_1 with current = (let Type.IncSomeList_List_Cons a b =  * self_1 in Type.IncSomeList_List_Cons a ( ^ ml_6)) };
-    assume { Resolve1.resolve self_1 };
+    assume { Resolve0.resolve self_1 };
     _9 <-  * ml_6;
-    _8 <- LemmaSumNonneg4.lemma_sum_nonneg _9;
+    _8 <- LemmaSumNonneg0.lemma_sum_nonneg _9;
     goto BB5
   }
   BB5 {
-    assume { Resolve5.resolve _9 };
-    _11 <- Random6.random ();
+    assume { Resolve3.resolve _9 };
+    _11 <- Random0.random ();
     goto BB6
   }
   BB6 {
@@ -275,44 +275,44 @@ module IncSomeList_Impl1_TakeSome
       end
   }
   BB7 {
-    assume { Resolve7.resolve ml_6 };
-    assume { Resolve8.resolve _11 };
+    assume { Resolve4.resolve ml_6 };
+    assume { Resolve5.resolve _11 };
     _12 <- borrow_mut ( * ma_5);
     ma_5 <- { ma_5 with current = ( ^ _12) };
-    assume { Resolve9.resolve ma_5 };
+    assume { Resolve6.resolve ma_5 };
     _10 <- borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _10) };
-    assume { Resolve9.resolve _12 };
+    assume { Resolve6.resolve _12 };
     goto BB10
   }
   BB8 {
-    assume { Resolve9.resolve ma_5 };
-    assume { Resolve8.resolve _11 };
+    assume { Resolve6.resolve ma_5 };
+    assume { Resolve5.resolve _11 };
     _14 <- borrow_mut ( * ml_6);
     ml_6 <- { ml_6 with current = ( ^ _14) };
-    assume { Resolve7.resolve ml_6 };
+    assume { Resolve4.resolve ml_6 };
     _13 <- take_some _14;
     goto BB9
   }
   BB9 {
     _10 <- borrow_mut ( * _13);
     _13 <- { _13 with current = ( ^ _10) };
-    assume { Resolve9.resolve _13 };
+    assume { Resolve6.resolve _13 };
     goto BB10
   }
   BB10 {
     _7 <- borrow_mut ( * _10);
     _10 <- { _10 with current = ( ^ _7) };
-    assume { Resolve9.resolve _10 };
+    assume { Resolve6.resolve _10 };
     _3 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _3) };
-    assume { Resolve9.resolve _7 };
+    assume { Resolve6.resolve _7 };
     _2 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _2) };
-    assume { Resolve9.resolve _3 };
+    assume { Resolve6.resolve _3 };
     _0 <- borrow_mut ( * _2);
     _2 <- { _2 with current = ( ^ _0) };
-    assume { Resolve9.resolve _2 };
+    assume { Resolve6.resolve _2 };
     return _0
   }
   BB11 {
@@ -320,7 +320,7 @@ module IncSomeList_Impl1_TakeSome
   }
   BB12 {
     _16 <- ();
-    assume { Resolve3.resolve _16 };
+    assume { Resolve2.resolve _16 };
     goto BB11
   }
   
@@ -354,14 +354,14 @@ module IncSomeList_IncSomeList
   use mach.int.UInt32
   clone IncSomeList_Impl1_Sum as Sum0
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = Type.incsomelist_list
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic6
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
-  clone IncSomeList_Impl1_TakeSome_Interface as TakeSome2 with function Sum0.sum = Sum0.sum
-  clone IncSomeList_Impl1_SumX_Interface as SumX1 with function Sum0.sum = Sum0.sum
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.incsomelist_list
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic0
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
+  clone IncSomeList_Impl1_TakeSome_Interface as TakeSome0 with function Sum0.sum = Sum0.sum
+  clone IncSomeList_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_list (l : Type.incsomelist_list) (k : uint32) : ()
     requires {Sum0.sum l + k <= 1000000}
     
@@ -390,32 +390,32 @@ module IncSomeList_IncSomeList
   }
   BB0 {
     _4 <- l_1;
-    sum0_3 <- SumX1.sum_x _4;
+    sum0_3 <- SumX0.sum_x _4;
     goto BB1
   }
   BB1 {
     _6 <- borrow_mut l_1;
     l_1 <-  ^ _6;
-    ma_5 <- TakeSome2.take_some _6;
+    ma_5 <- TakeSome0.take_some _6;
     goto BB2
   }
   BB2 {
-    assume { Resolve3.resolve _7 };
+    assume { Resolve0.resolve _7 };
     _7 <- k_2;
     ma_5 <- { ma_5 with current = ( * ma_5 + _7) };
-    assume { Resolve4.resolve ma_5 };
-    assume { Resolve3.resolve _7 };
+    assume { Resolve1.resolve ma_5 };
+    assume { Resolve0.resolve _7 };
     _12 <- l_1;
-    _11 <- SumX1.sum_x _12;
+    _11 <- SumX0.sum_x _12;
     goto BB3
   }
   BB3 {
-    assume { Resolve3.resolve _14 };
+    assume { Resolve0.resolve _14 };
     _14 <- sum0_3;
-    assume { Resolve3.resolve sum0_3 };
-    assume { Resolve3.resolve _15 };
+    assume { Resolve0.resolve sum0_3 };
+    assume { Resolve0.resolve _15 };
     _15 <- k_2;
-    assume { Resolve3.resolve k_2 };
+    assume { Resolve0.resolve k_2 };
     _13 <- _14 + _15;
     _10 <- _11 = _13;
     _9 <- not _10;
@@ -426,18 +426,18 @@ module IncSomeList_IncSomeList
       end
   }
   BB4 {
-    assume { Resolve5.resolve _9 };
+    assume { Resolve2.resolve _9 };
     absurd
   }
   BB5 {
-    assume { Resolve5.resolve _9 };
+    assume { Resolve2.resolve _9 };
     _8 <- ();
-    assume { Resolve7.resolve _8 };
+    assume { Resolve3.resolve _8 };
     _0 <- ();
     goto BB6
   }
   BB6 {
-    assume { Resolve8.resolve l_1 };
+    assume { Resolve4.resolve l_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -94,12 +94,12 @@ module IncSomeTree_Impl1_SumX
   use Type
   clone IncSomeTree_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.incsometree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.incsometree_tree
-  clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg3 with function Sum0.sum = Sum0.sum, axiom .
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = Type.incsometree_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.incsometree_tree
+  clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg sum_x (self : Type.incsometree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { result = Sum0.sum self }
@@ -133,49 +133,49 @@ module IncSomeTree_Impl1_SumX
       end
   }
   BB1 {
-    assume { Resolve2.resolve _2 };
+    assume { Resolve1.resolve _2 };
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     _0 <- (0 : uint32);
     goto BB9
   }
   BB3 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _2 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _2 };
     absurd
   }
   BB4 {
     tl_3 <- (let Type.IncSomeTree_Tree_Node a _ _ = self_1 in a);
     a_4 <- (let Type.IncSomeTree_Tree_Node _ a _ = self_1 in a);
     tr_5 <- (let Type.IncSomeTree_Tree_Node _ _ a = self_1 in a);
-    assume { Resolve1.resolve self_1 };
+    assume { Resolve0.resolve self_1 };
     _7 <- tl_3;
-    _6 <- LemmaSumNonneg3.lemma_sum_nonneg _7;
+    _6 <- LemmaSumNonneg0.lemma_sum_nonneg _7;
     goto BB5
   }
   BB5 {
-    assume { Resolve1.resolve _7 };
+    assume { Resolve0.resolve _7 };
     _9 <- tr_5;
-    _8 <- LemmaSumNonneg3.lemma_sum_nonneg _9;
+    _8 <- LemmaSumNonneg0.lemma_sum_nonneg _9;
     goto BB6
   }
   BB6 {
-    assume { Resolve1.resolve _9 };
+    assume { Resolve0.resolve _9 };
     _12 <- tl_3;
-    assume { Resolve4.resolve tl_3 };
+    assume { Resolve2.resolve tl_3 };
     _11 <- sum_x _12;
     goto BB7
   }
   BB7 {
-    assume { Resolve5.resolve _13 };
+    assume { Resolve3.resolve _13 };
     _13 <- a_4;
-    assume { Resolve6.resolve a_4 };
+    assume { Resolve4.resolve a_4 };
     _10 <- _11 + _13;
     _15 <- tr_5;
-    assume { Resolve4.resolve tr_5 };
+    assume { Resolve2.resolve tr_5 };
     _14 <- sum_x _15;
     goto BB8
   }
@@ -225,15 +225,15 @@ module IncSomeTree_Impl1_TakeSome
   use Type
   clone IncSomeTree_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve9 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve7 with type t = Type.incsometree_tree
-  clone Rand_Random_Interface as Random6 with type t = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.incsometree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsometree_tree
-  clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg4 with function Sum0.sum = Sum0.sum, axiom .
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.incsometree_tree
+  clone Rand_Random_Interface as Random0 with type t = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsometree_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.incsometree_tree
+  clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some (self : borrowed (Type.incsometree_tree)) : borrowed uint32
     ensures {  * result <= Sum0.sum ( * self) }
     ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result -  * result }
@@ -275,17 +275,17 @@ module IncSomeTree_Impl1_TakeSome
       end
   }
   BB1 {
-    assume { Resolve2.resolve _4 };
+    assume { Resolve1.resolve _4 };
     goto BB4
   }
   BB2 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _4 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _4 };
     goto BB17
   }
   BB3 {
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _4 };
+    assume { Resolve0.resolve self_1 };
+    assume { Resolve1.resolve _4 };
     absurd
   }
   BB4 {
@@ -295,20 +295,20 @@ module IncSomeTree_Impl1_TakeSome
     self_1 <- { self_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * self_1 in Type.IncSomeTree_Tree_Node a ( ^ ma_6) c) };
     mtr_7 <- borrow_mut (let Type.IncSomeTree_Tree_Node _ _ a =  * self_1 in a);
     self_1 <- { self_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * self_1 in Type.IncSomeTree_Tree_Node a b ( ^ mtr_7)) };
-    assume { Resolve1.resolve self_1 };
+    assume { Resolve0.resolve self_1 };
     _10 <-  * mtl_5;
-    _9 <- LemmaSumNonneg4.lemma_sum_nonneg _10;
+    _9 <- LemmaSumNonneg0.lemma_sum_nonneg _10;
     goto BB5
   }
   BB5 {
-    assume { Resolve5.resolve _10 };
+    assume { Resolve3.resolve _10 };
     _12 <-  * mtr_7;
-    _11 <- LemmaSumNonneg4.lemma_sum_nonneg _12;
+    _11 <- LemmaSumNonneg0.lemma_sum_nonneg _12;
     goto BB6
   }
   BB6 {
-    assume { Resolve5.resolve _12 };
-    _14 <- Random6.random ();
+    assume { Resolve3.resolve _12 };
+    _14 <- Random0.random ();
     goto BB7
   }
   BB7 {
@@ -319,21 +319,21 @@ module IncSomeTree_Impl1_TakeSome
       end
   }
   BB8 {
-    assume { Resolve7.resolve mtl_5 };
-    assume { Resolve7.resolve mtr_7 };
-    assume { Resolve8.resolve _14 };
+    assume { Resolve4.resolve mtl_5 };
+    assume { Resolve4.resolve mtr_7 };
+    assume { Resolve5.resolve _14 };
     _15 <- borrow_mut ( * ma_6);
     ma_6 <- { ma_6 with current = ( ^ _15) };
-    assume { Resolve9.resolve ma_6 };
+    assume { Resolve6.resolve ma_6 };
     _13 <- borrow_mut ( * _15);
     _15 <- { _15 with current = ( ^ _13) };
-    assume { Resolve9.resolve _15 };
+    assume { Resolve6.resolve _15 };
     goto BB16
   }
   BB9 {
-    assume { Resolve9.resolve ma_6 };
-    assume { Resolve8.resolve _14 };
-    _16 <- Random6.random ();
+    assume { Resolve6.resolve ma_6 };
+    assume { Resolve5.resolve _14 };
+    _16 <- Random0.random ();
     goto BB10
   }
   BB10 {
@@ -344,36 +344,36 @@ module IncSomeTree_Impl1_TakeSome
       end
   }
   BB11 {
-    assume { Resolve7.resolve mtr_7 };
-    assume { Resolve8.resolve _16 };
+    assume { Resolve4.resolve mtr_7 };
+    assume { Resolve5.resolve _16 };
     _19 <- borrow_mut ( * mtl_5);
     mtl_5 <- { mtl_5 with current = ( ^ _19) };
-    assume { Resolve7.resolve mtl_5 };
+    assume { Resolve4.resolve mtl_5 };
     _18 <- take_some _19;
     goto BB12
   }
   BB12 {
     _17 <- borrow_mut ( * _18);
     _18 <- { _18 with current = ( ^ _17) };
-    assume { Resolve9.resolve _18 };
+    assume { Resolve6.resolve _18 };
     _13 <- borrow_mut ( * _17);
     _17 <- { _17 with current = ( ^ _13) };
-    assume { Resolve9.resolve _17 };
+    assume { Resolve6.resolve _17 };
     goto BB15
   }
   BB13 {
-    assume { Resolve7.resolve mtl_5 };
-    assume { Resolve8.resolve _16 };
+    assume { Resolve4.resolve mtl_5 };
+    assume { Resolve5.resolve _16 };
     _21 <- borrow_mut ( * mtr_7);
     mtr_7 <- { mtr_7 with current = ( ^ _21) };
-    assume { Resolve7.resolve mtr_7 };
+    assume { Resolve4.resolve mtr_7 };
     _20 <- take_some _21;
     goto BB14
   }
   BB14 {
     _13 <- borrow_mut ( * _20);
     _20 <- { _20 with current = ( ^ _13) };
-    assume { Resolve9.resolve _20 };
+    assume { Resolve6.resolve _20 };
     goto BB15
   }
   BB15 {
@@ -382,16 +382,16 @@ module IncSomeTree_Impl1_TakeSome
   BB16 {
     _8 <- borrow_mut ( * _13);
     _13 <- { _13 with current = ( ^ _8) };
-    assume { Resolve9.resolve _13 };
+    assume { Resolve6.resolve _13 };
     _3 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _3) };
-    assume { Resolve9.resolve _8 };
+    assume { Resolve6.resolve _8 };
     _2 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _2) };
-    assume { Resolve9.resolve _3 };
+    assume { Resolve6.resolve _3 };
     _0 <- borrow_mut ( * _2);
     _2 <- { _2 with current = ( ^ _0) };
-    assume { Resolve9.resolve _2 };
+    assume { Resolve6.resolve _2 };
     return _0
   }
   BB17 {
@@ -399,7 +399,7 @@ module IncSomeTree_Impl1_TakeSome
   }
   BB18 {
     _23 <- ();
-    assume { Resolve3.resolve _23 };
+    assume { Resolve2.resolve _23 };
     goto BB17
   }
   
@@ -433,14 +433,14 @@ module IncSomeTree_IncSomeTree
   use mach.int.UInt32
   clone IncSomeTree_Impl1_Sum as Sum0
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = Type.incsometree_tree
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic6
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
-  clone IncSomeTree_Impl1_TakeSome_Interface as TakeSome2 with function Sum0.sum = Sum0.sum
-  clone IncSomeTree_Impl1_SumX_Interface as SumX1 with function Sum0.sum = Sum0.sum
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.incsometree_tree
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic0
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
+  clone IncSomeTree_Impl1_TakeSome_Interface as TakeSome0 with function Sum0.sum = Sum0.sum
+  clone IncSomeTree_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_tree (t : Type.incsometree_tree) (k : uint32) : ()
     requires {Sum0.sum t + k <= 1000000}
     
@@ -469,32 +469,32 @@ module IncSomeTree_IncSomeTree
   }
   BB0 {
     _4 <- t_1;
-    sum0_3 <- SumX1.sum_x _4;
+    sum0_3 <- SumX0.sum_x _4;
     goto BB1
   }
   BB1 {
     _6 <- borrow_mut t_1;
     t_1 <-  ^ _6;
-    ma_5 <- TakeSome2.take_some _6;
+    ma_5 <- TakeSome0.take_some _6;
     goto BB2
   }
   BB2 {
-    assume { Resolve3.resolve _7 };
+    assume { Resolve0.resolve _7 };
     _7 <- k_2;
     ma_5 <- { ma_5 with current = ( * ma_5 + _7) };
-    assume { Resolve4.resolve ma_5 };
-    assume { Resolve3.resolve _7 };
+    assume { Resolve1.resolve ma_5 };
+    assume { Resolve0.resolve _7 };
     _12 <- t_1;
-    _11 <- SumX1.sum_x _12;
+    _11 <- SumX0.sum_x _12;
     goto BB3
   }
   BB3 {
-    assume { Resolve3.resolve _14 };
+    assume { Resolve0.resolve _14 };
     _14 <- sum0_3;
-    assume { Resolve3.resolve sum0_3 };
-    assume { Resolve3.resolve _15 };
+    assume { Resolve0.resolve sum0_3 };
+    assume { Resolve0.resolve _15 };
     _15 <- k_2;
-    assume { Resolve3.resolve k_2 };
+    assume { Resolve0.resolve k_2 };
     _13 <- _14 + _15;
     _10 <- _11 = _13;
     _9 <- not _10;
@@ -505,18 +505,18 @@ module IncSomeTree_IncSomeTree
       end
   }
   BB4 {
-    assume { Resolve5.resolve _9 };
+    assume { Resolve2.resolve _9 };
     absurd
   }
   BB5 {
-    assume { Resolve5.resolve _9 };
+    assume { Resolve2.resolve _9 };
     _8 <- ();
-    assume { Resolve7.resolve _8 };
+    assume { Resolve3.resolve _8 };
     _0 <- ();
     goto BB6
   }
   BB6 {
-    assume { Resolve8.resolve t_1 };
+    assume { Resolve4.resolve t_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -70,12 +70,12 @@ module InvariantMoves_TestInvariantMove
   use mach.int.UInt32
   use prelude.Prelude
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = Type.core_option_option uint32
-  clone Alloc_Vec_Impl1_Pop_Interface as Pop1 with type t = uint32, type a = Type.alloc_alloc_global
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.core_option_option uint32
+  clone Alloc_Vec_Impl1_Pop_Interface as Pop0 with type t = uint32, type a = Type.alloc_alloc_global
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
   let rec cfg test_invariant_move (x : Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)) : () = 
   var _0 : ();
@@ -109,7 +109,7 @@ module InvariantMoves_TestInvariantMove
     _5 <- borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
     assume { Resolve0.resolve _6 };
-    _4 <- Pop1.pop _5;
+    _4 <- Pop0.pop _5;
     goto BB4
   }
   BB4 {
@@ -119,26 +119,26 @@ module InvariantMoves_TestInvariantMove
       end
   }
   BB5 {
-    assume { Resolve3.resolve _7 };
+    assume { Resolve2.resolve _7 };
     goto BB6
   }
   BB6 {
-    assume { Resolve5.resolve x_8 };
+    assume { Resolve4.resolve x_8 };
     x_8 <- (let Type.Core_Option_Option_Some a = _4 in a);
-    assume { Resolve2.resolve _4 };
-    assume { Resolve5.resolve x_8 };
+    assume { Resolve1.resolve _4 };
+    assume { Resolve4.resolve x_8 };
     _3 <- ();
-    assume { Resolve6.resolve _3 };
+    assume { Resolve5.resolve _3 };
     goto BB2
   }
   BB7 {
-    assume { Resolve2.resolve _4 };
-    assume { Resolve3.resolve _7 };
+    assume { Resolve1.resolve _4 };
+    assume { Resolve2.resolve _7 };
     _0 <- ();
     goto BB8
   }
   BB8 {
-    assume { Resolve4.resolve x_1 };
+    assume { Resolve3.resolve x_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -84,14 +84,14 @@ module ListIndexMut_IndexMut_Interface
   use prelude.Prelude
   use mach.int.UInt32
   use mach.int.UInt64
-  clone ListIndexMut_Get_Interface as Get1
+  clone ListIndexMut_Get_Interface as Get0
   clone ListIndexMut_Len_Interface as Len0
   val index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
     requires {param_ix < Len0.len ( * param_l)}
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
     ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get1.get ( ^ param_l) param_ix }
-    ensures { Type.ListIndexMut_Option_Some ( * result) = Get1.get ( * param_l) param_ix }
+    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get0.get ( ^ param_l) param_ix }
+    ensures { Type.ListIndexMut_Option_Some ( * result) = Get0.get ( * param_l) param_ix }
     
 end
 module ListIndexMut_IndexMut
@@ -101,23 +101,23 @@ module ListIndexMut_IndexMut
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone ListIndexMut_Get as Get1
+  clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve9 with type t = uint32
-  clone Std_Process_Abort_Interface as Abort8
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = ()
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = Type.listindexmut_list
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = usize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = uint32
+  clone Std_Process_Abort_Interface as Abort0
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = usize
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.listindexmut_list
   let rec cfg index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
     requires {param_ix < Len0.len ( * param_l)}
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
     ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get1.get ( ^ param_l) param_ix }
-    ensures { Type.ListIndexMut_Option_Some ( * result) = Get1.get ( * param_l) param_ix }
+    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get0.get ( ^ param_l) param_ix }
+    ensures { Type.ListIndexMut_Option_Some ( * result) = Get0.get ( * param_l) param_ix }
     
    = 
   var _0 : borrowed uint32;
@@ -145,23 +145,23 @@ module ListIndexMut_IndexMut
     goto BB0
   }
   BB0 {
-    assume { Resolve2.resolve l_4 };
+    assume { Resolve0.resolve l_4 };
     l_4 <- param_l_1;
-    assume { Resolve3.resolve ix_5 };
+    assume { Resolve1.resolve ix_5 };
     ix_5 <- param_ix_2;
-    assume { Resolve3.resolve param_ix_2 };
+    assume { Resolve1.resolve param_ix_2 };
     goto BB1
   }
   BB1 {
     invariant valid_ix { (0 : usize) <= ix_5 && ix_5 < Len0.len ( * l_4) };
-    invariant get_target_now { Get1.get ( * l_4) ix_5 = Get1.get ( * param_l_1) param_ix_2 };
-    invariant get_target_fin { Get1.get ( ^ l_4) ix_5 = Get1.get ( ^ param_l_1) param_ix_2 };
+    invariant get_target_now { Get0.get ( * l_4) ix_5 = Get0.get ( * param_l_1) param_ix_2 };
+    invariant get_target_fin { Get0.get ( ^ l_4) ix_5 = Get0.get ( ^ param_l_1) param_ix_2 };
     invariant len { Len0.len ( ^ l_4) = Len0.len ( * l_4) -> Len0.len ( ^ param_l_1) = Len0.len ( * param_l_1) };
-    invariant untouched { (forall i : (int) . 0 <= i && i < Len0.len ( * l_4) && i <> ix_5 -> Get1.get ( ^ l_4) i = Get1.get ( * l_4) i) -> (forall i : (int) . 0 <= i && i < Len0.len ( * param_l_1) && i <> param_ix_2 -> Get1.get ( ^ param_l_1) i = Get1.get ( * param_l_1) i) };
+    invariant untouched { (forall i : (int) . 0 <= i && i < Len0.len ( * l_4) && i <> ix_5 -> Get0.get ( ^ l_4) i = Get0.get ( * l_4) i) -> (forall i : (int) . 0 <= i && i < Len0.len ( * param_l_1) && i <> param_ix_2 -> Get0.get ( ^ param_l_1) i = Get0.get ( * param_l_1) i) };
     goto BB2
   }
   BB2 {
-    assume { Resolve3.resolve _14 };
+    assume { Resolve1.resolve _14 };
     _14 <- ix_5;
     _13 <- _14 > (0 : usize);
     switch (_13)
@@ -171,7 +171,7 @@ module ListIndexMut_IndexMut
       end
   }
   BB3 {
-    assume { Resolve4.resolve _13 };
+    assume { Resolve2.resolve _13 };
     switch (let Type.ListIndexMut_List _ a =  * l_4 in a)
       | Type.ListIndexMut_Option_None -> goto BB4
       | Type.ListIndexMut_Option_Some _ -> goto BB5
@@ -179,51 +179,51 @@ module ListIndexMut_IndexMut
       end
   }
   BB4 {
-    assume { Resolve2.resolve l_4 };
-    assume { Resolve3.resolve ix_5 };
-    assume { Resolve5.resolve _16 };
+    assume { Resolve0.resolve l_4 };
+    assume { Resolve1.resolve ix_5 };
+    assume { Resolve3.resolve _16 };
     absurd
   }
   BB5 {
-    assume { Resolve5.resolve _16 };
+    assume { Resolve3.resolve _16 };
     goto BB7
   }
   BB6 {
-    assume { Resolve2.resolve l_4 };
-    assume { Resolve3.resolve ix_5 };
-    assume { Resolve5.resolve _16 };
+    assume { Resolve0.resolve l_4 };
+    assume { Resolve1.resolve ix_5 };
+    assume { Resolve3.resolve _16 };
     absurd
   }
   BB7 {
     n_17 <- borrow_mut (let Type.ListIndexMut_Option_Some a = let Type.ListIndexMut_List _ a =  * l_4 in a in a);
     l_4 <- { l_4 with current = (let Type.ListIndexMut_List a b =  * l_4 in Type.ListIndexMut_List a (let Type.ListIndexMut_Option_Some a = let Type.ListIndexMut_List _ a =  * l_4 in a in Type.ListIndexMut_Option_Some ( ^ n_17))) };
-    assume { Resolve2.resolve l_4 };
+    assume { Resolve0.resolve l_4 };
     _18 <- borrow_mut ( * n_17);
     n_17 <- { n_17 with current = ( ^ _18) };
-    assume { Resolve6.resolve n_17 };
-    assume { Resolve2.resolve l_4 };
+    assume { Resolve4.resolve n_17 };
+    assume { Resolve0.resolve l_4 };
     l_4 <- _18;
     _15 <- ();
-    assume { Resolve7.resolve _15 };
+    assume { Resolve5.resolve _15 };
     ix_5 <- ix_5 - (1 : usize);
     _12 <- ();
-    assume { Resolve7.resolve _12 };
+    assume { Resolve5.resolve _12 };
     goto BB1
   }
   BB8 {
-    assume { Resolve3.resolve ix_5 };
-    assume { Resolve4.resolve _13 };
+    assume { Resolve1.resolve ix_5 };
+    assume { Resolve2.resolve _13 };
     _6 <- ();
-    assume { Resolve7.resolve _6 };
+    assume { Resolve5.resolve _6 };
     _23 <- borrow_mut (let Type.ListIndexMut_List a _ =  * l_4 in a);
     l_4 <- { l_4 with current = (let Type.ListIndexMut_List a b =  * l_4 in Type.ListIndexMut_List ( ^ _23) b) };
-    assume { Resolve2.resolve l_4 };
+    assume { Resolve0.resolve l_4 };
     _3 <- borrow_mut ( * _23);
     _23 <- { _23 with current = ( ^ _3) };
-    assume { Resolve9.resolve _23 };
+    assume { Resolve6.resolve _23 };
     _0 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve9.resolve _3 };
+    assume { Resolve6.resolve _3 };
     return _0
   }
   
@@ -235,13 +235,13 @@ module ListIndexMut_Write_Interface
   use prelude.Prelude
   use mach.int.UInt64
   use mach.int.UInt32
-  clone ListIndexMut_Get_Interface as Get1
+  clone ListIndexMut_Get_Interface as Get0
   clone ListIndexMut_Len_Interface as Len0
   val write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
     requires {ix < Len0.len ( * l)}
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
     ensures { Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { Type.ListIndexMut_Option_Some v = Get1.get ( ^ l) ix }
+    ensures { Type.ListIndexMut_Option_Some v = Get0.get ( ^ l) ix }
     
 end
 module ListIndexMut_Write
@@ -251,18 +251,18 @@ module ListIndexMut_Write
   use prelude.Prelude
   use mach.int.UInt64
   use mach.int.UInt32
-  clone ListIndexMut_Get as Get1
+  clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = usize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = Type.listindexmut_list
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
-  clone ListIndexMut_IndexMut_Interface as IndexMut5 with function Len0.len = Len0.len, function Get1.get = Get1.get
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
+  clone ListIndexMut_IndexMut_Interface as IndexMut0 with function Len0.len = Len0.len, function Get0.get = Get0.get
   let rec cfg write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
     requires {ix < Len0.len ( * l)}
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
     ensures { Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { Type.ListIndexMut_Option_Some v = Get1.get ( ^ l) ix }
+    ensures { Type.ListIndexMut_Option_Some v = Get0.get ( ^ l) ix }
     
    = 
   var _0 : ();
@@ -280,23 +280,23 @@ module ListIndexMut_Write
     goto BB0
   }
   BB0 {
-    assume { Resolve2.resolve _4 };
+    assume { Resolve0.resolve _4 };
     _4 <- v_3;
-    assume { Resolve2.resolve v_3 };
+    assume { Resolve0.resolve v_3 };
     _6 <- borrow_mut ( * l_1);
     l_1 <- { l_1 with current = ( ^ _6) };
-    assume { Resolve3.resolve l_1 };
-    assume { Resolve4.resolve _7 };
+    assume { Resolve1.resolve l_1 };
+    assume { Resolve2.resolve _7 };
     _7 <- ix_2;
-    assume { Resolve4.resolve ix_2 };
-    _5 <- IndexMut5.index_mut _6 _7;
+    assume { Resolve2.resolve ix_2 };
+    _5 <- IndexMut0.index_mut _6 _7;
     goto BB1
   }
   BB1 {
-    assume { Resolve2.resolve ( * _5) };
+    assume { Resolve0.resolve ( * _5) };
     _5 <- { _5 with current = _4 };
-    assume { Resolve2.resolve _4 };
-    assume { Resolve6.resolve _5 };
+    assume { Resolve0.resolve _4 };
+    assume { Resolve3.resolve _5 };
     _0 <- ();
     return _0
   }
@@ -320,10 +320,10 @@ module ListIndexMut_Main
   use prelude.Prelude
   use mach.int.UInt64
   use Type
-  clone ListIndexMut_Impl0_Resolve as Resolve2
-  clone ListIndexMut_Get as Get4
-  clone ListIndexMut_Len as Len3
-  clone ListIndexMut_Write_Interface as Write1 with function Len0.len = Len3.len, function Get1.get = Get4.get
+  clone ListIndexMut_Impl0_Resolve as Resolve1
+  clone ListIndexMut_Get as Get0
+  clone ListIndexMut_Len as Len0
+  clone ListIndexMut_Write_Interface as Write0 with function Len0.len = Len0.len, function Get0.get = Get0.get
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.listindexmut_list
   let rec cfg main () : () = 
   var _0 : ();
@@ -361,7 +361,7 @@ module ListIndexMut_Main
     _7 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     assume { Resolve0.resolve _8 };
-    _6 <- Write1.write _7 (0 : usize) (2 : uint32);
+    _6 <- Write0.write _7 (0 : usize) (2 : uint32);
     goto BB5
   }
   BB5 {
@@ -370,7 +370,7 @@ module ListIndexMut_Main
     goto BB6
   }
   BB6 {
-    assume { Resolve2.resolve l_1 };
+    assume { Resolve1.resolve l_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/model.stdout
+++ b/creusot/tests/should_succeed/model.stdout
@@ -72,11 +72,11 @@ module Model_Pair
   type t   
   type u   
   use Type
-  clone Model_Impl1_Model as Model2 with type t = t, type u = u
+  clone Model_Impl1_Model as Model0 with type t = t, type u = u
   clone Core_Marker_Sized as Sized1 with type self = u
   clone Core_Marker_Sized as Sized0 with type self = t
   val pair (a : t) (b : u) : Type.model_pair t u
-    ensures { Model2.model result = (a, b) }
+    ensures { Model0.model result = (a, b) }
     
 end
 module CreusotContracts_Builtins_Model

--- a/creusot/tests/should_succeed/modules.stdout
+++ b/creusot/tests/should_succeed/modules.stdout
@@ -66,7 +66,7 @@ module Modules_Main_Interface
   val main () : ()
 end
 module Modules_Main
-  clone Modules_Nested_Further_Another_Interface as Another1
+  clone Modules_Nested_Further_Another_Interface as Another0
   clone Modules_Nested_InnerFunc_Interface as InnerFunc0
   let rec cfg main () : () = 
   var _0 : ();
@@ -80,7 +80,7 @@ module Modules_Main
     goto BB1
   }
   BB1 {
-    _2 <- Another1.another ();
+    _2 <- Another0.another ();
     goto BB2
   }
   BB2 {

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -48,10 +48,10 @@ end
 module ProjectionToggle_ProjToggle
   type t   
   use prelude.Prelude
-  clone Core_Cmp_PartialEq as PartialEq1 with type self = t, type rhs = t
+  clone Core_Cmp_PartialEq as PartialEq0 with type self = t, type rhs = t
   clone Core_Marker_Sized as Sized0 with type self = t
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = bool
   let rec cfg proj_toggle (toggle : bool) (a : borrowed t) (b : borrowed t) : borrowed t
     ensures { match (toggle) with
       | True -> result = a &&  ^ b =  * b
@@ -74,9 +74,9 @@ module ProjectionToggle_ProjToggle
     goto BB0
   }
   BB0 {
-    assume { Resolve2.resolve _6 };
+    assume { Resolve0.resolve _6 };
     _6 <- toggle_1;
-    assume { Resolve2.resolve toggle_1 };
+    assume { Resolve0.resolve toggle_1 };
     switch (_6)
       | False -> goto BB2
       | True -> goto BB1
@@ -84,31 +84,31 @@ module ProjectionToggle_ProjToggle
       end
   }
   BB1 {
-    assume { Resolve3.resolve b_3 };
-    assume { Resolve2.resolve _6 };
+    assume { Resolve1.resolve b_3 };
+    assume { Resolve0.resolve _6 };
     _7 <- borrow_mut ( * a_2);
     a_2 <- { a_2 with current = ( ^ _7) };
-    assume { Resolve3.resolve a_2 };
+    assume { Resolve1.resolve a_2 };
     _5 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _5) };
-    assume { Resolve3.resolve _7 };
+    assume { Resolve1.resolve _7 };
     goto BB3
   }
   BB2 {
-    assume { Resolve3.resolve a_2 };
-    assume { Resolve2.resolve _6 };
+    assume { Resolve1.resolve a_2 };
+    assume { Resolve0.resolve _6 };
     _5 <- borrow_mut ( * b_3);
     b_3 <- { b_3 with current = ( ^ _5) };
-    assume { Resolve3.resolve b_3 };
+    assume { Resolve1.resolve b_3 };
     goto BB3
   }
   BB3 {
     _4 <- borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _4) };
-    assume { Resolve3.resolve _5 };
+    assume { Resolve1.resolve _5 };
     _0 <- borrow_mut ( * _4);
     _4 <- { _4 with current = ( ^ _0) };
-    assume { Resolve3.resolve _4 };
+    assume { Resolve1.resolve _4 };
     return _0
   }
   
@@ -132,10 +132,10 @@ module ProjectionToggle_Main
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
-  clone Core_Panicking_Panic_Interface as Panic4
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
-  clone ProjectionToggle_ProjToggle_Interface as ProjToggle2 with type t = int32
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic0
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone ProjectionToggle_ProjToggle_Interface as ProjToggle0 with type t = int32
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = int32
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = int32
   let rec cfg main () : () = 
@@ -169,7 +169,7 @@ module ProjectionToggle_Main
     _6 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
     assume { Resolve0.resolve _7 };
-    x_3 <- ProjToggle2.proj_toggle true _4 _6;
+    x_3 <- ProjToggle0.proj_toggle true _4 _6;
     goto BB1
   }
   BB1 {
@@ -187,13 +187,13 @@ module ProjectionToggle_Main
       end
   }
   BB2 {
-    assume { Resolve3.resolve _9 };
+    assume { Resolve2.resolve _9 };
     absurd
   }
   BB3 {
-    assume { Resolve3.resolve _9 };
+    assume { Resolve2.resolve _9 };
     _8 <- ();
-    assume { Resolve5.resolve _8 };
+    assume { Resolve3.resolve _8 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/pure_function.stdout
+++ b/creusot/tests/should_succeed/pure_function.stdout
@@ -107,11 +107,11 @@ module PureFunction_Test
   use mach.int.Int
   use prelude.Prelude
   use Type
-  clone PureFunction_Impl1_Len as Len1 with type t = t, axiom .
+  clone PureFunction_Impl1_Len as Len0 with type t = t, axiom .
   clone Core_Marker_Sized as Sized0 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = Type.purefunction_list t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.purefunction_list t
   let rec cfg test (l : Type.purefunction_list t) : int
-    requires {Len1.len l <= (10 : int)}
+    requires {Len0.len l <= (10 : int)}
     ensures { result <= (10 : int) }
     
    = 
@@ -124,8 +124,8 @@ module PureFunction_Test
   }
   BB0 {
     _2 <- l_1;
-    assume { Resolve2.resolve l_1 };
-    _0 <- Len1.len _2;
+    assume { Resolve0.resolve l_1 };
+    _0 <- Len0.len _2;
     goto BB1
   }
   BB1 {
@@ -160,13 +160,13 @@ module PureFunction_UsesBothLogicAndProg
   type t   
   use mach.int.Int
   use Type
-  clone PureFunction_Impl1_Len as Len2 with type t = t, axiom .
-  clone PureFunction_UsesLen as UsesLen1 with type t = t, function Len0.len = Len2.len
+  clone PureFunction_Impl1_Len as Len0 with type t = t, axiom .
+  clone PureFunction_UsesLen as UsesLen0 with type t = t, function Len0.len = Len0.len
   clone Core_Marker_Sized as Sized0 with type self = t
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.purefunction_list t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.purefunction_list t
   let rec cfg uses_both_logic_and_prog (l : Type.purefunction_list t) : int
-    ensures { result = UsesLen1.uses_len l }
+    ensures { result = UsesLen0.uses_len l }
     
    = 
   var _0 : int;
@@ -178,14 +178,14 @@ module PureFunction_UsesBothLogicAndProg
   }
   BB0 {
     _2 <- l_1;
-    _0 <- Len2.len _2;
+    _0 <- Len0.len _2;
     goto BB1
   }
   BB1 {
     goto BB2
   }
   BB2 {
-    assume { Resolve3.resolve l_1 };
+    assume { Resolve0.resolve l_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/rand.stdout
+++ b/creusot/tests/should_succeed/rand.stdout
@@ -32,8 +32,8 @@ end
 module Rand_TryRand
   use mach.int.Int
   use mach.int.UInt32
-  clone Rand_Random_Interface as Random2 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
+  clone Rand_Random_Interface as Random1 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = bool
   clone Rand_Random_Interface as Random0 with type t = bool
   let rec cfg try_rand () : uint32
     ensures { result >= (0 : uint32) }
@@ -56,13 +56,13 @@ module Rand_TryRand
       end
   }
   BB2 {
-    assume { Resolve1.resolve _1 };
+    assume { Resolve0.resolve _1 };
     _0 <- (7 : uint32);
     goto BB4
   }
   BB3 {
-    assume { Resolve1.resolve _1 };
-    _0 <- Random2.random ();
+    assume { Resolve0.resolve _1 };
+    _0 <- Random1.random ();
     goto BB4
   }
   BB4 {

--- a/creusot/tests/should_succeed/trait.stdout
+++ b/creusot/tests/should_succeed/trait.stdout
@@ -39,7 +39,7 @@ module Trait_UsesCustom
   type a   
   type b   
   type t   
-  clone Trait_TraitWParams as TraitWParams3 with type self = t, type d = a, type c = b
+  clone Trait_TraitWParams as TraitWParams0 with type self = t, type d = a, type c = b
   clone Core_Marker_Sized as Sized2 with type self = t
   clone Core_Marker_Sized as Sized1 with type self = b
   clone Core_Marker_Sized as Sized0 with type self = a
@@ -87,7 +87,7 @@ module Core_Cmp_PartialOrd
 end
 module Core_Cmp_Ord
   type self   
-  clone Core_Cmp_PartialOrd as PartialOrd1 with type self = self, type rhs = self
+  clone Core_Cmp_PartialOrd as PartialOrd0 with type self = self, type rhs = self
   clone Core_Cmp_Eq as Eq0 with type self = self
   use Type
   use prelude.Prelude
@@ -100,9 +100,9 @@ module Trait_TraitWParams2
   type self   
   type d   
   type c   
-  clone Core_Marker_Sized as Sized3 with type self = c
-  clone Core_Cmp_Ord as Ord2 with type self = d
-  clone Core_Marker_Sized as Sized1 with type self = d
+  clone Core_Marker_Sized as Sized1 with type self = c
+  clone Core_Cmp_Ord as Ord0 with type self = d
+  clone Core_Marker_Sized as Sized0 with type self = d
   clone Trait_TraitWParams as TraitWParams0 with type self = self, type d = d, type c = c
 end
 module Trait_UsesCustom2_Interface
@@ -115,10 +115,10 @@ module Trait_UsesCustom2
   type a   
   type b   
   type t   
-  clone Trait_TraitWParams2 as TraitWParams24 with type self = t, type d = a, type c = b
-  clone Core_Marker_Sized as Sized3 with type self = t
-  clone Core_Marker_Sized as Sized2 with type self = b
-  clone Core_Cmp_Ord as Ord1 with type self = a
+  clone Trait_TraitWParams2 as TraitWParams20 with type self = t, type d = a, type c = b
+  clone Core_Marker_Sized as Sized2 with type self = t
+  clone Core_Marker_Sized as Sized1 with type self = b
+  clone Core_Cmp_Ord as Ord0 with type self = a
   clone Core_Marker_Sized as Sized0 with type self = a
   let rec cfg uses_custom2 (t : t) : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/traits/01.stdout
+++ b/creusot/tests/should_succeed/traits/01.stdout
@@ -28,9 +28,9 @@ module C01_UsesGeneric
   type t   
   use mach.int.Int
   use mach.int.UInt32
-  clone C01_A as A1 with type self = t
+  clone C01_A as A0 with type self = t
   clone Core_Marker_Sized as Sized0 with type self = t
-  clone C01_A as A2 with type self = t
+  clone C01_A as A1 with type self = t
   let rec cfg uses_generic (b : t) : uint32 = 
   var _0 : uint32;
   var b_1 : t;
@@ -42,7 +42,7 @@ module C01_UsesGeneric
   BB0 {
     assume { (fun x -> true) _2 };
     _2 <- b_1;
-    _0 <- A2.from_b _2;
+    _0 <- A1.from_b _2;
     goto BB1
   }
   BB1 {

--- a/creusot/tests/should_succeed/traits/02.stdout
+++ b/creusot/tests/should_succeed/traits/02.stdout
@@ -32,10 +32,10 @@ module C02_Omg_Interface
 end
 module C02_Omg
   type t   
-  clone C02_A as A1 with type self = t
+  clone C02_A as A0 with type self = t
   clone Core_Marker_Sized as Sized0 with type self = t
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t
   let rec cfg omg (a : t) : bool
     ensures { result = true }
     
@@ -49,14 +49,14 @@ module C02_Omg
   }
   BB0 {
     _2 <- a_1;
-    _0 <- A1.is_true _2;
+    _0 <- A0.is_true _2;
     goto BB1
   }
   BB1 {
     goto BB2
   }
   BB2 {
-    assume { Resolve2.resolve a_1 };
+    assume { Resolve0.resolve a_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -76,7 +76,7 @@ module C03_Impl2_H
   type g   
   use prelude.Prelude
   clone Core_Marker_Sized as Sized0 with type self = g
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = g
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = g
   let rec cfg h (y : g) : g = 
   var _0 : g;
   var y_1 : g;
@@ -85,9 +85,9 @@ module C03_Impl2_H
     goto BB0
   }
   BB0 {
-    assume { Resolve1.resolve _0 };
+    assume { Resolve0.resolve _0 };
     _0 <- y_1;
-    assume { Resolve1.resolve y_1 };
+    assume { Resolve0.resolve y_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/traits/04.stdout
+++ b/creusot/tests/should_succeed/traits/04.stdout
@@ -34,10 +34,10 @@ end
 module C04_User
   type t   
   use prelude.Prelude
-  clone C04_A as A1 with type self = t
+  clone C04_A as A0 with type self = t
   clone Core_Marker_Sized as Sized0 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = bool
   let rec cfg user (a : t) (b : t) : bool
     ensures { result = false }
     
@@ -63,38 +63,38 @@ module C04_User
   BB0 {
     _5 <- a_1;
     _6 <- b_2;
-    _4 <- A1.func1 _5 _6;
+    _4 <- A0.func1 _5 _6;
     goto BB7
   }
   BB1 {
-    assume { Resolve3.resolve a_1 };
-    assume { Resolve3.resolve b_2 };
-    assume { Resolve2.resolve _3 };
+    assume { Resolve1.resolve a_1 };
+    assume { Resolve1.resolve b_2 };
+    assume { Resolve0.resolve _3 };
     _0 <- false;
     goto BB3
   }
   BB2 {
-    assume { Resolve2.resolve _3 };
+    assume { Resolve0.resolve _3 };
     _11 <- a_1;
-    assume { Resolve3.resolve a_1 };
+    assume { Resolve1.resolve a_1 };
     _12 <- b_2;
-    assume { Resolve3.resolve b_2 };
-    _10 <- A1.func3 _11 _12;
+    assume { Resolve1.resolve b_2 };
+    _10 <- A0.func3 _11 _12;
     goto BB9
   }
   BB3 {
     return _0
   }
   BB4 {
-    assume { Resolve2.resolve _4 };
+    assume { Resolve0.resolve _4 };
     _3 <- false;
     goto BB6
   }
   BB5 {
-    assume { Resolve2.resolve _4 };
+    assume { Resolve0.resolve _4 };
     _8 <- b_2;
     _9 <- a_1;
-    _7 <- A1.func2 _8 _9;
+    _7 <- A0.func2 _8 _9;
     goto BB8
   }
   BB6 {
@@ -112,12 +112,12 @@ module C04_User
       end
   }
   BB8 {
-    assume { Resolve2.resolve _3 };
+    assume { Resolve0.resolve _3 };
     _3 <- _7;
     goto BB6
   }
   BB9 {
-    assume { Resolve2.resolve _0 };
+    assume { Resolve0.resolve _0 };
     _0 <- _10;
     goto BB3
   }

--- a/creusot/tests/should_succeed/traits/06.stdout
+++ b/creusot/tests/should_succeed/traits/06.stdout
@@ -43,13 +43,13 @@ end
 module C06_Test
   type t   
   use prelude.Prelude
-  clone C06_Ix as Ix1 with type self = t
-  clone Core_Cmp_Eq as Eq2 with type self = Ix1.tgt
+  clone C06_Ix as Ix0 with type self = t
+  clone Core_Cmp_Eq as Eq0 with type self = Ix0.tgt
   clone Core_Marker_Sized as Sized0 with type self = t
   use mach.int.Int
   use mach.int.UInt64
-  let rec cfg test (a : t) : Ix1.tgt = 
-  var _0 : Ix1.tgt;
+  let rec cfg test (a : t) : Ix0.tgt = 
+  var _0 : Ix0.tgt;
   var a_1 : t;
   var _2 : t;
   {
@@ -59,7 +59,7 @@ module C06_Test
   BB0 {
     _2 <- a_1;
     assume { (fun x -> true) a_1 };
-    _0 <- Ix1.ix _2 (0 : usize);
+    _0 <- Ix0.ix _2 (0 : usize);
     goto BB1
   }
   BB1 {

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -59,9 +59,9 @@ module C07_Test
   use mach.int.UInt64
   use mach.int.UInt32
   use prelude.Prelude
-  clone C07_Ix as Ix3 with type self = t, type tgt = uint32
-  clone Core_Marker_Sized as Sized2 with type self = t
-  clone C07_Ix as Ix1 with type self = g, type tgt = uint64
+  clone C07_Ix as Ix1 with type self = t, type tgt = uint32
+  clone Core_Marker_Sized as Sized1 with type self = t
+  clone C07_Ix as Ix0 with type self = g, type tgt = uint64
   clone Core_Marker_Sized as Sized0 with type self = g
   let rec cfg test (a : uint32) (b : uint64) : bool = 
   var _0 : bool;

--- a/creusot/tests/should_succeed/traits/08.stdout
+++ b/creusot/tests/should_succeed/traits/08.stdout
@@ -31,9 +31,9 @@ module C08_Test_Interface
 end
 module C08_Test
   type t   
-  clone C08_Tr as Tr1 with type self = t
+  clone C08_Tr as Tr0 with type self = t
   clone Core_Marker_Sized as Sized0 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t
   let rec cfg test (_1 : t) : () = 
   var _0 : ();
   var _1 : t;
@@ -46,7 +46,7 @@ module C08_Test
     goto BB1
   }
   BB1 {
-    assume { Resolve2.resolve _1 };
+    assume { Resolve0.resolve _1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/traits/09.stdout
+++ b/creusot/tests/should_succeed/traits/09.stdout
@@ -27,7 +27,7 @@ module C09_Test
   type t   
   use mach.int.Int
   use mach.int.UInt32
-  clone C09_Tr as Tr1 with type self = t, type x = uint32
+  clone C09_Tr as Tr0 with type self = t, type x = uint32
   clone Core_Marker_Sized as Sized0 with type self = t
   let rec cfg test (t : uint32) : uint32 = 
   var _0 : uint32;
@@ -55,13 +55,13 @@ end
 module C09_Test2
   type t   
   type u   
-  clone Core_Marker_Sized as Sized2 with type self = u
-  clone C09_Tr as Tr1 with type self = t
-  clone C09_Tr as Tr3 with type self = u, type x = Tr1.x
+  clone Core_Marker_Sized as Sized1 with type self = u
+  clone C09_Tr as Tr0 with type self = t
+  clone C09_Tr as Tr1 with type self = u, type x = Tr0.x
   clone Core_Marker_Sized as Sized0 with type self = t
-  let rec cfg test2 (t : Tr1.x) : Tr1.x = 
-  var _0 : Tr1.x;
-  var t_1 : Tr1.x;
+  let rec cfg test2 (t : Tr0.x) : Tr0.x = 
+  var _0 : Tr0.x;
+  var t_1 : Tr0.x;
   {
     t_1 <- t;
     goto BB0

--- a/creusot/tests/should_succeed/traits/11.stdout
+++ b/creusot/tests/should_succeed/traits/11.stdout
@@ -40,9 +40,9 @@ module C11_Test_Interface
 end
 module C11_Test
   type t   
-  clone C11_A as A1 with type self = t
+  clone C11_A as A0 with type self = t
   clone Core_Marker_Sized as Sized0 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t
   let rec cfg test (_1 : t) : () = 
   var _0 : ();
   var _1 : t;
@@ -55,7 +55,7 @@ module C11_Test
     goto BB1
   }
   BB1 {
-    assume { Resolve2.resolve _1 };
+    assume { Resolve0.resolve _1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/traits/12_default_method.stdout
+++ b/creusot/tests/should_succeed/traits/12_default_method.stdout
@@ -40,8 +40,8 @@ module C12DefaultMethod_ShouldUseImpl
   use mach.int.UInt32
   clone C12DefaultMethod_Impl0 as T0
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg should_use_impl (x : uint32) : ()
     ensures { T0.logic_default x }
     
@@ -56,12 +56,12 @@ module C12DefaultMethod_ShouldUseImpl
   }
   BB0 {
     _3 <- x_1;
-    assume { Resolve1.resolve x_1 };
+    assume { Resolve0.resolve x_1 };
     _2 <- T0.default _3;
     goto BB1
   }
   BB1 {
-    assume { Resolve2.resolve _3 };
+    assume { Resolve1.resolve _3 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -134,7 +134,7 @@ module C01_Impl1_Index_Interface
   use mach.int.Int
   use mach.int.Int32
   use Type
-  clone C01_Impl1_Get_Interface as Get1 with type t = t
+  clone C01_Impl1_Get_Interface as Get0 with type t = t
   clone C01_Impl1_Len_Interface as Len0 with type t = t
   function index (self : Type.c01_list t) (ix : int) : t
 end
@@ -143,26 +143,26 @@ module C01_Impl1_Index
   use mach.int.Int
   use mach.int.Int32
   use Type
-  clone C01_Impl1_Get_Interface as Get1 with type t = t
+  clone C01_Impl1_Get_Interface as Get0 with type t = t
   clone C01_Impl1_Len_Interface as Len0 with type t = t
   function index (self : Type.c01_list t) (ix : int) : t
   val index (self : Type.c01_list t) (ix : int) : t
     requires {0 <= ix && ix < Len0.len self}
-    ensures { Type.Core_Option_Option_Some result = Get1.get self ix }
+    ensures { Type.Core_Option_Option_Some result = Get0.get self ix }
     ensures { result = index self ix }
     
-  axiom spec : forall self : Type.c01_list t, ix : int . 0 <= ix && ix < Len0.len self -> Type.Core_Option_Option_Some (index self ix) = Get1.get self ix
+  axiom spec : forall self : Type.c01_list t, ix : int . 0 <= ix && ix < Len0.len self -> Type.Core_Option_Option_Some (index self ix) = Get0.get self ix
 end
 module C01_Impl1_Index_Impl
   type t   
   use mach.int.Int
   use mach.int.Int32
   use Type
-  clone C01_Impl1_Get as Get1 with type t = t
+  clone C01_Impl1_Get as Get0 with type t = t
   clone C01_Impl1_Len as Len0 with type t = t, axiom .
   let rec index (self : Type.c01_list t) (ix : int) : t
     requires {0 <= ix && ix < Len0.len self}
-    ensures { Type.Core_Option_Option_Some result = Get1.get self ix }
+    ensures { Type.Core_Option_Option_Some result = Get0.get self ix }
     variant {self}
     
    = 
@@ -234,10 +234,10 @@ module C01_Impl5_Len_Interface
   use prelude.Prelude
   use mach.int.UInt64
   use Type
-  clone C01_Impl1_Len_Interface as Len1 with type t = t
+  clone C01_Impl1_Len_Interface as Len0 with type t = t
   clone C01_Impl4_Model_Interface as Model0 with type t = t
   val len (self : Type.c01_myvec t) : usize
-    ensures { result = Len1.len (Model0.model self) }
+    ensures { result = Len0.len (Model0.model self) }
     
 end
 module C01_Impl5_Len
@@ -246,10 +246,10 @@ module C01_Impl5_Len
   use prelude.Prelude
   use mach.int.UInt64
   use Type
-  clone C01_Impl1_Len as Len1 with type t = t, axiom .
+  clone C01_Impl1_Len as Len0 with type t = t, axiom .
   clone C01_Impl4_Model as Model0 with type t = t
   val len (self : Type.c01_myvec t) : usize
-    ensures { result = Len1.len (Model0.model self) }
+    ensures { result = Len0.len (Model0.model self) }
     
 end
 module C01_Impl5_Get_Interface
@@ -258,11 +258,11 @@ module C01_Impl5_Get_Interface
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt64
-  clone C01_Impl1_Get_Interface as Get2 with type t = t
-  clone C01_Impl4_Model_Interface as Model1 with type t = t
+  clone C01_Impl1_Get_Interface as Get0 with type t = t
+  clone C01_Impl4_Model_Interface as Model0 with type t = t
   clone C01_AsRef_Interface as AsRef0 with type t = t
   val get (self : Type.c01_myvec t) (ix : usize) : Type.core_option_option t
-    ensures { AsRef0.as_ref result = Get2.get (Model1.model self) ix }
+    ensures { AsRef0.as_ref result = Get0.get (Model0.model self) ix }
     
 end
 module C01_Impl5_Get
@@ -271,31 +271,31 @@ module C01_Impl5_Get
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt64
-  clone C01_Impl1_Get as Get2 with type t = t
-  clone C01_Impl4_Model as Model1 with type t = t
+  clone C01_Impl1_Get as Get0 with type t = t
+  clone C01_Impl4_Model as Model0 with type t = t
   clone C01_AsRef as AsRef0 with type t = t
   val get (self : Type.c01_myvec t) (ix : usize) : Type.core_option_option t
-    ensures { AsRef0.as_ref result = Get2.get (Model1.model self) ix }
+    ensures { AsRef0.as_ref result = Get0.get (Model0.model self) ix }
     
 end
 module C01_Impl5_Push_Interface
   type t   
   use prelude.Prelude
   use Type
-  clone C01_Impl1_Push_Interface as Push1 with type t = t
+  clone C01_Impl1_Push_Interface as Push0 with type t = t
   clone C01_Impl4_Model_Interface as Model0 with type t = t
   val push (self : borrowed (Type.c01_myvec t)) (v : t) : ()
-    ensures { Model0.model ( ^ self) = Push1.push (Model0.model ( * self)) v }
+    ensures { Model0.model ( ^ self) = Push0.push (Model0.model ( * self)) v }
     
 end
 module C01_Impl5_Push
   type t   
   use prelude.Prelude
   use Type
-  clone C01_Impl1_Push as Push1 with type t = t
+  clone C01_Impl1_Push as Push0 with type t = t
   clone C01_Impl4_Model as Model0 with type t = t
   val push (self : borrowed (Type.c01_myvec t)) (v : t) : ()
-    ensures { Model0.model ( ^ self) = Push1.push (Model0.model ( * self)) v }
+    ensures { Model0.model ( ^ self) = Push0.push (Model0.model ( * self)) v }
     
 end
 module C01_Impl5_Index_Interface
@@ -304,12 +304,12 @@ module C01_Impl5_Index_Interface
   use Type
   use mach.int.Int
   use mach.int.UInt64
-  clone C01_Impl1_Index_Interface as Index2 with type t = t
-  clone C01_Impl1_Len_Interface as Len1 with type t = t
+  clone C01_Impl1_Index_Interface as Index0 with type t = t
+  clone C01_Impl1_Len_Interface as Len0 with type t = t
   clone C01_Impl4_Model_Interface as Model0 with type t = t
   val index (self : Type.c01_myvec t) (ix : usize) : t
-    requires {ix < Len1.len (Model0.model self)}
-    ensures { result = Index2.index (Model0.model self) ix }
+    requires {ix < Len0.len (Model0.model self)}
+    ensures { result = Index0.index (Model0.model self) ix }
     
 end
 module C01_Impl5_Index
@@ -318,13 +318,13 @@ module C01_Impl5_Index
   use Type
   use mach.int.Int
   use mach.int.UInt64
-  clone C01_Impl1_Get as Get3 with type t = t
-  clone C01_Impl1_Len as Len1 with type t = t, axiom .
-  clone C01_Impl1_Index as Index2 with type t = t, function Len0.len = Len1.len, function Get1.get = Get3.get, axiom .
+  clone C01_Impl1_Get as Get0 with type t = t
+  clone C01_Impl1_Len as Len0 with type t = t, axiom .
+  clone C01_Impl1_Index as Index0 with type t = t, function Len0.len = Len0.len, function Get0.get = Get0.get, axiom .
   clone C01_Impl4_Model as Model0 with type t = t
   val index (self : Type.c01_myvec t) (ix : usize) : t
-    requires {ix < Len1.len (Model0.model self)}
-    ensures { result = Index2.index (Model0.model self) ix }
+    requires {ix < Len0.len (Model0.model self)}
+    ensures { result = Index0.index (Model0.model self) ix }
     
 end
 module C01_Impl5_IndexMut_Interface
@@ -334,15 +334,15 @@ module C01_Impl5_IndexMut_Interface
   use prelude.Prelude
   use Type
   use mach.int.UInt64
-  clone C01_Impl1_Index_Interface as Index2 with type t = t
-  clone C01_Impl1_Len_Interface as Len1 with type t = t
+  clone C01_Impl1_Index_Interface as Index0 with type t = t
+  clone C01_Impl1_Len_Interface as Len0 with type t = t
   clone C01_Impl4_Model_Interface as Model0 with type t = t
   val index_mut (self : borrowed (Type.c01_myvec t)) (ix : usize) : borrowed t
-    requires {ix < Len1.len (Model0.model ( * self))}
-    ensures { Len1.len (Model0.model ( * self)) = Len1.len (Model0.model ( ^ self)) }
-    ensures { forall j : (int) . 0 <= j && j <= Len1.len (Model0.model ( ^ self)) -> not (j = ix) -> Index2.index (Model0.model ( ^ self)) j = Index2.index (Model0.model ( * self)) j }
-    ensures {  ^ result = Index2.index (Model0.model ( ^ self)) ix }
-    ensures {  * result = Index2.index (Model0.model ( * self)) ix }
+    requires {ix < Len0.len (Model0.model ( * self))}
+    ensures { Len0.len (Model0.model ( * self)) = Len0.len (Model0.model ( ^ self)) }
+    ensures { forall j : (int) . 0 <= j && j <= Len0.len (Model0.model ( ^ self)) -> not (j = ix) -> Index0.index (Model0.model ( ^ self)) j = Index0.index (Model0.model ( * self)) j }
+    ensures {  ^ result = Index0.index (Model0.model ( ^ self)) ix }
+    ensures {  * result = Index0.index (Model0.model ( * self)) ix }
     
 end
 module C01_Impl5_IndexMut
@@ -352,16 +352,16 @@ module C01_Impl5_IndexMut
   use prelude.Prelude
   use Type
   use mach.int.UInt64
-  clone C01_Impl1_Get as Get3 with type t = t
-  clone C01_Impl1_Len as Len1 with type t = t, axiom .
-  clone C01_Impl1_Index as Index2 with type t = t, function Len0.len = Len1.len, function Get1.get = Get3.get, axiom .
+  clone C01_Impl1_Get as Get0 with type t = t
+  clone C01_Impl1_Len as Len0 with type t = t, axiom .
+  clone C01_Impl1_Index as Index0 with type t = t, function Len0.len = Len0.len, function Get0.get = Get0.get, axiom .
   clone C01_Impl4_Model as Model0 with type t = t
   val index_mut (self : borrowed (Type.c01_myvec t)) (ix : usize) : borrowed t
-    requires {ix < Len1.len (Model0.model ( * self))}
-    ensures { Len1.len (Model0.model ( * self)) = Len1.len (Model0.model ( ^ self)) }
-    ensures { forall j : (int) . 0 <= j && j <= Len1.len (Model0.model ( ^ self)) -> not (j = ix) -> Index2.index (Model0.model ( ^ self)) j = Index2.index (Model0.model ( * self)) j }
-    ensures {  ^ result = Index2.index (Model0.model ( ^ self)) ix }
-    ensures {  * result = Index2.index (Model0.model ( * self)) ix }
+    requires {ix < Len0.len (Model0.model ( * self))}
+    ensures { Len0.len (Model0.model ( * self)) = Len0.len (Model0.model ( ^ self)) }
+    ensures { forall j : (int) . 0 <= j && j <= Len0.len (Model0.model ( ^ self)) -> not (j = ix) -> Index0.index (Model0.model ( ^ self)) j = Index0.index (Model0.model ( * self)) j }
+    ensures {  ^ result = Index0.index (Model0.model ( ^ self)) ix }
+    ensures {  * result = Index0.index (Model0.model ( * self)) ix }
     
 end
 module CreusotContracts_Builtins_Resolve
@@ -385,12 +385,12 @@ module C01_AllZero_Interface
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone C01_Impl1_Index_Interface as Index2 with type t = uint32
-  clone C01_Impl1_Len_Interface as Len1 with type t = uint32
+  clone C01_Impl1_Index_Interface as Index0 with type t = uint32
+  clone C01_Impl1_Len_Interface as Len0 with type t = uint32
   clone C01_Impl4_Model_Interface as Model0 with type t = uint32
   val all_zero (v : borrowed (Type.c01_myvec uint32)) : ()
-    ensures { Len1.len (Model0.model ( * v)) = Len1.len (Model0.model ( ^ v)) }
-    ensures { forall i : (int) . 0 <= i && i < Len1.len (Model0.model ( ^ v)) -> Index2.index (Model0.model ( ^ v)) i = (0 : uint32) }
+    ensures { Len0.len (Model0.model ( * v)) = Len0.len (Model0.model ( ^ v)) }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len (Model0.model ( ^ v)) -> Index0.index (Model0.model ( ^ v)) i = (0 : uint32) }
     
 end
 module C01_AllZero
@@ -399,29 +399,29 @@ module C01_AllZero
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone C01_Impl1_Get as Get4 with type t = uint32
-  clone C01_Impl1_Len as Len2 with type t = uint32, axiom .
-  clone C01_Impl1_Index as Index3 with type t = uint32, function Len0.len = Len2.len, function Get1.get = Get4.get,
+  clone C01_Impl1_Get as Get0 with type t = uint32
+  clone C01_Impl1_Len as Len0 with type t = uint32, axiom .
+  clone C01_Impl1_Index as Index0 with type t = uint32, function Len0.len = Len0.len, function Get0.get = Get0.get,
   axiom .
   clone C01_Impl4_Model as Model1 with type t = uint32
   clone C01_Impl2_Model as Model0 with type t = borrowed (Type.c01_myvec uint32)
   use mach.int.UInt64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve14 with type t = Type.c01_myvec uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve13 with type self = ()
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve12 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve10 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = usize
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = Type.c01_ghostrecord (borrowed (Type.c01_myvec uint32))
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = borrowed (Type.c01_myvec uint32)
-  clone C01_Impl5_IndexMut_Interface as IndexMut11 with type t = uint32, function Model0.model = Model1.model,
-  function Len1.len = Len2.len, function Index2.index = Index3.index
-  clone C01_Impl5_Len_Interface as Len9 with type t = uint32, function Model0.model = Model1.model,
-  function Len1.len = Len2.len
-  clone C01_Impl3_Record_Interface as Record6 with type t = borrowed (Type.c01_myvec uint32),
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = Type.c01_myvec uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.c01_ghostrecord (borrowed (Type.c01_myvec uint32))
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = borrowed (Type.c01_myvec uint32)
+  clone C01_Impl5_IndexMut_Interface as IndexMut0 with type t = uint32, function Model0.model = Model1.model,
+  function Len0.len = Len0.len, function Index0.index = Index0.index
+  clone C01_Impl5_Len_Interface as Len1 with type t = uint32, function Model0.model = Model1.model,
+  function Len0.len = Len0.len
+  clone C01_Impl3_Record_Interface as Record0 with type t = borrowed (Type.c01_myvec uint32),
   function Model0.model = Model0.model
   let rec cfg all_zero (v : borrowed (Type.c01_myvec uint32)) : ()
-    ensures { Len2.len (Model1.model ( * v)) = Len2.len (Model1.model ( ^ v)) }
-    ensures { forall i : (int) . 0 <= i && i < Len2.len (Model1.model ( ^ v)) -> Index3.index (Model1.model ( ^ v)) i = (0 : uint32) }
+    ensures { Len0.len (Model1.model ( * v)) = Len0.len (Model1.model ( ^ v)) }
+    ensures { forall i : (int) . 0 <= i && i < Len0.len (Model1.model ( ^ v)) -> Index0.index (Model1.model ( ^ v)) i = (0 : uint32) }
     
    = 
   var _0 : ();
@@ -449,25 +449,25 @@ module C01_AllZero
     i_2 <- (0 : usize);
     _5 <- v_1;
     _4 <- _5;
-    assume { Resolve5.resolve _5 };
-    old_v_3 <- Record6.record _4;
+    assume { Resolve0.resolve _5 };
+    old_v_3 <- Record0.record _4;
     goto BB1
   }
   BB1 {
-    assume { Resolve7.resolve old_v_3 };
+    assume { Resolve1.resolve old_v_3 };
     goto BB2
   }
   BB2 {
     invariant proph_const {  ^ v_1 =  ^ Model0.model old_v_3 };
-    invariant in_bounds { Len2.len (Model1.model ( * v_1)) = Len2.len (Model1.model ( * Model0.model old_v_3)) };
-    invariant all_zero { forall j : (int) . 0 <= j && j < i_2 -> Index3.index (Model1.model ( * v_1)) j = (0 : uint32) };
+    invariant in_bounds { Len0.len (Model1.model ( * v_1)) = Len0.len (Model1.model ( * Model0.model old_v_3)) };
+    invariant all_zero { forall j : (int) . 0 <= j && j < i_2 -> Index0.index (Model1.model ( * v_1)) j = (0 : uint32) };
     goto BB3
   }
   BB3 {
-    assume { Resolve8.resolve _11 };
+    assume { Resolve2.resolve _11 };
     _11 <- i_2;
     _13 <-  * v_1;
-    _12 <- Len9.len _13;
+    _12 <- Len1.len _13;
     goto BB4
   }
   BB4 {
@@ -479,26 +479,26 @@ module C01_AllZero
       end
   }
   BB5 {
-    assume { Resolve10.resolve _10 };
+    assume { Resolve3.resolve _10 };
     _15 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _15) };
-    assume { Resolve8.resolve _16 };
+    assume { Resolve2.resolve _16 };
     _16 <- i_2;
-    _14 <- IndexMut11.index_mut _15 _16;
+    _14 <- IndexMut0.index_mut _15 _16;
     goto BB6
   }
   BB6 {
     _14 <- { _14 with current = (0 : uint32) };
-    assume { Resolve12.resolve _14 };
+    assume { Resolve4.resolve _14 };
     i_2 <- i_2 + (1 : usize);
     _9 <- ();
-    assume { Resolve13.resolve _9 };
+    assume { Resolve5.resolve _9 };
     goto BB2
   }
   BB7 {
-    assume { Resolve14.resolve v_1 };
-    assume { Resolve8.resolve i_2 };
-    assume { Resolve10.resolve _10 };
+    assume { Resolve6.resolve v_1 };
+    assume { Resolve2.resolve i_2 };
+    assume { Resolve3.resolve _10 };
     _0 <- ();
     return _0
   }


### PR DESCRIPTION
Addresses the annoyance I voiced in #130.

Now the number appended to clones is unique to each base name so it should be a LOT more stable to test updates.

cc @shiatsumat
