### PR TITLE
Generate type invariants for arrays, closures, and the never type

### DIFF
--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -223,8 +223,8 @@ impl<'tcx> Why3Generator<'tcx> {
             return;
         }
 
-        if let TyInvKind::Adt(adt_did) = inv_kind {
-            self.translate(adt_did);
+        if let TyInvKind::Adt(did) | TyInvKind::Closure(did) = inv_kind {
+            self.translate(did);
         }
 
         let (modl, deps) = ty_inv::build_inv_module(self, inv_kind);

--- a/creusot/src/backend/clone_map.rs
+++ b/creusot/src/backend/clone_map.rs
@@ -452,6 +452,10 @@ impl<'tcx> CloneMap<'tcx> {
             return;
         }
 
+        if let TransId::Item(self_did) = self.self_id && let TyInvKind::Closure(inv_did) = inv_kind && self_did == inv_did {
+            return;
+        }
+
         ctx.translate_tyinv(inv_kind);
         self.insert(DepNode::TyInv(ty, inv_kind));
     }
@@ -879,7 +883,7 @@ fn refineable_symbol<'tcx>(tcx: TyCtxt<'tcx>, dep: DepNode<'tcx>) -> Option<Symb
             ty::ImplContainer => None,
         },
         Trait | Impl => unreachable!("trait blocks have no refinable symbols"),
-        Type => None,
+        Type | Closure => None,
         Constant => Some(SymbolKind::Const(tcx.item_name(def_id))),
         _ => unreachable!(),
     }

--- a/creusot/src/backend/clone_map.rs
+++ b/creusot/src/backend/clone_map.rs
@@ -445,6 +445,15 @@ impl<'tcx> CloneMap<'tcx> {
         let inv_kind = if ty_inv::is_tyinv_trivial(ctx.tcx, param_env, ty, true) {
             TyInvKind::Trivial
         } else {
+            if let TyKind::Array(_, ct) = ty.kind() {
+                let ty::ConstKind::Value(ty::ValTree::Leaf(_)) = ct.kind() else {
+                    ctx.crash_and_error(
+                        DUMMY_SP,
+                        "type invariants for arrays with generic length are not supported!",
+                    );
+                };
+            }
+
             TyInvKind::from_ty(ty)
         };
 

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -243,9 +243,12 @@ pub(crate) fn inv_module_name(tcx: TyCtxt, kind: TyInvKind) -> Ident {
         TyInvKind::Borrow(Mutability::Not) => "TyInv_Borrow_Shared".into(),
         TyInvKind::Borrow(Mutability::Mut) => "TyInv_Borrow".into(),
         TyInvKind::Box => "TyInv_Box".into(),
-        TyInvKind::Adt(adt_did) => format!("{}_Inv", &*ident_path(tcx, adt_did)).into(),
+        TyInvKind::Adt(did) | TyInvKind::Closure(did) => {
+            format!("{}_Inv", &*ident_path(tcx, did)).into()
+        }
         TyInvKind::Tuple(arity) => format!("TyInv_Tuple{arity}").into(),
         TyInvKind::Slice => format!("TyInv_Slice").into(),
+        TyInvKind::Array(len) => format!("TyInv_Array{len}").into(),
     }
 }
 

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -247,8 +247,9 @@ pub(crate) fn inv_module_name(tcx: TyCtxt, kind: TyInvKind) -> Ident {
             format!("{}_Inv", &*ident_path(tcx, did)).into()
         }
         TyInvKind::Tuple(arity) => format!("TyInv_Tuple{arity}").into(),
-        TyInvKind::Slice => format!("TyInv_Slice").into(),
+        TyInvKind::Slice => "TyInv_Slice".into(),
         TyInvKind::Array(len) => format!("TyInv_Array{len}").into(),
+        TyInvKind::Never => "TyInv_Never".into(),
     }
 }
 

--- a/creusot/tests/should_fail/tyinv_array.rs
+++ b/creusot/tests/should_fail/tyinv_array.rs
@@ -1,0 +1,22 @@
+extern crate creusot_contracts;
+use creusot_contracts::{invariant::Invariant, *};
+
+pub struct Sum10(i32, i32);
+
+impl Invariant for Sum10 {
+    #[predicate]
+    #[open]
+    fn invariant(self) -> bool {
+        pearlite! { self.0@ + self.1@ == 10 }
+    }
+}
+
+pub fn take_array<const N: usize>(a: [Sum10; N]) -> [Sum10; N] {
+    a
+}
+
+pub fn test_array() {
+    let x = Sum10(3, 7);
+    let a = [x];
+    take_array(a);
+}

