### PR TITLE
Add Coma AST to `why3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,10 +93,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bstr"
@@ -154,7 +175,7 @@ checksum = "0fdc5d93c358224b4d6867ef1356d740de2303e9892edc06c5340daeccd96bab"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -315,23 +336,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -347,10 +357,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -384,7 +406,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "libgit2-sys",
  "log",
@@ -495,7 +517,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.18",
  "windows-sys 0.48.0",
 ]
 
@@ -531,9 +553,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
@@ -548,6 +570,12 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libssh2-sys"
@@ -586,6 +614,12 @@ name = "linux-raw-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
@@ -699,6 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -759,6 +794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "predicates"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +848,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.4.2",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.8.2",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +896,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +930,24 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "rdrand"
@@ -880,7 +986,7 @@ checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -894,6 +1000,12 @@ name = "regex-syntax"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "remove_dir_all"
@@ -919,12 +1031,37 @@ version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.13",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -993,8 +1130,20 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
- "rand",
+ "rand 0.4.6",
  "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix 0.38.31",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1041,6 +1190,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
@@ -1124,8 +1279,10 @@ dependencies = [
  "itertools",
  "num",
  "pretty",
+ "proptest",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -1192,7 +1349,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1211,6 +1377,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1402,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1235,6 +1422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1438,12 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1259,6 +1458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1474,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1283,6 +1494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1510,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "xmlparser"

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -236,12 +236,12 @@ fn print_crate<W, I: Iterator<Item = Module>>(
 where
     W: Write,
 {
-    let (alloc, mut pe) = mlcfg::printer::PrintEnv::new();
+    let alloc = mlcfg::printer::ALLOC;
 
     writeln!(out)?;
 
     for modl in functions {
-        modl.pretty(&alloc, &mut pe).1.render(120, out)?;
+        modl.pretty(&alloc).1.render(120, out)?;
         writeln!(out)?;
     }
 

--- a/why3/Cargo.toml
+++ b/why3/Cargo.toml
@@ -14,6 +14,11 @@ indexmap = "1.2.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 num = "*"
 serde_json = "1.0.107"
-[features]
 
+[dev-dependencies]
+proptest= "1.4.0"
+tempfile="3.10.0"
+
+
+[features]
 serialize = ["serde"]

--- a/why3/src/ce_models.rs
+++ b/why3/src/ce_models.rs
@@ -1,17 +1,18 @@
+#[cfg(feature = "serde")]
 use serde::Deserialize;
 use serde_json::Value as Json;
 use std::fmt::{Debug, Formatter};
 
-#[derive(Deserialize)]
-#[serde(untagged)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum Loc {
     Span(Why3Span),
     Other(Json),
 }
 
 #[allow(dead_code)]
-#[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Why3Span {
     pub file_name: String,
     pub start_line: u32,
@@ -31,41 +32,47 @@ impl Debug for Loc {
     }
 }
 
-#[derive(Deserialize, Debug)]
-#[serde(untagged)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum Fallible<T> {
     Ok(T),
     Err(Json),
 }
 
-#[derive(Deserialize, Debug)]
-#[serde(untagged)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
 pub enum Model {
     Model { answer: String, model: Vec<Fallible<Model2>> },
     Unknown(Json),
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Model2 {
     pub filename: String,
     pub model: Vec<Fallible<Model3>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Model3 {
     pub is_vc_line: bool,
     pub line: String,
     pub model_elements: Vec<Fallible<ModelElem>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct LSymbol {
     pub name: String,
     pub attrs: Vec<String>,
     pub loc: Loc,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct ModelElem {
     pub attrs: Vec<String>,
     pub kind: String,
@@ -74,20 +81,21 @@ pub struct ModelElem {
     pub value: Value,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Value {
     pub value_concrete_term: ConcreteTerm,
     pub value_term: Term,
     pub value_type: Type,
 }
 
-#[derive(Deserialize)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub enum Type {
-    #[serde(rename = "Tyvar")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tyvar"))]
     Var(String),
-    #[serde(rename = "Tyapp")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tyapp"))]
     App { ty_symbol: String, ty_args: Vec<Type> },
-    #[serde(untagged)]
+    #[cfg_attr(feature = "serde", serde(untagged))]
     Unknown(Json),
 }
 
@@ -107,102 +115,107 @@ impl Debug for Type {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct VSymbol {
     pub vs_name: String,
     pub vs_type: Type,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub enum TBool {
-    #[serde(rename = "Ttrue")]
+    #[cfg_attr(feature = "serde", serde(rename = "Ttrue"))]
     True,
-    #[serde(rename = "Tfalse")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tfalse"))]
     False,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub enum Term {
-    #[serde(rename = "Tvar")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tvar"))]
     Var(VSymbol),
-    #[serde(rename = "Tconst")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tconst"))]
     Const {
-        #[serde(rename = "const_type")]
+        #[cfg_attr(feature = "serde", serde(rename = "const_type"))]
         ty: String,
-        #[serde(rename = "const_value")]
+        #[cfg_attr(feature = "serde", serde(rename = "const_value"))]
         val: String,
     },
-    #[serde(rename = "Tapp")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tapp"))]
     App {
-        #[serde(rename = "app_ls")]
+        #[cfg_attr(feature = "serde", serde(rename = "app_ls"))]
         ls: String,
-        #[serde(rename = "app_args")]
+        #[cfg_attr(feature = "serde", serde(rename = "app_args"))]
         args: Vec<Term>,
     },
-    #[serde(rename = "Tif")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tif"))]
     If {
-        #[serde(rename = "if")]
+        #[cfg_attr(feature = "serde", serde(rename = "if"))]
         ift: Box<Term>,
         then: Box<Term>,
-        #[serde(rename = "else")]
+        #[cfg_attr(feature = "serde", serde(rename = "else"))]
         elset: Box<Term>,
     },
-    #[serde(rename = "Teps")]
+    #[cfg_attr(feature = "serde", serde(rename = "Teps"))]
     Eps {
-        #[serde(rename = "eps_vs")]
+        #[cfg_attr(feature = "serde", serde(rename = "eps_vs"))]
         vs: VSymbol,
-        #[serde(rename = "eps_t")]
+        #[cfg_attr(feature = "serde", serde(rename = "eps_t"))]
         t: Box<Term>,
     },
-    #[serde(rename = "Tfun")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tfun"))]
     Fun {
-        #[serde(rename = "fun_args")]
+        #[cfg_attr(feature = "serde", serde(rename = "fun_args"))]
         args: Vec<VSymbol>,
-        #[serde(rename = "fun_body")]
+        #[cfg_attr(feature = "serde", serde(rename = "fun_body"))]
         body: Box<Term>,
     },
-    #[serde(rename = "Tquant")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tquant"))]
     Quant {
         quant: String,
-        #[serde(rename = "quant_vs")]
+        #[cfg_attr(feature = "serde", serde(rename = "quant_vs"))]
         vs: Vec<VSymbol>,
-        #[serde(rename = "quant_t")]
+        #[cfg_attr(feature = "serde", serde(rename = "quant_t"))]
         t: Box<Term>,
     },
-    #[serde(rename = "Tbinop")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tbinop"))]
     Binop {
         binop: String,
-        #[serde(rename = "binop_t1")]
+        #[cfg_attr(feature = "serde", serde(rename = "binop_t1"))]
         t1: Box<Term>,
-        #[serde(rename = "binop_t2")]
+        #[cfg_attr(feature = "serde", serde(rename = "binop_t2"))]
         t2: Box<Term>,
     },
-    #[serde(rename = "Tnot")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tnot"))]
     Not(Box<Term>),
-    #[serde(rename = "Tlet")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tlet"))]
     Let(String),
-    #[serde(rename = "Tcase")]
+    #[cfg_attr(feature = "serde", serde(rename = "Tcase"))]
     Case(String),
-    #[serde(untagged)]
+    #[cfg_attr(feature = "serde", serde(untagged))]
     Bool(TBool),
-    #[serde(untagged)]
+    #[cfg_attr(feature = "serde", serde(untagged))]
     Unknown(Json),
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct BitVector {
     pub bv_value_as_decimal: String,
     pub bv_length: u32,
     pub bv_verbatim: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Real {
     pub real_value: String,
     pub real_verbatim: String,
 }
 
-#[derive(Deserialize)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Integer {
     pub int_value: String,
     pub int_verbatim: String,
@@ -231,28 +244,31 @@ impl Debug for Integer {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub enum Float {
     Infinity,
-    #[serde(rename = "Plus_zero")]
+    #[cfg_attr(feature = "serde", serde(rename = "Plus_zero"))]
     PlusZero,
-    #[serde(rename = "Minus_zero")]
+    #[cfg_attr(feature = "serde", serde(rename = "Minus_zero"))]
     MinusZero,
-    #[serde(rename = "Float_value")]
+    #[cfg_attr(feature = "serde", serde(rename = "Float_value"))]
     Value {
         float_hex: String,
     },
 }
 
 #[allow(dead_code)]
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct FunLitElt {
     pub indice: ConcreteTerm,
     pub value: ConcreteTerm,
 }
 
-#[derive(Deserialize, Debug)]
-#[serde(tag = "type", content = "val")]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type", content = "val"))]
 pub enum ConcreteTerm {
     Var(String),
     Boolean(bool),
@@ -261,92 +277,95 @@ pub enum ConcreteTerm {
     Real(Real),
     BitVector(BitVector),
     Fraction {
-        #[serde(rename = "frac_num")]
+        #[cfg_attr(feature = "serde", serde(rename = "frac_num"))]
         num: Real,
-        #[serde(rename = "frac_num")]
+        #[cfg_attr(feature = "serde", serde(rename = "frac_num"))]
         denom: Real,
-        #[serde(rename = "frac_verbatim")]
+        #[cfg_attr(feature = "serde", serde(rename = "frac_verbatim"))]
         verbatim: String,
     },
     Float(Float),
-    #[serde(rename = "Apply")]
+    #[cfg_attr(feature = "serde", serde(rename = "Apply"))]
     App {
-        #[serde(rename = "app_ls")]
+        #[cfg_attr(feature = "serde", serde(rename = "app_ls"))]
         ls: String,
-        #[serde(rename = "app_args")]
+        #[cfg_attr(feature = "serde", serde(rename = "app_args"))]
         args: Vec<ConcreteTerm>,
     },
     If {
-        #[serde(rename = "if")]
+        #[cfg_attr(feature = "serde", serde(rename = "if"))]
         ift: Box<ConcreteTerm>,
         then: Box<ConcreteTerm>,
-        #[serde(rename = "else")]
+        #[cfg_attr(feature = "serde", serde(rename = "else"))]
         elset: Box<ConcreteTerm>,
     },
-    #[serde(rename = "Epsilon")]
+    #[cfg_attr(feature = "serde", serde(rename = "Epsilon"))]
     Eps {
-        #[serde(rename = "eps_var")]
+        #[cfg_attr(feature = "serde", serde(rename = "eps_var"))]
         var: String,
-        #[serde(rename = "eps_t")]
+        #[cfg_attr(feature = "serde", serde(rename = "eps_t"))]
         t: Box<ConcreteTerm>,
     },
-    #[serde(rename = "Function")]
+    #[cfg_attr(feature = "serde", serde(rename = "Function"))]
     Fun {
-        #[serde(rename = "fun_args")]
+        #[cfg_attr(feature = "serde", serde(rename = "fun_args"))]
         args: Vec<String>,
-        #[serde(rename = "fun_body")]
+        #[cfg_attr(feature = "serde", serde(rename = "fun_body"))]
         body: Box<ConcreteTerm>,
     },
     Quant {
         quant: String,
-        #[serde(rename = "quant_vs")]
+        #[cfg_attr(feature = "serde", serde(rename = "quant_vs"))]
         vs: Vec<String>,
-        #[serde(rename = "quant_t")]
+        #[cfg_attr(feature = "serde", serde(rename = "quant_t"))]
         t: Box<ConcreteTerm>,
     },
     Binop {
         binop: String,
-        #[serde(rename = "binop_t1")]
+        #[cfg_attr(feature = "serde", serde(rename = "binop_t1"))]
         t1: Box<ConcreteTerm>,
-        #[serde(rename = "binop_t2")]
+        #[cfg_attr(feature = "serde", serde(rename = "binop_t2"))]
         t2: Box<ConcreteTerm>,
     },
     Not(Box<ConcreteTerm>),
     FunctionLiteral {
-        #[serde(rename = "funliteral_elts")]
+        #[cfg_attr(feature = "serde", serde(rename = "funliteral_elts"))]
         elts: Vec<FunLitElt>,
-        #[serde(rename = "funliteral_others")]
+        #[cfg_attr(feature = "serde", serde(rename = "funliteral_others"))]
         other: Box<ConcreteTerm>,
     },
     Proj {
-        #[serde(rename = "proj_name")]
+        #[cfg_attr(feature = "serde", serde(rename = "proj_name"))]
         name: String,
-        #[serde(rename = "proj_value")]
+        #[cfg_attr(feature = "serde", serde(rename = "proj_value"))]
         value: Box<ConcreteTerm>,
     },
-    #[serde(untagged)]
+    #[cfg_attr(feature = "serde", serde(untagged))]
     Unknown(Json),
 }
 
-#[derive(Deserialize)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct Goal {
     pub term: GoalTerm,
-    #[serde(alias = "prover-result")]
+    #[cfg_attr(feature = "serde", serde(alias = "prover-result"))]
     pub prover_result: ProverResult,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct GoalTerm {
     pub loc: Loc,
-    #[serde(alias = "goal-name")] //Why3 doesn't currently use kebab-case but this might change
+    #[cfg_attr(feature = "serde", serde(alias = "goal-name"))]
+    //Why3 doesn't currently use kebab-case but this might change
     pub goal_name: String,
     pub explanations: Vec<String>,
 }
 #[allow(dead_code)]
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 pub struct ProverResult {
     pub answer: String,
-    #[serde(rename = "ce-models")]
+    #[cfg_attr(feature = "serde", serde(rename = "ce-models"))]
     pub ce_models: Vec<Model>,
     pub time: f32,
     pub step: i32,

--- a/why3/src/coma.rs
+++ b/why3/src/coma.rs
@@ -1,4 +1,6 @@
-use crate::{declaration::Use, ty::Type, Ident};
+use pretty::docs;
+
+use crate::{declaration::Use, ty::Type, Ident, Print};
 
 type Term = crate::Exp;
 
@@ -15,6 +17,7 @@ type Term = crate::Exp;
 /// 2. User level control on transparency of functions
 /// 3. CPS structure
 
+#[derive(Clone, Debug)]
 pub enum Expr {
     /// Variables eg: `x`
     Symbol(Ident),
@@ -51,31 +54,48 @@ pub enum Expr {
     Any,
 }
 
-/// TODO: what is the bool?
-pub struct Var(Ident, Term, Type, bool);
+#[derive(Clone, Debug)]
+pub struct Var(Ident, Type, Term, IsRef);
+
+#[derive(Clone, Debug)]
+pub enum IsRef {
+    Ref,
+    NotRef,
+}
 
 /// Parameter declarations
+#[derive(Clone, Debug)]
 pub enum Param {
+    // Can only be type parameters
     Ty(Type),
     Term(Ident, Type),
-    Region(Ident, Type),
+    Reference(Ident, Type),
+    /// Continuations accept a set of handlers and a set of ordinary parameters
     Cont(Ident, Vec<Ident>, Vec<Param>),
 }
 
+#[derive(Clone, Debug)]
 pub enum Arg {
+    /// Type application
     Ty(Type),
+    /// Logical terms (and 'program' ones)
     Term(Term),
+    /// Reference
     Ref(Ident),
+    /// Continuation parameter
     Cont(Expr),
 }
 
+#[derive(Clone, Debug)]
 pub struct Defn {
     pub name: Ident,
+    /// Only relevant if using references
     pub writes: Vec<Ident>,
     pub params: Vec<Param>,
     pub body: Expr,
 }
 
+#[derive(Clone, Debug)]
 pub enum Decl {
     /// Coma definitions
     Defn(Vec<Defn>),
@@ -84,4 +104,185 @@ pub enum Decl {
     Use(Use),
 }
 
+#[derive(Clone, Debug)]
 pub struct Module(pub Vec<Decl>);
+
+impl Print for Param {
+    fn pretty<'b, 'a: 'b, A: pretty::DocAllocator<'a>>(
+        &'a self,
+        alloc: &'a A,
+    ) -> pretty::DocBuilder<'a, A>
+    where
+        A::Doc: Clone,
+    {
+        match self {
+            Param::Ty(ty) => ty.pretty(alloc),
+            Param::Term(id, ty) => docs![alloc, id.pretty(alloc), ":", ty.pretty(alloc)],
+            Param::Reference(id, ty) => docs![alloc, "&", id.pretty(alloc), ":", ty.pretty(alloc)],
+            Param::Cont(id, writes, params) => docs![
+                alloc,
+                id.pretty(alloc),
+                alloc.space(),
+                brackets(alloc.intersperse(writes.iter().map(|a| a.pretty(alloc)), " ")),
+                alloc.space(),
+                alloc.intersperse(params.iter().map(|a| a.pretty(alloc)), " "),
+            ]
+            .parens(),
+        }
+    }
+}
+impl Print for Var {
+    fn pretty<'b, 'a: 'b, A: pretty::DocAllocator<'a>>(
+        &'a self,
+        alloc: &'a A,
+    ) -> pretty::DocBuilder<'a, A>
+    where
+        A::Doc: Clone,
+    {
+        docs![
+            alloc,
+            if matches!(self.3, IsRef::Ref) { alloc.text("& ") } else { alloc.nil() },
+            self.0.pretty(alloc),
+            " : ",
+            self.1.pretty(alloc),
+            " = ",
+            self.2.pretty(alloc)
+        ]
+    }
+}
+
+impl Print for Arg {
+    fn pretty<'b, 'a: 'b, A: pretty::DocAllocator<'a>>(
+        &'a self,
+        alloc: &'a A,
+    ) -> pretty::DocBuilder<'a, A>
+    where
+        A::Doc: Clone,
+    {
+        match self {
+            Arg::Ty(ty) => ty.pretty(alloc).enclose("<", ">"),
+            Arg::Term(t) => t.pretty(alloc).braces(),
+            Arg::Ref(r) => alloc.text("& ").append(r.pretty(alloc)),
+            Arg::Cont(c) => c.pretty(alloc).parens(),
+        }
+    }
+}
+
+impl Print for Expr {
+    fn pretty<'b, 'a: 'b, A: pretty::DocAllocator<'a>>(
+        &'a self,
+        alloc: &'a A,
+    ) -> pretty::DocBuilder<'a, A>
+    where
+        A::Doc: Clone,
+    {
+        match self {
+            Expr::Symbol(id) => id.pretty(alloc),
+            Expr::App(e, arg) => {
+                let needs_paren = !matches!(
+                    &**e,
+                    Expr::App(_, _) | Expr::Symbol(_) | Expr::Any | Expr::Lambda(_, _)
+                );
+
+                let doc = e.pretty(alloc);
+
+                if needs_paren { doc.parens() } else { doc }.append(arg.pretty(alloc))
+            }
+            Expr::Lambda(params, body) => {
+                let header = if params.is_empty() {
+                    alloc.text("->")
+                } else {
+                    docs![
+                        alloc,
+                        "fun ",
+                        alloc.intersperse(params.iter().map(|p| p.pretty(alloc)), alloc.text(" "))
+                    ]
+                };
+
+                header.append(body.pretty(alloc)).parens()
+            }
+            Expr::Defn(cont, rec, handlers) => {
+                let handlers =
+                    handlers.iter().map(|d| print_defn(d, if *rec { "=" } else { "->" }, alloc));
+                cont.pretty(alloc).append(alloc.intersperse(handlers, alloc.text(" | ")).brackets())
+            }
+            Expr::Let(cont, lets) => docs![
+                alloc,
+                cont.pretty(alloc),
+                alloc.intersperse(lets.iter().map(|l| l.pretty(alloc)), alloc.text(" | "))
+            ],
+            Expr::Assign(cont, asgns) => docs![
+                alloc,
+                alloc
+                    .intersperse(
+                        asgns.iter().map(|(id, t)| docs![
+                            alloc,
+                            "&",
+                            id.pretty(alloc),
+                            "<-",
+                            t.pretty(alloc).braces()
+                        ]),
+                        alloc.text(" | ")
+                    )
+                    .brackets(),
+                cont.pretty(alloc)
+            ],
+            Expr::Assert(t, e) => docs![alloc, t.pretty(alloc).braces(), e.pretty(alloc)],
+            Expr::BlackBox(e) => docs![alloc, "!", alloc.space(), e.pretty(alloc)].parens(),
+            Expr::WhiteBox(e) => docs![alloc, "?", alloc.space(), e.pretty(alloc)].parens(),
+            Expr::Any => alloc.text("any"),
+        }
+    }
+}
+
+fn braces<'a, A: pretty::DocAllocator<'a>>(
+    doc: pretty::DocBuilder<'a, A>,
+) -> pretty::DocBuilder<'a, A> {
+    if !matches!(&*doc.1, pretty::Doc::Nil) {
+        doc.braces()
+    } else {
+        doc
+    }
+}
+
+fn brackets<'a, A: pretty::DocAllocator<'a>>(
+    doc: pretty::DocBuilder<'a, A>,
+) -> pretty::DocBuilder<'a, A> {
+    if !matches!(&*doc.1, pretty::Doc::Nil) {
+        doc.brackets()
+    } else {
+        doc
+    }
+}
+
+fn print_defn<'a, A: pretty::DocAllocator<'a>>(
+    defn: &'a Defn,
+    arrow_kind: &'a str,
+    alloc: &'a A,
+) -> pretty::DocBuilder<'a, A>
+where
+    A::Doc: Clone,
+{
+    docs![
+        alloc,
+        defn.name.pretty(alloc),
+        alloc.space(),
+        brackets(alloc.intersperse(defn.writes.iter().map(|a| a.pretty(alloc)), " ")),
+        alloc.space(),
+        alloc.intersperse(defn.params.iter().map(|a| a.pretty(alloc)), " "),
+        arrow_kind,
+        defn.body.pretty(alloc),
+    ]
+}
+
+impl Print for Defn {
+    fn pretty<'b, 'a: 'b, A: pretty::DocAllocator<'a>>(
+        &'a self,
+        alloc: &'a A,
+    ) -> pretty::DocBuilder<'a, A>
+    where
+        A::Doc: Clone,
+    {
+        docs![alloc, "let ", print_defn(self, "=", alloc),]
+    }
+}

--- a/why3/src/coma.rs
+++ b/why3/src/coma.rs
@@ -1,0 +1,87 @@
+use crate::{declaration::Use, ty::Type, Ident};
+
+type Term = crate::Exp;
+
+/// The Coma Intermediate Verification Language
+///
+/// This language is developed by Paul Patault, Andrei Paskeivich and Jean-Christophe Filiatre.
+/// In this module is a complete, faithful ast and pretty printer for Coma.
+///
+/// TODO: Document Coma and its motivation
+///
+/// Notable points
+///
+/// 1. Higher order functional language that always generates first-order VCs
+/// 2. User level control on transparency of functions
+/// 3. CPS structure
+
+pub enum Expr {
+    /// Variables eg: `x`
+    Symbol(Ident),
+    /// Generic application for type lambdas, terms, references and continuations
+    /// e <ty>... t... | e...
+    App(Box<Expr>, Box<Arg>),
+    /// Functions, used for anonymous closures
+    /// fun pl -> e
+    Lambda(Vec<Param>, Box<Expr>),
+    /// Handler group definitions, binds a set of (mutually recursive) handlers
+    /// Can be read as a "where" clause in haskell.
+    //
+    /// e / rec? h p e and ...
+    Defn(Box<Expr>, bool, Vec<Defn>),
+    /// Similarly to handlers, the assignment should be read "backwards", the expression happens in a context where
+    /// the identifiers have been updated
+    Assign(Box<Expr>, Vec<(Ident, Term)>),
+    /// Let binding, introduces a new lexical scope.
+    Let(Box<Expr>, Vec<Var>),
+    /// Asserts that the term holds before evaluating the expression
+    Assert(Box<Term>, Box<Expr>),
+    /// The core operator of coma is the "black box" or *abstraction barrier* operator.
+    /// This operator distinguishes the responsibility between the caller and callee for
+    /// verification. Everything under an abstraction is opaque to the outside world, whereas from the inside,
+    /// we can suppose than any surrounding assertions hold.
+    //
+    /// TODO: Write a more intuitive explanaitio
+    //
+    /// ! e
+    BlackBox(Box<Expr>),
+    /// Good question...
+    WhiteBox(Box<Expr>),
+    /// A non-deterministic value
+    Any,
+}
+
+/// TODO: what is the bool?
+pub struct Var(Ident, Term, Type, bool);
+
+/// Parameter declarations
+pub enum Param {
+    Ty(Type),
+    Term(Ident, Type),
+    Region(Ident, Type),
+    Cont(Ident, Vec<Ident>, Vec<Param>),
+}
+
+pub enum Arg {
+    Ty(Type),
+    Term(Term),
+    Ref(Ident),
+    Cont(Expr),
+}
+
+pub struct Defn {
+    pub name: Ident,
+    pub writes: Vec<Ident>,
+    pub params: Vec<Param>,
+    pub body: Expr,
+}
+
+pub enum Decl {
+    /// Coma definitions
+    Defn(Vec<Defn>),
+    /// Escape hatch for type declarations, predicates etc...
+    PureDecl(crate::declaration::Decl),
+    Use(Use),
+}
+
+pub struct Module(pub Vec<Decl>);

--- a/why3/src/lib.rs
+++ b/why3/src/lib.rs
@@ -6,6 +6,9 @@ pub mod mlcfg;
 pub mod name;
 pub mod ty;
 
+// Coma IR
+pub mod coma;
+
 pub use exp::Exp;
 pub use mlcfg::printer::Print;
 pub use name::*;

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -8,33 +8,20 @@ use crate::{
 use num::{Float, Zero};
 use pretty::*;
 
-#[derive(Default)]
-pub struct PrintEnv {
-    pub scopes: Vec<Ident>,
-}
-
-impl PrintEnv {
-    pub fn new() -> (BoxAllocator, Self) {
-        (BoxAllocator, PrintEnv::default())
-    }
-}
-
 pub struct PrintDisplay<'a, A: Print>(&'a A);
 
 impl<'a, A: Print> Display for PrintDisplay<'a, A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let (alloc, mut env) = PrintEnv::new();
-        self.0.pretty(&alloc, &mut env).1.render_fmt(120, f)?;
+        let alloc = BoxAllocator;
+        self.0.pretty(&alloc).1.render_fmt(120, f)?;
         Ok(())
     }
 }
 
+pub const ALLOC: BoxAllocator = BoxAllocator;
+
 pub trait Print {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone;
 
@@ -48,17 +35,16 @@ pub trait Print {
 
 // TODO: replace with functions
 macro_rules! parens {
-    ($alloc:ident, $env:ident, $parent:ident, $child:ident) => {
-        parens($alloc, $env, $parent.precedence(), $child)
+    ($alloc:ident, $parent:ident, $child:ident) => {
+        parens($alloc, $parent.precedence(), $child)
     };
-    ($alloc:ident, $env:ident, $par_prec:expr, $child:ident) => {
-        parens($alloc, $env, $par_prec, $child)
+    ($alloc:ident, $par_prec:expr, $child:ident) => {
+        parens($alloc, $par_prec, $child)
     };
 }
 
 fn parens<'b, 'a: 'b, A: DocAllocator<'a>>(
     alloc: &'a A,
-    env: &mut PrintEnv,
     prec: Precedence,
     child: &'a Exp,
 ) -> DocBuilder<'a, A>
@@ -67,81 +53,63 @@ where
 {
     let child_prec = child.precedence();
     if child_prec == Precedence::Atom {
-        child.pretty(alloc, env)
+        child.pretty(alloc)
     } else if child_prec < prec {
-        child.pretty(alloc, env).parens()
+        child.pretty(alloc).parens()
     } else if child_prec == prec && child.associativity() != child.associativity() {
-        child.pretty(alloc, env).parens()
+        child.pretty(alloc).parens()
     } else {
-        child.pretty(alloc, env)
+        child.pretty(alloc)
     }
 }
 
 impl Print for Decl {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         match self {
-            Decl::CfgDecl(fun) => fun.pretty(alloc, env),
-            Decl::LogicDefn(log) => log.pretty(alloc, env),
-            Decl::Module(modl) => modl.pretty(alloc, env),
-            Decl::Scope(scope) => scope.pretty(alloc, env),
-            Decl::PredDecl(p) => p.pretty(alloc, env),
-            Decl::TyDecl(t) => t.pretty(alloc, env),
-            Decl::Clone(c) => c.pretty(alloc, env),
-            Decl::ValDecl(v) => v.pretty(alloc, env),
-            Decl::UseDecl(u) => u.pretty(alloc, env),
-            Decl::Axiom(a) => a.pretty(alloc, env),
-            Decl::Goal(g) => g.pretty(alloc, env),
-            Decl::Let(l) => l.pretty(alloc, env),
+            Decl::CfgDecl(fun) => fun.pretty(alloc),
+            Decl::LogicDefn(log) => log.pretty(alloc),
+            Decl::Module(modl) => modl.pretty(alloc),
+            Decl::Scope(scope) => scope.pretty(alloc),
+            Decl::PredDecl(p) => p.pretty(alloc),
+            Decl::TyDecl(t) => t.pretty(alloc),
+            Decl::Clone(c) => c.pretty(alloc),
+            Decl::ValDecl(v) => v.pretty(alloc),
+            Decl::UseDecl(u) => u.pretty(alloc),
+            Decl::Axiom(a) => a.pretty(alloc),
+            Decl::Goal(g) => g.pretty(alloc),
+            Decl::Let(l) => l.pretty(alloc),
         }
     }
 }
 
 impl Print for Module {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
-        env.scopes.push(self.name.clone());
         let doc = alloc
             .text("module ")
             .append(&*self.name)
             .append(alloc.hardline())
             .append(
                 alloc
-                    .intersperse(
-                        self.decls.iter().map(|decl| decl.pretty(alloc, env)),
-                        alloc.hardline(),
-                    )
+                    .intersperse(self.decls.iter().map(|decl| decl.pretty(alloc)), alloc.hardline())
                     .indent(2),
             )
             .append(alloc.hardline())
             .append("end");
-        env.scopes.pop();
         doc
     }
 }
 
 impl Print for Scope {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
-        env.scopes.push(self.name.clone());
         let doc = alloc
             .text("scope")
             .append(alloc.space())
@@ -149,59 +117,43 @@ impl Print for Scope {
             .append(alloc.hardline())
             .append(
                 alloc
-                    .intersperse(
-                        self.decls.iter().map(|decl| decl.pretty(alloc, env)),
-                        alloc.hardline(),
-                    )
+                    .intersperse(self.decls.iter().map(|decl| decl.pretty(alloc)), alloc.hardline())
                     .indent(2),
             )
             .append(alloc.hardline())
             .append("end");
-        env.scopes.pop();
         doc
     }
 }
 
 impl Print for Axiom {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         alloc
             .text("axiom ")
-            .append(self.name.pretty(alloc, env))
+            .append(self.name.pretty(alloc))
             .append(if self.rewrite { " [@rewrite] : " } else { " : " })
-            .append(self.axiom.pretty(alloc, env))
+            .append(self.axiom.pretty(alloc))
     }
 }
 
 impl Print for Goal {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         alloc
             .text("goal ")
-            .append(self.name.pretty(alloc, env))
+            .append(self.name.pretty(alloc))
             .append(" : ")
-            .append(self.goal.pretty(alloc, env))
+            .append(self.goal.pretty(alloc))
     }
 }
 
 impl Print for LetDecl {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -225,24 +177,20 @@ impl Print for LetDecl {
         doc = doc
             .append(
                 self.sig
-                    .pretty(alloc, env)
+                    .pretty(alloc)
                     .append(alloc.line_())
                     .append(alloc.text(" = [@vc:do_not_keep_trace] [@vc:sp]")),
             )
             .group()
             .append(alloc.line())
-            .append(self.body.pretty(alloc, env).indent(2));
+            .append(self.body.pretty(alloc).indent(2));
 
         doc
     }
 }
 
 impl Print for Attribute {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        _: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -265,91 +213,70 @@ impl Print for Attribute {
 }
 
 impl Print for Signature {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         self.name
-            .pretty(alloc, env)
+            .pretty(alloc)
             .append(alloc.space())
             .append(alloc.intersperse(
-                self.attrs.iter().map(|a| a.pretty(alloc, env)).chain(once(alloc.nil())),
+                self.attrs.iter().map(|a| a.pretty(alloc)).chain(once(alloc.nil())),
                 alloc.space(),
             ))
-            .append(arg_list(alloc, env, &self.args))
+            .append(arg_list(alloc, &self.args))
             .append(
-                self.retty.as_ref().map_or_else(
-                    || alloc.nil(),
-                    |t| alloc.text(" : ").append(t.pretty(alloc, env)),
-                ),
+                self.retty
+                    .as_ref()
+                    .map_or_else(|| alloc.nil(), |t| alloc.text(" : ").append(t.pretty(alloc))),
             )
-            .append(alloc.line_().append(self.contract.pretty(alloc, env)))
+            .append(alloc.line_().append(self.contract.pretty(alloc)))
             .nest(2)
             .group()
         // .append(alloc.line())
-        // .append(self.contract.pretty(alloc, env).indent(2))
+        // .append(self.contract.pretty(alloc).indent(2))
     }
 }
 
 impl Print for Predicate {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         alloc
             .text("predicate ")
-            .append(self.sig.pretty(alloc, env).append(alloc.line_()).append(alloc.text(" =")))
+            .append(self.sig.pretty(alloc).append(alloc.line_()).append(alloc.text(" =")))
             .group()
             .append(alloc.line())
-            .append(self.body.pretty(alloc, env).indent(2))
+            .append(self.body.pretty(alloc).indent(2))
     }
 }
 
-fn arg_list<'b: 'a, 'a, A: DocAllocator<'a>>(
-    alloc: &'a A,
-    env: &mut PrintEnv,
-    args: &'a [Binder],
-) -> DocBuilder<'a, A>
+fn arg_list<'b: 'a, 'a, A: DocAllocator<'a>>(alloc: &'a A, args: &'a [Binder]) -> DocBuilder<'a, A>
 where
     A::Doc: Clone,
 {
     {
-        alloc.intersperse(args.iter().map(|b| b.pretty(alloc, env)), alloc.space())
+        alloc.intersperse(args.iter().map(|b| b.pretty(alloc)), alloc.space())
     }
 }
 
 impl Print for Logic {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         alloc
             .text("function ")
-            .append(self.sig.pretty(alloc, env).append(alloc.line_()).append(alloc.text(" =")))
+            .append(self.sig.pretty(alloc).append(alloc.line_()).append(alloc.text(" =")))
             .group()
             .append(alloc.line())
-            .append(self.body.pretty(alloc, env).indent(2))
+            .append(self.body.pretty(alloc).indent(2))
     }
 }
 
 impl Print for DeclClone {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -362,8 +289,7 @@ impl Print for DeclClone {
             _ => alloc.nil(),
         };
 
-        let doc =
-            alloc.text("clone ").append(kind).append(self.name.pretty(alloc, env)).append(as_doc);
+        let doc = alloc.text("clone ").append(kind).append(self.name.pretty(alloc)).append(as_doc);
 
         if self.subst.is_empty() {
             doc
@@ -371,7 +297,7 @@ impl Print for DeclClone {
             doc.append(" with").append(alloc.hardline()).append(
                 alloc
                     .intersperse(
-                        self.subst.iter().map(|s| s.pretty(alloc, env)),
+                        self.subst.iter().map(|s| s.pretty(alloc)),
                         alloc.text(",").append(alloc.hardline()),
                     )
                     .indent(2),
@@ -381,37 +307,29 @@ impl Print for DeclClone {
 }
 
 impl Print for CloneSubst {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         match self {
-            CloneSubst::Type(id, ty) => alloc
-                .text("type ")
-                .append(id.pretty(alloc, env))
-                .append(" = ")
-                .append(ty.pretty(alloc, env)),
-            CloneSubst::Val(id, o) => alloc
-                .text("val ")
-                .append(id.pretty(alloc, env))
-                .append(" = ")
-                .append(o.pretty(alloc, env)),
+            CloneSubst::Type(id, ty) => {
+                alloc.text("type ").append(id.pretty(alloc)).append(" = ").append(ty.pretty(alloc))
+            }
+            CloneSubst::Val(id, o) => {
+                alloc.text("val ").append(id.pretty(alloc)).append(" = ").append(o.pretty(alloc))
+            }
             CloneSubst::Predicate(id, o) => alloc
                 .text("predicate ")
-                .append(id.pretty(alloc, env))
+                .append(id.pretty(alloc))
                 .append(" = ")
-                .append(o.pretty(alloc, env)),
+                .append(o.pretty(alloc)),
             CloneSubst::Function(id, o) => alloc
                 .text("function ")
-                .append(id.pretty(alloc, env))
+                .append(id.pretty(alloc))
                 .append(" = ")
-                .append(o.pretty(alloc, env)),
+                .append(o.pretty(alloc)),
             CloneSubst::Axiom(id) => match id {
-                Some(id) => alloc.text("axiom ").append(id.pretty(alloc, env)),
+                Some(id) => alloc.text("axiom ").append(id.pretty(alloc)),
                 None => alloc.text("axiom ."),
             },
         }
@@ -419,20 +337,16 @@ impl Print for CloneSubst {
 }
 
 impl Print for Use {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         alloc
             .text("use ")
             .append(if self.export { alloc.text("export ") } else { alloc.nil() })
-            .append(self.name.pretty(alloc, env))
+            .append(self.name.pretty(alloc))
             .append(if let Some(as_) = &self.as_ {
-                alloc.text(" as ").append(as_.pretty(alloc, env))
+                alloc.text(" as ").append(as_.pretty(alloc))
             } else {
                 alloc.nil()
             })
@@ -440,11 +354,7 @@ impl Print for Use {
 }
 
 impl Print for ValDecl {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -465,17 +375,13 @@ impl Print for ValDecl {
             None => {}
         };
 
-        doc = doc.append(self.sig.pretty(alloc, env));
+        doc = doc.append(self.sig.pretty(alloc));
         doc
     }
 }
 
 impl Print for Contract {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -483,10 +389,7 @@ impl Print for Contract {
 
         for req in &self.requires {
             doc = doc.append(
-                alloc
-                    .text("requires ")
-                    .append(req.pretty(alloc, env).braces())
-                    .append(alloc.hardline()),
+                alloc.text("requires ").append(req.pretty(alloc).braces()).append(alloc.hardline()),
             )
         }
 
@@ -494,19 +397,14 @@ impl Print for Contract {
             doc = doc.append(
                 alloc
                     .text("ensures ")
-                    .append(
-                        alloc.space().append(req.pretty(alloc, env)).append(alloc.space()).braces(),
-                    )
+                    .append(alloc.space().append(req.pretty(alloc)).append(alloc.space()).braces())
                     .append(alloc.hardline()),
             )
         }
 
         for var in &self.variant {
             doc = doc.append(
-                alloc
-                    .text("variant ")
-                    .append(var.pretty(alloc, env).braces())
-                    .append(alloc.hardline()),
+                alloc.text("variant ").append(var.pretty(alloc).braces()).append(alloc.hardline()),
             )
         }
 
@@ -515,11 +413,7 @@ impl Print for Contract {
 }
 
 impl Print for CfgFunction {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -530,7 +424,7 @@ impl Print for CfgFunction {
             .append(if self.constant { "constant " } else { "" })
             .append(
                 self.sig
-                    .pretty(alloc, env)
+                    .pretty(alloc)
                     .append(alloc.line_())
                     .append(alloc.text(" = [@vc:do_not_keep_trace] [@vc:sp]")),
             )
@@ -542,9 +436,9 @@ impl Print for CfgFunction {
                     if *ghost { alloc.text("ghost var ") } else { alloc.text("var ") }
                         .append(alloc.as_string(&var.0))
                         .append(" : ")
-                        .append(ty.pretty(alloc, env))
+                        .append(ty.pretty(alloc))
                         .append(if let Some(init) = init {
-                            alloc.text(" = ").append(init.pretty(alloc, env))
+                            alloc.text(" = ").append(init.pretty(alloc))
                         } else {
                             alloc.nil()
                         })
@@ -552,11 +446,11 @@ impl Print for CfgFunction {
                 }),
                 alloc.hardline(),
             ))
-            .append(self.entry.pretty(alloc, env).append(alloc.hardline()))
+            .append(self.entry.pretty(alloc).append(alloc.hardline()))
             .append(sep_end_by(
                 alloc,
                 self.blocks.iter().map(|(id, block)| {
-                    id.pretty(alloc, env).append(alloc.space()).append(block.pretty(alloc, env))
+                    id.pretty(alloc).append(alloc.space()).append(block.pretty(alloc))
                 }),
                 alloc.hardline(),
             ))
@@ -564,22 +458,18 @@ impl Print for CfgFunction {
 }
 
 impl Print for Type {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         use Type::*;
 
         macro_rules! ty_parens {
-            ($alloc:ident, $env:ident, $e:ident) => {
+            ($alloc:ident, $e:ident) => {
                 if $e.complex() {
-                    $e.pretty($alloc, $env).parens()
+                    $e.pretty($alloc).parens()
                 } else {
-                    $e.pretty($alloc, $env)
+                    $e.pretty($alloc)
                 }
             };
         }
@@ -587,145 +477,127 @@ impl Print for Type {
             Bool => alloc.text("bool"),
             Char => alloc.text("char"),
             Integer => alloc.text("int"),
-            MutableBorrow(box t) => alloc.text("borrowed ").append(ty_parens!(alloc, env, t)),
+            MutableBorrow(box t) => alloc.text("borrowed ").append(ty_parens!(alloc, t)),
             TVar(v) => alloc.text(format!("'{}", v.0)),
-            TConstructor(ty) => ty.pretty(alloc, env),
+            TConstructor(ty) => ty.pretty(alloc),
 
-            TFun(box a, box b) => {
-                ty_parens!(alloc, env, a).append(" -> ").append(ty_parens!(alloc, env, b))
-            }
+            TFun(box a, box b) => ty_parens!(alloc, a).append(" -> ").append(ty_parens!(alloc, b)),
             TApp(box tyf, args) => {
                 if args.is_empty() {
-                    tyf.pretty(alloc, env)
+                    tyf.pretty(alloc)
                 } else {
-                    tyf.pretty(alloc, env).append(alloc.space()).append(alloc.intersperse(
-                        args.iter().map(|arg| ty_parens!(alloc, env, arg)),
-                        alloc.space(),
-                    ))
+                    tyf.pretty(alloc).append(alloc.space()).append(
+                        alloc.intersperse(
+                            args.iter().map(|arg| ty_parens!(alloc, arg)),
+                            alloc.space(),
+                        ),
+                    )
                 }
             }
-            Tuple(tys) if tys.len() == 1 => tys[0].pretty(alloc, env),
-            Tuple(tys) => {
-                alloc.intersperse(tys.iter().map(|ty| ty.pretty(alloc, env)), ", ").parens()
-            }
+            Tuple(tys) if tys.len() == 1 => tys[0].pretty(alloc),
+            Tuple(tys) => alloc.intersperse(tys.iter().map(|ty| ty.pretty(alloc)), ", ").parens(),
         }
     }
 }
 
 impl Print for Trigger {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         match &self.0 {
             None => alloc.nil(),
-            Some(exp) => exp.pretty(alloc, env).brackets(),
+            Some(exp) => exp.pretty(alloc).brackets(),
         }
     }
 }
 
 impl Print for Exp {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         match self {
-            Exp::Any(ty) => alloc.text("any ").append(ty.pretty(alloc, env)),
-            Exp::Current(box e) => alloc.text(" * ").append(parens!(alloc, env, self, e)),
-            Exp::Final(box e) => alloc.text(" ^ ").append(parens!(alloc, env, self, e)),
+            Exp::Any(ty) => alloc.text("any ").append(ty.pretty(alloc)),
+            Exp::Current(box e) => alloc.text(" * ").append(parens!(alloc, self, e)),
+            Exp::Final(box e) => alloc.text(" ^ ").append(parens!(alloc, self, e)),
             // TODO parenthesization
             Exp::Let { pattern, box arg, box body } => alloc
                 .text("let ")
-                .append(pattern.pretty(alloc, env))
+                .append(pattern.pretty(alloc))
                 .append(" = ")
-                .append(arg.pretty(alloc, env))
+                .append(arg.pretty(alloc))
                 .append(" in ")
-                .append(body.pretty(alloc, env)),
-            Exp::Var(v, _) => v.pretty(alloc, env),
-            Exp::QVar(v, _) => v.pretty(alloc, env),
+                .append(body.pretty(alloc)),
+            Exp::Var(v, _) => v.pretty(alloc),
+            Exp::QVar(v, _) => v.pretty(alloc),
             Exp::RecUp { box record, updates } => {
                 let mut res = alloc
                     .space()
-                    .append(parens!(alloc, env, self.precedence().next(), record))
+                    .append(parens!(alloc, self.precedence().next(), record))
                     .append(" with ");
                 for (label, val) in updates {
                     res = res
                         .append(alloc.text(label))
                         .append(" = ")
-                        .append(parens!(alloc, env, self, val))
+                        .append(parens!(alloc, self, val))
                         .append(" ; ");
                 }
                 res.braces()
             }
-            Exp::RecField { box record, label } => {
-                record.pretty(alloc, env).append(".").append(label)
-            }
+            Exp::RecField { box record, label } => record.pretty(alloc).append(".").append(label),
 
             Exp::Tuple(args) => alloc
-                .intersperse(args.iter().map(|a| parens!(alloc, env, Precedence::Cast, a)), ", ")
+                .intersperse(args.iter().map(|a| parens!(alloc, Precedence::Cast, a)), ", ")
                 .parens(),
 
-            Exp::Constructor { ctor, args } => ctor.pretty(alloc, env).append(if args.is_empty() {
-                alloc.nil()
-            } else {
-                alloc.space().append(alloc.intersperse(
-                    args.iter().map(|a| parens!(alloc, env, Precedence::Brackets, a)),
-                    " ",
-                ))
-            }),
-            Exp::Const(c) => c.pretty(alloc, env),
-
-            Exp::UnaryOp(UnOp::Not, box op) => {
-                alloc.text("not ").append(parens!(alloc, env, self, op))
+            Exp::Constructor { ctor, args } => {
+                ctor.pretty(alloc).append(if args.is_empty() {
+                    alloc.nil()
+                } else {
+                    alloc.space().append(alloc.intersperse(
+                        args.iter().map(|a| parens!(alloc, Precedence::Brackets, a)),
+                        " ",
+                    ))
+                })
             }
+            Exp::Const(c) => c.pretty(alloc),
 
-            Exp::UnaryOp(UnOp::Neg, box op) => {
-                alloc.text("- ").append(parens!(alloc, env, self, op))
-            }
+            Exp::UnaryOp(UnOp::Not, box op) => alloc.text("not ").append(parens!(alloc, self, op)),
+
+            Exp::UnaryOp(UnOp::Neg, box op) => alloc.text("- ").append(parens!(alloc, self, op)),
             Exp::UnaryOp(UnOp::FloatNeg, box op) => {
-                alloc.text(".- ").append(parens!(alloc, env, self, op))
+                alloc.text(".- ").append(parens!(alloc, self, op))
             }
             Exp::BinaryOp(op, box l, box r) => match self.associativity() {
-                Some(AssocDir::Left) => parens!(alloc, env, self, l),
-                Some(AssocDir::Right) | None => parens!(alloc, env, self.precedence().next(), l),
+                Some(AssocDir::Left) => parens!(alloc, self, l),
+                Some(AssocDir::Right) | None => parens!(alloc, self.precedence().next(), l),
             }
             .append(alloc.space())
             .append(bin_op_to_string(op))
             .append(alloc.space())
             .append(match self.associativity() {
-                Some(AssocDir::Right) => parens!(alloc, env, self, r),
-                Some(AssocDir::Left) | None => parens!(alloc, env, self.precedence().next(), r),
+                Some(AssocDir::Right) => parens!(alloc, self, r),
+                Some(AssocDir::Left) | None => parens!(alloc, self.precedence().next(), r),
             }),
             Exp::Call(box fun, args) => {
-                parens!(alloc, env, self, fun).append(alloc.space()).append(alloc.intersperse(
-                    args.iter().map(|a| parens!(alloc, env, Precedence::App.next(), a)),
+                parens!(alloc, self, fun).append(alloc.space()).append(alloc.intersperse(
+                    args.iter().map(|a| parens!(alloc, Precedence::App.next(), a)),
                     alloc.space(),
                 ))
             }
 
             Exp::Verbatim(verb) => alloc.text(verb),
-            Exp::Attr(attr, e) => {
-                attr.pretty(alloc, env).append(alloc.space()).append(e.pretty(alloc, env))
-            }
+            Exp::Attr(attr, e) => attr.pretty(alloc).append(alloc.space()).append(e.pretty(alloc)),
             Exp::Abs(binders, box body) => alloc
                 .text("fun ")
-                .append(
-                    alloc.intersperse(binders.iter().map(|b| b.pretty(alloc, env)), alloc.space()),
-                )
+                .append(alloc.intersperse(binders.iter().map(|b| b.pretty(alloc)), alloc.space()))
                 .append(" -> ")
-                .append(body.pretty(alloc, env)),
+                .append(body.pretty(alloc)),
 
             Exp::Match(box scrut, brs) => alloc
                 .text("match ")
-                .append(scrut.pretty(alloc, env))
+                .append(scrut.pretty(alloc))
                 .append(" with")
                 .append(alloc.hardline())
                 .append(
@@ -734,9 +606,9 @@ impl Print for Exp {
                         brs.iter().map(|(pat, br)| {
                             alloc
                                 .text("| ")
-                                .append(pat.pretty(alloc, env))
+                                .append(pat.pretty(alloc))
                                 .append(" -> ")
-                                .append(br.pretty(alloc, env))
+                                .append(br.pretty(alloc))
                         }),
                         alloc.hardline(),
                     )
@@ -745,52 +617,53 @@ impl Print for Exp {
                 .append("end"),
             Exp::IfThenElse(s, i, e) => alloc
                 .text("if ")
-                .append(s.pretty(alloc, env))
+                .append(s.pretty(alloc))
                 .append(" then")
-                .append(alloc.line().append(i.pretty(alloc, env)).nest(2).append(alloc.line()))
+                .append(alloc.line().append(i.pretty(alloc)).nest(2).append(alloc.line()))
                 .append("else")
-                .append(alloc.line().append(e.pretty(alloc, env)).nest(2).append(alloc.line_()))
+                .append(alloc.line().append(e.pretty(alloc)).nest(2).append(alloc.line_()))
                 .group(),
             Exp::Forall(binders, trig, box exp) => alloc
                 .text("forall ")
-                .append(alloc.intersperse(
-                    binders.iter().map(|(b, t)| {
-                        b.pretty(alloc, env).append(" : ").append(t.pretty(alloc, env))
-                    }),
-                    ", ",
-                ))
-                .append(trig.pretty(alloc, env))
+                .append(
+                    alloc.intersperse(
+                        binders
+                            .iter()
+                            .map(|(b, t)| b.pretty(alloc).append(" : ").append(t.pretty(alloc))),
+                        ", ",
+                    ),
+                )
+                .append(trig.pretty(alloc))
                 .append(" . ")
-                .append(exp.pretty(alloc, env)),
+                .append(exp.pretty(alloc)),
             Exp::Exists(binders, trig, box exp) => alloc
                 .text("exists ")
-                .append(alloc.intersperse(
-                    binders.iter().map(|(b, t)| {
-                        b.pretty(alloc, env).append(" : ").append(t.pretty(alloc, env))
-                    }),
-                    ", ",
-                ))
-                .append(trig.pretty(alloc, env))
+                .append(
+                    alloc.intersperse(
+                        binders
+                            .iter()
+                            .map(|(b, t)| b.pretty(alloc).append(" : ").append(t.pretty(alloc))),
+                        ", ",
+                    ),
+                )
+                .append(trig.pretty(alloc))
                 .append(" . ")
-                .append(exp.pretty(alloc, env)),
+                .append(exp.pretty(alloc)),
             Exp::Impl(box hyp, box exp) => {
-                parens!(alloc, env, self, hyp).append(" -> ").append(parens!(alloc, env, self, exp))
+                parens!(alloc, self, hyp).append(" -> ").append(parens!(alloc, self, exp))
             }
             Exp::Ascribe(e, t) => {
-                parens!(alloc, env, self, e).append(" : ").append(t.pretty(alloc, env)).group()
+                parens!(alloc, self, e).append(" : ").append(t.pretty(alloc)).group()
             }
-            Exp::Pure(e) => alloc.text("pure ").append(e.pretty(alloc, env).braces()),
-            Exp::Ghost(e) => {
-                alloc.text("ghost ").append(parens!(alloc, env, Precedence::App.next(), e))
-            }
+            Exp::Pure(e) => alloc.text("pure ").append(e.pretty(alloc).braces()),
+            Exp::Ghost(e) => alloc.text("ghost ").append(parens!(alloc, Precedence::App.next(), e)),
             Exp::Absurd => alloc.text("absurd"),
-            Exp::Old(e) => alloc.text("old").append(e.pretty(alloc, env).parens()),
+            Exp::Old(e) => alloc.text("old").append(e.pretty(alloc).parens()),
             Exp::Record { fields } => alloc
                 .intersperse(
                     fields.iter().map(|(nm, a)| {
                         alloc.text(nm).append(" = ").append(parens!(
                             alloc,
-                            env,
                             Precedence::Attr.next(),
                             a
                         ))
@@ -798,36 +671,30 @@ impl Print for Exp {
                     "; ",
                 )
                 .braces(),
-            Exp::Chain(fields) => {
-                alloc.intersperse(fields.iter().map(|f| f.pretty(alloc, env)), "; ")
-            }
-            Exp::FnLit(e) => alloc.text("fun _ -> ").append(e.pretty(alloc, env)).parens(),
-            Exp::Assert(e) => alloc.text("assert ").append(e.pretty(alloc, env).braces()),
-            Exp::Assume(e) => alloc.text("assume ").append(e.pretty(alloc, env).braces()),
+            Exp::Chain(fields) => alloc.intersperse(fields.iter().map(|f| f.pretty(alloc)), "; "),
+            Exp::FnLit(e) => alloc.text("fun _ -> ").append(e.pretty(alloc)).parens(),
+            Exp::Assert(e) => alloc.text("assert ").append(e.pretty(alloc).braces()),
+            Exp::Assume(e) => alloc.text("assume ").append(e.pretty(alloc).braces()),
         }
     }
 }
 
 impl Print for Binder {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         match self {
             Binder::Wild => alloc.text("_"),
-            Binder::UnNamed(ty) => ty.pretty(alloc, env),
-            Binder::Named(id) => id.pretty(alloc, env),
+            Binder::UnNamed(ty) => ty.pretty(alloc),
+            Binder::Named(id) => id.pretty(alloc),
             Binder::Typed(ghost, ids, ty) => {
                 (if *ghost { alloc.text("ghost ") } else { alloc.nil() })
                     .append(
                         alloc
-                            .intersperse(ids.iter().map(|id| id.pretty(alloc, env)), alloc.space())
+                            .intersperse(ids.iter().map(|id| id.pretty(alloc)), alloc.space())
                             .append(" : ")
-                            .append(ty.pretty(alloc, env)),
+                            .append(ty.pretty(alloc)),
                     )
                     .parens()
             }
@@ -838,52 +705,47 @@ impl Print for Binder {
 fn pretty_attr<'b, 'a: 'b, A: DocAllocator<'a>>(
     attr: &'a Option<Attribute>,
     alloc: &'a A,
-    env: &mut PrintEnv,
 ) -> DocBuilder<'a, A>
 where
     A::Doc: Clone,
 {
     match attr {
-        Some(attr) => attr.pretty(alloc, env).append(" "),
+        Some(attr) => attr.pretty(alloc).append(" "),
         None => alloc.nil(),
     }
 }
 
 impl Print for Statement {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         match self {
-            Statement::Assign { attr, lhs, rhs } => pretty_attr(attr, alloc, env)
-                .append(lhs.pretty(alloc, env))
+            Statement::Assign { attr, lhs, rhs } => pretty_attr(attr, alloc)
+                .append(lhs.pretty(alloc))
                 .append(" <- ")
-                .append(parens!(alloc, env, Precedence::Impl, rhs)),
+                .append(parens!(alloc, Precedence::Impl, rhs)),
             Statement::Invariant(e) => {
-                let doc = alloc.text("invariant ").append(
-                    alloc.space().append(e.pretty(alloc, env)).append(alloc.space()).braces(),
-                );
+                let doc = alloc
+                    .text("invariant ")
+                    .append(alloc.space().append(e.pretty(alloc)).append(alloc.space()).braces());
                 doc
             }
             Statement::Variant(e) => {
-                let doc = alloc.text("variant ").append(
-                    alloc.space().append(e.pretty(alloc, env)).append(alloc.space()).braces(),
-                );
+                let doc = alloc
+                    .text("variant ")
+                    .append(alloc.space().append(e.pretty(alloc)).append(alloc.space()).braces());
                 doc
             }
             Statement::Assume(assump) => {
                 let doc = alloc.text("assume ").append(
-                    alloc.space().append(assump.pretty(alloc, env)).append(alloc.space()).braces(),
+                    alloc.space().append(assump.pretty(alloc)).append(alloc.space()).braces(),
                 );
                 doc
             }
             Statement::Assert(assert) => {
                 let doc = alloc.text("assert ").append(
-                    alloc.space().append(assert.pretty(alloc, env)).append(alloc.space()).braces(),
+                    alloc.space().append(assert.pretty(alloc)).append(alloc.space()).braces(),
                 );
                 doc
             }
@@ -892,22 +754,18 @@ impl Print for Statement {
 }
 
 impl Print for Terminator {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         use Terminator::*;
         match self {
-            Goto(tgt) => alloc.text("goto ").append(tgt.pretty(alloc, env)),
+            Goto(tgt) => alloc.text("goto ").append(tgt.pretty(alloc)),
             Absurd => alloc.text("absurd"),
             Return => alloc.text("return _0"),
             Switch(discr, brs) => alloc
                 .text("switch ")
-                .append(discr.pretty(alloc, env).parens())
+                .append(discr.pretty(alloc).parens())
                 .append(alloc.hardline())
                 .append(
                     sep_end_by(
@@ -915,9 +773,9 @@ impl Print for Terminator {
                         brs.iter().map(|(pat, tgt)| {
                             alloc
                                 .text("| ")
-                                .append(pat.pretty(alloc, env))
+                                .append(pat.pretty(alloc))
                                 .append(" -> ")
-                                .append(tgt.pretty(alloc, env))
+                                .append(tgt.pretty(alloc))
                         }),
                         alloc.hardline(),
                     )
@@ -929,30 +787,26 @@ impl Print for Terminator {
 }
 
 impl Print for Pattern {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         match self {
             Pattern::Wildcard => alloc.text("_"),
-            Pattern::VarP(v) => v.pretty(alloc, env),
+            Pattern::VarP(v) => v.pretty(alloc),
             Pattern::TupleP(pats) => {
-                alloc.intersperse(pats.iter().map(|p| p.pretty(alloc, env)), ", ").parens()
+                alloc.intersperse(pats.iter().map(|p| p.pretty(alloc)), ", ").parens()
             }
             Pattern::ConsP(c, pats) => {
-                let mut doc = c.pretty(alloc, env);
+                let mut doc = c.pretty(alloc);
 
                 if !pats.is_empty() {
                     doc = doc.append(alloc.space()).append(alloc.intersperse(
                         pats.iter().map(|p| {
                             if matches!(p, Pattern::ConsP(_, _)) {
-                                p.pretty(alloc, env).parens()
+                                p.pretty(alloc).parens()
                             } else {
-                                p.pretty(alloc, env)
+                                p.pretty(alloc)
                             }
                         }),
                         " ",
@@ -965,11 +819,7 @@ impl Print for Pattern {
 }
 
 impl Print for BlockId {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        _: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -996,11 +846,7 @@ where
 }
 
 impl Print for Block {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -1009,10 +855,10 @@ impl Print for Block {
             .append(
                 sep_end_by(
                     alloc,
-                    self.statements.iter().map(|stmt| stmt.pretty(alloc, env)),
+                    self.statements.iter().map(|stmt| stmt.pretty(alloc)),
                     alloc.text(";").append(alloc.line()),
                 )
-                .append(self.terminator.pretty(alloc, env)),
+                .append(self.terminator.pretty(alloc)),
             )
             .nest(2)
             .append(alloc.hardline())
@@ -1051,11 +897,7 @@ fn bin_op_to_string(op: &BinOp) -> &str {
 }
 
 impl Print for Constant {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -1069,11 +911,11 @@ impl Print for Constant {
                 }
             }
             Constant::Int(i, Some(t)) => {
-                alloc.as_string(i).append(" : ").append(t.pretty(alloc, env)).parens()
+                alloc.as_string(i).append(" : ").append(t.pretty(alloc)).parens()
             }
             Constant::Int(i, None) => alloc.as_string(i),
             Constant::Uint(i, Some(t)) => {
-                alloc.as_string(i).append(" : ").append(t.pretty(alloc, env)).parens()
+                alloc.as_string(i).append(" : ").append(t.pretty(alloc)).parens()
             }
             Constant::String(s) => alloc.text(format!("{s:?}")),
             Constant::Uint(i, None) => alloc.as_string(i),
@@ -1088,7 +930,7 @@ impl Print for Constant {
             Constant::Float(f, Some(t)) => {
                 assert!(f.is_finite());
                 let f_str = print_float(*f);
-                alloc.text(f_str).append(" : ").append(t.pretty(alloc, env)).parens()
+                alloc.text(f_str).append(" : ").append(t.pretty(alloc)).parens()
             }
         }
     }
@@ -1112,21 +954,17 @@ fn print_float(f: f64) -> String {
 }
 
 impl Print for TyDecl {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         let ty_decl = match self {
             TyDecl::Opaque { ty_name, ty_params } => {
-                let mut decl = alloc.text("type ").append(ty_name.pretty(alloc, env));
+                let mut decl = alloc.text("type ").append(ty_name.pretty(alloc));
 
                 if !ty_params.is_empty() {
                     decl = decl.append(" ").append(alloc.intersperse(
-                        ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc, env))),
+                        ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc))),
                         alloc.space(),
                     ));
                 }
@@ -1134,14 +972,14 @@ impl Print for TyDecl {
             }
             TyDecl::Alias { ty_name, ty_params, alias } => alloc
                 .text("type ")
-                .append(ty_name.pretty(alloc, env))
+                .append(ty_name.pretty(alloc))
                 .append(" ")
                 .append(alloc.intersperse(
-                    ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc, env))),
+                    ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc))),
                     alloc.space(),
                 ))
                 .append(alloc.text(" =").append(alloc.hardline()))
-                .append(alias.pretty(alloc, env).indent(2)),
+                .append(alias.pretty(alloc).indent(2)),
             TyDecl::Adt { tys } => {
                 use std::iter::*;
                 let header = once("type").chain(repeat("with"));
@@ -1151,21 +989,21 @@ impl Print for TyDecl {
                     decl = decl
                         .append(hdr)
                         .append(" ")
-                        .append(ty_decl.ty_name.pretty(alloc, env))
+                        .append(ty_decl.ty_name.pretty(alloc))
                         .append(" ")
                         .append(
                             alloc.intersperse(
                                 ty_decl
                                     .ty_params
                                     .iter()
-                                    .map(|p| alloc.text("'").append(p.pretty(alloc, env))),
+                                    .map(|p| alloc.text("'").append(p.pretty(alloc))),
                                 alloc.space(),
                             ),
                         );
 
                     let mut inner_doc = alloc.nil();
                     for cons in &ty_decl.constrs {
-                        let ty_cons = alloc.text("| ").append(cons.pretty(alloc, env));
+                        let ty_cons = alloc.text("| ").append(cons.pretty(alloc));
                         inner_doc = inner_doc.append(ty_cons.append(alloc.hardline()))
                     }
                     decl = decl
@@ -1177,9 +1015,9 @@ impl Print for TyDecl {
         };
 
         // let mut ty_decl =
-        //     alloc.text("type ").append(self.ty_name.pretty(alloc, env)).append(" ").append(
+        //     alloc.text("type ").append(self.ty_name.pretty(alloc)).append(" ").append(
         //         alloc.intersperse(
-        //             self.ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc, env))),
+        //             self.ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc))),
         //             alloc.space(),
         //         ),
         //     );
@@ -1188,24 +1026,20 @@ impl Print for TyDecl {
         //     ty_decl = ty_decl.append(alloc.text(" =").append(alloc.hardline()));
         // }
         ty_decl
-        // ty_decl.append(self.kind.pretty(alloc, env).indent(2))
+        // ty_decl.append(self.kind.pretty(alloc).indent(2))
     }
 }
 
 impl Print for ConstructorDecl {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
-        let mut cons_doc = self.name.pretty(alloc, env);
+        let mut cons_doc = self.name.pretty(alloc);
 
         if !self.fields.is_empty() {
             cons_doc = cons_doc.append(alloc.space()).append(
-                alloc.intersperse(self.fields.iter().map(|ty_arg| ty_arg.pretty(alloc, env)), " "),
+                alloc.intersperse(self.fields.iter().map(|ty_arg| ty_arg.pretty(alloc)), " "),
             );
         }
 
@@ -1214,17 +1048,13 @@ impl Print for ConstructorDecl {
 }
 
 impl Print for Field {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
         let parens = self.ghost || self.ty.complex();
         let doc = if self.ghost { alloc.text("ghost ") } else { alloc.nil() }
-            .append(self.ty.pretty(alloc, env));
+            .append(self.ty.pretty(alloc));
 
         if parens {
             doc.parens()
@@ -1234,11 +1064,7 @@ impl Print for Field {
     }
 }
 impl Print for Ident {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        _env: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {
@@ -1247,11 +1073,7 @@ impl Print for Ident {
 }
 
 impl Print for QName {
-    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
-        &'a self,
-        alloc: &'a A,
-        _: &mut PrintEnv,
-    ) -> DocBuilder<'a, A>
+    fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(&'a self, alloc: &'a A) -> DocBuilder<'a, A>
     where
         A::Doc: Clone,
     {


### PR DESCRIPTION
This adds a Coma ast and pretty printer to the why3 crate.

I wanted to test this by defining `proptest` strategies but unfortunately there is no way to easily test the coma parser in why3, we would be required to generate well-typed programs (also possible but harder). 
