### PR TITLE
Add better support for builtins and use it for Seq

### DIFF
--- a/creusot-contracts/src/builtins.rs
+++ b/creusot-contracts/src/builtins.rs
@@ -1,138 +1,15 @@
 use crate as creusot_contracts;
 use creusot_contracts_proc::*;
 
+mod int;
+mod seq;
+pub use int::*;
+pub use seq::*;
+
 pub trait Model {
     type ModelTy;
     #[logic_rust]
     fn model(self) -> Self::ModelTy;
-}
-
-#[rustc_diagnostic_item = "creusot_int"]
-pub struct Int;
-
-impl PartialEq for Int {
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "eq_int"]
-    fn eq(&self, _: &Int) -> bool {
-        panic!()
-    }
-
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "ne_int"]
-    fn ne(&self, _: &Int) -> bool {
-        panic!()
-    }
-}
-
-impl PartialOrd for Int {
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "le_int"]
-    fn le(&self, _: &Int) -> bool {
-        panic!()
-    }
-
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "ge_int"]
-    fn ge(&self, _: &Int) -> bool {
-        panic!()
-    }
-
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "lt_int"]
-    fn lt(&self, _: &Int) -> bool {
-        panic!()
-    }
-
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "gt_int"]
-    fn gt(&self, _: &Int) -> bool {
-        panic!()
-    }
-
-    #[creusot::spec::no_translate]
-    fn partial_cmp(&self, _: &Self) -> Option<std::cmp::Ordering> {
-        panic!()
-    }
-}
-
-impl From<i32> for Int {
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "i32_to_int"]
-    fn from(_: i32) -> Self {
-        panic!()
-    }
-}
-
-impl From<u32> for Int {
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "u32_to_int"]
-    fn from(_: u32) -> Self {
-        panic!()
-    }
-}
-
-impl From<usize> for Int {
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "usize_to_int"]
-    fn from(_: usize) -> Self {
-        panic!()
-    }
-}
-
-use std::ops::*;
-
-impl Add<Int> for Int {
-    type Output = Int;
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "add_int"]
-    fn add(self, _: Int) -> Self {
-        panic!()
-    }
-}
-
-impl Sub<Int> for Int {
-    type Output = Int;
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "sub_int"]
-    fn sub(self, _: Int) -> Self {
-        panic!()
-    }
-}
-
-impl Mul<Int> for Int {
-    type Output = Int;
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "mul_int"]
-    fn mul(self, _: Int) -> Self {
-        panic!()
-    }
-}
-
-impl Div<Int> for Int {
-    type Output = Int;
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "div_int"]
-    fn div(self, _: Int) -> Self {
-        panic!()
-    }
-}
-
-impl Rem<Int> for Int {
-    type Output = Int;
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "rem_int"]
-    fn rem(self, _: Int) -> Self {
-        panic!()
-    }
-}
-
-impl Neg for Int {
-    type Output = Int;
-    #[creusot::spec::no_translate]
-    #[rustc_diagnostic_item = "neg_int"]
-    fn neg(self) -> Self {
-        panic!()
-    }
 }
 
 #[rustc_diagnostic_item = "creusot_resolve"]

--- a/creusot-contracts/src/builtins/int.rs
+++ b/creusot-contracts/src/builtins/int.rs
@@ -1,0 +1,127 @@
+use std::ops::*;
+
+#[rustc_diagnostic_item = "creusot_int"]
+pub struct Int;
+
+impl PartialEq for Int {
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "eq_int"]
+    fn eq(&self, _: &Int) -> bool {
+        panic!()
+    }
+
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "ne_int"]
+    fn ne(&self, _: &Int) -> bool {
+        panic!()
+    }
+}
+
+impl PartialOrd for Int {
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "le_int"]
+    fn le(&self, _: &Int) -> bool {
+        panic!()
+    }
+
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "ge_int"]
+    fn ge(&self, _: &Int) -> bool {
+        panic!()
+    }
+
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "lt_int"]
+    fn lt(&self, _: &Int) -> bool {
+        panic!()
+    }
+
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "gt_int"]
+    fn gt(&self, _: &Int) -> bool {
+        panic!()
+    }
+
+    #[creusot::spec::no_translate]
+    fn partial_cmp(&self, _: &Self) -> Option<std::cmp::Ordering> {
+        panic!()
+    }
+}
+
+impl From<i32> for Int {
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "i32_to_int"]
+    fn from(_: i32) -> Self {
+        panic!()
+    }
+}
+
+impl From<u32> for Int {
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "u32_to_int"]
+    fn from(_: u32) -> Self {
+        panic!()
+    }
+}
+
+impl From<usize> for Int {
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "usize_to_int"]
+    fn from(_: usize) -> Self {
+        panic!()
+    }
+}
+
+impl Add<Int> for Int {
+    type Output = Int;
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "add_int"]
+    fn add(self, _: Int) -> Self {
+        panic!()
+    }
+}
+
+impl Sub<Int> for Int {
+    type Output = Int;
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "sub_int"]
+    fn sub(self, _: Int) -> Self {
+        panic!()
+    }
+}
+
+impl Mul<Int> for Int {
+    type Output = Int;
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "mul_int"]
+    fn mul(self, _: Int) -> Self {
+        panic!()
+    }
+}
+
+impl Div<Int> for Int {
+    type Output = Int;
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "div_int"]
+    fn div(self, _: Int) -> Self {
+        panic!()
+    }
+}
+
+impl Rem<Int> for Int {
+    type Output = Int;
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "rem_int"]
+    fn rem(self, _: Int) -> Self {
+        panic!()
+    }
+}
+
+impl Neg for Int {
+    type Output = Int;
+    #[creusot::spec::no_translate]
+    #[rustc_diagnostic_item = "neg_int"]
+    fn neg(self) -> Self {
+        panic!()
+    }
+}

--- a/creusot-contracts/src/builtins/seq.rs
+++ b/creusot-contracts/src/builtins/seq.rs
@@ -1,0 +1,36 @@
+use creusot_contracts_proc::*;
+
+use crate::Int;
+
+#[creusot::builtins = "seq.Seq.seq"]
+pub struct Seq<T>(std::marker::PhantomData<T>);
+
+impl<T> Seq<T> {
+    #[trusted]
+    #[logic_rust]
+    #[creusot::builtins = "seq.Seq.get"]
+    pub fn index(self, ix: Int) -> T {
+        std::process::abort()
+    }
+
+    #[trusted]
+    #[logic_rust]
+    #[creusot::builtins = "seq.Seq.length"]
+    pub fn len(self) -> Int {
+        std::process::abort()
+    }
+
+    #[trusted]
+    #[logic_rust]
+    #[creusot::builtins = "seq.Seq.set"]
+    pub fn set(self, ix: Int, v: T) -> Self {
+        std::process::abort()
+    }
+
+    #[trusted]
+    #[logic_rust]
+    #[creusot::builtins = "seq.Seq.snoc"]
+    pub fn push(self, v: T) -> Self {
+        std::process::abort()
+    }
+}

--- a/creusot/src/translation/builtins.rs
+++ b/creusot/src/translation/builtins.rs
@@ -3,12 +3,13 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::{symbol::sym, Symbol};
 use why3::mlcfg::{BinOp, Constant, Exp, UnOp};
 
