### PR TITLE
Avoid emitting useless wildcard branches

### DIFF
--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -177,7 +177,6 @@ module BinarySearch_Impl0_Index
     _10 <- _11 > (0 : usize);
     switch (_10)
       | False -> goto BB6
-      | True -> goto BB5
       | _ -> goto BB5
       end
   }
@@ -444,7 +443,6 @@ module BinarySearch_BinarySearch
     _4 <- _5 = (0 : usize);
     switch (_4)
       | False -> goto BB3
-      | True -> goto BB2
       | _ -> goto BB2
       end
   }
@@ -477,7 +475,6 @@ module BinarySearch_BinarySearch
     _13 <- _14 > (1 : usize);
     switch (_13)
       | False -> goto BB13
-      | True -> goto BB7
       | _ -> goto BB7
       end
   }
@@ -510,7 +507,6 @@ module BinarySearch_BinarySearch
     _22 <- _23 > _27;
     switch (_22)
       | False -> goto BB11
-      | True -> goto BB10
       | _ -> goto BB10
       end
   }
@@ -561,7 +557,6 @@ module BinarySearch_BinarySearch
     _36 <- _37 = _38;
     switch (_36)
       | False -> goto BB16
-      | True -> goto BB15
       | _ -> goto BB15
       end
   }
@@ -584,7 +579,6 @@ module BinarySearch_BinarySearch
     _40 <- _41 < _42;
     switch (_40)
       | False -> goto BB18
-      | True -> goto BB17
       | _ -> goto BB17
       end
   }

--- a/creusot/tests/should_succeed/branch_borrow_2.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_2.stdout
@@ -130,7 +130,6 @@ module BranchBorrow2_Main
     _14 <- not _15;
     switch (_14)
       | False -> goto BB8
-      | True -> goto BB7
       | _ -> goto BB7
       end
   }

--- a/creusot/tests/should_succeed/branch_borrow_4.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_4.stdout
@@ -44,7 +44,6 @@ module BranchBorrow4_Main
     _7 <- true;
     switch (_7)
       | False -> goto BB2
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -229,7 +229,6 @@ module C01ResolveUnsoundness_MakeVecOfSize
     _7 <- _8 <= _9;
     switch (_7)
       | False -> goto BB6
-      | True -> goto BB4
       | _ -> goto BB4
       end
   }

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -148,7 +148,6 @@ module C01_AddsTwo
     _4 <- _5 < (100000 : uint32);
     switch (_4)
       | False -> goto BB4
-      | True -> goto BB2
       | _ -> goto BB2
       end
   }

--- a/creusot/tests/should_succeed/inc_max.stdout
+++ b/creusot/tests/should_succeed/inc_max.stdout
@@ -83,7 +83,6 @@ module IncMax_TakeMax
     _5 <- _6 >= _7;
     switch (_5)
       | False -> goto BB2
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }
@@ -193,7 +192,6 @@ module IncMax_IncMax
     _9 <- not _10;
     switch (_9)
       | False -> goto BB3
-      | True -> goto BB2
       | _ -> goto BB2
       end
   }

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -121,7 +121,6 @@ module IncMax3_IncMax3
     _5 <- _6 < _7;
     switch (_5)
       | False -> goto BB3
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }
@@ -157,7 +156,6 @@ module IncMax3_IncMax3
     _14 <- _15 < _16;
     switch (_14)
       | False -> goto BB7
-      | True -> goto BB5
       | _ -> goto BB5
       end
   }
@@ -195,7 +193,6 @@ module IncMax3_IncMax3
     _23 <- _24 < _25;
     switch (_23)
       | False -> goto BB11
-      | True -> goto BB9
       | _ -> goto BB9
       end
   }
@@ -324,7 +321,6 @@ module IncMax3_TestIncMax3
     _15 <- _16 <> _17;
     switch (_15)
       | False -> goto BB5
-      | True -> goto BB6
       | _ -> goto BB6
       end
   }
@@ -350,7 +346,6 @@ module IncMax3_TestIncMax3
     _12 <- not _13;
     switch (_12)
       | False -> goto BB9
-      | True -> goto BB8
       | _ -> goto BB8
       end
   }
@@ -373,7 +368,6 @@ module IncMax3_TestIncMax3
   BB7 {
     switch (_14)
       | False -> goto BB2
-      | True -> goto BB3
       | _ -> goto BB3
       end
   }

--- a/creusot/tests/should_succeed/inc_max_many.stdout
+++ b/creusot/tests/should_succeed/inc_max_many.stdout
@@ -83,7 +83,6 @@ module IncMaxMany_TakeMax
     _5 <- _6 >= _7;
     switch (_5)
       | False -> goto BB2
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }
@@ -207,7 +206,6 @@ module IncMaxMany_IncMaxMany
     _13 <- _14 >= _15;
     switch (_13)
       | False -> goto BB3
