### PR TITLE
Normalize traits in projection types

### DIFF
--- a/creusot/tests/should_succeed/traits/13_assoc_types.rs
+++ b/creusot/tests/should_succeed/traits/13_assoc_types.rs
@@ -1,0 +1,21 @@
+#![feature(register_tool, rustc_attrs)]
+#![register_tool(creusot)]
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
+
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+pub trait Model {
+    type ModelTy;
+
+    fn model(self) -> Self::ModelTy;
+}
+
+impl<T: Model> Model for &T {
+    type ModelTy = T::ModelTy;
+
+    fn model(self) -> Self::ModelTy {
+        self.model()
+    }
+}

--- a/creusot/tests/should_succeed/traits/13_assoc_types.stdout
+++ b/creusot/tests/should_succeed/traits/13_assoc_types.stdout
@@ -1,0 +1,61 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C13AssocTypes_Model
+  type self   
+  type modelty   
+  val model (self : self) : modelty
+end
+module CreusotContracts_Builtins_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module C13AssocTypes_Impl0_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone C13AssocTypes_Model as Model0 with type self = t
+  val model (self : t) : Model0.modelty
+end
+module C13AssocTypes_Impl0_Model
+  type t   
+  use prelude.Prelude
+  clone C13AssocTypes_Model as Model0 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t
+  let rec cfg model (self : t) : Model0.modelty = 
+  var _0 : Model0.modelty;
+  var self_1 : t;
+  var _2 : t;
+  {
+    self_1 <- self;
+    goto BB0
+  }
+  BB0 {
+    _2 <- self_1;
+    assume { Resolve0.resolve self_1 };
+    _0 <- model _2;
+    goto BB1
+  }
+  BB1 {
+    return _0
+  }
+  
+end
+module C13AssocTypes_Impl0
+  type t   
+  use prelude.Prelude
+  clone C13AssocTypes_Model as Model0 with type self = t
+  clone export C13AssocTypes_Impl0_Model_Interface with type t = t, type Model0.modelty = Model0.modelty,
+  val Model0.model = Model0.model
+  type modelty  = 
+    Model0.modelty
+  clone export C13AssocTypes_Model with type self = t, type modelty = modelty, val model = model
+end


### PR DESCRIPTION
Performs specialization when translating projection types in traits. This solves an issue found by @shiatsumat in #130. 

TODO:
- Clean up code
- Figure out why there is one instance of a type being printed wrong.