-use crate::ctx::TranslationCtx;
+use crate::{clone_map::CloneMap, ctx::TranslationCtx, util::get_builtin};
 
 use super::traits::{resolve_opt, MethodInstance};
 
 pub fn lookup_builtin(
     ctx: &mut TranslationCtx<'_, 'tcx>,
+    names: &mut CloneMap<'tcx>,
     method: &MethodInstance<'tcx>,
     args: &mut Vec<Exp>,
 ) -> Option<Exp> {
@@ -121,6 +122,9 @@ pub fn lookup_builtin(
         return Some(Exp::Absurd);
     } else if ctx.tcx.def_path_str(def_id.unwrap()) == "std::boxed::Box::<T>::new" {
         return Some(args.remove(0));
+    } else if let Some(builtin) = get_builtin(ctx.tcx, def_id.unwrap()) {
+        names.import_builtin_module(builtin.clone().module_qname());
+        return Some(Exp::Call(box Exp::QVar(builtin.without_search_path()), args.clone()));
     }
     None
 }

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -22,7 +22,7 @@ pub fn default_decl(ctx: &mut TranslationCtx, def_id: DefId, _span: rustc_span::
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));
 
     let sig = crate::util::signature_of(ctx, &mut names, def_id);
-    let name = translate_value_id(ctx.tcx, def_id).module_name().unwrap().clone();
+    let name = translate_value_id(ctx.tcx, def_id).module_ident().unwrap().clone();
 
     decls.extend(names.to_clones(ctx));
     decls.push(Decl::ValDecl(Val { sig }));

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -137,7 +137,7 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
 
         if util::is_trusted(self.tcx, self.def_id) {
             decls.push(Decl::ValDecl(ValKind::Val { sig }));
-            return Module { name: name.module_name().unwrap().clone(), decls };
+            return Module { name: name.module_ident().unwrap().clone(), decls };
         }
 
         self.translate_body();
@@ -165,7 +165,7 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
             entry,
             blocks: self.past_blocks,
         }));
-        Module { name: name.module_name().unwrap().clone(), decls }
+        Module { name: name.module_ident().unwrap().clone(), decls }
     }
 
     fn translate_body(&mut self) {

--- a/creusot/src/translation/interface.rs
+++ b/creusot/src/translation/interface.rs
@@ -49,5 +49,5 @@ pub fn interface_for(
 pub fn interface_name(tcx: TyCtxt, def_id: DefId) -> Ident {
     let name = translate_value_id(tcx, def_id);
 
-    format!("{}_Interface", Cow::from(name.module_name().unwrap_or(&name.name()))).into()
+    format!("{}_Interface", Cow::from(name.module_ident().unwrap_or(&name.name()))).into()
 }

--- a/creusot/src/translation/logic.rs
+++ b/creusot/src/translation/logic.rs
@@ -15,7 +15,7 @@ pub fn translate_logic(
     names.clone_self(def_id);
 
     let sig = crate::util::signature_of(ctx, &mut names, def_id);
-    let name = translate_value_id(ctx.tcx, def_id).module_name().unwrap().clone();
+    let name = translate_value_id(ctx.tcx, def_id).module_ident().unwrap().clone();
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));
@@ -45,7 +45,7 @@ pub fn translate_predicate(
 
     let mut sig = crate::util::signature_of(ctx, &mut names, def_id);
     sig.retty = None;
-    let name = translate_value_id(ctx.tcx, def_id).module_name().unwrap().clone();
+    let name = translate_value_id(ctx.tcx, def_id).module_ident().unwrap().clone();
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));

--- a/creusot/src/translation/pure.rs
+++ b/creusot/src/translation/pure.rs
@@ -24,7 +24,7 @@ pub fn translate_pure(
 
     let sig = crate::util::signature_of(ctx, &mut names, def_id);
 
-    let name = translate_value_id(ctx.tcx, def_id).module_name().unwrap().clone();
+    let name = translate_value_id(ctx.tcx, def_id).module_ident().unwrap().clone();
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));
@@ -123,5 +123,5 @@ fn implementation_module(
 pub fn impl_name(tcx: TyCtxt, def_id: DefId) -> Ident {
     let name = translate_value_id(tcx, def_id);
 
-    format!("{}_Impl", Cow::from(name.module_name().unwrap())).into()
+    format!("{}_Impl", Cow::from(name.module_ident().unwrap())).into()
 }

--- a/creusot/src/translation/specification/lower.rs
+++ b/creusot/src/translation/specification/lower.rs
@@ -47,7 +47,7 @@ pub fn lower_term_to_why3<'tcx>(
                 return args.remove(0);
             }
 