-      | True -> goto BB2
       | _ -> goto BB2
       end
   }
@@ -238,7 +236,6 @@ module IncMaxMany_IncMaxMany
     _11 <- not _12;
     switch (_11)
       | False -> goto BB6
-      | True -> goto BB5
       | _ -> goto BB5
       end
   }

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -83,7 +83,6 @@ module IncMaxRepeat_TakeMax
     _5 <- _6 >= _7;
     switch (_5)
       | False -> goto BB2
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }
@@ -204,7 +203,6 @@ module IncMaxRepeat_IncMaxRepeat
     _7 <- _8 < _9;
     switch (_7)
       | False -> goto BB5
-      | True -> goto BB3
       | _ -> goto BB3
       end
   }
@@ -244,7 +242,6 @@ module IncMaxRepeat_IncMaxRepeat
     _21 <- _22 >= _23;
     switch (_21)
       | False -> goto BB7
-      | True -> goto BB6
       | _ -> goto BB6
       end
   }
@@ -275,7 +272,6 @@ module IncMaxRepeat_IncMaxRepeat
     _19 <- not _20;
     switch (_19)
       | False -> goto BB10
-      | True -> goto BB9
       | _ -> goto BB9
       end
   }

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -119,7 +119,6 @@ module IncSome2List_Impl1_SumX
     switch (self_1)
       | Type.IncSome2List_List_Cons _ _ -> goto BB1
       | Type.IncSome2List_List_Nil -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -323,7 +322,6 @@ module IncSome2List_Impl1_TakeSomeRest
     switch ( * self_1)
       | Type.IncSome2List_List_Cons _ _ -> goto BB1
       | Type.IncSome2List_List_Nil -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -354,7 +352,6 @@ module IncSome2List_Impl1_TakeSomeRest
   BB6 {
     switch (_7)
       | False -> goto BB8
-      | True -> goto BB7
       | _ -> goto BB7
       end
   }
@@ -557,7 +554,6 @@ module IncSome2List_IncSome2List
     _16 <- not _17;
     switch (_16)
       | False -> goto BB7
-      | True -> goto BB6
       | _ -> goto BB6
       end
   }

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -128,7 +128,6 @@ module IncSome2Tree_Impl1_SumX
     switch (self_1)
       | Type.IncSome2Tree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSome2Tree_Tree_Leaf -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -358,7 +357,6 @@ module IncSome2Tree_Impl1_TakeSomeRest
     switch ( * self_1)
       | Type.IncSome2Tree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSome2Tree_Tree_Leaf -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -396,7 +394,6 @@ module IncSome2Tree_Impl1_TakeSomeRest
   BB7 {
     switch (_10)
       | False -> goto BB13
-      | True -> goto BB8
       | _ -> goto BB8
       end
   }
@@ -410,7 +407,6 @@ module IncSome2Tree_Impl1_TakeSomeRest
   BB9 {
     switch (_14)
       | False -> goto BB11
-      | True -> goto BB10
       | _ -> goto BB10
       end
   }
@@ -446,7 +442,6 @@ module IncSome2Tree_Impl1_TakeSomeRest
   BB14 {
     switch (_16)
       | False -> goto BB17
-      | True -> goto BB15
       | _ -> goto BB15
       end
   }
@@ -653,7 +648,6 @@ module IncSome2Tree_IncSome2Tree
     _16 <- not _17;
     switch (_16)
       | False -> goto BB7
-      | True -> goto BB6
       | _ -> goto BB6
       end
   }

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -119,7 +119,6 @@ module IncSomeList_Impl1_SumX
     switch (self_1)
       | Type.IncSomeList_List_Cons _ _ -> goto BB1
       | Type.IncSomeList_List_Nil -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -325,7 +324,6 @@ module IncSomeList_Impl1_TakeSome
     switch ( * self_1)
       | Type.IncSomeList_List_Cons _ _ -> goto BB1
       | Type.IncSomeList_List_Nil -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -356,7 +354,6 @@ module IncSomeList_Impl1_TakeSome
   BB6 {
     switch (_11)
       | False -> goto BB8
-      | True -> goto BB7
       | _ -> goto BB7
       end
   }
@@ -510,7 +507,6 @@ module IncSomeList_IncSomeList
     _9 <- not _10;
     switch (_9)
       | False -> goto BB6
