### PR TITLE
Add `impl` interfaces

### DIFF
--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -25,7 +25,7 @@ enum TranslatedItem<'tcx> {
     Logic { interface: Module, modl: Module, dependencies: CloneSummary<'tcx> },
     Program { interface: Module, modl: Module, dependencies: CloneSummary<'tcx> },
     Trait { modl: Module, dependencies: CloneSummary<'tcx> },
-    Impl { modl: Module, dependencies: CloneSummary<'tcx> },
+    Impl { interface: Module, modl: Module, dependencies: CloneSummary<'tcx> },
     Extern { interface: Module, body: DefaultOrExtern<'tcx> },
 }
 
@@ -79,7 +79,7 @@ impl TranslatedItem<'tcx> {
             Logic { interface, modl, .. } => box iter::once(interface).chain(iter::once(modl)),
             Program { interface, modl, .. } => box iter::once(interface).chain(iter::once(modl)),
             Trait { modl, .. } => box iter::once(modl),
-            Impl { modl, .. } => box iter::once(modl),
+            Impl { modl, interface, .. } => box iter::once(interface).chain(iter::once(modl)),
             Extern { interface, body, .. } => match body {
                 DefaultOrExtern::Default { modl, .. } => {
                     box iter::once(interface).chain(iter::once(modl))
@@ -250,10 +250,10 @@ impl<'tcx, 'sess> TranslationCtx<'sess, 'tcx> {
         );
     }
 
-    pub fn add_impl(&mut self, def_id: DefId, trait_impl: Module) {
+    pub fn add_impl(&mut self, def_id: DefId, modl: Module, interface: Module) {
         self.functions.insert(
             def_id,
-            TranslatedItem::Impl { modl: trait_impl, dependencies: CloneSummary::new() },
+            TranslatedItem::Impl { interface, modl, dependencies: CloneSummary::new() },
         );
     }
 

--- a/creusot/src/translation/interface.rs
+++ b/creusot/src/translation/interface.rs
@@ -49,5 +49,5 @@ pub fn interface_for(
 pub fn interface_name(tcx: TyCtxt, def_id: DefId) -> Ident {
     let name = translate_value_id(tcx, def_id);
 
-    format!("{}_Interface", Cow::from(name.module_name().unwrap())).into()
+    format!("{}_Interface", Cow::from(name.module_name().unwrap_or(&name.name()))).into()
 }

--- a/creusot/src/translation/specification/lower.rs
+++ b/creusot/src/translation/specification/lower.rs
@@ -41,6 +41,7 @@ pub fn lower_term_to_why3<'tcx>(
 
             let method = resolve_assoc_item_opt(ctx.tcx, param_env, id, subst)
                 .unwrap_or(MethodInstance::new(ctx.tcx, id, subst));
+            debug!("resolved_method={:?}", (method.def_id, method.substs));
 
             if is_identity_from(ctx.tcx, id, method.substs) {
                 return args.remove(0);

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -89,6 +89,13 @@ module C01_Impl1_Inv
   predicate inv (x : uint32) = 
     mod x (2 : uint32) = (0 : uint32)
 end
+module C01_Impl1_Interface
+  use Type
+  use mach.int.Int
+  use mach.int.UInt32
+  clone export C01_Impl1_Inv_Interface
+  clone export C01_Inv with type self = Type.c01_even, type t = uint32, predicate inv = inv
+end
 module C01_Impl1
   use Type
   use mach.int.Int

--- a/creusot/tests/should_succeed/drop_pair.stdout
+++ b/creusot/tests/should_succeed/drop_pair.stdout
@@ -53,6 +53,12 @@ module CreusotContracts_Builtins_Impl12_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Builtins_Impl12_Interface
+  type t   
+  use prelude.Prelude
+  clone export CreusotContracts_Builtins_Impl12_Resolve_Interface with type t = t
+  clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
+end
 module CreusotContracts_Builtins_Impl12
   type t   
   use prelude.Prelude

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -333,6 +333,12 @@ module Core_Panicking_Panic
     ensures { false }
     
 end
+module CreusotContracts_Builtins_Impl12_Interface
+  type t   
+  use prelude.Prelude
+  clone export CreusotContracts_Builtins_Impl12_Resolve_Interface with type t = t
+  clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
+end
 module CreusotContracts_Builtins_Impl12
   type t   
   use prelude.Prelude
@@ -486,6 +492,10 @@ module IncSome2List_IncSome2List
 end
 module CreusotContracts_WellFounded
   type self   
+end
+module IncSome2List_Impl0_Interface
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.incsome2list_list
 end
 module IncSome2List_Impl0
   use Type

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -436,6 +436,12 @@ module Core_Panicking_Panic
     ensures { false }
     
 end
+module CreusotContracts_Builtins_Impl12_Interface
+  type t   
+  use prelude.Prelude
+  clone export CreusotContracts_Builtins_Impl12_Resolve_Interface with type t = t
+  clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
+end
 module CreusotContracts_Builtins_Impl12
   type t   
   use prelude.Prelude
@@ -589,6 +595,10 @@ module IncSome2Tree_IncSome2Tree
 end
 module CreusotContracts_WellFounded
   type self   
+end
+module IncSome2Tree_Impl0_Interface
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.incsome2tree_tree
 end
 module IncSome2Tree_Impl0
   use Type

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -445,6 +445,10 @@ end
 module CreusotContracts_WellFounded
   type self   
 end
+module IncSomeList_Impl0_Interface
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.incsomelist_list
+end
 module IncSomeList_Impl0
   use Type
   clone export CreusotContracts_WellFounded with type self = Type.incsomelist_list

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -524,6 +524,10 @@ end
 module CreusotContracts_WellFounded
   type self   
 end
+module IncSomeTree_Impl0_Interface
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.incsometree_tree
+end
 module IncSomeTree_Impl0
   use Type
   clone export CreusotContracts_WellFounded with type self = Type.incsometree_tree

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -375,6 +375,11 @@ module ListIndexMut_Main
   }
   
 end
+module ListIndexMut_Impl0_Interface
+  use Type
+  clone export ListIndexMut_Impl0_Resolve_Interface
+  clone export CreusotContracts_Builtins_Resolve with type self = Type.listindexmut_list, predicate resolve = resolve
+end
 module ListIndexMut_Impl0
   use Type
   clone export ListIndexMut_Impl0_Resolve

--- a/creusot/tests/should_succeed/model.stdout
+++ b/creusot/tests/should_succeed/model.stdout
@@ -84,6 +84,15 @@ module CreusotContracts_Builtins_Model
   type modelty   
   function model (self : self) : modelty
 end
+module Model_Impl0_Interface
+  use Type
+  use mach.int.Int
+  clone export Model_Impl0_Model_Interface
+  type modelty  = 
+    int
+  clone export CreusotContracts_Builtins_Model with type self = Type.model_seven, type modelty = modelty,
+  function model = model
+end
 module Model_Impl0
   use Type
   use mach.int.Int
@@ -91,6 +100,16 @@ module Model_Impl0
   type modelty  = 
     int
   clone export CreusotContracts_Builtins_Model with type self = Type.model_seven, type modelty = modelty,
+  function model = model
+end
+module Model_Impl1_Interface
+  type t   
+  type u   
+  use Type
+  clone export Model_Impl1_Model_Interface with type t = t, type u = u
+  type modelty  = 
+    (t, u)
+  clone export CreusotContracts_Builtins_Model with type self = Type.model_pair t u, type modelty = modelty,
   function model = model
 end
 module Model_Impl1

--- a/creusot/tests/should_succeed/modules.stdout
+++ b/creusot/tests/should_succeed/modules.stdout
@@ -93,6 +93,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module Modules_Nested_Impl0_Interface
+  use Type
+  clone export Modules_Nested_Impl0_Resolve_Interface
+  clone export CreusotContracts_Builtins_Resolve with type self = Type.modules_nested_nested,
+  predicate resolve = resolve
+end
 module Modules_Nested_Impl0
   use Type
   clone export Modules_Nested_Impl0_Resolve

--- a/creusot/tests/should_succeed/pure_function.stdout
+++ b/creusot/tests/should_succeed/pure_function.stdout
@@ -193,6 +193,11 @@ end
 module CreusotContracts_WellFounded
   type self   
 end
+module PureFunction_Impl0_Interface
+  type t   
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.purefunction_list t
+end
 module PureFunction_Impl0
   type t   
   use Type

--- a/creusot/tests/should_succeed/trait_impl.stdout
+++ b/creusot/tests/should_succeed/trait_impl.stdout
@@ -85,12 +85,26 @@ module TraitImpl_T
   clone Core_Marker_Sized as Sized0 with type self = b
   val x (self : self) : ()
 end
+module TraitImpl_Impl0_Interface
+  type b   
+  type t2   
+  type t1   
+  clone export TraitImpl_Impl0_X_Interface with type b = b, type t2 = t2, type t1 = t1
+  clone export TraitImpl_T with type self = (t1, t2), type b = b, val x = x
+end
 module TraitImpl_Impl0
   type b   
   type t2   
   type t1   
   clone export TraitImpl_Impl0_X_Interface with type b = b, type t2 = t2, type t1 = t1
   clone export TraitImpl_T with type self = (t1, t2), type b = b, val x = x
+end
+module TraitImpl_Impl1_Interface
+  type b   
+  use mach.int.Int
+  use mach.int.UInt32
+  clone export TraitImpl_Impl1_X_Interface with type b = b
+  clone export TraitImpl_T with type self = uint32, type b = b, val x = x
 end
 module TraitImpl_Impl1
   type b   

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -97,6 +97,12 @@ module C03_A
   use prelude.Prelude
   val f (self : self) : self
 end
+module C03_Impl0_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  clone export C03_Impl0_F_Interface
+  clone export C03_A with type self = int32, val f = f
+end
 module C03_Impl0
   use mach.int.Int
   use mach.int.Int32
@@ -111,6 +117,12 @@ module C03_B
     ensures { result = result }
     
 end
+module C03_Impl1_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  clone export C03_Impl1_G_Interface
+  clone export C03_B with type self = uint32, val g = g
+end
 module C03_Impl1
   use mach.int.Int
   use mach.int.UInt32
@@ -122,6 +134,12 @@ module C03_C
   type t   
   use prelude.Prelude
   val h (x : t) : t
+end
+module C03_Impl2_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  clone export C03_Impl2_H_Interface
+  clone export C03_C with type self = uint32, type t = g, val h = h
 end
 module C03_Impl2
   use mach.int.Int

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -110,6 +110,14 @@ module C07_Test2
   }
   
 end
+module C07_Impl0_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  clone export C07_Impl0_Ix_Interface
+  type tgt  = 
+    ()
+  clone export C07_Ix with type self = int32, type tgt = tgt, val ix = ix
+end
 module C07_Impl0
   use mach.int.Int
   use mach.int.Int32

--- a/creusot/tests/should_succeed/traits/10.stdout
+++ b/creusot/tests/should_succeed/traits/10.stdout
@@ -27,6 +27,12 @@ module C10_Impl0_Resolve
   predicate resolve (self : (t1, t2)) = 
     Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
 end
+module C10_Impl0_Interface
+  type t1   
+  type t2   
+  clone export C10_Impl0_Resolve_Interface with type t1 = t1, type t2 = t2
+  clone export CreusotContracts_Builtins_Resolve with type self = (t1, t2), predicate resolve = resolve
+end
 module C10_Impl0
   type t1   
   type t2   

--- a/creusot/tests/should_succeed/traits/12_default_method.stdout
+++ b/creusot/tests/should_succeed/traits/12_default_method.stdout
@@ -18,6 +18,11 @@ module C12DefaultMethod_T
   val default (self : self) : uint32
   function logic_default (self : self) : bool
 end
+module C12DefaultMethod_Impl0_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  clone export C12DefaultMethod_T with type self = uint32
+end
 module C12DefaultMethod_Impl0
   use mach.int.Int
   use mach.int.UInt32
@@ -30,7 +35,7 @@ end
 module C12DefaultMethod_ShouldUseImpl_Interface
   use mach.int.Int
   use mach.int.UInt32
-  clone C12DefaultMethod_Impl0 as T0
+  clone C12DefaultMethod_Impl0_Interface as T0
   val should_use_impl (x : uint32) : ()
     ensures { T0.logic_default x }
     

--- a/creusot/tests/should_succeed/traits/13_assoc_types.stdout
+++ b/creusot/tests/should_succeed/traits/13_assoc_types.stdout
@@ -49,6 +49,16 @@ module C13AssocTypes_Impl0_Model
   }
   
 end
+module C13AssocTypes_Impl0_Interface
+  type t   
+  use prelude.Prelude
+  clone C13AssocTypes_Model as Model0 with type self = t
+  clone export C13AssocTypes_Impl0_Model_Interface with type t = t, type Model0.modelty = Model0.modelty,
+  val Model0.model = Model0.model
+  type modelty  = 
+    Model0.modelty
+  clone export C13AssocTypes_Model with type self = t, type modelty = modelty, val model = model
+end
 module C13AssocTypes_Impl0
   type t   
   use prelude.Prelude

--- a/creusot/tests/should_succeed/traits/15_impl_interfaces.rs
+++ b/creusot/tests/should_succeed/traits/15_impl_interfaces.rs
@@ -1,0 +1,33 @@
+#![feature(register_tool, rustc_attrs)]
+#![register_tool(creusot)]
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
+
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+// Verifies that instances are properly cloned as interfaces in
+// the interfaces of functions. Also ensures that we don't attempt
+// refine associated types of instances.
+
+trait Tr {
+    type A;
+}
+
+impl Tr for () {
+    type A = ();
+}
+
+#[trusted]
+#[logic_rust]
+fn x<T: Tr>(x: T) -> T::A {
+    panic!()
+}
+
+#[requires(x(a) === ())]
+fn calls(a: ()) -> <() as Tr>::A {}
+
+// This call used to break
+#[ensures(x(a) === ())]
+fn breaks(a: ()) {
+    calls(a)
+}

--- a/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
+++ b/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
@@ -1,0 +1,103 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C15ImplInterfaces_Tr
+  type self   
+  type a   
+end
+module C15ImplInterfaces_X_Interface
+  type t   
+  clone C15ImplInterfaces_Tr as Tr0 with type self = t
+  function x (x : t) : Tr0.a
+end
+module C15ImplInterfaces_X
+  type t   
+  clone C15ImplInterfaces_Tr as Tr0 with type self = t
+  function x (x : t) : Tr0.a
+end
+module C15ImplInterfaces_Impl0_Interface
+  type a  = 
+    ()
+  clone export C15ImplInterfaces_Tr with type self = (), type a = a
+end
+module C15ImplInterfaces_Impl0
+  type a  = 
+    ()
+  clone export C15ImplInterfaces_Tr with type self = (), type a = a
+end
+module CreusotContracts_Builtins_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module C15ImplInterfaces_Calls_Interface
+  clone C15ImplInterfaces_Impl0_Interface as Tr0
+  clone C15ImplInterfaces_X_Interface as X0 with type t = (), type Tr0.a = Tr0.a
+  val calls (a : ()) : ()
+    requires {X0.x a = ()}
+    
+end
+module C15ImplInterfaces_Calls
+  clone C15ImplInterfaces_Impl0 as Tr0
+  clone C15ImplInterfaces_X as X0 with type t = (), type Tr0.a = Tr0.a
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = ()
+  let rec cfg calls (a : ()) : ()
+    requires {X0.x a = ()}
+    
+   = 
+  var _0 : ();
+  var a_1 : ();
+  {
+    a_1 <- a;
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    assume { Resolve0.resolve a_1 };
+    return _0
+  }
+  
+end
+module C15ImplInterfaces_Breaks_Interface
+  clone C15ImplInterfaces_Impl0_Interface as Tr0
+  clone C15ImplInterfaces_X_Interface as X0 with type t = (), type Tr0.a = Tr0.a
+  val breaks (a : ()) : ()
+    ensures { X0.x a = () }
+    
+end
+module C15ImplInterfaces_Breaks
+  clone C15ImplInterfaces_Impl0 as Tr0
+  clone C15ImplInterfaces_X as X0 with type t = (), type Tr0.a = Tr0.a
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = ()
+  clone C15ImplInterfaces_Calls_Interface as Calls0 with function X0.x = X0.x
+  let rec cfg breaks (a : ()) : ()
+    ensures { X0.x a = () }
+    
+   = 
+  var _0 : ();
+  var a_1 : ();
+  var _2 : ();
+  {
+    a_1 <- a;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve _2 };
+    _2 <- a_1;
+    assume { Resolve0.resolve a_1 };
+    _0 <- Calls0.calls _2;
+    goto BB1
+  }
+  BB1 {
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -513,6 +513,15 @@ module CreusotContracts_Builtins_Model
   type modelty   
   function model (self : self) : modelty
 end
+module C01_Impl2_Interface
+  type t   
+  use Type
+  clone export C01_Impl2_Model_Interface with type t = t
+  type modelty  = 
+    t
+  clone export CreusotContracts_Builtins_Model with type self = Type.c01_ghostrecord t, type modelty = modelty,
+  function model = model
+end
 module C01_Impl2
   type t   
   use Type
@@ -520,6 +529,15 @@ module C01_Impl2
   type modelty  = 
     t
   clone export CreusotContracts_Builtins_Model with type self = Type.c01_ghostrecord t, type modelty = modelty,
+  function model = model
+end
+module C01_Impl4_Interface
+  type t   
+  use Type
+  clone export C01_Impl4_Model_Interface with type t = t
+  type modelty  = 
+    Type.c01_list t
+  clone export CreusotContracts_Builtins_Model with type self = Type.c01_myvec t, type modelty = modelty,
   function model = model
 end
 module C01_Impl4
@@ -533,6 +551,11 @@ module C01_Impl4
 end
 module CreusotContracts_WellFounded
   type self   
+end
+module C01_Impl0_Interface
+  type t   
+  use Type
+  clone export CreusotContracts_WellFounded with type self = Type.c01_list t
 end
 module C01_Impl0
   type t   


### PR DESCRIPTION
Like logic functions the module of an impl can easily
appear in both a function interface and body. This occurs when we
instantiate a constraint of a dependency with a concrete implementation.
As a result, we must ensure that impls have an interface as well as a
body module.

However, even the interface of an impl will still fully define
associated types, which in turn means we must ensure that we don't
attempt to further refine them.