-            builtins::lookup_builtin(ctx, &method, &mut args).unwrap_or_else(|| {
+            builtins::lookup_builtin(ctx, names, &method, &mut args).unwrap_or_else(|| {
                 ctx.translate(method.def_id);
                 let clone = names.insert(method.def_id, method.substs);
                 Exp::Call(box Exp::QVar(clone.qname_sym(method.ident)), args)

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -5,6 +5,7 @@ use rustc_hir::{def::DefKind, def_id::DefId};
 use rustc_middle::ty::Attributes;
 use rustc_middle::ty::{DefIdTree, TyCtxt};
 use rustc_span::Symbol;
+use why3::QName;
 use why3::{
     declaration::Signature,
     mlcfg::{Constant, Exp},
@@ -75,6 +76,12 @@ pub fn should_translate(tcx: TyCtxt, mut def_id: DefId) -> bool {
             return true;
         }
     }
+}
+
+pub fn get_builtin(tcx: TyCtxt, def_id: DefId) -> Option<QName> {
+    get_attr(tcx.get_attrs(def_id), &["creusot", "builtins"])
+        .and_then(|a| ts_to_symbol(a.args.inner_tokens()))
+        .and_then(|a| QName::from_string(&a.as_str()))
 }
 
 pub(crate) fn method_name(tcx: TyCtxt, def_id: DefId) -> Ident {

--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -72,12 +72,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -106,10 +106,10 @@ module AllZero_AllZero
   clone AllZero_Len as Len0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = ()
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = Type.allzero_list
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve3 with type t = Type.allzero_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve2 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.allzero_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = Type.allzero_list
   let rec cfg all_zero (l : borrowed (Type.allzero_list)) : ()
     ensures { Len0.len ( * l) = Len0.len ( ^ l) }
     ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) -> Get0.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -9,14 +9,14 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
+  type c01_even  = 
+    | C01_Even
+    
   type core_marker_phantomdata 't = 
     | Core_Marker_PhantomData
     
   type core_cell_unsafecell 't = 
     | Core_Cell_UnsafeCell 't
-    
-  type c01_even  = 
-    | C01_Even
     
   type core_cell_cell 't = 
     | Core_Cell_Cell (core_cell_unsafecell 't)

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -9,14 +9,14 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_option_option 't = 
-    | Core_Option_Option_None
-    | Core_Option_Option_Some 't
-    
   type core_cmp_ordering  = 
     | Core_Cmp_Ordering_Less
     | Core_Cmp_Ordering_Equal
     | Core_Cmp_Ordering_Greater
+    
+  type core_option_option 't = 
+    | Core_Option_Option_None
+    | Core_Option_Option_Some 't
     
 end
 module Core_Cmp_PartialEq

--- a/creusot/tests/should_succeed/drop_pair.stdout
+++ b/creusot/tests/should_succeed/drop_pair.stdout
@@ -29,12 +29,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl11_Resolve_Interface
+module CreusotContracts_Builtins_Impl0_Resolve_Interface
   type t1   
   type t2   
   predicate resolve (self : (t1, t2))
 end
-module CreusotContracts_Builtins_Impl11_Resolve
+module CreusotContracts_Builtins_Impl0_Resolve
   type t1   
   type t2   
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t2
@@ -42,27 +42,27 @@ module CreusotContracts_Builtins_Impl11_Resolve
   predicate resolve (self : (t1, t2)) = 
     Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Builtins_Impl12_Interface
+module CreusotContracts_Builtins_Impl1_Interface
   type t   
   use prelude.Prelude
-  clone export CreusotContracts_Builtins_Impl12_Resolve_Interface with type t = t
+  clone export CreusotContracts_Builtins_Impl1_Resolve_Interface with type t = t
   clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
 end
-module CreusotContracts_Builtins_Impl12
+module CreusotContracts_Builtins_Impl1
   type t   
   use prelude.Prelude
-  clone export CreusotContracts_Builtins_Impl12_Resolve with type t = t
+  clone export CreusotContracts_Builtins_Impl1_Resolve with type t = t
   clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
 end
 module DropPair_DropPair2_Interface
@@ -75,8 +75,8 @@ module DropPair_DropPair2
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl12 as Resolve1 with type t = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t1 = borrowed uint32, type t2 = borrowed uint32,
+  clone CreusotContracts_Builtins_Impl1 as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl0_Resolve as Resolve0 with type t1 = borrowed uint32, type t2 = borrowed uint32,
   predicate Resolve1.resolve = Resolve1.resolve
   let rec cfg drop_pair2 (x : (borrowed uint32, borrowed uint32)) : () = 
   var _0 : ();
@@ -105,7 +105,7 @@ module DropPair_Drop
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = uint32
   let rec cfg drop (x : borrowed uint32) (y : borrowed uint32) : () = 
   var _0 : ();
   var x_1 : borrowed uint32;
@@ -133,7 +133,7 @@ module DropPair_DropPair_Interface
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl11_Resolve_Interface as Resolve0 with type t1 = borrowed uint32,
+  clone CreusotContracts_Builtins_Impl0_Resolve_Interface as Resolve0 with type t1 = borrowed uint32,
   type t2 = borrowed uint32
   val drop_pair (x : (borrowed uint32, borrowed uint32)) : ()
     ensures {  ^ (let (a, _) = x in a) =  * (let (a, _) = x in a) }
@@ -144,8 +144,8 @@ module DropPair_DropPair
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl12 as Resolve1 with type t = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t1 = borrowed uint32, type t2 = borrowed uint32,
+  clone CreusotContracts_Builtins_Impl1 as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl0_Resolve as Resolve0 with type t1 = borrowed uint32, type t2 = borrowed uint32,
   predicate Resolve1.resolve = Resolve1.resolve
   let rec cfg drop_pair (x : (borrowed uint32, borrowed uint32)) : ()
     ensures {  ^ (let (a, _) = x in a) =  * (let (a, _) = x in a) }

--- a/creusot/tests/should_succeed/inc_max.stdout
+++ b/creusot/tests/should_succeed/inc_max.stdout
@@ -14,12 +14,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -41,7 +41,7 @@ module IncMax_TakeMax
   use mach.int.Int
   use mach.int.UInt32
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { match ( * ma >=  * mb) with
@@ -134,7 +134,7 @@ module IncMax_IncMax
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = uint32
   clone IncMax_TakeMax_Interface as TakeMax0
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max (a : uint32) (b : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32)}
     

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -14,12 +14,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -49,10 +49,10 @@ end
 module IncMax3_IncMax3
   use prelude.Prelude
   use mach.int.Int
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = int
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve4 with type t = int
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
   clone IncMax3_Swap_Interface as Swap0
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = borrowed int
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve2 with type t = borrowed int
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = int
   let rec cfg inc_max_3 (ma : borrowed int) (mb : borrowed int) (mc : borrowed int) : ()
@@ -252,7 +252,7 @@ module IncMax3_TestIncMax3
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = int
   clone IncMax3_IncMax3_Interface as IncMax30
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = int
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = int
   let rec cfg test_inc_max_3 (a : int) (b : int) (c : int) : () = 
   var _0 : ();
   var a_1 : int;

--- a/creusot/tests/should_succeed/inc_max_many.stdout
+++ b/creusot/tests/should_succeed/inc_max_many.stdout
@@ -14,12 +14,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -41,7 +41,7 @@ module IncMaxMany_TakeMax
   use mach.int.Int
   use mach.int.UInt32
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { match ( * ma >=  * mb) with
@@ -134,7 +134,7 @@ module IncMaxMany_IncMaxMany
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = uint32
   clone IncMaxMany_TakeMax_Interface as TakeMax0
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max_many (a : uint32) (b : uint32) (k : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && k <= (1000000 : uint32)}
     

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -14,12 +14,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -41,7 +41,7 @@ module IncMaxRepeat_TakeMax
   use mach.int.Int
   use mach.int.UInt32
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { match ( * ma >=  * mb) with
@@ -132,7 +132,7 @@ module IncMaxRepeat_IncMaxRepeat
   clone Core_Panicking_Panic_Interface as Panic0
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
   clone IncMaxRepeat_TakeMax_Interface as TakeMax0
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve2 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg inc_max_repeat (a : uint32) (b : uint32) (n : uint32) : ()

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -159,12 +159,12 @@ module IncSome2List_Impl1_SumX
   }
   
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -197,14 +197,14 @@ module IncSome2List_Impl1_TakeSomeRest
   use mach.int.UInt32
   clone IncSome2List_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve6 with type t = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve5 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
   clone Rand_Random_Interface as Random0 with type t = bool
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsome2list_list
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = Type.incsome2list_list
   clone IncSome2List_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some_rest (self : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
@@ -308,12 +308,12 @@ module IncSome2List_Impl1_TakeSomeRest
   }
   
 end
-module CreusotContracts_Builtins_Impl11_Resolve_Interface
+module CreusotContracts_Builtins_Impl0_Resolve_Interface
   type t1   
   type t2   
   predicate resolve (self : (t1, t2))
 end
-module CreusotContracts_Builtins_Impl11_Resolve
+module CreusotContracts_Builtins_Impl0_Resolve
   type t1   
   type t2   
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t2
@@ -333,16 +333,16 @@ module Core_Panicking_Panic
     ensures { false }
     
 end
-module CreusotContracts_Builtins_Impl12_Interface
+module CreusotContracts_Builtins_Impl1_Interface
   type t   
   use prelude.Prelude
-  clone export CreusotContracts_Builtins_Impl12_Resolve_Interface with type t = t
+  clone export CreusotContracts_Builtins_Impl1_Resolve_Interface with type t = t
   clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
 end
-module CreusotContracts_Builtins_Impl12
+module CreusotContracts_Builtins_Impl1
   type t   
   use prelude.Prelude
-  clone export CreusotContracts_Builtins_Impl12_Resolve with type t = t
+  clone export CreusotContracts_Builtins_Impl1_Resolve with type t = t
   clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
 end
 module IncSome2List_IncSome2List_Interface
@@ -367,13 +367,13 @@ module IncSome2List_IncSome2List
   clone Core_Panicking_Panic_Interface as Panic0
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
-  clone CreusotContracts_Builtins_Impl12 as Resolve8 with type t = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Impl12 as Resolve7 with type t = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t1 = borrowed uint32,
+  clone CreusotContracts_Builtins_Impl1 as Resolve8 with type t = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Impl1 as Resolve7 with type t = uint32
+  clone CreusotContracts_Builtins_Impl0_Resolve as Resolve2 with type t1 = borrowed uint32,
   type t2 = borrowed (Type.incsome2list_list), predicate Resolve0.resolve = Resolve7.resolve,
   predicate Resolve1.resolve = Resolve8.resolve
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsome2list_list
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = Type.incsome2list_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = uint32
   clone IncSome2List_Impl1_TakeSomeRest_Interface as TakeSomeRest0 with function Sum0.sum = Sum0.sum
   clone IncSome2List_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_2_list (l : Type.incsome2list_list) (j : uint32) (k : uint32) : ()

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -188,12 +188,12 @@ module IncSome2Tree_Impl1_SumX
   }
   
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -226,14 +226,14 @@ module IncSome2Tree_Impl1_TakeSomeRest
   use mach.int.UInt32
   clone IncSome2Tree_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve6 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve5 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
   clone Rand_Random_Interface as Random0 with type t = bool
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsome2tree_tree
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = Type.incsome2tree_tree
   clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some_rest (self : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
@@ -411,12 +411,12 @@ module IncSome2Tree_Impl1_TakeSomeRest
   }
   
 end
-module CreusotContracts_Builtins_Impl11_Resolve_Interface
+module CreusotContracts_Builtins_Impl0_Resolve_Interface
   type t1   
   type t2   
   predicate resolve (self : (t1, t2))
 end
-module CreusotContracts_Builtins_Impl11_Resolve
+module CreusotContracts_Builtins_Impl0_Resolve
   type t1   
   type t2   
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t2
@@ -436,16 +436,16 @@ module Core_Panicking_Panic
     ensures { false }
     
 end
-module CreusotContracts_Builtins_Impl12_Interface
+module CreusotContracts_Builtins_Impl1_Interface
   type t   
   use prelude.Prelude
-  clone export CreusotContracts_Builtins_Impl12_Resolve_Interface with type t = t
+  clone export CreusotContracts_Builtins_Impl1_Resolve_Interface with type t = t
   clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
 end
-module CreusotContracts_Builtins_Impl12
+module CreusotContracts_Builtins_Impl1
   type t   
   use prelude.Prelude
-  clone export CreusotContracts_Builtins_Impl12_Resolve with type t = t
+  clone export CreusotContracts_Builtins_Impl1_Resolve with type t = t
   clone export CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
 end
 module IncSome2Tree_IncSome2Tree_Interface
@@ -470,13 +470,13 @@ module IncSome2Tree_IncSome2Tree
   clone Core_Panicking_Panic_Interface as Panic0
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = uint32
-  clone CreusotContracts_Builtins_Impl12 as Resolve8 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Impl12 as Resolve7 with type t = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t1 = borrowed uint32,
+  clone CreusotContracts_Builtins_Impl1 as Resolve8 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Impl1 as Resolve7 with type t = uint32
+  clone CreusotContracts_Builtins_Impl0_Resolve as Resolve2 with type t1 = borrowed uint32,
   type t2 = borrowed (Type.incsome2tree_tree), predicate Resolve0.resolve = Resolve7.resolve,
   predicate Resolve1.resolve = Resolve8.resolve
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = uint32
   clone IncSome2Tree_Impl1_TakeSomeRest_Interface as TakeSomeRest0 with function Sum0.sum = Sum0.sum
   clone IncSome2Tree_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_2_tree (t : Type.incsome2tree_tree) (j : uint32) (k : uint32) : ()

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -159,12 +159,12 @@ module IncSomeList_Impl1_SumX
   }
   
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -196,14 +196,14 @@ module IncSomeList_Impl1_TakeSome
   use mach.int.UInt32
   clone IncSomeList_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve6 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.incsomelist_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve4 with type t = Type.incsomelist_list
   clone Rand_Random_Interface as Random0 with type t = bool
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsomelist_list
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.incsomelist_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = Type.incsomelist_list
   clone IncSomeList_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some (self : borrowed (Type.incsomelist_list)) : borrowed uint32
     ensures {  * result <= Sum0.sum ( * self) }
@@ -358,7 +358,7 @@ module IncSomeList_IncSomeList
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
   clone Core_Panicking_Panic_Interface as Panic0
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   clone IncSomeList_Impl1_TakeSome_Interface as TakeSome0 with function Sum0.sum = Sum0.sum
   clone IncSomeList_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -188,12 +188,12 @@ module IncSomeTree_Impl1_SumX
   }
   
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -225,14 +225,14 @@ module IncSomeTree_Impl1_TakeSome
   use mach.int.UInt32
   clone IncSomeTree_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve6 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.incsometree_tree
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve4 with type t = Type.incsometree_tree
   clone Rand_Random_Interface as Random0 with type t = bool
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.incsometree_tree
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.incsometree_tree
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = Type.incsometree_tree
   clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some (self : borrowed (Type.incsometree_tree)) : borrowed uint32
     ensures {  * result <= Sum0.sum ( * self) }
@@ -437,7 +437,7 @@ module IncSomeTree_IncSomeTree
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
   clone Core_Panicking_Panic_Interface as Panic0
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   clone IncSomeTree_Impl1_TakeSome_Interface as TakeSome0 with function Sum0.sum = Sum0.sum
   clone IncSomeTree_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -13,11 +13,11 @@ module Type
     | Core_Option_Option_None
     | Core_Option_Option_Some 't
     
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
   type alloc_alloc_global  = 
     | Alloc_Alloc_Global
+    
+  type core_marker_phantomdata 't = 
+    | Core_Marker_PhantomData
     
   type core_ptr_unique_unique 't = 
     | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
@@ -33,12 +33,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -76,7 +76,7 @@ module InvariantMoves_TestInvariantMove
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.core_option_option uint32
   clone Alloc_Vec_Impl1_Pop_Interface as Pop0 with type t = uint32, type a = Type.alloc_alloc_global
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
   let rec cfg test_invariant_move (x : Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)) : () = 
   var _0 : ();
   var x_1 : Type.alloc_vec_vec uint32 (Type.alloc_alloc_global);

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -21,12 +21,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -104,14 +104,14 @@ module ListIndexMut_IndexMut
   clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
   use mach.int.Int64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve6 with type t = uint32
   clone Std_Process_Abort_Interface as Abort0
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve4 with type t = Type.listindexmut_list
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = usize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = Type.listindexmut_list
   let rec cfg index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
     requires {param_ix < Len0.len ( * param_l)}
     ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
@@ -253,9 +253,9 @@ module ListIndexMut_Write
   use mach.int.UInt32
   clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve3 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = Type.listindexmut_list
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   clone ListIndexMut_IndexMut_Interface as IndexMut0 with function Len0.len = Len0.len, function Get0.get = Get0.get
   let rec cfg write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
@@ -324,7 +324,7 @@ module ListIndexMut_Main
   clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
   clone ListIndexMut_Write_Interface as Write0 with function Len0.len = Len0.len, function Get0.get = Get0.get
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = Type.listindexmut_list
   let rec cfg main () : () = 
   var _0 : ();
   var l_1 : Type.listindexmut_list;

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -14,12 +14,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -50,7 +50,7 @@ module ProjectionToggle_ProjToggle
   use prelude.Prelude
   clone Core_Cmp_PartialEq as PartialEq0 with type self = t, type rhs = t
   clone Core_Marker_Sized as Sized0 with type self = t
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = t
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = t
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = bool
   let rec cfg proj_toggle (toggle : bool) (a : borrowed t) (b : borrowed t) : borrowed t
     ensures { match (toggle) with
@@ -137,7 +137,7 @@ module ProjectionToggle_Main
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
   clone ProjectionToggle_ProjToggle_Interface as ProjToggle0 with type t = int32
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = int32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = int32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = int32
   let rec cfg main () : () = 
   var _0 : ();
   var a_1 : int32;

--- a/creusot/tests/should_succeed/trait.stdout
+++ b/creusot/tests/should_succeed/trait.stdout
@@ -9,14 +9,14 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_option_option 't = 
-    | Core_Option_Option_None
-    | Core_Option_Option_Some 't
-    
   type core_cmp_ordering  = 
     | Core_Cmp_Ordering_Less
     | Core_Cmp_Ordering_Equal
     | Core_Cmp_Ordering_Greater
+    
+  type core_option_option 't = 
+    | Core_Option_Option_None
+    | Core_Option_Option_Some 't
     
 end
 module Core_Marker_Sized

--- a/creusot/tests/should_succeed/unnest.stdout
+++ b/creusot/tests/should_succeed/unnest.stdout
@@ -29,12 +29,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -54,8 +54,8 @@ module Unnest_Unnest
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = borrowed uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve0 with type t = borrowed uint32
   let rec cfg unnest (x : borrowed (borrowed uint32)) : borrowed uint32
     ensures {  ^  * x =  ^  ^ x }
     ensures {  ^ result =  *  ^ x }

--- a/creusot/tests/should_succeed/vector/01.rs
+++ b/creusot/tests/should_succeed/vector/01.rs
@@ -7,74 +7,6 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-enum List<T> {
-    Cons(T, Box<List<T>>),
-    Nil,
-}
-impl<T> WellFounded for List<T> {}
-
-use List::*;
-
-impl<T> List<T> {
-    // This is sucky because why3 won't automatically attempt to rewrite using the `def` axiom
-    #[pure]
-    #[ensures(result >= 0)]
-    #[variant(*self)]
-    fn len(&self) -> Int {
-        match self {
-            Cons(_, ls) => Int::from(1) + ls.len(),
-            Nil => 0.into(),
-        }
-    }
-
-    #[logic_rust]
-    fn get(self, ix: Int) -> Option<T> {
-        match self {
-            Cons(hd, tl) => {
-                if ix == 0 {
-                    Some(hd)
-                } else {
-                    tl.get(ix - 1)
-                }
-            }
-            Nil => None,
-        }
-    }
-
-    #[logic_rust]
-    fn push(self, v: T) -> Self {
-        match self {
-            Cons(h, tl) => Cons(h, Box::new(tl.push(v))),
-            Nil => Cons(v, Box::new(Nil)),
-        }
-    }
-
-    #[pure]
-    #[requires(0 <= ix && ix < self.len())]
-    #[ensures(Some(result) === self.get(ix))]
-    #[variant(self)]
-    fn index(self, ix: Int) -> T {
-        match self {
-            Cons(x, ls) => {
-                if ix == Int::from(0) {
-                    x
-                } else {
-                    ls.index(ix - Int::from(1))
-                }
-            }
-            Nil => unreachable!("invalid index"),
-        }
-    }
-}
-
-#[logic_rust]
-fn as_ref<'a, T>(opt: Option<&T>) -> &'a Option<T> {
-    match opt {
-        Some(r) => &Some(*r),
-        None => &None,
-    }
-}
-
 struct MyVec<T>(Vec<T>);
 
 pub struct GhostRecord<T>
@@ -99,7 +31,7 @@ impl<T> GhostRecord<T> {
 }
 
 impl<T> Model for MyVec<T> {
-    type ModelTy = List<T>;
+    type ModelTy = Seq<T>;
     #[logic_rust]
     #[trusted]
     fn model(self) -> Self::ModelTy {
@@ -115,7 +47,10 @@ impl<T> MyVec<T> {
     }
 
     #[trusted]
-    #[ensures(*as_ref(result) === (@*self).get(ix.into()))]
+    #[ensures(match result {
+        Some(t) => *t === (@*self).index(ix.into()),
+        None => (@*self).len() <= ix.into(),
+    })]
     fn get(&self, ix: usize) -> Option<&T> {
         self.0.get(ix)
     }

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -9,22 +9,18 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type c01_ghostrecord 't = 
-    | C01_GhostRecord
-    
   type core_option_option 't = 
     | Core_Option_Option_None
     | Core_Option_Option_Some 't
     
-  type c01_list 't = 
-    | C01_List_Cons 't (c01_list 't)
-    | C01_List_Nil
+  type alloc_alloc_global  = 
+    | Alloc_Alloc_Global
+    
+  type core_marker_phantomdata 't = 
+    | Core_Marker_PhantomData
+    
+  type c01_ghostrecord 't = 
+    | C01_GhostRecord
     
   type core_ptr_unique_unique 't = 
     | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
