### PR TITLE
[WIP] Use Index trait in Vec stub.

### DIFF
--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -42,13 +42,26 @@ impl<T> Vec<T> {
     }
 
     #[trusted]
+    #[requires(@i < (@self).len())]
+    #[requires(@j < (@self).len())]
+    #[ensures((@^self).exchange(@*self, @i, @j))]
+    pub fn swap(&mut self, i: usize, j: usize) {
+        self.0.swap(i, j)
+    }
+}
+
+impl<T> std::ops::Index<usize> for Vec<T> {
+    type Output = T;
+
+    #[trusted]
     #[requires(@ix < (@self).len())]
     #[ensures(*result === (@self)[@ix])]
-    pub fn index(&self, ix: usize) -> &T {
-        use std::ops::Index;
-        self.0.index(ix)
+    fn index(&self, ix: usize) -> &T {
+        &self.0[ix]
     }
+}
 
+impl<T> std::ops::IndexMut<usize> for Vec<T> {
     #[trusted]
     #[requires(@ix < (@*self).len())]
     #[ensures(*result === (@self)[@ix])]
@@ -57,16 +70,7 @@ impl<T> Vec<T> {
         !(j === @ix) ==>
         (@^self)[j] === (@*self)[j])]
     #[ensures((@*self).len() === (@^self).len())]
-    pub fn index_mut(&mut self, ix: usize) -> &mut T {
-        use std::ops::IndexMut;
-        self.0.index_mut(ix)
-    }
-
-    #[trusted]
-    #[requires(@i < (@self).len())]
-    #[requires(@j < (@self).len())]
-    #[ensures((@^self).exchange(@*self, @i, @j))]
-    pub fn swap(&mut self, i: usize, j: usize) {
-        self.0.swap(i, j)
+    fn index_mut(&mut self, ix: usize) -> &mut T {
+        &mut self.0[ix]
     }
 }

--- a/creusot/tests/should_succeed/vector/01.rs
+++ b/creusot/tests/should_succeed/vector/01.rs
@@ -38,7 +38,7 @@ fn all_zero(v: &mut Vec<u32>) {
     #[invariant(in_bounds, (@*v).len() === (@*@old_v).len())]
     #[invariant(all_zero, forall<j : Int> 0 <= j && j < i.into() ==> (@*v)[j] === 0u32)]
     while i < v.len() {
-        *v.index_mut(i) = 0;
+        v[i] = 0;
         i += 1;
     }
 }

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -204,6 +204,20 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     ensures { result = Seq.length (Model0.model self) }
     
 end
+module Core_Ops_Index_Index
+  type self   
+  type idx   
+  type output   
+  use prelude.Prelude
+  val index (self : self) (index : idx) : output
+end
+module Core_Ops_Index_IndexMut
+  type self   
+  type idx   
+  clone Core_Ops_Index_Index as Index0 with type self = self, type idx = idx
+  use prelude.Prelude
+  val index_mut (self : borrowed self) (index : idx) : borrowed Index0.output
+end
 module CreusotContracts_Builtins_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -239,7 +253,7 @@ module CreusotContracts_Builtins_Model_Impl1
   clone export CreusotContracts_Builtins_Model_Model with type self = borrowed t, type modelty = modelty,
   function model = model
 end
-module CreusotContracts_Std1_Vec_Impl1_IndexMut_Interface
+module CreusotContracts_Std1_Vec_Impl3_IndexMut_Interface
   type t   
   use seq.Seq
   use mach.int.Int
@@ -258,7 +272,7 @@ module CreusotContracts_Std1_Vec_Impl1_IndexMut_Interface
     ensures {  * result = Seq.get (Model1.model self) ix }
     
 end
-module CreusotContracts_Std1_Vec_Impl1_IndexMut
+module CreusotContracts_Std1_Vec_Impl3_IndexMut
   type t   
   use seq.Seq
   use mach.int.Int
@@ -276,6 +290,34 @@ module CreusotContracts_Std1_Vec_Impl1_IndexMut
     ensures {  ^ result = Seq.get (Model0.model ( ^ self)) ix }
     ensures {  * result = Seq.get (Model1.model self) ix }
     
+end
+module CreusotContracts_Std1_Vec_Impl3_Interface
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Interface as Model0 with type t = t
+  clone CreusotContracts_Builtins_Model_Impl1_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
+  clone export CreusotContracts_Std1_Vec_Impl3_IndexMut_Interface with type t = t, function Model0.model = Model0.model,
+  function Model1.model = Model1.model
+  clone export Core_Ops_Index_IndexMut with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  val index_mut = index_mut
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0 as Model0 with type t = t
+  clone CreusotContracts_Builtins_Model_Impl1 as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
+  clone export CreusotContracts_Std1_Vec_Impl3_IndexMut_Interface with type t = t, function Model0.model = Model0.model,
+  function Model1.model = Model1.model
+  clone export Core_Ops_Index_IndexMut with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  val index_mut = index_mut
 end
 module CreusotContracts_Builtins_Resolve_Impl1_Resolve_Interface
   type t   
@@ -331,8 +373,8 @@ module C01_AllZero
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
   clone CreusotContracts_Builtins_Model_Impl1 as Model3 with type t = Type.creusotcontracts_std1_vec_vec uint32,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl1_IndexMut_Interface as IndexMut0 with type t = uint32,
-  function Model0.model = Model1.model, function Model1.model = Model3.model
+  clone CreusotContracts_Std1_Vec_Impl3 as IndexMut0 with type t = uint32, function Model0.model = Model1.model,
+  function Model1.model = Model3.model
   clone CreusotContracts_Builtins_Model_Impl0 as Model2 with type t = Type.creusotcontracts_std1_vec_vec uint32,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = uint32,

--- a/creusot/tests/should_succeed/vector/02_gnome.rs
+++ b/creusot/tests/should_succeed/vector/02_gnome.rs
@@ -62,7 +62,7 @@ fn gnome_sort<T: Ord>(v: &mut Vec<T>) {
     #[invariant(in_len, @i <= (@*v).len())]
     #[invariant(permutation, (@*v).permutation_of(@*@old_v))]
     while i < v.len() {
-        if i == 0 || v.index(i - 1).le(v.index(i)) {
+        if i == 0 || v[i-1].le(&v[i]) {
             i += 1;
         } else {
             v.swap(i - 1, i);

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -315,7 +315,14 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
     ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) i j }
     
 end
-module CreusotContracts_Std1_Vec_Impl1_Index_Interface
+module Core_Ops_Index_Index
+  type self   
+  type idx   
+  type output   
+  use prelude.Prelude
+  val index (self : self) (index : idx) : output
+end
+module CreusotContracts_Std1_Vec_Impl2_Index_Interface
   type t   
   use seq.Seq
   use prelude.Prelude
@@ -330,7 +337,7 @@ module CreusotContracts_Std1_Vec_Impl1_Index_Interface
     ensures { result = Seq.get (Model0.model self) ix }
     
 end
-module CreusotContracts_Std1_Vec_Impl1_Index
+module CreusotContracts_Std1_Vec_Impl2_Index
   type t   
   use seq.Seq
   use prelude.Prelude
@@ -344,6 +351,38 @@ module CreusotContracts_Std1_Vec_Impl1_Index
     requires {ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) ix }
     
+end
+module CreusotContracts_Std1_Vec_Impl2_Interface
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
+  clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
+  clone export CreusotContracts_Std1_Vec_Impl2_Index_Interface with type t = t, function Model0.model = Model0.model,
+  function Model1.model = Model1.model
+  type output  = 
+    t
+  clone export Core_Ops_Index_Index with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = output, val index = index
+end
+module CreusotContracts_Std1_Vec_Impl2
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0 as Model1 with type t = t
+  clone CreusotContracts_Builtins_Model_Impl0 as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
+  clone export CreusotContracts_Std1_Vec_Impl2_Index_Interface with type t = t, function Model0.model = Model0.model,
+  function Model1.model = Model1.model
+  type output  = 
+    t
+  clone export Core_Ops_Index_Index with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = output, val index = index
 end
 module CreusotContracts_Builtins_Resolve_Impl1_Resolve_Interface
   type t   
@@ -409,7 +448,7 @@ module C02Gnome_GnomeSort
   function Model0.model = Model1.model
   clone CreusotContracts_Builtins_Model_Impl0 as Model3 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model2.modelty, function Model0.model = Model2.model
-  clone CreusotContracts_Std1_Vec_Impl1_Index_Interface as Index0 with type t = t, function Model0.model = Model3.model,
+  clone CreusotContracts_Std1_Vec_Impl2 as Index0 with type t = t, function Model0.model = Model3.model,
   function Model1.model = Model2.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = t, function Model0.model = Model3.model,
   function Model1.model = Model2.model
@@ -442,16 +481,17 @@ module C02Gnome_GnomeSort
   var _19 : usize;
   var _20 : t;
   var _21 : t;
-  var _22 : Type.creusotcontracts_std1_vec_vec t;
-  var _23 : usize;
-  var _24 : ();
-  var _25 : borrowed (Type.creusotcontracts_std1_vec_vec t);
-  var _26 : usize;
+  var _22 : t;
+  var _23 : Type.creusotcontracts_std1_vec_vec t;
+  var _24 : usize;
+  var _25 : ();
+  var _26 : borrowed (Type.creusotcontracts_std1_vec_vec t);
   var _27 : usize;
   var _28 : usize;
-  var _29 : ();
+  var _29 : usize;
   var _30 : ();
   var _31 : ();
+  var _32 : ();
   {
     v_1 <- v;
     goto BB0
@@ -522,13 +562,15 @@ module C02Gnome_GnomeSort
   BB9 {
     _15 <- _16;
     assume { Resolve4.resolve _16 };
-    _22 <-  * v_1;
-    assume { Resolve2.resolve _23 };
-    _23 <- i_5;
-    _21 <- Index0.index _22 _23;
+    _23 <-  * v_1;
+    assume { Resolve2.resolve _24 };
+    _24 <- i_5;
+    _22 <- Index0.index _23 _24;
     goto BB10
   }
   BB10 {
+    _21 <- _22;
+    assume { Resolve4.resolve _22 };
     _20 <- _21;
     assume { Resolve4.resolve _21 };
     _14 <- Ord0.le _15 _20;
@@ -546,14 +588,14 @@ module C02Gnome_GnomeSort
     goto BB15
   }
   BB13 {
-    _25 <- borrow_mut ( * v_1);
-    v_1 <- { v_1 with current = ( ^ _25) };
-    assume { Resolve2.resolve _27 };
-    _27 <- i_5;
-    _26 <- _27 - (1 : usize);
+    _26 <- borrow_mut ( * v_1);
+    v_1 <- { v_1 with current = ( ^ _26) };
     assume { Resolve2.resolve _28 };
     _28 <- i_5;
-    _24 <- Swap0.swap _25 _26 _28;
+    _27 <- _28 - (1 : usize);
+    assume { Resolve2.resolve _29 };
+    _29 <- i_5;
+    _25 <- Swap0.swap _26 _27 _29;
     goto BB14
   }
   BB14 {


### PR DESCRIPTION
This is a WIP in simplifying notations in programs using Vec. However, it fails in Why3 with error:

```
Symbol modelty is already defined in the current scope
```