-      | True -> goto BB5
       | _ -> goto BB5
       end
   }

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -128,7 +128,6 @@ module IncSomeTree_Impl1_SumX
     switch (self_1)
       | Type.IncSomeTree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSomeTree_Tree_Leaf -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -359,7 +358,6 @@ module IncSomeTree_Impl1_TakeSome
     switch ( * self_1)
       | Type.IncSomeTree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSomeTree_Tree_Leaf -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -397,7 +395,6 @@ module IncSomeTree_Impl1_TakeSome
   BB7 {
     switch (_14)
       | False -> goto BB9
-      | True -> goto BB8
       | _ -> goto BB8
       end
   }
@@ -420,7 +417,6 @@ module IncSomeTree_Impl1_TakeSome
   BB10 {
     switch (_16)
       | False -> goto BB13
-      | True -> goto BB11
       | _ -> goto BB11
       end
   }
@@ -584,7 +580,6 @@ module IncSomeTree_IncSomeTree
     _9 <- not _10;
     switch (_9)
       | False -> goto BB6
-      | True -> goto BB5
       | _ -> goto BB5
       end
   }

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -176,7 +176,6 @@ module ListIndexMut_IndexMut
     _8 <- _9 > (0 : usize);
     switch (_8)
       | False -> goto BB8
-      | True -> goto BB3
       | _ -> goto BB3
       end
   }
@@ -184,7 +183,6 @@ module ListIndexMut_IndexMut
     switch (let Type.ListIndexMut_List _ a =  * l_4 in a)
       | Type.ListIndexMut_Option_None -> goto BB4
       | Type.ListIndexMut_Option_Some _ -> goto BB5
-      | _ -> goto BB6
       end
   }
   BB4 {

--- a/creusot/tests/should_succeed/loop.stdout
+++ b/creusot/tests/should_succeed/loop.stdout
@@ -45,7 +45,6 @@ module Loop_Main
     _5 <- true;
     switch (_5)
       | False -> goto BB4
-      | True -> goto BB3
       | _ -> goto BB3
       end
   }

--- a/creusot/tests/should_succeed/match_int.stdout
+++ b/creusot/tests/should_succeed/match_int.stdout
@@ -49,7 +49,6 @@ module MatchInt_Main
     _2 <- (0 : int32) <= _1;
     switch (_2)
       | False -> goto BB3
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }
@@ -57,7 +56,6 @@ module MatchInt_Main
     _3 <- _1 < (10 : int32);
     switch (_3)
       | False -> goto BB3
-      | True -> goto BB2
       | _ -> goto BB2
       end
   }
@@ -87,7 +85,6 @@ module MatchInt_Main
     _8 <- not false;
     switch (_8)
       | False -> goto BB14
-      | True -> goto BB13
       | _ -> goto BB13
       end
   }
@@ -95,7 +92,6 @@ module MatchInt_Main
     _4 <- not true;
     switch (_4)
       | False -> goto BB9
-      | True -> goto BB8
       | _ -> goto BB8
       end
   }
@@ -110,7 +106,6 @@ module MatchInt_Main
     _6 <- not false;
     switch (_6)
       | False -> goto BB12
-      | True -> goto BB11
       | _ -> goto BB11
       end
   }

--- a/creusot/tests/should_succeed/mc91.stdout
+++ b/creusot/tests/should_succeed/mc91.stdout
@@ -62,7 +62,6 @@ module Mc91_Mc91
     _2 <- _3 > (100 : uint32);
     switch (_2)
       | False -> goto BB2
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }

--- a/creusot/tests/should_succeed/one_side_update.stdout
+++ b/creusot/tests/should_succeed/one_side_update.stdout
@@ -39,7 +39,6 @@ module OneSideUpdate_Main
     _3 <- true;
     switch (_3)
       | False -> goto BB2
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -103,7 +103,6 @@ module ProjectionToggle_ProjToggle
     assume { Resolve0.resolve toggle_1 };
     switch (_6)
       | False -> goto BB2
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }
@@ -203,7 +202,6 @@ module ProjectionToggle_Main
     _9 <- not _10;
     switch (_9)
       | False -> goto BB3
-      | True -> goto BB2
       | _ -> goto BB2
       end
   }