@@ -54,378 +50,232 @@ module C01_Main
   }
   
 end
-module C01_Impl1_Len_Interface
+module C01_Impl0_Model_Interface
   type t   
-  use mach.int.Int
-  use mach.int.Int32
-  use prelude.Prelude
   use Type
-  function len (self : Type.c01_list t) : int
+  function model (self : Type.c01_ghostrecord t) : t
 end
-module C01_Impl1_Len
+module C01_Impl0_Model
   type t   
-  use mach.int.Int
-  use mach.int.Int32
+  use Type
+  function model (self : Type.c01_ghostrecord t) : t
+end
+module C01_Impl1_Record_Interface
+  type t   
   use prelude.Prelude
   use Type
-  function len (self : Type.c01_list t) : int
-  val len (self : Type.c01_list t) : int
-    ensures { result >= 0 }
-    ensures { result = len self }
+  clone C01_Impl0_Model_Interface as Model0 with type t = t
+  val record (a : t) : Type.c01_ghostrecord t
+    ensures { Model0.model result = a }
     
-  axiom spec : forall self : Type.c01_list t . len self >= 0
-  axiom def : forall self : Type.c01_list t . len self = match (self) with
-    | Type.C01_List_Cons _ ls -> 1 + len ls
-    | Type.C01_List_Nil -> 0
-    end
 end
