### PR TITLE
Always print coercions in logical terms.

### DIFF
--- a/creusot-contracts/src/builtins/int.rs
+++ b/creusot-contracts/src/builtins/int.rs
@@ -60,8 +60,10 @@ impl PartialOrd for Int {
 }
 
 impl From<u32> for Int {
-    #[creusot::spec::no_translate]
+    #[logic]
+    #[trusted]
     #[rustc_diagnostic_item = "u32_to_int"]
+    #[creusot::builtins = "mach.int.UInt32.to_int"]
     fn from(_: u32) -> Self {
         panic!()
     }
@@ -70,14 +72,17 @@ impl Model for u32 {
     type ModelTy = Int;
     #[logic]
     #[rustc_diagnostic_item = "u32_model"]
+    #[creusot::builtins = "mach.int.UInt32.to_int"]
     fn model(self) -> Self::ModelTy {
         Int::from(self)
     }
 }
 
 impl From<i32> for Int {
-    #[creusot::spec::no_translate]
+    #[logic]
+    #[trusted]
     #[rustc_diagnostic_item = "i32_to_int"]
+    #[creusot::builtins = "mach.int.Int32.to_int"]
     fn from(_: i32) -> Self {
         panic!()
     }
@@ -86,14 +91,17 @@ impl Model for i32 {
     type ModelTy = Int;
     #[logic]
     #[rustc_diagnostic_item = "i32_model"]
+    #[creusot::builtins = "mach.int.Int32.to_int"]
     fn model(self) -> Self::ModelTy {
         Int::from(self)
     }
 }
 
 impl From<usize> for Int {
-    #[creusot::spec::no_translate]
+    #[logic]
+    #[trusted]
     #[rustc_diagnostic_item = "usize_to_int"]
+    #[creusot::builtins = "mach.int.UInt64.to_int"]
     fn from(_: usize) -> Self {
         panic!()
     }
@@ -102,13 +110,15 @@ impl Model for usize {
     type ModelTy = Int;
     #[logic]
     #[rustc_diagnostic_item = "usize_model"]
+    #[creusot::builtins = "mach.int.UInt64.to_int"]
     fn model(self) -> Self::ModelTy {
         Int::from(self)
     }
 }
 
 impl From<isize> for Int {
-    #[creusot::spec::no_translate]
+    #[logic]
+    #[trusted]
     #[rustc_diagnostic_item = "isize_to_int"]
     fn from(_: isize) -> Self {
         panic!()
@@ -118,6 +128,7 @@ impl Model for isize {
     type ModelTy = Int;
     #[logic]
     #[rustc_diagnostic_item = "isize_model"]
+    #[creusot::builtins = "mach.int.Int64.to_int"]
     fn model(self) -> Self::ModelTy {
         Int::from(self)
     }

--- a/creusot/src/translation/builtins.rs
+++ b/creusot/src/translation/builtins.rs
@@ -92,44 +92,35 @@ pub fn lookup_builtin(
     } else if def_id == ctx.tcx.get_diagnostic_item(Symbol::intern("u32_to_int"))
         || def_id == ctx.tcx.get_diagnostic_item(Symbol::intern("u32_model"))
     {
-        let a = args.remove(0);
-        let i = if let Exp::Const(Constant::Uint(v, _)) = a {
-            Exp::Const(Constant::Uint(v, None))
-        } else {
-            a
-        };
-
-        return Some(i);
+        if let Exp::Const(Constant::Uint(v, _)) = args[0] {
+            return Some(Exp::Const(Constant::Uint(v, None)));
+        } else if !ctx.opts.bounds_check {
+            return Some(args.remove(0));
+        }
     } else if def_id == ctx.tcx.get_diagnostic_item(Symbol::intern("i32_to_int"))
         || def_id == ctx.tcx.get_diagnostic_item(Symbol::intern("i32_model"))
     {
-        let a = args.remove(0);
-        let i = if let Exp::Const(Constant::Int(v, _)) = a {
-            Exp::Const(Constant::Int(v, None))
-        } else {
-            a
-        };
-        return Some(i);
+        if let Exp::Const(Constant::Int(v, _)) = args[0] {
+            return Some(Exp::Const(Constant::Int(v, None)));
+        } else if !ctx.opts.bounds_check {
+            return Some(args.remove(0));
+        }
     } else if def_id == ctx.tcx.get_diagnostic_item(Symbol::intern("usize_to_int"))
         || def_id == ctx.tcx.get_diagnostic_item(Symbol::intern("usize_model"))
     {
-        let a = args.remove(0);
-        let i = if let Exp::Const(Constant::Uint(v, _)) = a {
-            Exp::Const(Constant::Uint(v, None))
-        } else {
-            a
-        };
-        return Some(i);
+        if let Exp::Const(Constant::Uint(v, _)) = args[0] {
+            return Some(Exp::Const(Constant::Uint(v, None)));
+        } else if !ctx.opts.bounds_check {
+            return Some(args.remove(0));
+        }
     } else if def_id == ctx.tcx.get_diagnostic_item(Symbol::intern("isize_to_int"))
         || def_id == ctx.tcx.get_diagnostic_item(Symbol::intern("isize_model"))
     {
-        let a = args.remove(0);
-        let i = if let Exp::Const(Constant::Int(v, _)) = a {
-            Exp::Const(Constant::Int(v, None))
-        } else {
-            a
-        };
-        return Some(i);
+        if let Exp::Const(Constant::Int(v, _)) = args[0] {
+            return Some(Exp::Const(Constant::Int(v, None)));
+        } else if !ctx.opts.bounds_check {
+            return Some(args.remove(0));
+        }
     } else if def_id == ctx.tcx.get_diagnostic_item(sym::abort) {
         // Semi-questionable: we allow abort() & unreachable() in pearlite but
         // interpret them as `absurd` (aka prove false).
@@ -138,7 +129,9 @@ pub fn lookup_builtin(
         return Some(Exp::Absurd);
     } else if ctx.tcx.def_path_str(def_id.unwrap()) == "std::boxed::Box::<T>::new" {
         return Some(args.remove(0));
-    } else if let Some(builtin) = get_builtin(ctx.tcx, def_id.unwrap()) {
+    }
+
+    if let Some(builtin) = get_builtin(ctx.tcx, def_id.unwrap()) {
         names.import_builtin_module(builtin.clone().module_qname());
         return Some(Exp::Call(box Exp::QVar(builtin.without_search_path()), args.clone()));
     }

--- a/creusot/src/translation/specification/typing.rs
+++ b/creusot/src/translation/specification/typing.rs
@@ -422,9 +422,7 @@ fn not_spec(tcx: TyCtxt<'tcx>, thir: &Thir<'tcx>, id: StmtId) -> bool {
 fn not_spec_expr(tcx: TyCtxt<'tcx>, thir: &Thir<'tcx>, id: ExprId) -> bool {
     match thir[id].kind {
         ExprKind::Scope { value, .. } => not_spec_expr(tcx, thir, value),
-        ExprKind::Closure { closure_id, .. } => {
-            !util::is_spec(tcx, closure_id)
-        }
+        ExprKind::Closure { closure_id, .. } => !util::is_spec(tcx, closure_id),
         _ => true,
     }
 }

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -90,23 +90,23 @@ module Std_Process_Abort
 end
 module BinarySearch_Impl0_Index_Interface
   type t   
+  use mach.int.UInt64
   use Type
   use prelude.Prelude
   use mach.int.Int
-  use mach.int.UInt64
   clone BinarySearch_Get_Interface as Get0 with type t = t
   clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
   val index (self : Type.binarysearch_list t) (ix : usize) : t
-    requires {ix < LenLogic0.len_logic self}
-    ensures { Type.Core_Option_Option_Some result = Get0.get self ix }
+    requires {UInt64.to_int ix < LenLogic0.len_logic self}
+    ensures { Type.Core_Option_Option_Some result = Get0.get self (UInt64.to_int ix) }
     
 end
 module BinarySearch_Impl0_Index
   type t   
+  use mach.int.UInt64
   use Type
   use prelude.Prelude
   use mach.int.Int
-  use mach.int.UInt64
   clone BinarySearch_Get as Get0 with type t = t
   clone BinarySearch_LenLogic as LenLogic0 with type t = t
   use mach.int.Int64
@@ -117,8 +117,8 @@ module BinarySearch_Impl0_Index
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve1 with type self = Type.binarysearch_list t
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve0 with type self = usize
   let rec cfg index (self : Type.binarysearch_list t) (ix : usize) : t
-    requires {ix < LenLogic0.len_logic self}
-    ensures { Type.Core_Option_Option_Some result = Get0.get self ix }
+    requires {UInt64.to_int ix < LenLogic0.len_logic self}
+    ensures { Type.Core_Option_Option_Some result = Get0.get self (UInt64.to_int ix) }
     
    = 
   var _0 : t;
@@ -155,8 +155,8 @@ module BinarySearch_Impl0_Index
     goto BB1
   }
   BB1 {
-    invariant ix_valid { ix_2 < LenLogic0.len_logic l_4 };
-    invariant res_get { Get0.get self_1 orig_ix_3 = Get0.get l_4 ix_2 };
+    invariant ix_valid { UInt64.to_int ix_2 < LenLogic0.len_logic l_4 };
+    invariant res_get { Get0.get self_1 (UInt64.to_int orig_ix_3) = Get0.get l_4 (UInt64.to_int ix_2) };
     goto BB2
   }
   BB2 {
@@ -213,22 +213,22 @@ module BinarySearch_Impl0_Len_Interface
   type t   
   use mach.int.Int
   use mach.int.Int32
-  use prelude.Prelude
   use mach.int.UInt64
+  use prelude.Prelude
   use Type
   clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
   val len (self : Type.binarysearch_list t) : usize
     requires {LenLogic0.len_logic self <= 1000000}
-    ensures { result = LenLogic0.len_logic self }
+    ensures { UInt64.to_int result = LenLogic0.len_logic self }
     ensures { result >= (0 : usize) }
     
 end
 module BinarySearch_Impl0_Len
   type t   
+  use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  use mach.int.UInt64
   use Type
   clone BinarySearch_LenLogic as LenLogic0 with type t = t
   use mach.int.Int64
@@ -238,7 +238,7 @@ module BinarySearch_Impl0_Len
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve0 with type self = Type.binarysearch_list t
   let rec cfg len (self : Type.binarysearch_list t) : usize
     requires {LenLogic0.len_logic self <= 1000000}
-    ensures { result = LenLogic0.len_logic self }
+    ensures { UInt64.to_int result = LenLogic0.len_logic self }
     ensures { result >= (0 : usize) }
     
    = 
@@ -266,7 +266,7 @@ module BinarySearch_Impl0_Len
     goto BB1
   }
   BB1 {
-    invariant len_valid { len_2 + LenLogic0.len_logic l_3 = LenLogic0.len_logic self_1 };
+    invariant len_valid { UInt64.to_int len_2 + LenLogic0.len_logic l_3 = LenLogic0.len_logic self_1 };
     goto BB2
   }
   BB2 {
@@ -350,16 +350,16 @@ module BinarySearch_BinarySearch_Interface
   val binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
     requires {IsSorted0.is_sorted arr}
     requires {LenLogic0.len_logic arr <= 1000000}
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . x < i && i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr i (0 : uint32)) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < x -> GetDefault0.get_default arr i (0 : uint32) < elem) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get0.get arr x = Type.Core_Option_Option_Some elem }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr i (0 : uint32)) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < UInt64.to_int x -> GetDefault0.get_default arr i (0 : uint32) < elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get0.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some elem }
     
 end
 module BinarySearch_BinarySearch
+  use mach.int.UInt64
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  use mach.int.UInt64
   use mach.int.Int32
   use Type
   clone BinarySearch_Get as Get0 with type t = uint32
@@ -378,9 +378,9 @@ module BinarySearch_BinarySearch
   let rec cfg binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
     requires {IsSorted0.is_sorted arr}
     requires {LenLogic0.len_logic arr <= 1000000}
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . x < i && i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr i (0 : uint32)) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < x -> GetDefault0.get_default arr i (0 : uint32) < elem) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get0.get arr x = Type.Core_Option_Option_Some elem }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr i (0 : uint32)) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < UInt64.to_int x -> GetDefault0.get_default arr i (0 : uint32) < elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get0.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some elem }
     
    = 
   var _0 : Type.core_result_result usize usize;
