### PR TITLE
WIP: Add support for partial orders

### DIFF
--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -59,16 +59,16 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
                     Ok(quote_spanned! {sp=> ::creusot_contracts::__stubs::neq(#left, #right) })
                 }
                 Lt(_) => Ok(
-                    quote_spanned! {sp=> ::creusot_contracts::logic::OrdLogic::lt_log(#left, #right) },
+                    quote_spanned! {sp=> ::creusot_contracts::logic::PartialOrdLogic::lt_log(#left, #right) },
                 ),
                 Le(_) => Ok(
-                    quote_spanned! {sp=> ::creusot_contracts::logic::OrdLogic::le_log(#left, #right) },
+                    quote_spanned! {sp=> ::creusot_contracts::logic::PartialOrdLogic::le_log(#left, #right) },
                 ),
                 Ge(_) => Ok(
-                    quote_spanned! {sp=> ::creusot_contracts::logic::OrdLogic::ge_log(#left, #right) },
+                    quote_spanned! {sp=> ::creusot_contracts::logic::PartialOrdLogic::ge_log(#left, #right) },
                 ),
                 Gt(_) => Ok(
-                    quote_spanned! {sp=> ::creusot_contracts::logic::OrdLogic::gt_log(#left, #right) },
+                    quote_spanned! {sp=> ::creusot_contracts::logic::PartialOrdLogic::gt_log(#left, #right) },
                 ),
                 _ => Ok(quote_spanned! {sp=> #left #op #right }),
             }

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -175,7 +175,7 @@ pub mod well_founded;
 // We add some common things at the root of the creusot-contracts library
 pub use crate::{
     ghost::Ghost,
-    logic::{Int, OrdLogic, Seq},
+    logic::{Int, PartialOrdLogic, OrdLogic, Seq},
     macros::*,
     model::{DeepModel, ShallowModel},
     resolve::Resolve,

--- a/creusot-contracts/src/logic.rs
+++ b/creusot-contracts/src/logic.rs
@@ -14,6 +14,6 @@ pub use fset::FSet;
 pub use int::Int;
 pub use mapping::Mapping;
 pub use ops::IndexLogic;
-pub use ord::OrdLogic;
+pub use ord::{PartialOrdLogic, OrdLogic};
 pub use seq::Seq;
 pub use set::Set;

--- a/creusot/tests/should_succeed/constrained_types.rs
+++ b/creusot/tests/should_succeed/constrained_types.rs
@@ -1,10 +1,10 @@
 extern crate creusot_contracts;
 
-use creusot_contracts::{logic::OrdLogic, *};
+use creusot_contracts::{logic::PartialOrdLogic, *};
 
 extern_spec! {
     impl<U: PartialOrd<U> + DeepModel, T: PartialOrd<T> + DeepModel> PartialOrd for (U, T)
-    where U::DeepModelTy: OrdLogic, T::DeepModelTy: OrdLogic
+    where U::DeepModelTy: PartialOrdLogic, T::DeepModelTy: PartialOrdLogic
     {
         #[ensures(result == self.deep_model().lt_log(o.deep_model()))]
         fn lt(&self, o: &(U, T)) -> bool;


### PR DESCRIPTION
I do not know yet if the proofs still pass, as this seems to be breaking trait resolution somehow.  There are many instances (e.g. 08_haystack) where I get errors about Creusot's inability to find an instance for PartialOrdLogic but everything that used to have an OrdLogic instance should still have one, and OrdLogic implies PartialOrdLogic -- so I'm not sure what's going on there...