--- a/creusot/tests/should_succeed/projections.stdout
+++ b/creusot/tests/should_succeed/projections.stdout
@@ -70,7 +70,6 @@ module Projections_CopyOutOfSum
     switch (x_1)
       | Type.Core_Result_Result_Ok _ -> goto BB1
       | Type.Core_Result_Result_Err _ -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -129,7 +128,6 @@ module Projections_WriteIntoSum
     switch ( * x_1)
       | Type.Core_Option_Option_None -> goto BB1
       | Type.Core_Option_Option_Some _ -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -182,7 +180,6 @@ module Projections_Main
     switch (_2)
       | Type.Core_Option_Option_None -> goto BB1
       | Type.Core_Option_Option_Some _ -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {

--- a/creusot/tests/should_succeed/rand.stdout
+++ b/creusot/tests/should_succeed/rand.stdout
@@ -46,7 +46,6 @@ module Rand_TryRand
   BB1 {
     switch (_1)
       | False -> goto BB3
-      | True -> goto BB2
       | _ -> goto BB2
       end
   }

--- a/creusot/tests/should_succeed/split_borrow.stdout
+++ b/creusot/tests/should_succeed/split_borrow.stdout
@@ -64,7 +64,6 @@ module SplitBorrow_Main
   BB1 {
     switch (_6)
       | False -> goto BB3
-      | True -> goto BB2
       | _ -> goto BB2
       end
   }

--- a/creusot/tests/should_succeed/sum.stdout
+++ b/creusot/tests/should_succeed/sum.stdout
@@ -80,7 +80,6 @@ module Sum_SumFirstN
     _6 <- _7 <= _8;
     switch (_6)
       | False -> goto BB4
-      | True -> goto BB3
       | _ -> goto BB3
       end
   }

--- a/creusot/tests/should_succeed/switch.stdout
+++ b/creusot/tests/should_succeed/switch.stdout
@@ -40,7 +40,6 @@ module Switch_Test
     switch (o_1)
       | Type.Switch_Option_Some _ -> goto BB1
       | Type.Switch_Option_None -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {
@@ -95,7 +94,6 @@ module Switch_Test2
     switch (let (a, _) = o_1 in a)
       | Type.Switch_Option_Some _ -> goto BB1
       | Type.Switch_Option_None -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {

--- a/creusot/tests/should_succeed/switch_struct.stdout
+++ b/creusot/tests/should_succeed/switch_struct.stdout
@@ -42,7 +42,6 @@ module SwitchStruct_Test
     switch (o_1)
       | Type.SwitchStruct_M_F _ -> goto BB1
       | Type.SwitchStruct_M_G _ -> goto BB2
-      | _ -> goto BB3
       end
   }
   BB1 {

--- a/creusot/tests/should_succeed/traits/04.stdout
+++ b/creusot/tests/should_succeed/traits/04.stdout
@@ -96,14 +96,12 @@ module C04_User
   BB6 {
     switch (_3)
       | False -> goto BB1
-      | True -> goto BB2
       | _ -> goto BB2
       end
   }
   BB7 {
     switch (_4)
       | False -> goto BB4
-      | True -> goto BB5
       | _ -> goto BB5
       end
   }

--- a/creusot/tests/should_succeed/unary_op.stdout
+++ b/creusot/tests/should_succeed/unary_op.stdout
@@ -42,7 +42,6 @@ module UnaryOp_Main
     _2 <- not _3;
     switch (_2)
       | False -> goto BB2
-      | True -> goto BB1
       | _ -> goto BB1
       end
   }

--- a/creusot/tests/should_succeed/unused_in_loop.stdout
+++ b/creusot/tests/should_succeed/unused_in_loop.stdout
@@ -70,7 +70,6 @@ module UnusedInLoop_UnusedInLoop
     _5 <- b_1;
     switch (_5)
       | False -> goto BB4
-      | True -> goto BB3
       | _ -> goto BB3
       end
   }

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -394,7 +394,6 @@ module C01_AllZero
     _7 <- _8 < _9;
     switch (_7)
       | False -> goto BB7
-      | True -> goto BB5
       | _ -> goto BB5
       end
   }

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -486,7 +486,6 @@ module C02Gnome_GnomeSort
     _7 <- _8 < _9;
     switch (_7)
       | False -> goto BB16
-      | True -> goto BB5
       | _ -> goto BB5
       end
   }
@@ -496,7 +495,6 @@ module C02Gnome_GnomeSort
     _12 <- _13 = (0 : usize);
     switch (_12)
       | False -> goto BB7
-      | True -> goto BB6
       | _ -> goto BB6
       end
   }
@@ -515,7 +513,6 @@ module C02Gnome_GnomeSort
   BB8 {
     switch (_11)
       | False -> goto BB13
-      | True -> goto BB12
       | _ -> goto BB12
       end
   }

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -415,7 +415,6 @@ module C03KnuthShuffle_KnuthShuffle
     _7 <- _8 < _9;
     switch (_7)
       | False -> goto BB9
-      | True -> goto BB5
       | _ -> goto BB5
       end
   }


### PR DESCRIPTION
Technically this can cause the graph to become disconnected. With Stackify this causes no issue in Why3, and in the future should only be a warning. 