### PR TITLE
Only emit requires false for unverified external functions

### DIFF
--- a/creusot/src/metadata.rs
+++ b/creusot/src/metadata.rs
@@ -35,6 +35,12 @@ impl Metadata<'tcx> {
         self.crates.get(&cnum)
     }
 
+    /// Determines whether a DefId has been verified by Creusot or not.
+    /// We consider that if we don't have metadata about a crate then it must be unverified
+    pub fn verified(&self, def_id: DefId) -> bool {
+        self.crates.contains_key(&def_id.krate)
+    }
+
     pub fn dependencies(&self, def_id: DefId) -> Option<&CloneSummary<'tcx>> {
         assert!(!def_id.is_local());
         self.get(def_id.krate)?.dependencies.get(&def_id)

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -28,7 +28,7 @@ pub fn default_decl(
             ValKind::Predicate { sig }
         }
         ItemType::Program => {
-            if !util::is_trusted(ctx.tcx, def_id) {
+            if !ctx.externs.verified(def_id) {
                 sig.contract.requires.push(why3::mlcfg::Exp::mk_false());
             }
             Val { sig }

--- a/creusot/src/translation/interface.rs
+++ b/creusot/src/translation/interface.rs
@@ -34,7 +34,7 @@ pub fn interface_for(
             decls.push(Decl::ValDecl(ValKind::Function { sig }));
         }
         _ => {
-            if !util::is_trusted(ctx.tcx, def_id) {
+            if !def_id.is_local() && !ctx.externs.verified(def_id) {
                 sig.contract.requires.push(why3::mlcfg::Exp::mk_false());
             }
 

--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -20,8 +20,6 @@ module Type
 end
 module AllZero_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module AllZero_Main
   let rec cfg main () : () = 
@@ -105,7 +103,6 @@ module AllZero_AllZero_Interface
   clone AllZero_Get_Interface as Get0
   clone AllZero_Len_Interface as Len0
   val all_zero (l : borrowed (Type.allzero_list)) : ()
-    requires {false}
     ensures { Len0.len ( * l) = Len0.len ( ^ l) }
     ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) -> Get0.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
     

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -24,8 +24,6 @@ module Type
 end
 module BinarySearch_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module BinarySearch_Main
   let rec cfg main () : () = 
@@ -86,13 +84,11 @@ module CreusotContracts_Builtins_Resolve_Resolve_Resolve
 end
 module Std_Process_Abort_Interface
   val abort () : ()
-    requires {false}
     ensures { false }
     
 end
 module Std_Process_Abort
   val abort () : ()
-    requires {false}
     ensures { false }
     
 end
@@ -106,7 +102,6 @@ module BinarySearch_Impl0_Index_Interface
   clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
   val index (self : Type.binarysearch_list t) (ix : usize) : t
     requires {UInt64.to_int ix < LenLogic0.len_logic self}
-    requires {false}
     ensures { Type.Core_Option_Option_Some result = Get0.get self (UInt64.to_int ix) }
     
 end
@@ -228,7 +223,6 @@ module BinarySearch_Impl0_Len_Interface
   clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
   val len (self : Type.binarysearch_list t) : usize
     requires {LenLogic0.len_logic self <= 1000000}
-    requires {false}
     ensures { UInt64.to_int result = LenLogic0.len_logic self }
     ensures { result >= (0 : usize) }
     
@@ -360,7 +354,6 @@ module BinarySearch_BinarySearch_Interface
   val binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
     requires {IsSorted0.is_sorted arr}
     requires {LenLogic0.len_logic arr <= 1000000}
-    requires {false}
     ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr i (0 : uint32)) }
     ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . 0 <= i && i < UInt64.to_int x -> GetDefault0.get_default arr i (0 : uint32) < elem) }
     ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get0.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some elem }

--- a/creusot/tests/should_succeed/branch_borrow_2.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_2.stdout
@@ -26,8 +26,6 @@ module Core_Panicking_Panic
 end
 module BranchBorrow2_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module BranchBorrow2_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/branch_borrow_3.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_3.stdout
@@ -15,8 +15,6 @@ module Type
 end
 module BranchBorrow3_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module BranchBorrow3_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/branch_borrow_4.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_4.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module BranchBorrow4_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module BranchBorrow4_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -170,7 +170,6 @@ module C01ResolveUnsoundness_MakeVecOfSize_Interface
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = bool
   val make_vec_of_size (n : usize) : Type.creusotcontracts_std1_vec_vec bool
-    requires {false}
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
     
 end

--- a/creusot/tests/should_succeed/bug/02_derive.stdout
+++ b/creusot/tests/should_succeed/bug/02_derive.stdout
@@ -45,8 +45,6 @@ module C02Derive_Impl0_Clone_Interface
   use prelude.Prelude
   use Type
   val clone' (self : Type.c02derive_lit) : Type.c02derive_lit
-    requires {false}
-    
 end
 module C02Derive_Impl0_Clone
   use prelude.Prelude

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -107,8 +107,6 @@ module C01_AddsTwo_Interface
   use mach.int.Int
   use mach.int.UInt32
   val adds_two (c : Type.c01_cell uint32 (Type.c01_even)) : ()
-    requires {false}
-    
 end
 module C01_AddsTwo
   use prelude.Prelude

--- a/creusot/tests/should_succeed/cell/02.stdout
+++ b/creusot/tests/should_succeed/cell/02.stdout
@@ -411,7 +411,6 @@ module C02_FibMemo_Interface
     requires {UInt64.to_int i <= 63}
     requires {UInt64.to_int i < Seq.length (Model0.model mem)}
     requires {FibCell0.fib_cell mem}
-    requires {false}
     ensures { UInt64.to_int result = Fib0.fib (UInt64.to_int i) }
     
 end

--- a/creusot/tests/should_succeed/clones/01.stdout
+++ b/creusot/tests/should_succeed/clones/01.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module C01_Func1_Interface
   val func1 () : ()
-    requires {false}
-    
 end
 module C01_Func1
   let rec cfg func1 () : () = 
@@ -29,8 +27,6 @@ module C01_Func1
 end
 module C01_Func2_Interface
   val func2 () : ()
-    requires {false}
-    
 end
 module C01_Func2
   clone C01_Func1_Interface as Func10
@@ -50,8 +46,6 @@ module C01_Func2
 end
 module C01_Func3_Interface
   val func3 () : ()
-    requires {false}
-    
 end
 module C01_Func3
   clone C01_Func2_Interface as Func20

--- a/creusot/tests/should_succeed/clones/02.stdout
+++ b/creusot/tests/should_succeed/clones/02.stdout
@@ -30,7 +30,6 @@ module C02_Program_Interface
   clone C02_UsesSimple_Interface as UsesSimple0
   val program () : ()
     requires {UsesSimple0.uses_simple ()}