--- a/creusot/tests/should_fail/tyinv_array.stderr
+++ b/creusot/tests/should_fail/tyinv_array.stderr
@@ -1,0 +1,4 @@
+error[creusot]: type invariants for arrays with generic length are not supported!
+
+error: aborting due to previous error
+

--- a/creusot/tests/should_succeed/closures/08_multiple_calls.mlcfg
+++ b/creusot/tests/should_succeed/closures/08_multiple_calls.mlcfg
@@ -57,6 +57,12 @@ module CreusotContracts_Std1_Ops_Impl1_Unnest
     ensures { result = unnest self _2 }
     
 end
+module TyInv_Trivial
+  type t
+  clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
+    type t = t
+  axiom inv_trivial : forall self : t . Inv0.inv self = true
+end
 module C08MultipleCalls_MultiUse_Closure0_Type
   use prelude.Borrow
   type c08multiplecalls_multiuse_closure0 't =
@@ -71,6 +77,8 @@ module C08MultipleCalls_MultiUse_Closure0_Interface
   use prelude.UInt32
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t
+  clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
+    type t = c08multiplecalls_multiuse_closure0 t
   let function field_0 [#"../08_multiple_calls.rs" 5 12 5 31] (self : c08multiplecalls_multiuse_closure0 t) : t
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../08_multiple_calls.rs" 1 0 1 0] let C08MultipleCalls_MultiUse_Closure0 a = self in a
@@ -96,6 +104,7 @@ module C08MultipleCalls_MultiUse_Closure0_Interface
     [#"../08_multiple_calls.rs" 1 0 1 0] true
   val c08MultipleCalls_MultiUse_Closure0 [#"../08_multiple_calls.rs" 5 12 5 31] (_1 : c08multiplecalls_multiuse_closure0 t) : uint32
     requires {[#"../08_multiple_calls.rs" 5 23 5 29] field_0 _1 = field_0 _1}
+    requires {[#"../08_multiple_calls.rs" 1 0 1 0] Inv0.inv _1}
     
 end
 module C08MultipleCalls_MultiUse_Closure0
@@ -104,6 +113,12 @@ module C08MultipleCalls_MultiUse_Closure0
   use prelude.Int
   use prelude.UInt32
   use prelude.Borrow
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
+    type t = c08multiplecalls_multiuse_closure0 t
+  clone TyInv_Trivial as TyInv_Trivial0 with
+    type t = c08multiplecalls_multiuse_closure0 t,
+    predicate Inv0.inv = Inv0.inv,
+    axiom .
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
     type self = t
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
@@ -133,6 +148,7 @@ module C08MultipleCalls_MultiUse_Closure0
     [#"../08_multiple_calls.rs" 1 0 1 0] true
   let rec cfg c08MultipleCalls_MultiUse_Closure0 [#"../08_multiple_calls.rs" 5 12 5 31] [@cfg:stackify] [@cfg:subregion_analysis] (_1 : c08multiplecalls_multiuse_closure0 t) : uint32
     requires {[#"../08_multiple_calls.rs" 5 23 5 29] field_0 _1 = field_0 _1}
+    requires {[#"../08_multiple_calls.rs" 1 0 1 0] Inv0.inv _1}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : uint32;
@@ -142,6 +158,7 @@ module C08MultipleCalls_MultiUse_Closure0
     goto BB0
   }
   BB0 {
+    assert { [@expl:type invariant] Inv0.inv _1 };
     assume { Resolve0.resolve _1 };
     res <- ([#"../08_multiple_calls.rs" 8 8 8 9] (0 : uint32));
     _0 <- res;
@@ -230,12 +247,6 @@ module C08MultipleCalls_UsesFn_Interface
     ensures { [#"../08_multiple_calls.rs" 18 0 18 70] exists r : uint32 . exists f2 : f . Inv1.inv f2 /\ f2 = f /\ Postcondition0.postcondition f2 () r }
     
 end
-module TyInv_Trivial
-  type t
-  clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
-    type t = t
-  axiom inv_trivial : forall self : t . Inv0.inv self = true
-end
 module C08MultipleCalls_MultiUse_Interface
   type t
   use prelude.Borrow
@@ -252,6 +263,7 @@ module C08MultipleCalls_MultiUse
     type self = t
   clone C08MultipleCalls_MultiUse_Closure0_Interface as Closure00 with
     type t = t,
+    predicate Inv0.inv = Inv2.inv,
     predicate Resolve0.resolve = Resolve1.resolve
   clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
     type t = Closure00.c08multiplecalls_multiuse_closure0 t
@@ -260,15 +272,15 @@ module C08MultipleCalls_MultiUse
     predicate Inv0.inv = Inv2.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
-    type t = Closure00.c08multiplecalls_multiuse_closure0 t
+    type t = t
   clone TyInv_Trivial as TyInv_Trivial1 with
-    type t = Closure00.c08multiplecalls_multiuse_closure0 t,
+    type t = t,
     predicate Inv0.inv = Inv1.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = t
+    type t = Closure00.c08multiplecalls_multiuse_closure0 t
   clone TyInv_Trivial as TyInv_Trivial0 with
-    type t = t,
+    type t = Closure00.c08multiplecalls_multiuse_closure0 t,
     predicate Inv0.inv = Inv0.inv,
     axiom .
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
@@ -277,10 +289,10 @@ module C08MultipleCalls_MultiUse
     type f = Closure00.c08multiplecalls_multiuse_closure0 t,
     predicate Precondition0.precondition = Closure00.precondition,
     predicate Postcondition0.postcondition = Closure00.postcondition,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv0.inv,
     predicate Inv1.inv = Inv2.inv
   let rec cfg multi_use [#"../08_multiple_calls.rs" 4 0 4 26] [@cfg:stackify] [@cfg:subregion_analysis] (x : t) : ()
-    requires {[#"../08_multiple_calls.rs" 4 20 4 21] Inv0.inv x}
+    requires {[#"../08_multiple_calls.rs" 4 20 4 21] Inv1.inv x}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -292,12 +304,13 @@ module C08MultipleCalls_MultiUse
   }
   BB0 {
     c <- Closure00.C08MultipleCalls_MultiUse_Closure0 x;
+    assert { [@expl:type invariant] Inv0.inv c };
     assume { Closure00.resolve c };
     _4 <- ([#"../08_multiple_calls.rs" 11 4 11 14] UsesFn0.uses_fn c);
     goto BB1
   }
   BB1 {
-    assert { [@expl:type invariant] Inv0.inv x };
+    assert { [@expl:type invariant] Inv1.inv x };
     assume { Resolve0.resolve x };
     _0 <- ();
     return _0

--- a/creusot/tests/should_succeed/type_invariants/generated.mlcfg
+++ b/creusot/tests/should_succeed/type_invariants/generated.mlcfg
@@ -131,9 +131,8 @@ module Generated_UseFoo_Interface
   use Generated_Foo_Type as Generated_Foo_Type
   clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
     type t = Generated_Foo_Type.t_foo (Generated_Foo_Type.t_foo uint32, borrowed (Generated_Sum10_Type.t_sum10))
-  val use_foo [#"../generated.rs" 23 0 23 61] (x : Generated_Foo_Type.t_foo (Generated_Foo_Type.t_foo uint32, borrowed (Generated_Sum10_Type.t_sum10))) : ()
-    requires {[#"../generated.rs" 22 11 22 28] Inv0.inv x}
-    requires {[#"../generated.rs" 23 19 23 20] Inv0.inv x}
+  val use_foo [#"../generated.rs" 22 0 22 61] (x : Generated_Foo_Type.t_foo (Generated_Foo_Type.t_foo uint32, borrowed (Generated_Sum10_Type.t_sum10))) : ()
+    requires {[#"../generated.rs" 22 19 22 20] Inv0.inv x}
     
 end
 module Generated_UseFoo
@@ -187,9 +186,8 @@ module Generated_UseFoo
     predicate Inv1.inv = Inv1.inv,
     predicate Inv2.inv = Inv2.inv,
     axiom .
-  let rec cfg use_foo [#"../generated.rs" 23 0 23 61] [@cfg:stackify] [@cfg:subregion_analysis] (x : Generated_Foo_Type.t_foo (Generated_Foo_Type.t_foo uint32, borrowed (Generated_Sum10_Type.t_sum10))) : ()
-    requires {[#"../generated.rs" 22 11 22 28] Inv0.inv x}
-    requires {[#"../generated.rs" 23 19 23 20] Inv0.inv x}
+  let rec cfg use_foo [#"../generated.rs" 22 0 22 61] [@cfg:stackify] [@cfg:subregion_analysis] (x : Generated_Foo_Type.t_foo (Generated_Foo_Type.t_foo uint32, borrowed (Generated_Sum10_Type.t_sum10))) : ()
+    requires {[#"../generated.rs" 22 19 22 20] Inv0.inv x}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -198,7 +196,367 @@ module Generated_UseFoo
     goto BB0
   }
   BB0 {
-    assert { [@expl:assertion] [#"../generated.rs" 24 18 24 35] Inv0.inv x };
+    assert { [@expl:assertion] [#"../generated.rs" 23 18 23 35] Inv0.inv x };
+    _0 <- ();
+    return _0
+  }
+  
+end
+module CreusotContracts_Std1_Ops_FnOnceExt_Precondition_Stub
+  type self
+  type args
+  predicate precondition (self : self) (a : args)
+end
+module CreusotContracts_Std1_Ops_FnOnceExt_Precondition_Interface
+  type self
+  type args
+  predicate precondition (self : self) (a : args)
+  val precondition (self : self) (a : args) : bool
+    ensures { result = precondition self a }
+    
+end
+module CreusotContracts_Std1_Ops_FnOnceExt_Precondition
+  type self
+  type args
+  predicate precondition (self : self) (a : args)
+  val precondition (self : self) (a : args) : bool
+    ensures { result = precondition self a }
+    
+end
+module Core_Ops_Function_FnOnce_Output_Type
+  type self
+  type args
+  type output
+end
+module CreusotContracts_Std1_Ops_FnOnceExt_PostconditionOnce_Stub
+  type self
+  type args
+  clone Core_Ops_Function_FnOnce_Output_Type as Output0 with
+    type self = self,
+    type args = args
+  predicate postcondition_once (self : self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Std1_Ops_FnOnceExt_PostconditionOnce_Interface
+  type self
+  type args
+  clone Core_Ops_Function_FnOnce_Output_Type as Output0 with
+    type self = self,
+    type args = args
+  predicate postcondition_once (self : self) (a : args) (res : Output0.output)
+  val postcondition_once (self : self) (a : args) (res : Output0.output) : bool
+    ensures { result = postcondition_once self a res }
+    
+end
+module CreusotContracts_Std1_Ops_FnOnceExt_PostconditionOnce
+  type self
+  type args
+  clone Core_Ops_Function_FnOnce_Output_Type as Output0 with
+    type self = self,
+    type args = args
+  predicate postcondition_once (self : self) (a : args) (res : Output0.output)
+  val postcondition_once (self : self) (a : args) (res : Output0.output) : bool
+    ensures { result = postcondition_once self a res }
+    
+end
+module Core_Ops_Function_FnOnce_CallOnce_Interface
+  type self
+  type args
+  clone Core_Ops_Function_FnOnce_Output_Type as Output0 with
+    type self = self,
+    type args = args
+  clone CreusotContracts_Invariant_Inv_Stub as Inv2 with
+    type t = Output0.output
+  clone CreusotContracts_Std1_Ops_FnOnceExt_PostconditionOnce_Stub as PostconditionOnce0 with
+    type self = self,
+    type args = args,
+    type Output0.output = Output0.output
+  clone CreusotContracts_Invariant_Inv_Stub as Inv1 with
+    type t = args
+  clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
+    type t = self
+  clone CreusotContracts_Std1_Ops_FnOnceExt_Precondition_Stub as Precondition0 with
+    type self = self,
+    type args = args
+  val call_once (self : self) (args : args) : Output0.output
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 148 0 172 1] Precondition0.precondition self args}
+    requires {Inv0.inv self}
+    requires {Inv1.inv args}
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 148 0 172 1] PostconditionOnce0.postcondition_once self args result }
+    ensures { Inv2.inv result }
+    
+end
+module CreusotContracts_Std1_Ops_Impl0_Precondition_Stub
+  type args
+  type f
+  predicate precondition (self : f) (_2 : args)
+end
+module CreusotContracts_Std1_Ops_Impl0_Precondition_Interface
+  type args
+  type f
+  predicate precondition (self : f) (_2 : args)
+  val precondition (self : f) (_2 : args) : bool
+    ensures { result = precondition self _2 }
+    
+end
+module CreusotContracts_Std1_Ops_Impl0_Precondition
+  type args
+  type f
+  predicate precondition (self : f) (_2 : args)
+  val precondition (self : f) (_2 : args) : bool
+    ensures { result = precondition self _2 }
+    
+end
+module CreusotContracts_Std1_Ops_Impl0_PostconditionOnce_Stub
+  type args
+  type f
+  clone Core_Ops_Function_FnOnce_Output_Type as Output0 with
+    type self = f,
+    type args = args
+  predicate postcondition_once (self : f) (_2 : args) (_3 : Output0.output)
+end
+module CreusotContracts_Std1_Ops_Impl0_PostconditionOnce_Interface
+  type args
+  type f
+  clone Core_Ops_Function_FnOnce_Output_Type as Output0 with
+    type self = f,
+    type args = args
+  predicate postcondition_once (self : f) (_2 : args) (_3 : Output0.output)
+  val postcondition_once (self : f) (_2 : args) (_3 : Output0.output) : bool
+    ensures { result = postcondition_once self _2 _3 }
+    
+end
+module CreusotContracts_Std1_Ops_Impl0_PostconditionOnce
+  type args
+  type f
+  clone Core_Ops_Function_FnOnce_Output_Type as Output0 with
+    type self = f,
+    type args = args
+  predicate postcondition_once (self : f) (_2 : args) (_3 : Output0.output)
+  val postcondition_once (self : f) (_2 : args) (_3 : Output0.output) : bool
+    ensures { result = postcondition_once self _2 _3 }
+    
+end
+module Generated_TakeClosure_Interface
+  type t
+  type f
+  clone CreusotContracts_Invariant_Inv_Stub as Inv1 with
+    type t = t
+  clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
+    type t = f
+  val take_closure [#"../generated.rs" 26 0 26 51] (f : f) : t
+    requires {[#"../generated.rs" 26 41 26 42] Inv0.inv f}
+    ensures { [#"../generated.rs" 26 50 26 51] Inv1.inv result }
+    
+end
+module Generated_TakeClosure
+  type t
+  type f
+  clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
+    type t = ()
+  clone TyInv_Trivial as TyInv_Trivial2 with
+    type t = (),
+    predicate Inv0.inv = Inv2.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = t
+  clone TyInv_Trivial as TyInv_Trivial1 with
+    type t = t,
+    predicate Inv0.inv = Inv1.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
+    type t = f
+  clone TyInv_Trivial as TyInv_Trivial0 with
+    type t = f,
+    predicate Inv0.inv = Inv0.inv,
+    axiom .
+  clone CreusotContracts_Std1_Ops_Impl0_PostconditionOnce_Interface as PostconditionOnce0 with
+    type args = (),
+    type f = f,
+    type Output0.output = t
+  clone CreusotContracts_Std1_Ops_Impl0_Precondition_Interface as Precondition0 with
+    type args = (),
+    type f = f
+  clone Core_Ops_Function_FnOnce_CallOnce_Interface as CallOnce0 with
+    type self = f,
+    type args = (),
+    predicate Precondition0.precondition = Precondition0.precondition,
+    predicate Inv0.inv = Inv0.inv,
+    predicate Inv1.inv = Inv2.inv,
+    predicate PostconditionOnce0.postcondition_once = PostconditionOnce0.postcondition_once,
+    predicate Inv2.inv = Inv1.inv,
+    type Output0.output = t
+  let rec cfg take_closure [#"../generated.rs" 26 0 26 51] [@cfg:stackify] [@cfg:subregion_analysis] (f : f) : t
+    requires {[#"../generated.rs" 26 41 26 42] Inv0.inv f}
+    ensures { [#"../generated.rs" 26 50 26 51] Inv1.inv result }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : t;
+  var f : f = f;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ([#"../generated.rs" 27 4 27 7] CallOnce0.call_once f ());
+    f <- any f;
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    return _0
+  }
+  
+end
+module CreusotContracts_Resolve_Impl2_Resolve_Stub
+  type t
+  predicate resolve (self : t)
+end
+module CreusotContracts_Resolve_Impl2_Resolve_Interface
+  type t
+  predicate resolve (self : t)
+  val resolve (self : t) : bool
+    ensures { result = resolve self }
+    
+end
+module CreusotContracts_Resolve_Impl2_Resolve
+  type t
+  predicate resolve (self : t) =
+    [#"../../../../../creusot-contracts/src/resolve.rs" 36 8 36 12] true
+  val resolve (self : t) : bool
+    ensures { result = resolve self }
+    
+end
+module Generated_TestClosure_Closure0_Type
+  use Generated_Sum10_Type as Generated_Sum10_Type
+  type generated_testclosure_closure0  =
+    | Generated_TestClosure_Closure0 (Generated_Sum10_Type.t_sum10)
+    
+end
+module Generated_TestClosure_Closure0_Interface
+  use export Generated_TestClosure_Closure0_Type
+  use Generated_Sum10_Type as Generated_Sum10_Type
+  clone CreusotContracts_Invariant_Inv_Stub as Inv1 with
+    type t = Generated_Sum10_Type.t_sum10
+  clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
+    type t = generated_testclosure_closure0
+  let function field_0 [#"../generated.rs" 32 12 32 19] (self : generated_testclosure_closure0) : Generated_Sum10_Type.t_sum10
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+    [#"../generated.rs" 1 0 1 0] let Generated_TestClosure_Closure0 a = self in a
+  predicate resolve [#"../generated.rs" 32 12 32 19] (_1 : generated_testclosure_closure0) =
+    [#"../generated.rs" 1 0 1 0] true
+  predicate precondition [#"../generated.rs" 32 12 32 19] (self : generated_testclosure_closure0) (_ : ()) =
+    [#"../generated.rs" 1 0 1 0] true
+  predicate postcondition_once [#"../generated.rs" 32 12 32 19] (self : generated_testclosure_closure0) (_ : ()) (result : Generated_Sum10_Type.t_sum10)
+    
+   =
+    [#"../generated.rs" 1 0 1 0] true
+  val generated_TestClosure_Closure0 [#"../generated.rs" 32 12 32 19] (_1 : generated_testclosure_closure0) : Generated_Sum10_Type.t_sum10
+    requires {[#"../generated.rs" 1 0 1 0] Inv0.inv _1}
+    ensures { [#"../generated.rs" 32 12 32 19] Inv1.inv result }
+    
+end
+module Generated_TestClosure_Closure0
+  use export Generated_TestClosure_Closure0_Type
+  use Generated_Sum10_Type as Generated_Sum10_Type
+  clone Generated_Impl0_Invariant as Invariant0
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = Generated_Sum10_Type.t_sum10
+  clone Generated_Sum10_Type_Inv as Generated_Sum10_Type_Inv0 with
+    predicate Inv0.inv = Inv1.inv,
+    predicate Invariant0.invariant' = Invariant0.invariant',
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
+    type t = generated_testclosure_closure0
+  let function field_0 [#"../generated.rs" 32 12 32 19] (self : generated_testclosure_closure0) : Generated_Sum10_Type.t_sum10
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+    [#"../generated.rs" 1 0 1 0] let Generated_TestClosure_Closure0 a = self in a
+  predicate resolve [#"../generated.rs" 32 12 32 19] (_1 : generated_testclosure_closure0) =
+    [#"../generated.rs" 1 0 1 0] true
+  predicate precondition [#"../generated.rs" 32 12 32 19] (self : generated_testclosure_closure0) (_ : ()) =
+    [#"../generated.rs" 1 0 1 0] true
+  predicate postcondition_once [#"../generated.rs" 32 12 32 19] (self : generated_testclosure_closure0) (_ : ()) (result : Generated_Sum10_Type.t_sum10)
+    
+   =
+    [#"../generated.rs" 1 0 1 0] true
+  let rec cfg generated_TestClosure_Closure0 [#"../generated.rs" 32 12 32 19] [@cfg:stackify] [@cfg:subregion_analysis] (_1 : generated_testclosure_closure0) : Generated_Sum10_Type.t_sum10
+    requires {[#"../generated.rs" 1 0 1 0] Inv0.inv _1}
+    ensures { [#"../generated.rs" 32 12 32 19] Inv1.inv result }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : Generated_Sum10_Type.t_sum10;
+  var _1 : generated_testclosure_closure0 = _1;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- field_0 _1;
+    _1 <- (let Generated_TestClosure_Closure0 a = _1 in Generated_TestClosure_Closure0 (any Generated_Sum10_Type.t_sum10));
+    assert { [@expl:type invariant] Inv0.inv _1 };
+    assume { resolve _1 };
+    return _0
+  }
+  
+end
+module Generated_TestClosure_Closure0_Inv
+  use Generated_Sum10_Type as Generated_Sum10_Type
+  clone CreusotContracts_Invariant_Inv_Stub as Inv1 with
+    type t = Generated_Sum10_Type.t_sum10
+  clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
+    type t = Closure00.generated_testclosure_closure0
+  clone Generated_TestClosure_Closure0_Interface as Closure00 with
+    predicate Inv0.inv = Inv0.inv,
+    predicate Inv1.inv = Inv1.inv
+  axiom inv_generated_testclosure_closure0 [@rewrite] : forall self : Closure00.generated_testclosure_closure0 . Inv0.inv self = Inv1.inv (Closure00.field_0 self)
+end
+module Generated_TestClosure_Interface
+  val test_closure [#"../generated.rs" 30 0 30 21] (_1 : ()) : ()
+end
+module Generated_TestClosure
+  use prelude.Int
+  use prelude.Int32
+  use Generated_Sum10_Type as Generated_Sum10_Type
+  clone Generated_Impl0_Invariant as Invariant0
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = Generated_Sum10_Type.t_sum10
+  clone Generated_Sum10_Type_Inv as Generated_Sum10_Type_Inv0 with
+    predicate Inv0.inv = Inv1.inv,
+    predicate Invariant0.invariant' = Invariant0.invariant',
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
+    type t = Closure00.generated_testclosure_closure0
+  clone Generated_TestClosure_Closure0_Interface as Closure00 with
+    predicate Inv0.inv = Inv0.inv,
+    predicate Inv1.inv = Inv1.inv
+  clone Generated_TestClosure_Closure0_Inv as Generated_TestClosure_Closure0_Inv0 with
+    predicate Inv0.inv = Inv0.inv,
+    predicate Inv1.inv = Inv1.inv,
+    axiom .
+  clone Generated_TakeClosure_Interface as TakeClosure0 with
+    type t = Generated_Sum10_Type.t_sum10,
+    type f = Closure00.generated_testclosure_closure0,
+    predicate Inv0.inv = Inv0.inv,
+    predicate Inv1.inv = Inv1.inv
+  let rec cfg test_closure [#"../generated.rs" 30 0 30 21] [@cfg:stackify] [@cfg:subregion_analysis] (_1 : ()) : ()
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var x : Generated_Sum10_Type.t_sum10;
+  var c : Closure00.generated_testclosure_closure0;
+  var _3 : Generated_Sum10_Type.t_sum10;
+  {
+    goto BB0
+  }
+  BB0 {
+    x <- Generated_Sum10_Type.C_Sum10 ([#"../generated.rs" 31 18 31 19] (3 : int32)) ([#"../generated.rs" 31 21 31 22] (7 : int32));
+    c <- Closure00.Generated_TestClosure_Closure0 x;
+    x <- any Generated_Sum10_Type.t_sum10;
+    _3 <- ([#"../generated.rs" 33 4 33 19] TakeClosure0.take_closure c);
+    c <- any Closure00.generated_testclosure_closure0;
+    goto BB1
+  }
+  BB1 {
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/type_invariants/generated.rs
+++ b/creusot/tests/should_succeed/type_invariants/generated.rs
@@ -19,7 +19,16 @@ pub enum Foo<'a, T> {
     B(T),
 }
 
-#[requires(invariant::inv(x))]
 pub fn use_foo<'a>(x: Foo<'a, (Foo<'a, u32>, &'a mut Sum10)>) {
     proof_assert!(invariant::inv(x));
+}
+
+pub fn take_closure<T, F: FnOnce() -> T>(f: F) -> T {
+    f()
+}
+
+pub fn test_closure() {
+    let x = Sum10(3, 7);
+    let c = move || x;
+    take_closure(c);
 }


### PR DESCRIPTION
We only handle array types with non-generic lengths.
The invariant modules generated for closures still have issues with clones.