### PR TITLE
Add `pearlite!` macro

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -151,7 +151,7 @@ Instead, we replace the `discriminant` / `switchInt` pair with a match directly 
 
 ## Logical functions
 
-Logical functions are created by `#[logic_rust]`/`logic!`, `#[pure]`, or `#[predicate_rust]`/`predicate!`.
+Logical functions are created by `#[logic]`, `#[pure]`, or `#[predicate]`.
 
 ## Specifications
 

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ Contracts and logic functions are written in Pearlite, a specification language 
 - Rust specific logical expressions: access to the **final** value of a mutable reference `^`, access to the *model* of an object `@`
 
 We also provide two new attributes on Rust functions: `logic` and `pure`.
-Marked either `logic` or `pure`, a function can be used in specs and other logical conditions (`requires`/`ensures` and `invariant`).
+Marked either `#[logic]` or `#[pure]`, a function can be used in specs and other logical conditions (`requires`/`ensures` and `invariant`).
 The two attributes have the following difference.
 - A `logic` function can freely have logical, non-executable operations, such as quantifiers, logic equalities, etc. Instead, this function can't be called in normal Rust code (the function body of a `logic` function is replaced with a panic).
-  To write logic functions, there are two ways: add `#[logic_rust]` attribute or put the function in `logic! { ... }` macro. The former gets better IDE support but the latter allows you to use pearlite syntax like `===` and `forall<x: T>`.
+  You can use pearlite syntax for any part in the logic function by marking that part with the `pearlite! { ... }` macro.
 - A `pure` function can be used in both normal Rust code and logical conditions.
 
 When you write *recursive* `logic` or `pure` functions, you have to show that the function terminates.

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -178,8 +178,8 @@ impl syn::parse::Parse for LogicItem {
     }
 }
 