-module C01_Impl1_Len_Impl
+module C01_Impl1_Record
   type t   
-  use mach.int.Int
-  use mach.int.Int32
   use prelude.Prelude
   use Type
-  let rec len (self : Type.c01_list t) : int
-    ensures { result >= 0 }
-    variant {self}
+  clone C01_Impl0_Model as Model0 with type t = t
+  val record (a : t) : Type.c01_ghostrecord t
+    ensures { Model0.model result = a }
     
-   = 
-    match (self) with
-      | Type.C01_List_Cons _ ls -> 1 + len ls
-      | Type.C01_List_Nil -> 0
-      end
-end
-module C01_Impl1_Get_Interface
-  type t   
-  use Type
-  use mach.int.Int
-  function get (self : Type.c01_list t) (ix : int) : Type.core_option_option t
-end
-module C01_Impl1_Get
-  type t   
-  use Type
-  use mach.int.Int
-  use mach.int.Int32
-  function get (self : Type.c01_list t) (ix : int) : Type.core_option_option t = 
-    match (self) with
-      | Type.C01_List_Cons hd tl -> match (ix = 0) with
-        | True -> Type.Core_Option_Option_Some hd
-        | False -> get tl (ix - 1)
-        end
-      | Type.C01_List_Nil -> Type.Core_Option_Option_None
-      end
-end
-module C01_Impl1_Push_Interface
-  type t   
-  use Type
-  function push (self : Type.c01_list t) (v : t) : Type.c01_list t
-end
-module C01_Impl1_Push
-  type t   
-  use Type
-  function push (self : Type.c01_list t) (v : t) : Type.c01_list t = 
-    match (self) with
-      | Type.C01_List_Cons h tl -> Type.C01_List_Cons h (push tl v)
-      | Type.C01_List_Nil -> Type.C01_List_Cons v (Type.C01_List_Nil)
-      end
-end
-module C01_Impl1_Index_Interface
-  type t   
-  use mach.int.Int
-  use mach.int.Int32
-  use Type
-  clone C01_Impl1_Get_Interface as Get0 with type t = t
-  clone C01_Impl1_Len_Interface as Len0 with type t = t
-  function index (self : Type.c01_list t) (ix : int) : t
-end
-module C01_Impl1_Index
-  type t   
-  use mach.int.Int
-  use mach.int.Int32
-  use Type
-  clone C01_Impl1_Get_Interface as Get0 with type t = t
-  clone C01_Impl1_Len_Interface as Len0 with type t = t
-  function index (self : Type.c01_list t) (ix : int) : t
-  val index (self : Type.c01_list t) (ix : int) : t
-    requires {0 <= ix && ix < Len0.len self}
-    ensures { Type.Core_Option_Option_Some result = Get0.get self ix }
-    ensures { result = index self ix }
-    
-  axiom spec : forall self : Type.c01_list t, ix : int . 0 <= ix && ix < Len0.len self -> Type.Core_Option_Option_Some (index self ix) = Get0.get self ix
-end
-module C01_Impl1_Index_Impl
-  type t   
-  use mach.int.Int
-  use mach.int.Int32
-  use Type
-  clone C01_Impl1_Get as Get0 with type t = t
-  clone C01_Impl1_Len as Len0 with type t = t, axiom .
-  let rec index (self : Type.c01_list t) (ix : int) : t
-    requires {0 <= ix && ix < Len0.len self}
-    ensures { Type.Core_Option_Option_Some result = Get0.get self ix }
-    variant {self}
-    
-   = 
-    match (self) with
-      | Type.C01_List_Cons x ls -> match (ix = 0) with
-        | True -> x
-        | False -> index ls (ix - 1)
-        end
-      | Type.C01_List_Nil -> absurd
-      end
-end
-module C01_AsRef_Interface
-  type t   
-  use Type
-  use prelude.Prelude
-  function as_ref (opt : Type.core_option_option t) : Type.core_option_option t
-end
-module C01_AsRef
-  type t   
-  use Type
-  use prelude.Prelude
-  function as_ref (opt : Type.core_option_option t) : Type.core_option_option t = 
-    match (opt) with
-      | Type.Core_Option_Option_Some r -> Type.Core_Option_Option_Some r
-      | Type.Core_Option_Option_None -> Type.Core_Option_Option_None
-      end
 end
 module C01_Impl2_Model_Interface
   type t   
   use Type