-    requires {false}
     ensures { Simple0.simple () }
     
 end

--- a/creusot/tests/should_succeed/clones/03.stdout
+++ b/creusot/tests/should_succeed/clones/03.stdout
@@ -31,7 +31,6 @@ module C03_Prog_Interface
   type t   
   clone C03_Omg_Interface as Omg0 with type t = t
   val prog (x : t) : ()
-    requires {false}
     ensures { Omg0.omg x }
     
 end
@@ -67,7 +66,6 @@ module C03_Prog2_Interface
   use mach.int.Int32
   clone C03_Omg_Interface as Omg0 with type t = int
   val prog2 () : ()
-    requires {false}
     ensures { Omg0.omg 0 }
     
 end
@@ -101,7 +99,6 @@ module C03_Prog3_Interface
   use mach.int.Int32
   clone C03_Omg_Interface as Omg0 with type t = (int, int)
   val prog3 () : ()
-    requires {false}
     ensures { Omg0.omg (0, 0) }
     
 end

--- a/creusot/tests/should_succeed/clones/04.stdout
+++ b/creusot/tests/should_succeed/clones/04.stdout
@@ -59,7 +59,6 @@ module C04_F_Interface
   clone C04_C_Interface as C0
   val f (x : uint32) : ()
     requires {C0.c x}
-    requires {false}
     
 end
 module C04_F

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -202,8 +202,6 @@ module ConstrainedTypes_UsesConcreteInstance_Interface
   use mach.int.Int
   use mach.int.UInt32
   val uses_concrete_instance (x : (uint32, uint32)) (y : (uint32, uint32)) : bool
-    requires {false}
-    
 end
 module ConstrainedTypes_UsesConcreteInstance
   use mach.int.Int
@@ -236,8 +234,6 @@ module ConstrainedTypes_UsesConcreteInstance
 end
 module ConstrainedTypes_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module ConstrainedTypes_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/drop_pair.stdout
+++ b/creusot/tests/should_succeed/drop_pair.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module DropPair_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module DropPair_Main
   let rec cfg main () : () = 
@@ -81,8 +79,6 @@ module DropPair_DropPair2_Interface
   use mach.int.Int
   use mach.int.UInt32
   val drop_pair2 (x : (borrowed uint32, borrowed uint32)) : ()
-    requires {false}
-    
 end
 module DropPair_DropPair2
   use prelude.Prelude
@@ -113,8 +109,6 @@ module DropPair_Drop_Interface
   use mach.int.Int
   use mach.int.UInt32
   val drop (x : borrowed uint32) (y : borrowed uint32) : ()
-    requires {false}
-    
 end
 module DropPair_Drop
   use prelude.Prelude
@@ -150,7 +144,6 @@ module DropPair_DropPair_Interface
   clone CreusotContracts_Builtins_Resolve_Impl0_Resolve_Interface as Resolve0 with type t1 = borrowed uint32,
   type t2 = borrowed uint32
   val drop_pair (x : (borrowed uint32, borrowed uint32)) : ()
-    requires {false}
     ensures {  ^ (let (a, _) = x in a) =  * (let (a, _) = x in a) }
     ensures { Resolve0.resolve x }
     

--- a/creusot/tests/should_succeed/empty.stdout
+++ b/creusot/tests/should_succeed/empty.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module Empty_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Empty_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/forall.stdout
+++ b/creusot/tests/should_succeed/forall.stdout
@@ -14,7 +14,6 @@ module Forall_Main_Interface
   use mach.int.Int
   use mach.int.UInt32
   val main () : ()
-    requires {false}
     ensures { forall x : (uint32) . true && true && true && true && true && true && true && true && true }
     
 end

--- a/creusot/tests/should_succeed/immut.stdout
+++ b/creusot/tests/should_succeed/immut.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module Immut_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Immut_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/inc_max.stdout
+++ b/creusot/tests/should_succeed/inc_max.stdout
@@ -41,7 +41,6 @@ module IncMax_TakeMax_Interface
   use mach.int.UInt32
   use prelude.Prelude
   val take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
-    requires {false}
     ensures { match ( * ma >=  * mb) with
       | True ->  * mb =  ^ mb && result = ma
       | False ->  * ma =  ^ ma && result = mb
@@ -133,7 +132,6 @@ module IncMax_IncMax_Interface
   use mach.int.UInt32
   val inc_max (a : uint32) (b : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32)}
-    requires {false}
     
 end
 module IncMax_IncMax

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -58,7 +58,6 @@ module IncMax3_IncMax3_Interface
   use prelude.Prelude
   val inc_max_3 (ma : borrowed uint32) (mb : borrowed uint32) (mc : borrowed uint32) : ()
     requires { * ma <= (1000000 : uint32) &&  * mb <= (1000000 : uint32) &&  * mc <= (1000000 : uint32)}
-    requires {false}
     ensures {  ^ ma <>  ^ mb &&  ^ mb <>  ^ mc &&  ^ mc <>  ^ ma }
     
 end
@@ -249,7 +248,6 @@ module IncMax3_TestIncMax3_Interface
   use mach.int.UInt32
   val test_inc_max_3 (a : uint32) (b : uint32) (c : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && c <= (1000000 : uint32)}
-    requires {false}
     
 end
 module IncMax3_TestIncMax3

--- a/creusot/tests/should_succeed/inc_max_many.stdout
+++ b/creusot/tests/should_succeed/inc_max_many.stdout
@@ -41,7 +41,6 @@ module IncMaxMany_TakeMax_Interface
   use mach.int.UInt32
   use prelude.Prelude
   val take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