@@ -464,8 +464,8 @@ module BinarySearch_BinarySearch
     goto BB5
   }
   BB5 {
-    invariant size_valid { size_8 + base_10 <= LenLogic0.len_logic arr_1 };
-    invariant in_interval { GetDefault0.get_default arr_1 base_10 (0 : uint32) <= elem_2 && elem_2 <= GetDefault0.get_default arr_1 (base_10 + size_8) (0 : uint32) };
+    invariant size_valid { UInt64.to_int size_8 + UInt64.to_int base_10 <= LenLogic0.len_logic arr_1 };
+    invariant in_interval { GetDefault0.get_default arr_1 (UInt64.to_int base_10) (0 : uint32) <= elem_2 && elem_2 <= GetDefault0.get_default arr_1 (UInt64.to_int base_10 + UInt64.to_int size_8) (0 : uint32) };
     invariant size_pos { size_8 > (0 : usize) };
     goto BB6
   }

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -162,13 +162,13 @@ module CreusotContracts_Std1_Vec_Impl1_Push
 end
 module C01ResolveUnsoundness_MakeVecOfSize_Interface
   use seq.Seq
+  use mach.int.UInt64
   use mach.int.Int
   use prelude.Prelude
-  use mach.int.UInt64
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model0 with type t = bool
   val make_vec_of_size (n : usize) : Type.creusotcontracts_std1_vec_vec bool