-  function model (self : Type.c01_ghostrecord t) : t
+  use seq.Seq
+  function model (self : Type.c01_myvec t) : Seq.seq t
 end
 module C01_Impl2_Model
   type t   
   use Type
-  function model (self : Type.c01_ghostrecord t) : t
+  use seq.Seq
+  function model (self : Type.c01_myvec t) : Seq.seq t
 end
-module C01_Impl3_Record_Interface
+module C01_Impl3_Len_Interface
   type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C01_Impl2_Model_Interface as Model0 with type t = t
+  val len (self : Type.c01_myvec t) : usize
+    ensures { result = Seq.length (Model0.model self) }
+    
+end
+module C01_Impl3_Len
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C01_Impl2_Model as Model0 with type t = t
+  val len (self : Type.c01_myvec t) : usize
+    ensures { result = Seq.length (Model0.model self) }
+    
+end
+module C01_Impl3_Get_Interface
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C01_Impl2_Model_Interface as Model0 with type t = t
+  val get (self : Type.c01_myvec t) (ix : usize) : Type.core_option_option t
+    ensures { match (result) with
+      | Type.Core_Option_Option_Some t -> t = Seq.get (Model0.model self) ix
+      | Type.Core_Option_Option_None -> Seq.length (Model0.model self) <= ix
+      end }
+    
+end
+module C01_Impl3_Get
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C01_Impl2_Model as Model0 with type t = t
+  val get (self : Type.c01_myvec t) (ix : usize) : Type.core_option_option t
+    ensures { match (result) with
+      | Type.Core_Option_Option_Some t -> t = Seq.get (Model0.model self) ix
+      | Type.Core_Option_Option_None -> Seq.length (Model0.model self) <= ix
+      end }
+    
+end
+module C01_Impl3_Push_Interface
+  type t   
+  use seq.Seq
   use prelude.Prelude
   use Type
   clone C01_Impl2_Model_Interface as Model0 with type t = t
-  val record (a : t) : Type.c01_ghostrecord t
-    ensures { Model0.model result = a }
+  val push (self : borrowed (Type.c01_myvec t)) (v : t) : ()
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model0.model ( * self)) v }
     
 end
-module C01_Impl3_Record
+module C01_Impl3_Push
   type t   
+  use seq.Seq
   use prelude.Prelude
   use Type
   clone C01_Impl2_Model as Model0 with type t = t
-  val record (a : t) : Type.c01_ghostrecord t
-    ensures { Model0.model result = a }
-    
-end
-module C01_Impl4_Model_Interface
-  type t   
-  use Type
-  function model (self : Type.c01_myvec t) : Type.c01_list t
-end
-module C01_Impl4_Model
-  type t   
-  use Type
-  function model (self : Type.c01_myvec t) : Type.c01_list t
-end
-module C01_Impl5_Len_Interface
-  type t   
-  use prelude.Prelude
-  use Type
-  use mach.int.Int
-  use mach.int.UInt64
-  clone C01_Impl1_Len_Interface as Len0 with type t = t
-  clone C01_Impl4_Model_Interface as Model0 with type t = t
-  val len (self : Type.c01_myvec t) : usize
-    ensures { result = Len0.len (Model0.model self) }
-    
-end
-module C01_Impl5_Len
-  type t   
-  use prelude.Prelude
-  use Type
-  use mach.int.Int
-  use mach.int.UInt64
-  clone C01_Impl1_Len as Len0 with type t = t, axiom .
-  clone C01_Impl4_Model as Model0 with type t = t
-  val len (self : Type.c01_myvec t) : usize
-    ensures { result = Len0.len (Model0.model self) }
-    
-end
-module C01_Impl5_Get_Interface
-  type t   
-  use prelude.Prelude
-  use Type
-  use mach.int.Int
-  use mach.int.UInt64
-  clone C01_Impl1_Get_Interface as Get0 with type t = t
-  clone C01_Impl4_Model_Interface as Model0 with type t = t
-  clone C01_AsRef_Interface as AsRef0 with type t = t
-  val get (self : Type.c01_myvec t) (ix : usize) : Type.core_option_option t
-    ensures { AsRef0.as_ref result = Get0.get (Model0.model self) ix }
-    
-end
-module C01_Impl5_Get
-  type t   
-  use prelude.Prelude
-  use Type
-  use mach.int.Int
-  use mach.int.UInt64
-  clone C01_Impl1_Get as Get0 with type t = t
-  clone C01_Impl4_Model as Model0 with type t = t
-  clone C01_AsRef as AsRef0 with type t = t
-  val get (self : Type.c01_myvec t) (ix : usize) : Type.core_option_option t
-    ensures { AsRef0.as_ref result = Get0.get (Model0.model self) ix }
-    
-end
-module C01_Impl5_Push_Interface
-  type t   
-  use prelude.Prelude
-  use Type
-  clone C01_Impl1_Push_Interface as Push0 with type t = t
-  clone C01_Impl4_Model_Interface as Model0 with type t = t
   val push (self : borrowed (Type.c01_myvec t)) (v : t) : ()
