### PR TITLE
Fix bug which occured when translating clone instances

### DIFF
--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -60,7 +60,7 @@ impl<'tcx> TranslationCtx<'_, 'tcx> {
             decls.extend(own_generic_decls_for(self.tcx, item.def_id));
 
             let trait_item = trait_assocs
-                .find_by_name_and_kind(self.tcx, item.ident, item.kind, impl_id)
+                .find_by_name_and_kind(self.tcx, item.ident, item.kind, trait_ref.def_id)
                 .unwrap();
             let s = subst.rebase_onto(self.tcx, impl_id, trait_ref.substs);
 

--- a/creusot/tests/should_succeed/bug/02_derive.rs
+++ b/creusot/tests/should_succeed/bug/02_derive.rs
@@ -1,0 +1,2 @@
+#[derive(Clone)]
+struct Lit {}

--- a/creusot/tests/should_succeed/bug/02_derive.stdout
+++ b/creusot/tests/should_succeed/bug/02_derive.stdout
@@ -1,0 +1,72 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+  type c02derive_lit  = 
+    | C02Derive_Lit
+    
+end
+module Core_Clone_Clone_Clone_Interface
+  type self   
+  use prelude.Prelude
+  val clone' (self : self) : self
+    requires {false}
+    
+end
+module Core_Clone_Clone_Clone
+  type self   
+  use prelude.Prelude
+  val clone' (self : self) : self
+    requires {false}
+    
+end
+module Core_Clone_Clone_CloneFrom_Interface
+  type self   
+  use prelude.Prelude
+  val clone_from (self : borrowed self) (source : self) : ()
+    requires {false}
+    
+end
+module Core_Clone_Clone_CloneFrom
+  type self   
+  use prelude.Prelude
+  val clone_from (self : borrowed self) (source : self) : ()
+    requires {false}
+    
+end
+module C02Derive_Impl0_Clone_Interface
+  use prelude.Prelude
+  use Type
+  val clone' (self : Type.c02derive_lit) : Type.c02derive_lit
+    requires {false}
+    
+end
+module C02Derive_Impl0_Clone
+  use prelude.Prelude
+  use Type
+  let rec cfg clone' (self : Type.c02derive_lit) : Type.c02derive_lit = 
+  var _0 : Type.c02derive_lit;
+  var self_1 : Type.c02derive_lit;
+  {
+    self_1 <- self;
+    goto BB0
+  }
+  BB0 {
+    assume { (fun x -> true) self_1 };
+    _0 <- Type.C02Derive_Lit;
+    return _0
+  }
+  
+end
+module C02Derive_Impl0
+  use Type
+  clone C02Derive_Impl0_Clone_Interface as Clone0
+  clone Core_Clone_Clone_Clone_Interface as Clone1 with type self = Type.c02derive_lit, val clone' = Clone0.clone'
+end


### PR DESCRIPTION
The clone instance would cause a panic before. It turns out (by searching the rustc codebase) that I was calling `find_by_name_and_kind` incorrectly. The `parent_id` argument refers to the `AssociatedItems` parent which here is the trait itself.

thanks @sarsko