-    ensures { Seq.length (Model0.model result) = n }
+    ensures { Seq.length (Model0.model result) = UInt64.to_int n }
     
 end
 module C01ResolveUnsoundness_MakeVecOfSize
@@ -187,7 +187,7 @@ module C01ResolveUnsoundness_MakeVecOfSize
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl1_New_Interface as New0 with type t = bool, function Model0.model = Model0.model
   let rec cfg make_vec_of_size (n : usize) : Type.creusotcontracts_std1_vec_vec bool
-    ensures { Seq.length (Model0.model result) = n }
+    ensures { Seq.length (Model0.model result) = UInt64.to_int n }
     
    = 
   var _0 : Type.creusotcontracts_std1_vec_vec bool;

--- a/creusot/tests/should_succeed/cell/02.stdout
+++ b/creusot/tests/should_succeed/cell/02.stdout
@@ -191,7 +191,7 @@ module C02_Impl2_Inv
   predicate inv (self : Type.c02_fib) (v : Type.core_option_option usize) = 
     match (v) with
       | Type.Core_Option_Option_None -> true
-      | Type.Core_Option_Option_Some i -> i = Fib0.fib (let Type.C02_Fib a = self in a)
+      | Type.Core_Option_Option_Some i -> UInt64.to_int i = Fib0.fib (UInt64.to_int (let Type.C02_Fib a = self in a))
       end
 end
 module C02_Impl2_Interface
@@ -266,7 +266,7 @@ module C02_FibCell
   predicate fib_cell (v : Type.creusotcontracts_std1_vec_vec (Type.c02_cell (Type.core_option_option usize) (Type.c02_fib)))
     
    = 
-    forall i : (int) . (let Type.C02_Fib a = let Type.C02_Cell _ a = Seq.get (Model0.model v) i in a in a) = i
+    forall i : (int) . UInt64.to_int (let Type.C02_Fib a = let Type.C02_Cell _ a = Seq.get (Model0.model v) i in a in a) = i
 end
 module C02_LemmaMaxInt_Interface
   use mach.int.Int
@@ -339,60 +339,60 @@ module CreusotContracts_Builtins_Resolve_Resolve
 end
 module CreusotContracts_Std1_Vec_Impl1_Index_Interface
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
-    requires {ix < Seq.length (Model0.model self)}
-    ensures { result = Seq.get (Model0.model self) ix }
+    requires {UInt64.to_int ix < Seq.length (Model0.model self)}
+    ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Index
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
-    requires {ix < Seq.length (Model0.model self)}
-    ensures { result = Seq.get (Model0.model self) ix }
+    requires {UInt64.to_int ix < Seq.length (Model0.model self)}
+    ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
 module C02_FibMemo_Interface
+  use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
   use prelude.Prelude
   use Type
-  use mach.int.UInt64
   clone C02_Fib_Interface as Fib0 with axiom .
   clone C02_FibCell_Interface as FibCell0
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = Type.c02_cell (Type.core_option_option usize) (Type.c02_fib)
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec (Type.c02_cell (Type.core_option_option usize) (Type.c02_fib)),
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val fib_memo (mem : Type.creusotcontracts_std1_vec_vec (Type.c02_cell (Type.core_option_option usize) (Type.c02_fib))) (i : usize) : usize
-    requires {i <= 63}
-    requires {i < Seq.length (Model0.model mem)}
+    requires {UInt64.to_int i <= 63}
+    requires {UInt64.to_int i < Seq.length (Model0.model mem)}
     requires {FibCell0.fib_cell mem}
-    ensures { result = Fib0.fib i }
+    ensures { UInt64.to_int result = Fib0.fib (UInt64.to_int i) }
     
 end
 module C02_FibMemo
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0 as Model1 with type t = Type.c02_cell (Type.core_option_option usize) (Type.c02_fib)
   clone C02_FibCell as FibCell0 with function Model0.model = Model1.model
   clone CreusotContracts_Builtins_Model_Impl0 as Model0 with type t = Type.creusotcontracts_std1_vec_vec (Type.c02_cell (Type.core_option_option usize) (Type.c02_fib)),
@@ -414,10 +414,10 @@ module C02_FibMemo
   clone C02_Impl0_Get_Interface as Get0 with type t = Type.core_option_option usize, type i = Type.c02_fib,
   predicate Inv0.inv = Inv0.inv
   let rec cfg fib_memo (mem : Type.creusotcontracts_std1_vec_vec (Type.c02_cell (Type.core_option_option usize) (Type.c02_fib))) (i : usize) : usize
-    requires {i <= 63}
-    requires {i < Seq.length (Model0.model mem)}
+    requires {UInt64.to_int i <= 63}
+    requires {UInt64.to_int i < Seq.length (Model0.model mem)}
     requires {FibCell0.fib_cell mem}
-    ensures { result = Fib0.fib i }
+    ensures { UInt64.to_int result = Fib0.fib (UInt64.to_int i) }
     
    = 
   var _0 : usize;