-#[proc_macro]
-pub fn logic(tokens: TS1) -> TS1 {
+#[proc_macro_attribute]
+pub fn logic(_: TS1, tokens: TS1) -> TS1 {
     match syn::parse::<LogicItem>(tokens.clone()) {
         Ok(log) => logic_item(log),
         Err(_) => match syn::parse(tokens) {
@@ -233,8 +233,8 @@ impl syn::parse::Parse for PredicateItem {
     }
 }
 
-#[proc_macro]
-pub fn predicate(tokens: TS1) -> TS1 {
+#[proc_macro_attribute]
+pub fn predicate(_: TS1, tokens: TS1) -> TS1 {
     match syn::parse::<PredicateItem>(tokens.clone()) {
         Ok(log) => predicate_item(log),
         Err(_) => match syn::parse(tokens) {
@@ -280,16 +280,6 @@ pub fn trusted(_: TS1, tokens: TS1) -> TS1 {
 }
 
 #[proc_macro_attribute]
-pub fn logic_rust(_: TS1, tokens: TS1) -> TS1 {
-    logic(tokens)
-}
-
-#[proc_macro_attribute]
-pub fn predicate_rust(_: TS1, tokens: TS1) -> TS1 {
-    predicate(tokens)
-}
-
-#[proc_macro_attribute]
 pub fn pure(_: TS1, tokens: TS1) -> TS1 {
     let p: ItemFn = parse_macro_input!(tokens);
 
@@ -297,4 +287,10 @@ pub fn pure(_: TS1, tokens: TS1) -> TS1 {
         #[creusot::spec::pure]
         #p
     })
+}
+
+#[proc_macro]
+pub fn pearlite(tokens: TS1) -> TS1 {
+    let term: Term = parse_macro_input!(tokens);
+    TS1::from(pretyping::encode_term(term).unwrap())
 }

--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -17,30 +17,21 @@ pub fn encode_term(term: RT) -> Result<TokenStream, EncodeError> {
         RT::Binary(TermBinary { left, op, right }) => {
             let left = encode_term(*left)?;
             let right = encode_term(*right)?;
-
             Ok(quote! { #left #op #right })
         }
         RT::Block(TermBlock { block, .. }) => {
             let stmts: Vec<_> =
                 block.stmts.into_iter().map(encode_stmt).collect::<Result<_, _>>()?;
-
-            Ok(quote! {
-                {
-                    #(#stmts)*
-                }
-            })
+            Ok(quote! { { #(#stmts)* } })
         }
         RT::Call(TermCall { func, args, .. }) => {
             let func = encode_term(*func)?;
-
             let args: Vec<_> = args.into_iter().map(encode_term).collect::<Result<_, _>>()?;
-
             Ok(quote! { #func (#(#args),*)})
         }
         RT::Cast(_) => todo!("Cast"),
         RT::Field(TermField { base, member, .. }) => {
             let base = encode_term(*base)?;
-
             Ok(quote!({ #base . #member }))
         }
         RT::Group(_) => todo!("Group"),
@@ -55,10 +46,7 @@ pub fn encode_term(term: RT) -> Result<TokenStream, EncodeError> {
                 }
                 None => None,
             };
-
-            Ok(quote! {
-                if #cond { #(#then_branch)* } #else_branch
-            })
+            Ok(quote! { if #cond { #(#then_branch)* } #else_branch })
         }
         RT::Index(_) => todo!("Index"),
         RT::Let(_) => todo!("Let"),
@@ -69,24 +57,17 @@ pub fn encode_term(term: RT) -> Result<TokenStream, EncodeError> {
         RT::Match(TermMatch { expr, arms, .. }) => {
             let arms: Vec<_> = arms.into_iter().map(encode_arm).collect::<Result<_, _>>()?;
             let expr = encode_term(*expr)?;
-
-            Ok(quote! {
-                match #expr {
-                    #(#arms)*
-                }
-            })
+            Ok(quote! { match #expr { #(#arms)* } })
         }
         RT::MethodCall(TermMethodCall { receiver, method, turbofish, args, .. }) => {
             let receiver = encode_term(*receiver)?;
             let args: Vec<_> = args.into_iter().map(encode_term).collect::<Result<_, _>>()?;
 
-            Ok(quote! {
-                #receiver . #method #turbofish ( #(#args),*)
-            })
+            Ok(quote! { #receiver . #method #turbofish ( #(#args),*) })
         }
         RT::Paren(TermParen { expr, .. }) => {
             let term = encode_term(*expr)?;
-            Ok(quote! { (#term ) })
+            Ok(quote! { (#term) })
         }
         RT::Path(_) => Ok(quote! { #term }),
         RT::Range(_) => todo!("Range"),
@@ -94,10 +75,7 @@ pub fn encode_term(term: RT) -> Result<TokenStream, EncodeError> {
         RT::Struct(_) => todo!("Struct"),
         RT::Tuple(TermTuple { elems, .. }) => {
             let elems: Vec<_> = elems.into_iter().map(encode_term).collect::<Result<_, _>>()?;
-
-            Ok(quote! {
-                (#(#elems),*)
-            })
+            Ok(quote! { (#(#elems),*) })
         }
         RT::Type(ty) => Ok(quote! { #ty }),
         RT::Unary(TermUnary { op, expr }) => {
@@ -158,6 +136,7 @@ pub fn encode_term(term: RT) -> Result<TokenStream, EncodeError> {
             Ok(ts)
         }
         RT::Absurd(_) => Ok(quote! { creusot_contracts::stubs::abs() }),
+        RT::Pearlite(term) => Ok(quote! { (#term) }),
         RT::__Nonexhaustive => todo!(),
     }
 }

--- a/creusot-contracts/src/builtins/int.rs
+++ b/creusot-contracts/src/builtins/int.rs
@@ -59,7 +59,7 @@ impl From<u32> for Int {
 }
 impl Model for u32 {
     type ModelTy = Int;
-    #[logic_rust]
+    #[logic]
     #[rustc_diagnostic_item = "u32_model"]
     fn model(self) -> Self::ModelTy {
         Int::from(self)
@@ -75,7 +75,7 @@ impl From<i32> for Int {
 }
 impl Model for i32 {
     type ModelTy = Int;
-    #[logic_rust]
+    #[logic]
     #[rustc_diagnostic_item = "i32_model"]
     fn model(self) -> Self::ModelTy {
         Int::from(self)
@@ -91,7 +91,7 @@ impl From<usize> for Int {
 }
 impl Model for usize {
     type ModelTy = Int;
-    #[logic_rust]
+    #[logic]
     #[rustc_diagnostic_item = "usize_model"]
     fn model(self) -> Self::ModelTy {
         Int::from(self)
@@ -107,7 +107,7 @@ impl From<isize> for Int {
 }
 impl Model for isize {
     type ModelTy = Int;
-    #[logic_rust]
+    #[logic]
     #[rustc_diagnostic_item = "isize_model"]
     fn model(self) -> Self::ModelTy {
         Int::from(self)

--- a/creusot-contracts/src/builtins/model.rs
+++ b/creusot-contracts/src/builtins/model.rs
@@ -2,13 +2,13 @@ use creusot_contracts_proc::*;
 
 pub trait Model {
     type ModelTy;
-    #[logic_rust]
+    #[logic]
     fn model(self) -> Self::ModelTy;
 }
 
 impl<T: Model> Model for &T {
     type ModelTy = T::ModelTy;
-    #[logic_rust]
+    #[logic]
     fn model(self) -> Self::ModelTy {
         (*self).model()
     }
@@ -16,7 +16,7 @@ impl<T: Model> Model for &T {
 
 impl<T: Model> Model for &mut T {
     type ModelTy = T::ModelTy;
-    #[logic_rust]
+    #[logic]
     fn model(self) -> Self::ModelTy {
         (*self).model()
     }

--- a/creusot-contracts/src/builtins/resolve.rs
+++ b/creusot-contracts/src/builtins/resolve.rs
@@ -3,22 +3,21 @@ use creusot_contracts_proc::*;
 
 #[rustc_diagnostic_item = "creusot_resolve"]
 pub unsafe trait Resolve {
-    #[predicate_rust]
+    #[predicate]
     #[rustc_diagnostic_item = "creusot_resolve_method"]
     fn resolve(self) -> bool;
 }
 
 unsafe impl<T1: Resolve, T2: Resolve> Resolve for (T1, T2) {
-    #[predicate_rust]
+    #[predicate]
     fn resolve(self) -> bool {
         Resolve::resolve(self.0) && Resolve::resolve(self.1)
     }
 }
 
 unsafe impl<T> Resolve for &mut T {
-    predicate! {
-        fn resolve(self) -> bool {
-            ^self === *self
-        }
+    #[predicate]
+    fn resolve(self) -> bool {
+        pearlite! { ^self === *self }
     }
 }

--- a/creusot-contracts/src/builtins/seq.rs
+++ b/creusot-contracts/src/builtins/seq.rs
@@ -7,28 +7,28 @@ pub struct Seq<T>(std::marker::PhantomData<T>);
 
 impl<T> Seq<T> {
     #[trusted]
-    #[logic_rust]
+    #[logic]
     #[creusot::builtins = "seq.Seq.get"]
     pub fn index(self, _: Int) -> T {
         std::process::abort()
     }
 
     #[trusted]
-    #[logic_rust]
+    #[logic]
     #[creusot::builtins = "seq.Seq.length"]
     pub fn len(self) -> Int {
         std::process::abort()
     }
 
     #[trusted]
-    #[logic_rust]
+    #[logic]
     #[creusot::builtins = "seq.Seq.set"]
     pub fn set(self, _: Int, _: T) -> Self {
         std::process::abort()
     }
 
     #[trusted]
-    #[logic_rust]
+    #[logic]
     #[creusot::builtins = "seq.Seq.snoc"]
     pub fn push(self, _: T) -> Self {
         std::process::abort()

--- a/creusot/tests/should_succeed/all_zero.rs
+++ b/creusot/tests/should_succeed/all_zero.rs
@@ -13,7 +13,7 @@ enum List {
 }
 use List::*;
 
-#[logic_rust]
+#[logic]
 fn len(l: List) -> Int {
     match l {
         Cons(_, ls) => 1 + len(*ls),
@@ -21,15 +21,14 @@ fn len(l: List) -> Int {
     }
 }
 
-logic! {
-    fn get(l: List, ix: Int) -> Option<u32> {
-        match l {
-            Cons(x, ls) => match (ix === 0) {
-                true => Some(x),
-                false => get(*ls, ix - 1),
-            },
-            Nil => None
-        }
+#[logic]
+fn get(l: List, ix: Int) -> Option<u32> {
+    match l {
+        Cons(x, ls) => match (pearlite! { ix === 0 }) {
+            true => Some(x),
+            false => get(*ls, ix - 1),
+        },
+        Nil => None,
     }
 }
 

--- a/creusot/tests/should_succeed/binary_search.rs
+++ b/creusot/tests/should_succeed/binary_search.rs
@@ -20,7 +20,7 @@ enum List<T> {
 }
 use List::*;
 
-#[logic_rust]
+#[logic]
 fn len_logic<T>(l: List<T>) -> Int {
     match l {
         Cons(_, ls) => 1 + len_logic(*ls),
@@ -28,7 +28,7 @@ fn len_logic<T>(l: List<T>) -> Int {
     }
 }
 
-#[logic_rust]
+#[logic]
 fn get<T>(l: List<T>, ix: Int) -> Option<T> {
     match l {
         Cons(t, ls) => {
@@ -78,9 +78,10 @@ impl<T> List<T> {
     }
 }
 
-logic! {
-    fn is_sorted(l : List<u32>) -> bool {
-        {
+#[logic]
+fn is_sorted(l: List<u32>) -> bool {
+    {
+        pearlite! {
             forall<x1 : Int, x2 : Int> x1 <= x2 ==>
             match (get(l, x1), get(l, x2)) {
                 (Some(v1), Some(v2)) => v1 <= v2,
@@ -91,7 +92,7 @@ logic! {
     }
 }
 
-#[logic_rust]
+#[logic]
 fn get_default<T>(l: List<T>, ix: Int, def: T) -> T {
     match get(l, ix) {
         Some(v) => v,

--- a/creusot/tests/should_succeed/cell/01.rs
+++ b/creusot/tests/should_succeed/cell/01.rs
@@ -8,7 +8,7 @@ use creusot_contracts::*;
 use std::marker::PhantomData;
 
 trait Inv<T> {
-    #[predicate_rust]
+    #[predicate]
     fn inv(x: T) -> bool;
 }
 
@@ -34,7 +34,7 @@ impl<T: Copy, I: Inv<T>> Cell<T, I> {
 struct Even;
 
 impl Inv<u32> for Even {
-    #[predicate_rust]
+    #[predicate]
     fn inv(x: u32) -> bool {
         x % 2u32 == 0u32
     }

--- a/creusot/tests/should_succeed/clones/02.rs
+++ b/creusot/tests/should_succeed/clones/02.rs
@@ -10,12 +10,12 @@ use creusot_contracts::*;
 // Here we want to ensure that `program` properly shares
 // the implementation of simple between itself and `uses_simple`.
 
-#[logic_rust]
+#[logic]
 fn simple() -> bool {
     true
 }
 
-#[logic_rust]
+#[logic]
 fn uses_simple() -> bool {
     simple()
 }

--- a/creusot/tests/should_succeed/clones/03.rs
+++ b/creusot/tests/should_succeed/clones/03.rs
@@ -7,7 +7,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[logic_rust]
+#[logic]
 fn omg<T>(x: T) -> bool {
     true
 }

--- a/creusot/tests/should_succeed/clones/04.rs
+++ b/creusot/tests/should_succeed/clones/04.rs
@@ -7,17 +7,17 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[logic_rust]
+#[logic]
 fn a(x: u32) -> bool {
     x > 0u32
 }
 
-#[logic_rust]
+#[logic]
 fn b(x: u32) -> bool {
     x > 10u32 && a(x)
 }
 
-#[logic_rust]
+#[logic]
 fn c(x: u32) -> bool {
     x < 50u32 && b(x)
 }

--- a/creusot/tests/should_succeed/inc_some_2_list.rs
+++ b/creusot/tests/should_succeed/inc_some_2_list.rs
@@ -13,7 +13,7 @@ use List::*;
 impl WellFounded for List {}
 
 impl List {
-    #[logic_rust]
+    #[logic]
     fn sum(self) -> Int {
         match self {
             Cons(a, l) => a.model() + l.sum(),

--- a/creusot/tests/should_succeed/inc_some_2_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_2_tree.rs
@@ -13,7 +13,7 @@ use Tree::*;
 impl WellFounded for Tree {}
 
 impl Tree {
-    #[logic_rust]
+    #[logic]
     fn sum(self) -> Int {
         match self {
             Node(tl, a, tr) => tl.sum() + a.model() + tr.sum(),

--- a/creusot/tests/should_succeed/inc_some_list.rs
+++ b/creusot/tests/should_succeed/inc_some_list.rs
@@ -13,7 +13,7 @@ use List::*;
 impl WellFounded for List {}
 
 impl List {
-    #[logic_rust]
+    #[logic]
     fn sum(self) -> Int {
         match self {
             Cons(a, l) => a.model() + l.sum(),

--- a/creusot/tests/should_succeed/inc_some_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_tree.rs
@@ -13,7 +13,7 @@ use Tree::*;
 impl WellFounded for Tree {}
 
 impl Tree {
-    #[logic_rust]
+    #[logic]
     fn sum(self) -> Int {
         match self {
             Node(tl, a, tr) => tl.sum() + a.model() + tr.sum(),

--- a/creusot/tests/should_succeed/list_index_mut.rs
+++ b/creusot/tests/should_succeed/list_index_mut.rs
@@ -17,13 +17,13 @@ use Option::*;
 pub struct List(u32, Option<Box<List>>);
 
 unsafe impl Resolve for List {
-    #[predicate_rust]
+    #[predicate]
     fn resolve(self) -> bool {
         true
     }
 }
 
-#[logic_rust]
+#[logic]
 fn len(l: List) -> Int {
     {
         let List(_, ls) = l;
@@ -34,7 +34,7 @@ fn len(l: List) -> Int {
     }
 }
 
-#[logic_rust]
+#[logic]
 fn get(l: List, ix: Int) -> Option<u32> {
     {
         let List(i, ls) = l;

--- a/creusot/tests/should_succeed/logic_functions.rs
+++ b/creusot/tests/should_succeed/logic_functions.rs
@@ -6,7 +6,7 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-#[logic_rust]
+#[logic]
 fn logic() -> bool {
     true
 }
@@ -14,27 +14,25 @@ fn logic() -> bool {
 #[ensures(logic())]
 fn use_logic() {}
 
-// To use pearlite syntax like `===`,
-// we need to use `logic!` instead of `#[logic_rust]`
-logic! {
-    fn logical() -> bool {
-        0 === 0
-    }
+// When we want to use pearlite syntax, we use pearlite! macro
+#[logic]
+fn logic_pearlite() -> bool {
+    pearlite! { 0 === 0 }
 }
 
-#[ensures(logical())]
-fn use_logical() {}
+#[ensures(logic_pearlite())]
+fn use_logic_pearlite() {}
 
 mod nested {
     use creusot_contracts::*;
 
-    #[logic_rust]
+    #[logic]
     fn nested() -> bool {
         true
     }
 }
 
-#[logic_rust]
+#[logic]
 fn arith(n: Int, b: bool) -> Int {
     if !b {
         -n + n - n * n
@@ -43,7 +41,7 @@ fn arith(n: Int, b: bool) -> Int {
     }
 }
 
-#[logic_rust]
+#[logic]
 fn deref_pat<'a>(o: &'a Option<Int>) -> Int {
     match o {
         Some(a) => *a,

--- a/creusot/tests/should_succeed/logic_functions.stdout
+++ b/creusot/tests/should_succeed/logic_functions.stdout
@@ -43,25 +43,25 @@ module LogicFunctions_UseLogic
   }
   
 end
-module LogicFunctions_Logical_Interface
-  function logical () : bool
+module LogicFunctions_LogicPearlite_Interface
+  function logic_pearlite () : bool
 end
-module LogicFunctions_Logical
+module LogicFunctions_LogicPearlite
   use mach.int.Int
   use mach.int.Int32
-  function logical () : bool = 
+  function logic_pearlite () : bool = 
     0 = 0
 end
-module LogicFunctions_UseLogical_Interface
-  clone LogicFunctions_Logical_Interface as Logical0
-  val use_logical () : ()
-    ensures { Logical0.logical () }
+module LogicFunctions_UseLogicPearlite_Interface
+  clone LogicFunctions_LogicPearlite_Interface as LogicPearlite0
+  val use_logic_pearlite () : ()
+    ensures { LogicPearlite0.logic_pearlite () }
     
 end
-module LogicFunctions_UseLogical
-  clone LogicFunctions_Logical as Logical0
-  let rec cfg use_logical () : ()
-    ensures { Logical0.logical () }
+module LogicFunctions_UseLogicPearlite
+  clone LogicFunctions_LogicPearlite as LogicPearlite0
+  let rec cfg use_logic_pearlite () : ()
+    ensures { LogicPearlite0.logic_pearlite () }
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/model.rs
+++ b/creusot/tests/should_succeed/model.rs
@@ -7,7 +7,7 @@ struct Seven();
 
 impl Model for Seven {
     type ModelTy = Int;
-    #[logic_rust]
+    #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
         panic!()
@@ -24,7 +24,7 @@ struct Pair<T, U>(T, U);
 
 impl<T, U> Model for Pair<T, U> {
     type ModelTy = (T, U);
-    #[logic_rust]
+    #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
         panic!()

--- a/creusot/tests/should_succeed/modules.rs
+++ b/creusot/tests/should_succeed/modules.rs
@@ -10,7 +10,7 @@ pub mod nested {
     }
 
     unsafe impl Resolve for Nested {
-        #[predicate_rust]
+        #[predicate]
         fn resolve(self) -> bool {
             true
         }

--- a/creusot/tests/should_succeed/pure_function.rs
+++ b/creusot/tests/should_succeed/pure_function.rs
@@ -46,7 +46,7 @@ fn test<T>(l: &List<T>) -> usize {
     l.len()
 }
 
-#[logic_rust]
+#[logic]
 fn uses_len<T>(l: List<T>) -> Int {
     l.len().model()
 }

--- a/creusot/tests/should_succeed/specification/logic_call.rs
+++ b/creusot/tests/should_succeed/specification/logic_call.rs
@@ -6,10 +6,9 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-logic! {
-    fn reflexive<T : PartialEq>(x : T) -> bool {
-        x === x
-    }
+#[logic]
+fn reflexive<T: PartialEq>(x: T) -> bool {
+    pearlite! { x === x }
 }
 
 #[ensures(reflexive(result))]

--- a/creusot/tests/should_succeed/syntax/02_operators.rs
+++ b/creusot/tests/should_succeed/syntax/02_operators.rs
@@ -10,12 +10,12 @@ fn division(x: usize, y: usize) -> usize {
     x / y
 }
 
-// #[logic_rust]
+// #[logic]
 // fn division_logic(x : usize, y : usize) -> usize {
 //     x / y
 // }
 
-#[logic_rust]
+#[logic]
 fn division_int(x: Int, y: Int) -> Int {
     x / y
 }
@@ -24,12 +24,12 @@ fn modulus(x: usize, y: usize) -> usize {
     x % y
 }
 
-// #[logic_rust]
+// #[logic]
 // fn modulus_logic(x : usize, y : usize) -> usize {
 //     x % y
 // }
 
-#[logic_rust]
+#[logic]
 fn modulus_int(x: Int, y: Int) -> Int {
     x % y
 }
@@ -38,7 +38,7 @@ fn multiply(x: usize, y: usize) -> usize {
     x * y
 }
 
-#[logic_rust]
+#[logic]
 fn multiply_int(x: Int, y: Int) -> Int {
     x * y
 }
@@ -47,12 +47,12 @@ fn add(x: usize, y: usize) -> usize {
     x + y
 }
 
-#[logic_rust]
+#[logic]
 fn add_int(x: Int, y: Int) -> Int {
     x + y
 }
 
-// #[logic_rust]
+// #[logic]
 // fn add_logic(x : usize, y : usize) -> usize {
 //     x + y
 // }
@@ -61,7 +61,7 @@ fn sub(x: usize, y: usize) -> usize {
     x - y
 }
 
-#[logic_rust]
+#[logic]
 fn sub_int(x: Int, y: Int) -> Int {
     x - y
 }
@@ -72,7 +72,7 @@ fn expression(x: usize, y: usize, z: usize) -> bool {
     x / y * z == (x / y) * z
 }
 
-#[logic_rust]
+#[logic]
 fn expression_logic(x: usize, y: usize, z: usize) -> bool {
     x / y * z == (x / y) * z
 }

--- a/creusot/tests/should_succeed/syntax/03_unbounded.rs
+++ b/creusot/tests/should_succeed/syntax/03_unbounded.rs
@@ -12,7 +12,7 @@ fn no_bounds_check(x: u32, y: u32) -> u32 {
     2_147_483_647 + 2_147_483_647
 }
 
-#[logic_rust]
+#[logic]
 fn no_conversion(x: u32) -> Int {
     x.model()
 }

--- a/creusot/tests/should_succeed/traits/08.rs
+++ b/creusot/tests/should_succeed/traits/08.rs
@@ -9,9 +9,9 @@ use creusot_contracts::*;
 // Ensure that different kinds of functions are translated to the
 // correct abstract symbol in Rust
 trait Tr {
-    #[logic_rust]
+    #[logic]
     fn logical(&self) -> Int;
-    #[predicate_rust]
+    #[predicate]
     fn predicate(&self) -> bool;
     fn program(&self) {}
 }

--- a/creusot/tests/should_succeed/traits/10.rs
+++ b/creusot/tests/should_succeed/traits/10.rs
@@ -7,7 +7,7 @@ extern crate creusot_contracts;
 use creusot_contracts::*;
 
 unsafe impl<T1: Resolve, T2: Resolve> Resolve for (T1, T2) {
-    #[predicate_rust]
+    #[predicate]
     fn resolve(self) -> bool {
         Resolve::resolve(self.0) && Resolve::resolve(self.1)
     }

--- a/creusot/tests/should_succeed/traits/11.rs
+++ b/creusot/tests/should_succeed/traits/11.rs
@@ -6,7 +6,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[logic_rust]
+#[logic]
 fn id<T>(x: T) -> T {
     x
 }

--- a/creusot/tests/should_succeed/traits/12_default_method.rs
+++ b/creusot/tests/should_succeed/traits/12_default_method.rs
@@ -11,7 +11,7 @@ trait T {
         0
     }
 
-    #[logic_rust]
+    #[logic]
     fn logic_default(self) -> bool {
         true
     }

--- a/creusot/tests/should_succeed/traits/14_assoc_in_logic.rs
+++ b/creusot/tests/should_succeed/traits/14_assoc_in_logic.rs
@@ -10,13 +10,13 @@ trait Assoc {
     type Ty;
 }
 
-#[logic_rust]
+#[logic]
 #[trusted]
 fn from_ty<T: Assoc>(x: T::Ty) -> T {
     panic!()
 }
 
-#[logic_rust]
+#[logic]
 #[trusted]
 fn to_ty<T: Assoc>(x: T) -> T::Ty {
     panic!()

--- a/creusot/tests/should_succeed/traits/15_impl_interfaces.rs
+++ b/creusot/tests/should_succeed/traits/15_impl_interfaces.rs
@@ -18,7 +18,7 @@ impl Tr for () {
 }
 
 #[trusted]
-#[logic_rust]
+#[logic]
 fn x<T: Tr>(x: T) -> T::A {
     panic!()
 }

--- a/creusot/tests/should_succeed/trusted.rs
+++ b/creusot/tests/should_succeed/trusted.rs
@@ -23,7 +23,7 @@ fn victim_of_lie() -> u32 {
     lie()
 }
 
-#[predicate_rust]
+#[predicate]
 #[trusted]
 fn trusted_pred(x: u32) {
     true

--- a/creusot/tests/should_succeed/vector/01.rs
+++ b/creusot/tests/should_succeed/vector/01.rs
@@ -15,7 +15,7 @@ where
 
 impl<T> Model for GhostRecord<T> {
     type ModelTy = T;
-    #[logic_rust]
+    #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
         panic!()
@@ -32,7 +32,7 @@ impl<T> GhostRecord<T> {
 
 impl<T: ?Sized> Model for MyVec<T> {
     type ModelTy = Seq<T>;
-    #[logic_rust]
+    #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
         panic!()

--- a/pearlite-syn/tests/test_term.rs
+++ b/pearlite-syn/tests/test_term.rs
@@ -217,6 +217,34 @@ fn test_absurd() {
 }
 
 #[test]
+fn test_pearlite() {
+    snapshot!(quote!(pearlite!{ x }) as Term, @r###"
+    TermPearlite {
+        pearlite_token: Keyword [pearlite],
+        bang_token: Bang,
+        brace_token: Brace,
+        term: TermPath {
+            inner: ExprPath {
+                attrs: [],
+                qself: None,
+                path: Path {
+                    leading_colon: None,
+                    segments: [
+                        PathSegment {
+                            ident: Ident(
+                                x,
+                            ),
+                            arguments: None,
+                        },
+                    ],
+                },
+            },
+        },
+    }
+    "###);
+}
+
+#[test]
 fn test_match() {
     snapshot!(quote!(match x {
         Some(x) => true,


### PR DESCRIPTION
Add the `pearlite!` macro, based on Xavier and JH's suggestion. This allows us to embed pearlite syntax into Rust code in a IDE-friendly way.
Now we have `#[logic]`/`#[predicate]` attributes instead of `#[logic_rust]`/`#[predicate_rust]` and get free of `logic!`/`predicate!` macros. This resolves the concerns about #129.

For a function with `#[logic]` (similarly for `#[predicate]`), Rust first interprets the function body as Rust code *before* executing the `logic` proc-macro. At this stage, it calls the `pearlite!` proc-macro, which actually translates the pearlite syntax into Rust code. So interestingly, Rust actually type-checks the code here.

Then, Rust executes the `logic` proc-macro, which interprets the function body as pearlite code. In pearlite, `pearlite! { ... }` is treated as special syntax.