-    ensures { Model0.model ( ^ self) = Push0.push (Model0.model ( * self)) v }
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model0.model ( * self)) v }
     
 end
-module C01_Impl5_Push
+module C01_Impl3_Index_Interface
   type t   
-  use prelude.Prelude
-  use Type
-  clone C01_Impl1_Push as Push0 with type t = t
-  clone C01_Impl4_Model as Model0 with type t = t
-  val push (self : borrowed (Type.c01_myvec t)) (v : t) : ()
-    ensures { Model0.model ( ^ self) = Push0.push (Model0.model ( * self)) v }
-    
-end
-module C01_Impl5_Index_Interface
-  type t   
+  use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
   use mach.int.UInt64
-  clone C01_Impl1_Get_Interface as Get0 with type t = t
-  clone C01_Impl1_Len_Interface as Len0 with type t = t
-  clone C01_Impl1_Index_Interface as Index0 with type t = t, function Len0.len = Len0.len, function Get0.get = Get0.get
-  clone C01_Impl4_Model_Interface as Model0 with type t = t
+  clone C01_Impl2_Model_Interface as Model0 with type t = t
   val index (self : Type.c01_myvec t) (ix : usize) : t
-    requires {ix < Len0.len (Model0.model self)}
-    ensures { result = Index0.index (Model0.model self) ix }
+    requires {ix < Seq.length (Model0.model self)}
+    ensures { result = Seq.get (Model0.model self) ix }
     
 end
-module C01_Impl5_Index
+module C01_Impl3_Index
   type t   
+  use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
   use mach.int.UInt64
-  clone C01_Impl1_Get as Get0 with type t = t
-  clone C01_Impl1_Len as Len0 with type t = t, axiom .
-  clone C01_Impl1_Index as Index0 with type t = t, function Len0.len = Len0.len, function Get0.get = Get0.get, axiom .
-  clone C01_Impl4_Model as Model0 with type t = t
+  clone C01_Impl2_Model as Model0 with type t = t
   val index (self : Type.c01_myvec t) (ix : usize) : t
-    requires {ix < Len0.len (Model0.model self)}
-    ensures { result = Index0.index (Model0.model self) ix }
+    requires {ix < Seq.length (Model0.model self)}
+    ensures { result = Seq.get (Model0.model self) ix }
     
 end
-module C01_Impl5_IndexMut_Interface
+module C01_Impl3_IndexMut_Interface
   type t   
+  use seq.Seq
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
   use Type
   use mach.int.UInt64
-  clone C01_Impl1_Get_Interface as Get0 with type t = t
-  clone C01_Impl1_Len_Interface as Len0 with type t = t
-  clone C01_Impl1_Index_Interface as Index0 with type t = t, function Len0.len = Len0.len, function Get0.get = Get0.get
-  clone C01_Impl4_Model_Interface as Model0 with type t = t
+  clone C01_Impl2_Model_Interface as Model0 with type t = t
   val index_mut (self : borrowed (Type.c01_myvec t)) (ix : usize) : borrowed t