@@ -554,7 +554,7 @@ module C02_FibMemo
     goto BB14
   }
   BB14 {
-    assert { fib_i_10 = Fib0.fib i_2 };
+    assert { UInt64.to_int fib_i_10 = Fib0.fib (UInt64.to_int i_2) };
     _25 <- ();
     assume { Resolve4.resolve _25 };
     _29 <- mem_1;

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -22,10 +22,11 @@ end
 module IncSome2List_Impl1_Sum
   use Type
   use mach.int.Int
+  use mach.int.UInt32
   use mach.int.Int32
   function sum (self : Type.incsome2list_list) : int = 
     match (self) with
-      | Type.IncSome2List_List_Cons a l -> a + sum l
+      | Type.IncSome2List_List_Cons a l -> UInt32.to_int a + sum l
       | Type.IncSome2List_List_Nil -> 0
       end
 end
@@ -77,21 +78,21 @@ end
 module IncSome2List_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
-  use mach.int.UInt32
   clone IncSome2List_Impl1_Sum_Interface as Sum0
   val sum_x (self : Type.incsome2list_list) : uint32
     requires {Sum0.sum self <= 1000000}
-    ensures { result = Sum0.sum self }
+    ensures { UInt32.to_int result = Sum0.sum self }
     
 end
 module IncSome2List_Impl1_SumX
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
-  use mach.int.UInt32
   clone IncSome2List_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve3 with type self = Type.incsome2list_list
@@ -100,7 +101,7 @@ module IncSome2List_Impl1_SumX
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve0 with type self = Type.incsome2list_list
   let rec cfg sum_x (self : Type.incsome2list_list) : uint32
     requires {Sum0.sum self <= 1000000}
-    ensures { result = Sum0.sum self }
+    ensures { UInt32.to_int result = Sum0.sum self }
     
    = 
   var _0 : uint32;
@@ -213,7 +214,7 @@ module CreusotContracts_Builtins_Int_Impl4_Model
   use mach.int.Int
   use mach.int.UInt32
   function model (self : uint32) : int = 
-    self
+    UInt32.to_int self
 end
 module CreusotContracts_Builtins_Int_Impl4_Interface
   use mach.int.Int
@@ -265,10 +266,10 @@ module Rand_Random
   val random () : t
 end
 module IncSome2List_Impl1_TakeSomeRest_Interface
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt32
   clone CreusotContracts_Builtins_Int_Impl4_Interface as Model1
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model0 with type t = uint32,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
@@ -276,14 +277,14 @@ module IncSome2List_Impl1_TakeSomeRest_Interface
   val take_some_rest (self : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     ensures { Model0.model (let (a, _) = result in a) <= Sum0.sum ( * self) }
-    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ (let (a, _) = result in a) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     
 end
 module IncSome2List_Impl1_TakeSomeRest
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt32
   clone CreusotContracts_Builtins_Int_Impl4 as Model1
   clone CreusotContracts_Builtins_Model_Impl1 as Model0 with type t = uint32, type Model0.modelty = Model1.modelty,
   function Model0.model = Model1.model
@@ -298,7 +299,7 @@ module IncSome2List_Impl1_TakeSomeRest
   let rec cfg take_some_rest (self : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     ensures { Model0.model (let (a, _) = result in a) <= Sum0.sum ( * self) }
-    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ (let (a, _) = result in a) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     
    = 
   var _0 : (borrowed uint32, borrowed (Type.incsome2list_list));
@@ -430,20 +431,20 @@ module Core_Panicking_Panic
     
 end
 module IncSome2List_IncSome2List_Interface
+  use mach.int.UInt32
   use mach.int.Int
   use mach.int.Int32
   use Type
-  use mach.int.UInt32
   clone IncSome2List_Impl1_Sum_Interface as Sum0
   val inc_some_2_list (l : Type.incsome2list_list) (j : uint32) (k : uint32) : ()
-    requires {Sum0.sum l + j + k <= 1000000}
+    requires {Sum0.sum l + UInt32.to_int j + UInt32.to_int k <= 1000000}
     
 end
 module IncSome2List_IncSome2List
+  use mach.int.UInt32
   use mach.int.Int
   use mach.int.Int32
   use Type
-  use mach.int.UInt32
   clone IncSome2List_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve5 with type self = Type.incsome2list_list
@@ -462,7 +463,7 @@ module IncSome2List_IncSome2List
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone IncSome2List_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_2_list (l : Type.incsome2list_list) (j : uint32) (k : uint32) : ()
-    requires {Sum0.sum l + j + k <= 1000000}
+    requires {Sum0.sum l + UInt32.to_int j + UInt32.to_int k <= 1000000}
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -22,10 +22,11 @@ end
 module IncSome2Tree_Impl1_Sum
   use Type
   use mach.int.Int
+  use mach.int.UInt32
   use mach.int.Int32
   function sum (self : Type.incsome2tree_tree) : int = 
     match (self) with
-      | Type.IncSome2Tree_Tree_Node tl a tr -> sum tl + a + sum tr
+      | Type.IncSome2Tree_Tree_Node tl a tr -> sum tl + UInt32.to_int a + sum tr
       | Type.IncSome2Tree_Tree_Leaf -> 0
       end
 end
@@ -77,21 +78,21 @@ end
 module IncSome2Tree_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
-  use mach.int.UInt32
   clone IncSome2Tree_Impl1_Sum_Interface as Sum0
   val sum_x (self : Type.incsome2tree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
-    ensures { result = Sum0.sum self }
+    ensures { UInt32.to_int result = Sum0.sum self }
     
 end
 module IncSome2Tree_Impl1_SumX
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
-  use mach.int.UInt32
   clone IncSome2Tree_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve3 with type self = uint32
@@ -101,7 +102,7 @@ module IncSome2Tree_Impl1_SumX
   clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg sum_x (self : Type.incsome2tree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
-    ensures { result = Sum0.sum self }
+    ensures { UInt32.to_int result = Sum0.sum self }
     
    = 
   var _0 : uint32;
@@ -240,7 +241,7 @@ module CreusotContracts_Builtins_Int_Impl4_Model
   use mach.int.Int
   use mach.int.UInt32
   function model (self : uint32) : int = 
-    self
+    UInt32.to_int self
 end
 module CreusotContracts_Builtins_Int_Impl4_Interface
   use mach.int.Int
@@ -292,10 +293,10 @@ module Rand_Random
   val random () : t
 end
 module IncSome2Tree_Impl1_TakeSomeRest_Interface
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt32
   clone CreusotContracts_Builtins_Int_Impl4_Interface as Model1
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model0 with type t = uint32,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
@@ -303,14 +304,14 @@ module IncSome2Tree_Impl1_TakeSomeRest_Interface
   val take_some_rest (self : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     ensures { Model0.model (let (a, _) = result in a) <= Sum0.sum ( * self) }
-    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ (let (a, _) = result in a) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     
 end
 module IncSome2Tree_Impl1_TakeSomeRest
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt32
   clone CreusotContracts_Builtins_Int_Impl4 as Model1
   clone CreusotContracts_Builtins_Model_Impl1 as Model0 with type t = uint32, type Model0.modelty = Model1.modelty,
   function Model0.model = Model1.model
@@ -325,7 +326,7 @@ module IncSome2Tree_Impl1_TakeSomeRest
   let rec cfg take_some_rest (self : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     ensures { Model0.model (let (a, _) = result in a) <= Sum0.sum ( * self) }
-    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ (let (a, _) = result in a) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     
    = 
   var _0 : (borrowed uint32, borrowed (Type.incsome2tree_tree));
@@ -524,20 +525,20 @@ module Core_Panicking_Panic
     
 end
 module IncSome2Tree_IncSome2Tree_Interface
+  use mach.int.UInt32
   use mach.int.Int
   use mach.int.Int32
   use Type
-  use mach.int.UInt32
   clone IncSome2Tree_Impl1_Sum_Interface as Sum0
   val inc_some_2_tree (t : Type.incsome2tree_tree) (j : uint32) (k : uint32) : ()
-    requires {Sum0.sum t + j + k <= 1000000}
+    requires {Sum0.sum t + UInt32.to_int j + UInt32.to_int k <= 1000000}
     
 end
 module IncSome2Tree_IncSome2Tree
+  use mach.int.UInt32
   use mach.int.Int
   use mach.int.Int32
   use Type
-  use mach.int.UInt32
   clone IncSome2Tree_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve5 with type self = Type.incsome2tree_tree
@@ -556,7 +557,7 @@ module IncSome2Tree_IncSome2Tree
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone IncSome2Tree_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_2_tree (t : Type.incsome2tree_tree) (j : uint32) (k : uint32) : ()
-    requires {Sum0.sum t + j + k <= 1000000}
+    requires {Sum0.sum t + UInt32.to_int j + UInt32.to_int k <= 1000000}
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -22,10 +22,11 @@ end
 module IncSomeList_Impl1_Sum
   use Type
   use mach.int.Int
+  use mach.int.UInt32
   use mach.int.Int32
   function sum (self : Type.incsomelist_list) : int = 
     match (self) with
-      | Type.IncSomeList_List_Cons a l -> a + sum l
+      | Type.IncSomeList_List_Cons a l -> UInt32.to_int a + sum l
       | Type.IncSomeList_List_Nil -> 0
       end
 end
@@ -77,21 +78,21 @@ end
 module IncSomeList_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
-  use mach.int.UInt32
   clone IncSomeList_Impl1_Sum_Interface as Sum0
   val sum_x (self : Type.incsomelist_list) : uint32
     requires {Sum0.sum self <= 1000000}
-    ensures { result = Sum0.sum self }
+    ensures { UInt32.to_int result = Sum0.sum self }
     
 end
 module IncSomeList_Impl1_SumX
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
-  use mach.int.UInt32
   clone IncSomeList_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve3 with type self = Type.incsomelist_list
@@ -100,7 +101,7 @@ module IncSomeList_Impl1_SumX
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve0 with type self = Type.incsomelist_list
   let rec cfg sum_x (self : Type.incsomelist_list) : uint32
     requires {Sum0.sum self <= 1000000}
-    ensures { result = Sum0.sum self }
+    ensures { UInt32.to_int result = Sum0.sum self }
     
    = 
   var _0 : uint32;
@@ -213,7 +214,7 @@ module CreusotContracts_Builtins_Int_Impl4_Model
   use mach.int.Int
   use mach.int.UInt32
   function model (self : uint32) : int = 
-    self
+    UInt32.to_int self
 end
 module CreusotContracts_Builtins_Int_Impl4_Interface
   use mach.int.Int
@@ -265,24 +266,24 @@ module Rand_Random
   val random () : t
 end
 module IncSomeList_Impl1_TakeSome_Interface
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt32
   clone IncSomeList_Impl1_Sum_Interface as Sum0
   clone CreusotContracts_Builtins_Int_Impl4_Interface as Model1
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model0 with type t = uint32,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val take_some (self : borrowed (Type.incsomelist_list)) : borrowed uint32
     ensures { Model0.model result <= Sum0.sum ( * self) }
-    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result - Model0.model result }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - Model0.model result }
     
 end
 module IncSomeList_Impl1_TakeSome
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt32
   clone IncSomeList_Impl1_Sum as Sum0
   clone CreusotContracts_Builtins_Int_Impl4 as Model1
   clone CreusotContracts_Builtins_Model_Impl1 as Model0 with type t = uint32, type Model0.modelty = Model1.modelty,
@@ -296,7 +297,7 @@ module IncSomeList_Impl1_TakeSome
   clone IncSomeList_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some (self : borrowed (Type.incsomelist_list)) : borrowed uint32
     ensures { Model0.model result <= Sum0.sum ( * self) }
-    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result - Model0.model result }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - Model0.model result }
     
    = 
   var _0 : borrowed uint32;
@@ -419,20 +420,20 @@ module Core_Panicking_Panic
     
 end
 module IncSomeList_IncSomeList_Interface
+  use mach.int.UInt32
   use mach.int.Int
   use mach.int.Int32
   use Type
-  use mach.int.UInt32
   clone IncSomeList_Impl1_Sum_Interface as Sum0
   val inc_some_list (l : Type.incsomelist_list) (k : uint32) : ()
-    requires {Sum0.sum l + k <= 1000000}
+    requires {Sum0.sum l + UInt32.to_int k <= 1000000}
     
 end
 module IncSomeList_IncSomeList
+  use mach.int.UInt32
   use mach.int.Int
   use mach.int.Int32
   use Type
-  use mach.int.UInt32
   clone IncSomeList_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve3 with type self = Type.incsomelist_list
@@ -447,7 +448,7 @@ module IncSomeList_IncSomeList
   function Sum0.sum = Sum0.sum, function Model1.model = Model1.model
   clone IncSomeList_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_list (l : Type.incsomelist_list) (k : uint32) : ()
-    requires {Sum0.sum l + k <= 1000000}
+    requires {Sum0.sum l + UInt32.to_int k <= 1000000}
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -22,10 +22,11 @@ end
 module IncSomeTree_Impl1_Sum
   use Type
   use mach.int.Int
+  use mach.int.UInt32
   use mach.int.Int32
   function sum (self : Type.incsometree_tree) : int = 
     match (self) with
-      | Type.IncSomeTree_Tree_Node tl a tr -> sum tl + a + sum tr
+      | Type.IncSomeTree_Tree_Node tl a tr -> sum tl + UInt32.to_int a + sum tr
       | Type.IncSomeTree_Tree_Leaf -> 0
       end
 end
@@ -77,21 +78,21 @@ end
 module IncSomeTree_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
-  use mach.int.UInt32
   clone IncSomeTree_Impl1_Sum_Interface as Sum0
   val sum_x (self : Type.incsometree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
-    ensures { result = Sum0.sum self }
+    ensures { UInt32.to_int result = Sum0.sum self }
     
 end
 module IncSomeTree_Impl1_SumX
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
-  use mach.int.UInt32
   clone IncSomeTree_Impl1_Sum as Sum0
   use mach.int.Int64
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve3 with type self = uint32
@@ -101,7 +102,7 @@ module IncSomeTree_Impl1_SumX
   clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg sum_x (self : Type.incsometree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
-    ensures { result = Sum0.sum self }
+    ensures { UInt32.to_int result = Sum0.sum self }
     
    = 
   var _0 : uint32;
@@ -240,7 +241,7 @@ module CreusotContracts_Builtins_Int_Impl4_Model
   use mach.int.Int
   use mach.int.UInt32
   function model (self : uint32) : int = 
-    self
+    UInt32.to_int self
 end
 module CreusotContracts_Builtins_Int_Impl4_Interface
   use mach.int.Int
@@ -292,24 +293,24 @@ module Rand_Random
   val random () : t
 end
 module IncSomeTree_Impl1_TakeSome_Interface
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt32
   clone IncSomeTree_Impl1_Sum_Interface as Sum0
   clone CreusotContracts_Builtins_Int_Impl4_Interface as Model1
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model0 with type t = uint32,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val take_some (self : borrowed (Type.incsometree_tree)) : borrowed uint32
     ensures { Model0.model result <= Sum0.sum ( * self) }
-    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result - Model0.model result }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - Model0.model result }
     
 end
 module IncSomeTree_Impl1_TakeSome
+  use mach.int.UInt32
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt32
   clone IncSomeTree_Impl1_Sum as Sum0
   clone CreusotContracts_Builtins_Int_Impl4 as Model1
   clone CreusotContracts_Builtins_Model_Impl1 as Model0 with type t = uint32, type Model0.modelty = Model1.modelty,
@@ -323,7 +324,7 @@ module IncSomeTree_Impl1_TakeSome
   clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   let rec cfg take_some (self : borrowed (Type.incsometree_tree)) : borrowed uint32
     ensures { Model0.model result <= Sum0.sum ( * self) }
-    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) =  ^ result - Model0.model result }
+    ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - Model0.model result }
     
    = 
   var _0 : borrowed uint32;