-    requires {false}
     ensures { match ( * ma >=  * mb) with
       | True ->  * mb =  ^ mb && result = ma
       | False ->  * ma =  ^ ma && result = mb
@@ -133,7 +132,6 @@ module IncMaxMany_IncMaxMany_Interface
   use mach.int.UInt32
   val inc_max_many (a : uint32) (b : uint32) (k : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && k <= (1000000 : uint32)}
-    requires {false}
     
 end
 module IncMaxMany_IncMaxMany

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -41,7 +41,6 @@ module IncMaxRepeat_TakeMax_Interface
   use mach.int.UInt32
   use prelude.Prelude
   val take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
-    requires {false}
     ensures { match ( * ma >=  * mb) with
       | True ->  * mb =  ^ mb && result = ma
       | False ->  * ma =  ^ ma && result = mb
@@ -133,7 +132,6 @@ module IncMaxRepeat_IncMaxRepeat_Interface
   use mach.int.UInt32
   val inc_max_repeat (a : uint32) (b : uint32) (n : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && n <= (1000000 : uint32)}
-    requires {false}
     
 end
 module IncMaxRepeat_IncMaxRepeat

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -84,7 +84,6 @@ module IncSome2List_Impl1_SumX_Interface
   clone IncSome2List_Impl1_Sum_Interface as Sum0
   val sum_x (self : Type.incsome2list_list) : uint32
     requires {Sum0.sum self <= 1000000}
-    requires {false}
     ensures { UInt32.to_int result = Sum0.sum self }
     
 end
@@ -272,7 +271,6 @@ module IncSome2List_Impl1_TakeSomeRest_Interface
   type ModelTy0.modelty = ModelTy0.modelty
   clone IncSome2List_Impl1_Sum_Interface as Sum0
   val take_some_rest (self : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
-    requires {false}
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     ensures { Model0.model (let (a, _) = result in a) <= Sum0.sum ( * self) }
     ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
@@ -431,7 +429,6 @@ module IncSome2List_IncSome2List_Interface
   clone IncSome2List_Impl1_Sum_Interface as Sum0
   val inc_some_2_list (l : Type.incsome2list_list) (j : uint32) (k : uint32) : ()
     requires {Sum0.sum l + UInt32.to_int j + UInt32.to_int k <= 1000000}
-    requires {false}
     
 end
 module IncSome2List_IncSome2List

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -84,7 +84,6 @@ module IncSome2Tree_Impl1_SumX_Interface
   clone IncSome2Tree_Impl1_Sum_Interface as Sum0
   val sum_x (self : Type.incsome2tree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
-    requires {false}
     ensures { UInt32.to_int result = Sum0.sum self }
     
 end
@@ -290,7 +289,6 @@ module IncSome2Tree_Impl1_TakeSomeRest_Interface
   type ModelTy0.modelty = ModelTy0.modelty
   clone IncSome2Tree_Impl1_Sum_Interface as Sum0
   val take_some_rest (self : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
-    requires {false}
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     ensures { Model0.model (let (a, _) = result in a) <= Sum0.sum ( * self) }
     ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - Model0.model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
@@ -509,7 +507,6 @@ module IncSome2Tree_IncSome2Tree_Interface
   clone IncSome2Tree_Impl1_Sum_Interface as Sum0
   val inc_some_2_tree (t : Type.incsome2tree_tree) (j : uint32) (k : uint32) : ()
     requires {Sum0.sum t + UInt32.to_int j + UInt32.to_int k <= 1000000}
-    requires {false}
     
 end
 module IncSome2Tree_IncSome2Tree

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -84,7 +84,6 @@ module IncSomeList_Impl1_SumX_Interface
   clone IncSomeList_Impl1_Sum_Interface as Sum0
   val sum_x (self : Type.incsomelist_list) : uint32
     requires {Sum0.sum self <= 1000000}
-    requires {false}
     ensures { UInt32.to_int result = Sum0.sum self }
     
 end
@@ -272,7 +271,6 @@ module IncSomeList_Impl1_TakeSome_Interface
   clone CreusotContracts_Builtins_Model_Impl1_Model_Interface as Model0 with type t = uint32,
   type ModelTy0.modelty = ModelTy0.modelty
   val take_some (self : borrowed (Type.incsomelist_list)) : borrowed uint32
-    requires {false}
     ensures { Model0.model result <= Sum0.sum ( * self) }
     ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - Model0.model result }
     
@@ -425,7 +423,6 @@ module IncSomeList_IncSomeList_Interface
   clone IncSomeList_Impl1_Sum_Interface as Sum0
   val inc_some_list (l : Type.incsomelist_list) (k : uint32) : ()
     requires {Sum0.sum l + UInt32.to_int k <= 1000000}
-    requires {false}
     
 end
 module IncSomeList_IncSomeList

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -84,7 +84,6 @@ module IncSomeTree_Impl1_SumX_Interface
   clone IncSomeTree_Impl1_Sum_Interface as Sum0
   val sum_x (self : Type.incsometree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
-    requires {false}
     ensures { UInt32.to_int result = Sum0.sum self }
     
 end
@@ -290,7 +289,6 @@ module IncSomeTree_Impl1_TakeSome_Interface
   clone CreusotContracts_Builtins_Model_Impl1_Model_Interface as Model0 with type t = uint32,
   type ModelTy0.modelty = ModelTy0.modelty
   val take_some (self : borrowed (Type.incsometree_tree)) : borrowed uint32
-    requires {false}
     ensures { Model0.model result <= Sum0.sum ( * self) }
     ensures { Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - Model0.model result }
     
@@ -482,7 +480,6 @@ module IncSomeTree_IncSomeTree_Interface
   clone IncSomeTree_Impl1_Sum_Interface as Sum0
   val inc_some_tree (t : Type.incsometree_tree) (k : uint32) : ()
     requires {Sum0.sum t + UInt32.to_int k <= 1000000}
-    requires {false}
     
 end
 module IncSomeTree_IncSomeTree

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -78,8 +78,6 @@ module InvariantMoves_TestInvariantMove_Interface
   use mach.int.Int
   use mach.int.UInt32
   val test_invariant_move (x : Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)) : ()
-    requires {false}
-    
 end
 module InvariantMoves_TestInvariantMove
   use Type

--- a/creusot/tests/should_succeed/iter_mut.stdout
+++ b/creusot/tests/should_succeed/iter_mut.stdout
@@ -339,7 +339,6 @@ module IterMut_IncVec_Interface
   type ModelTy0.modelty = ModelTy0.modelty
   clone IterMut_Impl0_Model_Interface as Model0 with type t = int
   val inc_vec (v : borrowed (Type.itermut_vec int)) : ()
-    requires {false}
     ensures { forall i : (int) . 0 <= i && i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = Seq.get (Model1.model v) i + 5 }
     ensures { Seq.length (Model0.model ( ^ v)) = Seq.length (Model1.model v) }
     

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -80,13 +80,11 @@ module ListIndexMut_Get
 end
 module Std_Process_Abort_Interface
   val abort () : ()
-    requires {false}
     ensures { false }
     
 end
 module Std_Process_Abort
   val abort () : ()
-    requires {false}
     ensures { false }
     
 end
@@ -101,7 +99,6 @@ module ListIndexMut_IndexMut_Interface
   clone ListIndexMut_Len_Interface as Len0
   val index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
     requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
-    requires {false}
     ensures { forall i : (int) . 0 <= i && i < Len0.len ( * param_l) && i <> UInt64.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
     ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
     ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get0.get ( ^ param_l) (UInt64.to_int param_ix) }
@@ -244,7 +241,6 @@ module ListIndexMut_Write_Interface
   clone ListIndexMut_Len_Interface as Len0
   val write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
     requires {UInt64.to_int ix < Len0.len ( * l)}
-    requires {false}
     ensures { forall i : (int) . 0 <= i && i < Len0.len ( * l) && i <> UInt64.to_int ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
     ensures { Len0.len ( ^ l) = Len0.len ( * l) }
     ensures { Type.ListIndexMut_Option_Some v = Get0.get ( ^ l) (UInt64.to_int ix) }
@@ -324,8 +320,6 @@ module ListIndexMut_Impl0
 end
 module ListIndexMut_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module ListIndexMut_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/logic_functions.stdout
+++ b/creusot/tests/should_succeed/logic_functions.stdout
@@ -24,7 +24,6 @@ end
 module LogicFunctions_UseLogic_Interface
   clone LogicFunctions_Logic_Interface as Logic0
   val use_logic () : ()
-    requires {false}
     ensures { Logic0.logic () }
     
 end
@@ -56,7 +55,6 @@ end
 module LogicFunctions_UseLogicPearlite_Interface
   clone LogicFunctions_LogicPearlite_Interface as LogicPearlite0
   val use_logic_pearlite () : ()
-    requires {false}
     ensures { LogicPearlite0.logic_pearlite () }
     
 end

--- a/creusot/tests/should_succeed/loop.stdout
+++ b/creusot/tests/should_succeed/loop.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module Loop_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Loop_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/match_int.stdout
+++ b/creusot/tests/should_succeed/match_int.stdout
@@ -26,8 +26,6 @@ module Core_Panicking_Panic
 end
 module MatchInt_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module MatchInt_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/mc91.stdout
+++ b/creusot/tests/should_succeed/mc91.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module Mc91_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Mc91_Main
   let rec cfg main () : () = 
@@ -39,7 +37,6 @@ module Mc91_Mc91_Interface
   use mach.int.Int
   use mach.int.UInt32
   val mc91 (x : uint32) : uint32
-    requires {false}
     ensures { x <= (100 : uint32) -> result = (91 : uint32) && x > (100 : uint32) -> result = x - (10 : uint32) }
     
 end

--- a/creusot/tests/should_succeed/module_paths.stdout
+++ b/creusot/tests/should_succeed/module_paths.stdout
@@ -25,7 +25,6 @@ end
 module ModulePaths_Test_Interface
   use Type
   val test (a : Type.modulepaths_a_t) (b : Type.modulepaths_s) (c : Type.modulepaths_b_o) (d : Type.modulepaths_b_c_t) : ()
-    requires {false}
     
 end
 module ModulePaths_Test
@@ -57,8 +56,6 @@ module ModulePaths_Test
 end
 module ModulePaths_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module ModulePaths_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/modules.stdout
+++ b/creusot/tests/should_succeed/modules.stdout
@@ -15,8 +15,6 @@ module Type
 end
 module Modules_Nested_Further_Another_Interface
   val another () : bool
-    requires {false}
-    
 end
 module Modules_Nested_Further_Another
   let rec cfg another () : bool = 
@@ -55,7 +53,6 @@ module Modules_Nested_Impl0
 end
 module Modules_Nested_InnerFunc_Interface
   val inner_func () : bool
-    requires {false}
     ensures { result = true }
     
 end
@@ -81,8 +78,6 @@ module Modules_Nested_InnerFunc
 end
 module Modules_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Modules_Main
   clone Modules_Nested_Further_Another_Interface as Another0

--- a/creusot/tests/should_succeed/move_path.stdout
+++ b/creusot/tests/should_succeed/move_path.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module MovePath_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module MovePath_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/multiple_scopes.stdout
+++ b/creusot/tests/should_succeed/multiple_scopes.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module MultipleScopes_MultipleScopes_Interface
   val multiple_scopes () : ()
-    requires {false}
-    
 end
 module MultipleScopes_MultipleScopes
   use mach.int.Int
@@ -45,8 +43,6 @@ module MultipleScopes_MultipleScopes
 end
 module MultipleScopes_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module MultipleScopes_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/mut_call.stdout
+++ b/creusot/tests/should_succeed/mut_call.stdout
@@ -15,8 +15,6 @@ module MutCall_Kill_Interface
   use mach.int.Int
   use mach.int.UInt32
   val kill (_1 : borrowed uint32) : ()
-    requires {false}
-    
 end
 module MutCall_Kill
   use prelude.Prelude
@@ -38,8 +36,6 @@ module MutCall_Kill
 end
 module MutCall_Test_Interface
   val test () : ()
-    requires {false}
-    
 end
 module MutCall_Test
   use mach.int.Int
@@ -74,8 +70,6 @@ module MutCall_Test
 end
 module MutCall_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module MutCall_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/one_side_update.stdout
+++ b/creusot/tests/should_succeed/one_side_update.stdout
@@ -15,8 +15,6 @@ module Type
 end
 module OneSideUpdate_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module OneSideUpdate_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -40,7 +40,6 @@ module ProjectionToggle_ProjToggle_Interface
   type t   
   use prelude.Prelude
   val proj_toggle (toggle : bool) (a : borrowed t) (b : borrowed t) : borrowed t
-    requires {false}
     ensures { match (toggle) with
       | True -> result = a &&  ^ b =  * b
       | False -> result = b &&  ^ a =  * a
@@ -126,8 +125,6 @@ module Core_Panicking_Panic
 end
 module ProjectionToggle_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module ProjectionToggle_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/projections.stdout
+++ b/creusot/tests/should_succeed/projections.stdout
@@ -23,8 +23,6 @@ module Projections_CopyOutOfRef_Interface
   use mach.int.Int
   use mach.int.UInt32
   val copy_out_of_ref (x : uint32) : uint32
-    requires {false}
-    
 end
 module Projections_CopyOutOfRef
   use prelude.Prelude
@@ -51,8 +49,6 @@ module Projections_CopyOutOfSum_Interface
   use mach.int.Int
   use mach.int.UInt32
   val copy_out_of_sum (x : Type.core_result_result (borrowed uint32) (borrowed uint32)) : uint32
-    requires {false}
-    
 end
 module Projections_CopyOutOfSum
   use Type
@@ -112,8 +108,6 @@ module Projections_WriteIntoSum_Interface
   use mach.int.Int
   use mach.int.UInt32
   val write_into_sum (x : borrowed (Type.core_option_option uint32)) : ()
-    requires {false}
-    
 end
 module Projections_WriteIntoSum
   use prelude.Prelude
@@ -164,8 +158,6 @@ module Projections_WriteIntoSum
 end
 module Projections_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Projections_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/prophecy.stdout
+++ b/creusot/tests/should_succeed/prophecy.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module Prophecy_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Prophecy_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/rand.stdout
+++ b/creusot/tests/should_succeed/rand.stdout
@@ -26,7 +26,6 @@ module Rand_TryRand_Interface
   use mach.int.Int
   use mach.int.UInt32
   val try_rand () : uint32
-    requires {false}
     ensures { result >= (0 : uint32) }
     
 end

--- a/creusot/tests/should_succeed/replace.stdout
+++ b/creusot/tests/should_succeed/replace.stdout
@@ -20,8 +20,6 @@ end
 module Replace_Test_Interface
   use Type
   val test (a : Type.replace_something) (b : Type.replace_something) : ()
-    requires {false}
-    
 end
 module Replace_Test
   use Type
@@ -60,8 +58,6 @@ module Replace_Test
 end
 module Replace_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Replace_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/spec_tests.stdout
+++ b/creusot/tests/should_succeed/spec_tests.stdout
@@ -19,8 +19,6 @@ module Type
 end
 module SpecTests_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module SpecTests_Main
   let rec cfg main () : () = 
@@ -39,7 +37,6 @@ module SpecTests_TestSpecs_Interface
   use mach.int.Int
   use mach.int.UInt32
   val test_specs () : ()
-    requires {false}
     ensures { Type.SpecTests_S (0 : uint32) true = Type.SpecTests_S (1 : uint32) false }
     ensures { Type.SpecTests_T_A = Type.SpecTests_T_B }
     

--- a/creusot/tests/should_succeed/specification/division.stdout
+++ b/creusot/tests/should_succeed/specification/division.stdout
@@ -23,7 +23,6 @@ module Division_Divide_Interface
   use mach.int.UInt32
   val divide (y : uint32) (x : uint32) : uint32
     requires {x <> (0 : uint32)}
-    requires {false}
     
 end
 module Division_Divide

--- a/creusot/tests/should_succeed/specification/logic_call.stdout
+++ b/creusot/tests/should_succeed/specification/logic_call.stdout
@@ -24,7 +24,6 @@ module LogicCall_Dummy_Interface
   use mach.int.UInt32
   clone LogicCall_Reflexive_Interface as Reflexive0 with type t = uint32
   val dummy () : uint32
-    requires {false}
     ensures { Reflexive0.reflexive result }
     
 end

--- a/creusot/tests/should_succeed/split_borrow.stdout
+++ b/creusot/tests/should_succeed/split_borrow.stdout
@@ -15,8 +15,6 @@ module Type
 end
 module SplitBorrow_Z_Interface
   val z () : bool
-    requires {false}
-    
 end
 module SplitBorrow_Z
   let rec cfg z () : bool = 
@@ -32,8 +30,6 @@ module SplitBorrow_Z
 end
 module SplitBorrow_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module SplitBorrow_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/split_move.stdout
+++ b/creusot/tests/should_succeed/split_move.stdout
@@ -15,8 +15,6 @@ module Type
 end
 module SplitMove_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module SplitMove_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/std_types.stdout
+++ b/creusot/tests/should_succeed/std_types.stdout
@@ -20,8 +20,6 @@ end
 module StdTypes_X_Interface
   use Type
   val x (x : Type.stdtypes_mytype) : ()
-    requires {false}
-    
 end
 module StdTypes_X
   use Type
@@ -41,8 +39,6 @@ module StdTypes_X
 end
 module StdTypes_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module StdTypes_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/sum.stdout
+++ b/creusot/tests/should_succeed/sum.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module Sum_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Sum_Main
   let rec cfg main () : () = 
@@ -39,7 +37,6 @@ module Sum_SumFirstN_Interface
   use mach.int.Int
   use mach.int.UInt32
   val sum_first_n (n : uint32) : uint32
-    requires {false}
     ensures { result = div (n * (n + (1 : uint32))) (2 : uint32) }
     
 end

--- a/creusot/tests/should_succeed/switch.stdout
+++ b/creusot/tests/should_succeed/switch.stdout
@@ -19,8 +19,6 @@ module Switch_Test_Interface
   use mach.int.Int
   use mach.int.UInt32
   val test (o : Type.switch_option uint32) : bool
-    requires {false}
-    
 end
 module Switch_Test
   use Type
@@ -76,8 +74,6 @@ module Switch_Test2_Interface
   use mach.int.Int
   use mach.int.UInt32
   val test2 (o : (Type.switch_option uint32, uint32)) : uint32
-    requires {false}
-    
 end
 module Switch_Test2
   use Type
@@ -129,8 +125,6 @@ module Switch_Test2
 end
 module Switch_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Switch_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/switch_struct.stdout
+++ b/creusot/tests/should_succeed/switch_struct.stdout
@@ -19,8 +19,6 @@ module SwitchStruct_Test_Interface
   use mach.int.Int
   use mach.int.UInt32
   val test (o : Type.switchstruct_m uint32) : bool
-    requires {false}
-    
 end
 module SwitchStruct_Test
   use Type
@@ -80,8 +78,6 @@ module SwitchStruct_Test
 end
 module SwitchStruct_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module SwitchStruct_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/syntax/01_idents.stdout
+++ b/creusot/tests/should_succeed/syntax/01_idents.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module C01Idents_Clone_Interface
   val clone' () : ()
-    requires {false}
-    
 end
 module C01Idents_Clone
   let rec cfg clone' () : () = 
@@ -29,8 +27,6 @@ module C01Idents_Clone
 end
 module C01Idents_Function_Interface
   val function' () : ()
-    requires {false}
-    
 end
 module C01Idents_Function
   let rec cfg function' () : () = 
@@ -46,8 +42,6 @@ module C01Idents_Function
 end
 module C01Idents_Import_Interface
   val import' () : ()
-    requires {false}
-    
 end
 module C01Idents_Import
   let rec cfg import' () : () = 
@@ -63,8 +57,6 @@ module C01Idents_Import
 end
 module C01Idents_Export_Interface
   val export' () : ()
-    requires {false}
-    
 end
 module C01Idents_Export
   let rec cfg export' () : () = 

--- a/creusot/tests/should_succeed/syntax/02_operators.stdout
+++ b/creusot/tests/should_succeed/syntax/02_operators.stdout
@@ -26,8 +26,6 @@ module C02Operators_Division_Interface
   use prelude.Prelude
   use mach.int.UInt64
   val division (x : usize) (y : usize) : usize
-    requires {false}
-    
 end
 module C02Operators_Division
   use mach.int.Int
@@ -68,8 +66,6 @@ module C02Operators_Modulus_Interface
   use prelude.Prelude
   use mach.int.UInt64
   val modulus (x : usize) (y : usize) : usize
-    requires {false}
-    
 end
 module C02Operators_Modulus
   use mach.int.Int
@@ -110,8 +106,6 @@ module C02Operators_Multiply_Interface
   use prelude.Prelude
   use mach.int.UInt64
   val multiply (x : usize) (y : usize) : usize
-    requires {false}
-    
 end
 module C02Operators_Multiply
   use mach.int.Int
@@ -146,8 +140,6 @@ module C02Operators_Add_Interface
   use prelude.Prelude
   use mach.int.UInt64
   val add (x : usize) (y : usize) : usize
-    requires {false}
-    
 end
 module C02Operators_Add
   use mach.int.Int
@@ -182,8 +174,6 @@ module C02Operators_Sub_Interface
   use prelude.Prelude
   use mach.int.UInt64
   val sub (x : usize) (y : usize) : usize
-    requires {false}
-    
 end
 module C02Operators_Sub
   use mach.int.Int
@@ -218,8 +208,6 @@ module C02Operators_Expression_Interface
   use prelude.Prelude
   use mach.int.UInt64
   val expression (x : usize) (y : usize) (z : usize) : bool
-    requires {false}
-    
 end
 module C02Operators_Expression
   use mach.int.Int
@@ -348,7 +336,6 @@ module C02Operators_PrimitiveComparison_Interface
   use mach.int.UInt64
   use Type
   val primitive_comparison (x : Type.c02operators_x) : ()
-    requires {false}
     ensures { (let Type.C02Operators_X a = x in a) <= (let Type.C02Operators_X a = x in a) }
     
 end
@@ -377,7 +364,6 @@ module C02Operators_PrimitiveComparison
 end
 module C02Operators_BoolEq_Interface
   val bool_eq (a : bool) (b : bool) : bool
-    requires {false}
     ensures { result = (a = b) }
     
 end

--- a/creusot/tests/should_succeed/syntax/03_unbounded.stdout
+++ b/creusot/tests/should_succeed/syntax/03_unbounded.stdout
@@ -21,7 +21,6 @@ end
 module C03Unbounded_NoBoundsCheck_Interface
   use mach.int.Int
   val no_bounds_check (x : int) (y : int) : int
-    requires {false}
     ensures { result = (4294967294 : int) }
     
 end

--- a/creusot/tests/should_succeed/syntax/04_assoc_prec.stdout
+++ b/creusot/tests/should_succeed/syntax/04_assoc_prec.stdout
@@ -23,7 +23,6 @@ module C04AssocPrec_RespectPrec_Interface
   use mach.int.UInt32
   use mach.int.Int32
   val respect_prec (x : (uint32, uint32)) : ()
-    requires {false}
     ensures { (let (a, _) = x in a) = (let (_, a) = x in a) }
     ensures { div (5 * 3) 2 <> 4 * (40 + 1) }
     ensures { 5 = 3 -> 2 + 1 = 3 }
@@ -58,7 +57,6 @@ module C04AssocPrec_RespectAssoc_Interface
   use mach.int.UInt32
   use mach.int.Int32
   val respect_assoc () : ()
-    requires {false}
     ensures { 0 + 1 = 0 }
     
 end

--- a/creusot/tests/should_succeed/syntax/05_annotations.stdout
+++ b/creusot/tests/should_succeed/syntax/05_annotations.stdout
@@ -21,8 +21,6 @@ end
 module C05Annotations_Assertion_Interface
   type t   
   val assertion (x : t) : ()
-    requires {false}
-    
 end
 module C05Annotations_Assertion
   type t   

--- a/creusot/tests/should_succeed/trait.stdout
+++ b/creusot/tests/should_succeed/trait.stdout
@@ -15,8 +15,6 @@ module Trait_UsesCustom_Interface
   type b   
   type t   
   val uses_custom (t : t) : ()
-    requires {false}
-    
 end
 module Trait_UsesCustom
   type a   
@@ -44,8 +42,6 @@ module Trait_UsesCustom2_Interface
   type b   
   type t   
   val uses_custom2 (t : t) : ()
-    requires {false}
-    
 end
 module Trait_UsesCustom2
   type a   
@@ -70,8 +66,6 @@ module Trait_UsesCustom2
 end
 module Trait_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Trait_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/trait_impl.stdout
+++ b/creusot/tests/should_succeed/trait_impl.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module TraitImpl_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module TraitImpl_Main
   let rec cfg main () : () = 
@@ -31,8 +29,6 @@ module TraitImpl_T_X_Interface
   type self   
   type b   
   val x (self : self) : ()
-    requires {false}
-    
 end
 module TraitImpl_T_X
   type self   
@@ -44,8 +40,6 @@ module TraitImpl_Impl0_X_Interface
   type t2   
   type t1   
   val x (self : (t1, t2)) : ()
-    requires {false}
-    
 end
 module TraitImpl_Impl0_X
   type b   
@@ -80,8 +74,6 @@ module TraitImpl_Impl1_X_Interface
   use mach.int.Int
   use mach.int.UInt32
   val x (self : uint32) : ()
-    requires {false}
-    
 end
 module TraitImpl_Impl1_X
   type b   

--- a/creusot/tests/should_succeed/traits/01.stdout
+++ b/creusot/tests/should_succeed/traits/01.stdout
@@ -14,8 +14,6 @@ module C01_A_FromB_Interface
   type self   
   type b   
   val from_b (x : self) : b
-    requires {false}
-    
 end
 module C01_A_FromB
   type self   
@@ -27,8 +25,6 @@ module C01_UsesGeneric_Interface
   use mach.int.Int
   use mach.int.UInt32
   val uses_generic (b : t) : uint32
-    requires {false}
-    
 end
 module C01_UsesGeneric
   type t   
@@ -59,8 +55,6 @@ module C01_UsesGeneric
 end
 module C01_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module C01_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/traits/02.stdout
+++ b/creusot/tests/should_succeed/traits/02.stdout
@@ -14,7 +14,6 @@ module C02_A_IsTrue_Interface
   type self   
   use prelude.Prelude
   val is_true (self : self) : bool
-    requires {false}
     ensures { result = true }
     
 end
@@ -36,7 +35,6 @@ end
 module C02_Omg_Interface
   type t   
   val omg (a : t) : bool
-    requires {false}
     ensures { result = true }
     
 end

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -14,8 +14,6 @@ module C03_A_F_Interface
   type self   
   use prelude.Prelude
   val f (self : self) : self
-    requires {false}
-    
 end
 module C03_A_F
   type self   
@@ -35,8 +33,6 @@ module C03_Impl0_F_Interface
   use mach.int.Int
   use mach.int.Int32
   val f (self : int32) : int32
-    requires {false}
-    
 end
 module C03_Impl0_F
   use prelude.Prelude
@@ -67,7 +63,6 @@ module C03_B_G_Interface
   type self   
   use prelude.Prelude
   val g (self : self) : self
-    requires {false}
     ensures { result = result }
     
 end
@@ -83,8 +78,6 @@ module C03_Impl1_G_Interface
   use mach.int.Int
   use mach.int.UInt32
   val g (self : uint32) : uint32
-    requires {false}
-    
 end
 module C03_Impl1_G
   use prelude.Prelude
@@ -116,8 +109,6 @@ module C03_C_H_Interface
   type t   
   use prelude.Prelude
   val h (x : t) : t
-    requires {false}
-    
 end
 module C03_C_H
   type self   
@@ -129,8 +120,6 @@ module C03_Impl2_H_Interface
   type g   
   use prelude.Prelude
   val h (y : g) : g
-    requires {false}
-    
 end
 module C03_Impl2_H
   type g   

--- a/creusot/tests/should_succeed/traits/04.stdout
+++ b/creusot/tests/should_succeed/traits/04.stdout
@@ -14,8 +14,6 @@ module C04_A_Func1_Interface
   type self   
   use prelude.Prelude
   val func1 (self : self) (o : self) : bool
-    requires {false}
-    
 end
 module C04_A_Func1
   type self   
@@ -26,8 +24,6 @@ module C04_A_Func2_Interface
   type self   
   use prelude.Prelude
   val func2 (self : self) (o : self) : bool
-    requires {false}
-    
 end
 module C04_A_Func2
   type self   
@@ -38,8 +34,6 @@ module C04_A_Func3_Interface
   type self   
   use prelude.Prelude
   val func3 (self : self) (o : self) : bool
-    requires {false}
-    
 end
 module C04_A_Func3
   type self   
@@ -58,7 +52,6 @@ module C04_User_Interface
   type t   
   use prelude.Prelude
   val user (a : t) (b : t) : bool
-    requires {false}
     ensures { result = false }
     
 end

--- a/creusot/tests/should_succeed/traits/06.stdout
+++ b/creusot/tests/should_succeed/traits/06.stdout
@@ -21,8 +21,6 @@ module C06_Ix_Ix_Interface
   use mach.int.UInt64
   clone C06_Ix_Tgt as Tgt0 with type self = self
   val ix (self : self) (ix : usize) : Tgt0.tgt
-    requires {false}
-    
 end
 module C06_Ix_Ix
   type self   
@@ -37,8 +35,6 @@ module C06_Test_Interface
   use prelude.Prelude
   clone C06_Ix_Tgt as Tgt0 with type self = t
   val test (a : t) : Tgt0.tgt
-    requires {false}
-    
 end
 module C06_Test
   type t   

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -19,8 +19,6 @@ module C07_Ix_Ix_Interface
   use prelude.Prelude
   clone C07_Ix_Tgt as Tgt0 with type self = self
   val ix (self : self) : Tgt0.tgt
-    requires {false}
-    
 end
 module C07_Ix_Ix
   type self   
@@ -37,8 +35,6 @@ module C07_Impl0_Ix_Interface
   use mach.int.Int
   use mach.int.Int32
   val ix (self : int32) : ()
-    requires {false}
-    
 end
 module C07_Impl0_Ix
   use prelude.Prelude
@@ -74,8 +70,6 @@ module C07_Test_Interface
   use mach.int.UInt32
   use mach.int.UInt64
   val test (a : uint32) (b : uint64) : bool
-    requires {false}
-    
 end
 module C07_Test
   type g   
@@ -106,8 +100,6 @@ module C07_Test2_Interface
   use mach.int.Int
   use mach.int.Int32
   val test2 (a : int32) : ()
-    requires {false}
-    
 end
 module C07_Test2
   use prelude.Prelude

--- a/creusot/tests/should_succeed/traits/08.stdout
+++ b/creusot/tests/should_succeed/traits/08.stdout
@@ -44,8 +44,6 @@ module C08_Tr_Program_Interface
   type self   
   use prelude.Prelude
   val program (self : self) : ()
-    requires {false}
-    
 end
 module C08_Tr_Program
   type self   
@@ -68,8 +66,6 @@ end
 module C08_Test_Interface
   type t   
   val test (_1 : t) : ()
-    requires {false}
-    
 end
 module C08_Test
   type t   

--- a/creusot/tests/should_succeed/traits/09.stdout
+++ b/creusot/tests/should_succeed/traits/09.stdout
@@ -15,8 +15,6 @@ module C09_Test_Interface
   use mach.int.Int
   use mach.int.UInt32
   val test (t : uint32) : uint32
-    requires {false}
-    
 end
 module C09_Test
   type t   
@@ -48,8 +46,6 @@ module C09_Test2_Interface
   type u   
   clone C09_Tr_X as X0 with type self = t
   val test2 (t : X0.x) : X0.x
-    requires {false}
-    
 end
 module C09_Test2
   type t   

--- a/creusot/tests/should_succeed/traits/11.stdout
+++ b/creusot/tests/should_succeed/traits/11.stdout
@@ -21,8 +21,6 @@ end
 module C11_Test_Interface
   type t   
   val test (_1 : t) : ()
-    requires {false}
-    
 end
 module C11_Test
   type t   

--- a/creusot/tests/should_succeed/traits/12_default_method.stdout
+++ b/creusot/tests/should_succeed/traits/12_default_method.stdout
@@ -24,8 +24,6 @@ module C12DefaultMethod_T_Default_Interface
   use mach.int.Int
   use mach.int.UInt32
   val default (self : self) : uint32
-    requires {false}
-    
 end
 module C12DefaultMethod_T_Default
   type self   
@@ -61,7 +59,6 @@ module C12DefaultMethod_ShouldUseImpl_Interface
   use mach.int.UInt32
   clone C12DefaultMethod_T_LogicDefault_Interface as LogicDefault0 with type self = uint32
   val should_use_impl (x : uint32) : ()
-    requires {false}
     ensures { LogicDefault0.logic_default x }
     
 end

--- a/creusot/tests/should_succeed/traits/13_assoc_types.stdout
+++ b/creusot/tests/should_succeed/traits/13_assoc_types.stdout
@@ -18,8 +18,6 @@ module C13AssocTypes_Model_Model_Interface
   type self   
   clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = self
   val model (self : self) : ModelTy0.modelty
-    requires {false}
-    
 end
 module C13AssocTypes_Model_Model
   type self   
@@ -45,8 +43,6 @@ module C13AssocTypes_Impl0_Model_Interface
   use prelude.Prelude
   clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = t
   val model (self : t) : ModelTy0.modelty
-    requires {false}
-    
 end
 module C13AssocTypes_Impl0_Model
   type t   

--- a/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
+++ b/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
@@ -41,7 +41,6 @@ module C15ImplInterfaces_Calls_Interface
   clone C15ImplInterfaces_X_Interface as X0 with type t = (), type A0.a = A0.a
   val calls (a : ()) : ()
     requires {X0.x a = ()}
-    requires {false}
     
 end
 module C15ImplInterfaces_Calls

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.stdout
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.stdout
@@ -141,7 +141,6 @@ module C16ImplCloning_Test_Interface
   clone CreusotContracts_Builtins_Model_Impl1_Model_Interface as Model0 with type t = Type.c16implcloning_vec t,
   type ModelTy0.modelty = ModelTy0.modelty
   val test (x : borrowed (Type.c16implcloning_vec t)) : ()
-    requires {false}
     ensures { Model0.model x = Model1.model ( * x) }
     
 end

--- a/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
+++ b/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
@@ -17,7 +17,6 @@ module C17ImplRefinement_Tr_MyFunction_Interface
   use mach.int.Int32
   use prelude.Prelude
   val my_function (self : self) : usize
-    requires {false}
     ensures { UInt64.to_int result >= 10 }
     
 end
@@ -46,7 +45,6 @@ module C17ImplRefinement_Impl0_MyFunction_Interface
   use prelude.Prelude
   val my_function (self : ()) : usize
     requires {true}
-    requires {false}
     ensures { UInt64.to_int result >= 15 }
     
 end

--- a/creusot/tests/should_succeed/trusted.stdout
+++ b/creusot/tests/should_succeed/trusted.stdout
@@ -34,7 +34,6 @@ module Trusted_VictimOfLie_Interface
   use mach.int.Int
   use mach.int.UInt32
   val victim_of_lie () : uint32
-    requires {false}
     ensures { result = (10 : uint32) }
     
 end

--- a/creusot/tests/should_succeed/two_modules.stdout
+++ b/creusot/tests/should_succeed/two_modules.stdout
@@ -18,8 +18,6 @@ end
 module TwoModules_Mod2_X_Interface
   use Type
   val x (t : Type.twomodules_mod1_t) : bool
-    requires {false}
-    
 end
 module TwoModules_Mod2_X
   use Type
@@ -39,8 +37,6 @@ module TwoModules_Mod2_X
 end
 module TwoModules_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module TwoModules_Main
   use Type

--- a/creusot/tests/should_succeed/type_constructors.stdout
+++ b/creusot/tests/should_succeed/type_constructors.stdout
@@ -20,8 +20,6 @@ module Type
 end
 module TypeConstructors_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module TypeConstructors_Main
   use Type

--- a/creusot/tests/should_succeed/unary_op.stdout
+++ b/creusot/tests/should_succeed/unary_op.stdout
@@ -26,8 +26,6 @@ module Core_Panicking_Panic
 end
 module UnaryOp_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module UnaryOp_Main
   use prelude.Prelude

--- a/creusot/tests/should_succeed/unnest.stdout
+++ b/creusot/tests/should_succeed/unnest.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module Unnest_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module Unnest_Main
   let rec cfg main () : () = 
@@ -58,7 +56,6 @@ module Unnest_Unnest_Interface
   use mach.int.UInt32
   use prelude.Prelude
   val unnest (x : borrowed (borrowed uint32)) : borrowed uint32
-    requires {false}
     ensures {  ^  * x =  ^  ^ x }
     ensures {  ^ result =  *  ^ x }
     ensures {  * result =  *  * x }

--- a/creusot/tests/should_succeed/unused_in_loop.stdout
+++ b/creusot/tests/should_succeed/unused_in_loop.stdout
@@ -12,8 +12,6 @@ module Type
 end
 module UnusedInLoop_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module UnusedInLoop_Main
   let rec cfg main () : () = 
@@ -39,7 +37,6 @@ module UnusedInLoop_UnusedInLoop_Interface
   use mach.int.Int
   use mach.int.UInt32
   val unused_in_loop (b : bool) : uint32
-    requires {false}
     ensures { result = (10 : uint32) }
     
 end

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -33,8 +33,6 @@ module Type
 end
 module C01_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module C01_Main
   let rec cfg main () : () = 
@@ -369,7 +367,6 @@ module C01_AllZero_Interface
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = uint32
   val all_zero (v : borrowed (Type.creusotcontracts_std1_vec_vec uint32)) : ()
-    requires {false}
     ensures { Seq.length (Model0.model ( * v)) = Seq.length (Model0.model ( ^ v)) }
     ensures { forall i : (int) . 0 <= i && i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = (0 : uint32) }
     

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -101,7 +101,6 @@ module C02Gnome_Ord_Le_Interface
   use prelude.Prelude
   clone C02Gnome_Ord_LeLog_Interface as LeLog0 with type self = self
   val le (self : self) (o : self) : bool
-    requires {false}
     ensures { result = LeLog0.le_log self o }
     
 end
@@ -438,7 +437,6 @@ module C02Gnome_GnomeSort_Interface
   clone CreusotContracts_Builtins_Seq_Impl0_PermutationOf_Interface as PermutationOf0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
   val gnome_sort (v : borrowed (Type.creusotcontracts_std1_vec_vec t)) : ()
-    requires {false}
     ensures { PermutationOf0.permutation_of (Model0.model ( ^ v)) (Model0.model ( * v)) }
     ensures { Sorted0.sorted (Model0.model ( ^ v)) }
     

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -317,7 +317,6 @@ module C03KnuthShuffle_KnuthShuffle_Interface
   type ModelTy0.modelty = ModelTy0.modelty
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
   val knuth_shuffle (v : borrowed (Type.creusotcontracts_std1_vec_vec t)) : ()
-    requires {false}
     ensures { PermutationOf0.permutation_of (Model0.model ( ^ v)) (Model1.model v) }
     
 end

--- a/creusot/tests/should_succeed/while_let.stdout
+++ b/creusot/tests/should_succeed/while_let.stdout
@@ -42,8 +42,6 @@ module CreusotContracts_Builtins_Resolve_Impl1
 end
 module WhileLet_Main_Interface
   val main () : ()
-    requires {false}
-    
 end
 module WhileLet_Main
   use mach.int.Int


### PR DESCRIPTION
Oops. This fixes it so we only add `requires { false }` when the function comes from an unverified external crate.