-    requires {ix < Len0.len (Model0.model ( * self))}
-    ensures { Len0.len (Model0.model ( * self)) = Len0.len (Model0.model ( ^ self)) }
-    ensures { forall j : (int) . 0 <= j && j <= Len0.len (Model0.model ( ^ self)) -> not (j = ix) -> Index0.index (Model0.model ( ^ self)) j = Index0.index (Model0.model ( * self)) j }
-    ensures {  ^ result = Index0.index (Model0.model ( ^ self)) ix }
-    ensures {  * result = Index0.index (Model0.model ( * self)) ix }
+    requires {ix < Seq.length (Model0.model ( * self))}
+    ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
+    ensures { forall j : (int) . 0 <= j && j <= Seq.length (Model0.model ( ^ self)) -> not (j = ix) -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
+    ensures {  ^ result = Seq.get (Model0.model ( ^ self)) ix }
+    ensures {  * result = Seq.get (Model0.model ( * self)) ix }
     
 end
-module C01_Impl5_IndexMut
+module C01_Impl3_IndexMut
   type t   
+  use seq.Seq
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
   use Type
   use mach.int.UInt64
-  clone C01_Impl1_Get as Get0 with type t = t
-  clone C01_Impl1_Len as Len0 with type t = t, axiom .
-  clone C01_Impl1_Index as Index0 with type t = t, function Len0.len = Len0.len, function Get0.get = Get0.get, axiom .
-  clone C01_Impl4_Model as Model0 with type t = t
+  clone C01_Impl2_Model as Model0 with type t = t
   val index_mut (self : borrowed (Type.c01_myvec t)) (ix : usize) : borrowed t
-    requires {ix < Len0.len (Model0.model ( * self))}
-    ensures { Len0.len (Model0.model ( * self)) = Len0.len (Model0.model ( ^ self)) }
-    ensures { forall j : (int) . 0 <= j && j <= Len0.len (Model0.model ( ^ self)) -> not (j = ix) -> Index0.index (Model0.model ( ^ self)) j = Index0.index (Model0.model ( * self)) j }
-    ensures {  ^ result = Index0.index (Model0.model ( ^ self)) ix }
-    ensures {  * result = Index0.index (Model0.model ( * self)) ix }
+    requires {ix < Seq.length (Model0.model ( * self))}
+    ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
+    ensures { forall j : (int) . 0 <= j && j <= Seq.length (Model0.model ( ^ self)) -> not (j = ix) -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
+    ensures {  ^ result = Seq.get (Model0.model ( ^ self)) ix }
+    ensures {  * result = Seq.get (Model0.model ( * self)) ix }
     
 end
 module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module C01_AllZero_Interface
+  use seq.Seq
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone C01_Impl1_Get_Interface as Get0 with type t = uint32
-  clone C01_Impl1_Len_Interface as Len0 with type t = uint32
-  clone C01_Impl1_Index_Interface as Index0 with type t = uint32, function Len0.len = Len0.len,
-  function Get0.get = Get0.get
-  clone C01_Impl4_Model_Interface as Model0 with type t = uint32
+  clone C01_Impl2_Model_Interface as Model0 with type t = uint32
   val all_zero (v : borrowed (Type.c01_myvec uint32)) : ()
-    ensures { Len0.len (Model0.model ( * v)) = Len0.len (Model0.model ( ^ v)) }
-    ensures { forall i : (int) . 0 <= i && i < Len0.len (Model0.model ( ^ v)) -> Index0.index (Model0.model ( ^ v)) i = (0 : uint32) }
+    ensures { Seq.length (Model0.model ( * v)) = Seq.length (Model0.model ( ^ v)) }
+    ensures { forall i : (int) . 0 <= i && i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = (0 : uint32) }
     
 end
 module C01_AllZero
+  use seq.Seq
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt32
   use prelude.Prelude
   use Type
-  clone C01_Impl1_Get as Get0 with type t = uint32
-  clone C01_Impl1_Len as Len0 with type t = uint32, axiom .
-  clone C01_Impl1_Index as Index0 with type t = uint32, function Len0.len = Len0.len, function Get0.get = Get0.get,
-  axiom .
-  clone C01_Impl4_Model as Model1 with type t = uint32
-  clone C01_Impl2_Model as Model0 with type t = borrowed (Type.c01_myvec uint32)
+  clone C01_Impl2_Model as Model1 with type t = uint32
+  clone C01_Impl0_Model as Model0 with type t = borrowed (Type.c01_myvec uint32)
   use mach.int.UInt64
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve6 with type t = Type.c01_myvec uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve6 with type t = Type.c01_myvec uint32
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve4 with type t = uint32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve4 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.c01_ghostrecord (borrowed (Type.c01_myvec uint32))
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = borrowed (Type.c01_myvec uint32)
-  clone C01_Impl5_IndexMut_Interface as IndexMut0 with type t = uint32, function Model0.model = Model1.model,
-  function Len0.len = Len0.len, function Index0.index = Index0.index, function Get0.get = Get0.get
-  clone C01_Impl5_Len_Interface as Len1 with type t = uint32, function Model0.model = Model1.model,
-  function Len0.len = Len0.len
-  clone C01_Impl3_Record_Interface as Record0 with type t = borrowed (Type.c01_myvec uint32),
+  clone C01_Impl3_IndexMut_Interface as IndexMut0 with type t = uint32, function Model0.model = Model1.model
+  clone C01_Impl3_Len_Interface as Len0 with type t = uint32, function Model0.model = Model1.model
+  clone C01_Impl1_Record_Interface as Record0 with type t = borrowed (Type.c01_myvec uint32),
   function Model0.model = Model0.model
   let rec cfg all_zero (v : borrowed (Type.c01_myvec uint32)) : ()
-    ensures { Len0.len (Model1.model ( * v)) = Len0.len (Model1.model ( ^ v)) }
-    ensures { forall i : (int) . 0 <= i && i < Len0.len (Model1.model ( ^ v)) -> Index0.index (Model1.model ( ^ v)) i = (0 : uint32) }
+    ensures { Seq.length (Model1.model ( * v)) = Seq.length (Model1.model ( ^ v)) }
+    ensures { forall i : (int) . 0 <= i && i < Seq.length (Model1.model ( ^ v)) -> Seq.get (Model1.model ( ^ v)) i = (0 : uint32) }
     
    = 
   var _0 : ();
@@ -463,15 +313,15 @@ module C01_AllZero
   }
   BB2 {
     invariant proph_const {  ^ v_1 =  ^ Model0.model old_v_3 };
-    invariant in_bounds { Len0.len (Model1.model ( * v_1)) = Len0.len (Model1.model ( * Model0.model old_v_3)) };
-    invariant all_zero { forall j : (int) . 0 <= j && j < i_2 -> Index0.index (Model1.model ( * v_1)) j = (0 : uint32) };
+    invariant in_bounds { Seq.length (Model1.model ( * v_1)) = Seq.length (Model1.model ( * Model0.model old_v_3)) };
+    invariant all_zero { forall j : (int) . 0 <= j && j < i_2 -> Seq.get (Model1.model ( * v_1)) j = (0 : uint32) };
     goto BB3
   }
   BB3 {
     assume { Resolve2.resolve _11 };
     _11 <- i_2;
     _13 <-  * v_1;
-    _12 <- Len1.len _13;
+    _12 <- Len0.len _13;
     goto BB4
   }
   BB4 {
@@ -513,52 +363,41 @@ module CreusotContracts_Builtins_Model
   type modelty   
   function model (self : self) : modelty
 end
-module C01_Impl2_Interface
+module C01_Impl0_Interface
   type t   
   use Type
-  clone export C01_Impl2_Model_Interface with type t = t
+  clone export C01_Impl0_Model_Interface with type t = t
   type modelty  = 
     t
   clone export CreusotContracts_Builtins_Model with type self = Type.c01_ghostrecord t, type modelty = modelty,
+  function model = model
+end
+module C01_Impl0
+  type t   
+  use Type
+  clone export C01_Impl0_Model with type t = t
+  type modelty  = 
+    t
+  clone export CreusotContracts_Builtins_Model with type self = Type.c01_ghostrecord t, type modelty = modelty,
+  function model = model
+end
+module C01_Impl2_Interface
+  type t   
+  use Type
+  use seq.Seq
+  clone export C01_Impl2_Model_Interface with type t = t
+  type modelty  = 
+    Seq.seq t
+  clone export CreusotContracts_Builtins_Model with type self = Type.c01_myvec t, type modelty = modelty,
   function model = model
 end
 module C01_Impl2
   type t   
   use Type
+  use seq.Seq
   clone export C01_Impl2_Model with type t = t
   type modelty  = 
-    t
-  clone export CreusotContracts_Builtins_Model with type self = Type.c01_ghostrecord t, type modelty = modelty,
-  function model = model
-end
-module C01_Impl4_Interface
-  type t   
-  use Type
-  clone export C01_Impl4_Model_Interface with type t = t
-  type modelty  = 
-    Type.c01_list t
+    Seq.seq t
   clone export CreusotContracts_Builtins_Model with type self = Type.c01_myvec t, type modelty = modelty,
   function model = model
-end
-module C01_Impl4
-  type t   
-  use Type
-  clone export C01_Impl4_Model with type t = t
-  type modelty  = 
-    Type.c01_list t
-  clone export CreusotContracts_Builtins_Model with type self = Type.c01_myvec t, type modelty = modelty,
-  function model = model
-end
-module CreusotContracts_WellFounded
-  type self   
-end
-module C01_Impl0_Interface
-  type t   
-  use Type
-  clone export CreusotContracts_WellFounded with type self = Type.c01_list t
-end
-module C01_Impl0
-  type t   
-  use Type
-  clone export CreusotContracts_WellFounded with type self = Type.c01_list t
 end

--- a/creusot/tests/should_succeed/while_let.stdout
+++ b/creusot/tests/should_succeed/while_let.stdout
@@ -18,12 +18,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
+module CreusotContracts_Builtins_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
-module CreusotContracts_Builtins_Impl12_Resolve
+module CreusotContracts_Builtins_Impl1_Resolve
   type t   
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
@@ -40,7 +40,7 @@ module WhileLet_Main
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = Type.whilelet_option int32
+  clone CreusotContracts_Builtins_Impl1_Resolve as Resolve1 with type t = Type.whilelet_option int32
   clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.whilelet_option int32
   let rec cfg main () : () = 
   var _0 : ();

--- a/why3/src/name.rs
+++ b/why3/src/name.rs
@@ -68,8 +68,28 @@ impl QName {
         self.name.clone()
     }
 
-    pub fn module_name(&self) -> Option<&Ident> {
+    // ooof this is a bad function
+    pub fn module_ident(&self) -> Option<&Ident> {
         self.module.last()
+    }
+
+    pub fn module_qname(mut self) -> QName {
+        assert!(self.module.len() > 0, "ident has no module");
+        let id = self.module.pop().unwrap();
+        self.name = id;
+        self
+    }
+
+    pub fn without_search_path(mut self) -> QName {
+        let mut i = 0;
+        while i < self.module.len() {
+            if self.module[i].starts_with(char::is_lowercase) {
+                self.module.remove(i);
+            } else {
+                i += 1
+            }
+        }
+        self
     }
 
     pub fn from_string(s: &str) -> Option<QName> {


### PR DESCRIPTION
Updates the vector test suite to use `Seq` as a model for vectors.