@@ -492,20 +493,20 @@ module Core_Panicking_Panic
     
 end
 module IncSomeTree_IncSomeTree_Interface
+  use mach.int.UInt32
   use mach.int.Int
   use mach.int.Int32
   use Type
-  use mach.int.UInt32
   clone IncSomeTree_Impl1_Sum_Interface as Sum0
   val inc_some_tree (t : Type.incsometree_tree) (k : uint32) : ()
-    requires {Sum0.sum t + k <= 1000000}
+    requires {Sum0.sum t + UInt32.to_int k <= 1000000}
     
 end
 module IncSomeTree_IncSomeTree
+  use mach.int.UInt32
   use mach.int.Int
   use mach.int.Int32
   use Type
-  use mach.int.UInt32
   clone IncSomeTree_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve3 with type self = Type.incsometree_tree
@@ -520,7 +521,7 @@ module IncSomeTree_IncSomeTree
   function Sum0.sum = Sum0.sum, function Model1.model = Model1.model
   clone IncSomeTree_Impl1_SumX_Interface as SumX0 with function Sum0.sum = Sum0.sum
   let rec cfg inc_some_tree (t : Type.incsometree_tree) (k : uint32) : ()
-    requires {Sum0.sum t + k <= 1000000}
+    requires {Sum0.sum t + UInt32.to_int k <= 1000000}
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -90,20 +90,20 @@ module Std_Process_Abort
     
 end
 module ListIndexMut_IndexMut_Interface
+  use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
   use Type
   use prelude.Prelude
-  use mach.int.UInt64
   use mach.int.UInt32
   clone ListIndexMut_Get_Interface as Get0
   clone ListIndexMut_Len_Interface as Len0
   val index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
-    requires {param_ix < Len0.len ( * param_l)}
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
+    requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> UInt64.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
     ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get0.get ( ^ param_l) param_ix }
-    ensures { Type.ListIndexMut_Option_Some ( * result) = Get0.get ( * param_l) param_ix }
+    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get0.get ( ^ param_l) (UInt64.to_int param_ix) }
+    ensures { Type.ListIndexMut_Option_Some ( * result) = Get0.get ( * param_l) (UInt64.to_int param_ix) }
     
 end
 module ListIndexMut_IndexMut
@@ -123,11 +123,11 @@ module ListIndexMut_IndexMut
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve1 with type self = usize
   clone CreusotContracts_Builtins_Resolve_Impl1 as Resolve0 with type t = Type.listindexmut_list
   let rec cfg index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
-    requires {param_ix < Len0.len ( * param_l)}
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
+    requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> UInt64.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
     ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get0.get ( ^ param_l) param_ix }
-    ensures { Type.ListIndexMut_Option_Some ( * result) = Get0.get ( * param_l) param_ix }
+    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get0.get ( ^ param_l) (UInt64.to_int param_ix) }
+    ensures { Type.ListIndexMut_Option_Some ( * result) = Get0.get ( * param_l) (UInt64.to_int param_ix) }
     
    = 
   var _0 : borrowed uint32;
@@ -163,11 +163,11 @@ module ListIndexMut_IndexMut
     goto BB1
   }
   BB1 {
-    invariant valid_ix { (0 : usize) <= ix_5 && ix_5 < Len0.len ( * l_4) };
-    invariant get_target_now { Get0.get ( * l_4) ix_5 = Get0.get ( * param_l_1) param_ix_2 };
-    invariant get_target_fin { Get0.get ( ^ l_4) ix_5 = Get0.get ( ^ param_l_1) param_ix_2 };
+    invariant valid_ix { (0 : usize) <= ix_5 && UInt64.to_int ix_5 < Len0.len ( * l_4) };
+    invariant get_target_now { Get0.get ( * l_4) (UInt64.to_int ix_5) = Get0.get ( * param_l_1) (UInt64.to_int param_ix_2) };
+    invariant get_target_fin { Get0.get ( ^ l_4) (UInt64.to_int ix_5) = Get0.get ( ^ param_l_1) (UInt64.to_int param_ix_2) };
     invariant len { Len0.len ( ^ l_4) = Len0.len ( * l_4) -> Len0.len ( ^ param_l_1) = Len0.len ( * param_l_1) };
-    invariant untouched { (forall i : (int) . 0 <= i && i < Len0.len ( * l_4) && i <> ix_5 -> Get0.get ( ^ l_4) i = Get0.get ( * l_4) i) -> (forall i : (int) . 0 <= i && i < Len0.len ( * param_l_1) && i <> param_ix_2 -> Get0.get ( ^ param_l_1) i = Get0.get ( * param_l_1) i) };
+    invariant untouched { (forall i : (int) . 0 <= i && i < Len0.len ( * l_4) && i <> UInt64.to_int ix_5 -> Get0.get ( ^ l_4) i = Get0.get ( * l_4) i) -> (forall i : (int) . 0 <= i && i < Len0.len ( * param_l_1) && i <> UInt64.to_int param_ix_2 -> Get0.get ( ^ param_l_1) i = Get0.get ( * param_l_1) i) };
     goto BB2
   }
   BB2 {
@@ -232,27 +232,27 @@ module ListIndexMut_IndexMut
   
 end
 module ListIndexMut_Write_Interface
+  use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
   use Type
   use prelude.Prelude
-  use mach.int.UInt64
   use mach.int.UInt32
   clone ListIndexMut_Get_Interface as Get0
   clone ListIndexMut_Len_Interface as Len0
   val write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
-    requires {ix < Len0.len ( * l)}
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
+    requires {UInt64.to_int ix < Len0.len ( * l)}
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> UInt64.to_int ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
     ensures { Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { Type.ListIndexMut_Option_Some v = Get0.get ( ^ l) ix }
+    ensures { Type.ListIndexMut_Option_Some v = Get0.get ( ^ l) (UInt64.to_int ix) }
     
 end
 module ListIndexMut_Write
+  use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
   use Type
   use prelude.Prelude
-  use mach.int.UInt64
   use mach.int.UInt32
   clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
@@ -262,10 +262,10 @@ module ListIndexMut_Write
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve0 with type self = uint32
   clone ListIndexMut_IndexMut_Interface as IndexMut0 with function Len0.len = Len0.len, function Get0.get = Get0.get
   let rec cfg write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
-    requires {ix < Len0.len ( * l)}
-    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
+    requires {UInt64.to_int ix < Len0.len ( * l)}
+    ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> UInt64.to_int ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
     ensures { Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { Type.ListIndexMut_Option_Some v = Get0.get ( ^ l) ix }
+    ensures { Type.ListIndexMut_Option_Some v = Get0.get ( ^ l) (UInt64.to_int ix) }
     
    = 
   var _0 : ();

--- a/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
+++ b/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
@@ -12,12 +12,12 @@ module Type
 end
 module C17ImplRefinement_Tr
   type self   
+  use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  use mach.int.UInt64
   val my_function (self : self) : usize
-    ensures { result >= 10 }
+    ensures { UInt64.to_int result >= 10 }
     
 end
 module CreusotContracts_Builtins_Resolve_Resolve
@@ -25,24 +25,24 @@ module CreusotContracts_Builtins_Resolve_Resolve
   predicate resolve (self : self)
 end
 module C17ImplRefinement_Impl0_MyFunction_Interface
+  use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  use mach.int.UInt64
   val my_function (self : ()) : usize
     requires {true}
-    ensures { result >= 15 }
+    ensures { UInt64.to_int result >= 15 }
     
 end
 module C17ImplRefinement_Impl0_MyFunction
+  use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  use mach.int.UInt64
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve0 with type self = ()
   let rec cfg my_function (self : ()) : usize
     requires {true}
-    ensures { result >= 15 }
+    ensures { UInt64.to_int result >= 15 }
     
    = 
   var _0 : usize;

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -178,30 +178,30 @@ module CreusotContracts_Builtins_Model_Impl0
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
-    ensures { result = Seq.length (Model0.model self) }
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
-    ensures { result = Seq.length (Model0.model self) }
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
 end
 module CreusotContracts_Builtins_Model_Impl1_Model_Interface
@@ -241,40 +241,40 @@ module CreusotContracts_Builtins_Model_Impl1
 end
 module CreusotContracts_Std1_Vec_Impl1_IndexMut_Interface
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
   use Type
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model0 with type t = t
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
   val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
-    requires {ix < Seq.length (Model0.model ( * self))}
+    requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
     ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
-    ensures { forall j : (int) . 0 <= j && j < Seq.length (Model0.model ( ^ self)) -> not (j = ix) -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
-    ensures {  ^ result = Seq.get (Model0.model ( ^ self)) ix }
-    ensures {  * result = Seq.get (Model1.model self) ix }
+    ensures { forall j : (int) . 0 <= j && j < Seq.length (Model0.model ( ^ self)) -> not (j = UInt64.to_int ix) -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
+    ensures {  ^ result = Seq.get (Model0.model ( ^ self)) (UInt64.to_int ix) }
+    ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_IndexMut
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
   use Type
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model0 with type t = t
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
   val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
-    requires {ix < Seq.length (Model0.model ( * self))}
+    requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
     ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
-    ensures { forall j : (int) . 0 <= j && j < Seq.length (Model0.model ( ^ self)) -> not (j = ix) -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
-    ensures {  ^ result = Seq.get (Model0.model ( ^ self)) ix }
-    ensures {  * result = Seq.get (Model1.model self) ix }
+    ensures { forall j : (int) . 0 <= j && j < Seq.length (Model0.model ( ^ self)) -> not (j = UInt64.to_int ix) -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
+    ensures {  ^ result = Seq.get (Model0.model ( ^ self)) (UInt64.to_int ix) }
+    ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
 module CreusotContracts_Builtins_Resolve_Impl1_Resolve_Interface
@@ -317,12 +317,12 @@ module C01_AllZero
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt64
   use mach.int.UInt32
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0 as Model1 with type t = uint32
   clone C01_Impl0 as Model0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
-  use mach.int.UInt64
   clone CreusotContracts_Builtins_Resolve_Impl1 as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec uint32
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve4 with type self = ()
   clone CreusotContracts_Builtins_Resolve_Impl1 as Resolve3 with type t = uint32
@@ -380,7 +380,7 @@ module C01_AllZero
   BB2 {
     invariant proph_const {  ^ v_1 =  ^ Model0.model old_v_3 };
     invariant in_bounds { Seq.length (Model1.model ( * v_1)) = Seq.length (Model1.model ( * Model0.model old_v_3)) };
-    invariant all_zero { forall j : (int) . 0 <= j && j < i_2 -> Seq.get (Model1.model ( * v_1)) j = (0 : uint32) };
+    invariant all_zero { forall j : (int) . 0 <= j && j < UInt64.to_int i_2 -> Seq.get (Model1.model ( * v_1)) j = (0 : uint32) };
     goto BB3
   }
   BB3 {

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -255,94 +255,94 @@ module CreusotContracts_Builtins_Model_Impl0
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
-    ensures { result = Seq.length (Model0.model self) }
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
-    ensures { result = Seq.length (Model0.model self) }
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use seq.Permut
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val swap (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (i : usize) (j : usize) : ()
-    requires {j < Seq.length (Model0.model self)}
-    requires {i < Seq.length (Model0.model self)}
-    ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) i j }
+    requires {UInt64.to_int j < Seq.length (Model0.model self)}
+    requires {UInt64.to_int i < Seq.length (Model0.model self)}
+    ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) (UInt64.to_int i) (UInt64.to_int j) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use seq.Permut
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val swap (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (i : usize) (j : usize) : ()
-    requires {j < Seq.length (Model0.model self)}
-    requires {i < Seq.length (Model0.model self)}
-    ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) i j }
+    requires {UInt64.to_int j < Seq.length (Model0.model self)}
+    requires {UInt64.to_int i < Seq.length (Model0.model self)}
+    ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) (UInt64.to_int i) (UInt64.to_int j) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Index_Interface
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
-    requires {ix < Seq.length (Model0.model self)}
-    ensures { result = Seq.get (Model0.model self) ix }
+    requires {UInt64.to_int ix < Seq.length (Model0.model self)}
+    ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Index
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
-    requires {ix < Seq.length (Model0.model self)}
-    ensures { result = Seq.get (Model0.model self) ix }
+    requires {UInt64.to_int ix < Seq.length (Model0.model self)}
+    ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
 module CreusotContracts_Builtins_Resolve_Impl1_Resolve_Interface
@@ -384,6 +384,7 @@ module C02Gnome_GnomeSort
   type t   
   use mach.int.Int
   use mach.int.Int32
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -397,7 +398,6 @@ module C02Gnome_GnomeSort
   clone CreusotContracts_Std1_Vec_Impl0 as Model2 with type t = t
   clone CreusotContracts_Builtins_Model_Impl1 as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model2.modelty, function Model0.model = Model2.model
-  use mach.int.UInt64
   clone CreusotContracts_Builtins_Resolve_Impl1 as Resolve6 with type t = Type.creusotcontracts_std1_vec_vec t
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve5 with type self = bool
   clone CreusotContracts_Builtins_Resolve_Resolve as Resolve4 with type self = t
@@ -469,9 +469,9 @@ module C02Gnome_GnomeSort
     goto BB2
   }
   BB2 {
-    invariant sorted { SortedRange0.sorted_range (Model0.model v_1) 0 i_5 };
+    invariant sorted { SortedRange0.sorted_range (Model0.model v_1) 0 (UInt64.to_int i_5) };
     invariant proph_const {  ^ v_1 =  ^ Model1.model old_v_2 };
-    invariant in_len { i_5 <= Seq.length (Model2.model ( * v_1)) };
+    invariant in_len { UInt64.to_int i_5 <= Seq.length (Model2.model ( * v_1)) };
     invariant permutation { PermutationOf0.permutation_of (Model2.model ( * v_1)) (Model2.model ( * Model1.model old_v_2)) };
     goto BB3
   }

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -83,19 +83,19 @@ module C03KnuthShuffle_Impl1_Record
     
 end
 module C03KnuthShuffle_RandInRange_Interface
+  use mach.int.UInt64
   use mach.int.Int
   use prelude.Prelude
-  use mach.int.UInt64
   val rand_in_range (l : usize) (u : usize) : usize
-    ensures { l <= result && result < u }
+    ensures { UInt64.to_int l <= UInt64.to_int result && UInt64.to_int result < UInt64.to_int u }
     
 end
 module C03KnuthShuffle_RandInRange
+  use mach.int.UInt64
   use mach.int.Int
   use prelude.Prelude
-  use mach.int.UInt64
   val rand_in_range (l : usize) (u : usize) : usize
-    ensures { l <= result && result < u }
+    ensures { UInt64.to_int l <= UInt64.to_int result && UInt64.to_int result < UInt64.to_int u }
     
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
@@ -231,64 +231,64 @@ module CreusotContracts_Builtins_Model_Impl0
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
-    ensures { result = Seq.length (Model0.model self) }
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
-    ensures { result = Seq.length (Model0.model self) }
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use seq.Permut
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val swap (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (i : usize) (j : usize) : ()
-    requires {j < Seq.length (Model0.model self)}
-    requires {i < Seq.length (Model0.model self)}
-    ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) i j }
+    requires {UInt64.to_int j < Seq.length (Model0.model self)}
+    requires {UInt64.to_int i < Seq.length (Model0.model self)}
+    ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) (UInt64.to_int i) (UInt64.to_int j) }
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap
   type t   
+  use mach.int.UInt64
   use seq.Seq
   use seq.Permut
   use prelude.Prelude
   use Type
   use mach.int.Int
-  use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
   clone CreusotContracts_Builtins_Model_Impl1_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
   val swap (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (i : usize) (j : usize) : ()
-    requires {j < Seq.length (Model0.model self)}
-    requires {i < Seq.length (Model0.model self)}
-    ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) i j }
+    requires {UInt64.to_int j < Seq.length (Model0.model self)}
+    requires {UInt64.to_int i < Seq.length (Model0.model self)}
+    ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) (UInt64.to_int i) (UInt64.to_int j) }
     
 end
 module CreusotContracts_Builtins_Resolve_Impl1_Resolve_Interface


### PR DESCRIPTION
Always print the integer coercions in logical terms (except when in unbounded mode of course). 
Keeps intelligent printing for the case where we do a coercion of a constant (very common).

cc @jhjourdan this should solve one half of the issue you had today.
