### PR TITLE
fix: emit correct relative paths in spans with 'cargo creusot'

### DIFF
--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -1,6 +1,6 @@
 use clap::*;
 use serde::{Deserialize, Serialize};
-use std::{error::Error, ffi::OsString};
+use std::{error::Error, ffi::OsString, path::PathBuf};
 
 #[derive(Parser, Serialize, Deserialize)]
 pub struct CreusotArgs {
@@ -10,6 +10,11 @@ pub struct CreusotArgs {
     /// [None] provides the clearest diffs.
     #[clap(long, value_enum, default_value_t=SpanMode::Relative)]
     pub span_mode: SpanMode,
+    #[clap(long, default_value_os_t = get_default_root_path_relative_from_output())]
+    /// Relative path of the root of the Rust project relative to the output files
+    /// of Creusot. This is used when producing [Relative] spans, to know the location
+    /// of Rust files corresponding to the generated Why3 files.
+    pub root_path_relative_from_output: PathBuf,
     #[clap(long)]
     /// Only generate proofs for items matching the provided string. The string is treated
     /// as a Rust qualified path.
@@ -59,6 +64,13 @@ pub enum Why3SubCommand {
     Prove,
     Ide,
     Replay,
+}
+
+/// Default relative path of the root project wrt the output.
+/// This corresponds to the default scenario where the user invokes "cargo creusot"
+/// which writes its output in target/debug/
+fn get_default_root_path_relative_from_output() -> PathBuf {
+    ["..", ".."].iter().collect()
 }
 
 /// Parse a single key-value pair

--- a/creusot-rustc/src/options.rs
+++ b/creusot-rustc/src/options.rs
@@ -42,6 +42,7 @@ impl CreusotArgsExt for CreusotArgs {
             output_file,
             in_cargo: cargo_creusot,
             span_mode: span_mode,
+            root_path_relative_from_output: self.root_path_relative_from_output,
             match_str: self.focus_on,
             simple_triggers: self.simple_triggers,
             why3_cmd: self.subcommand.map(why3_command),

--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -383,7 +383,6 @@ impl<'tcx> Why3Generator<'tcx> {
         let filename = match self.opts.span_mode {
             SpanMode::Absolute => path.to_string_lossy().into_owned(),
             SpanMode::Relative => {
-                // Why3 treats the spans as relative to the session not the source file??
                 format!("{}", self.opts.relative_to_output(&path).to_string_lossy())
             }
             _ => return None,

--- a/creusot/tests/ui.rs
+++ b/creusot/tests/ui.rs
@@ -91,6 +91,7 @@ fn run_creusot(
         "--stdout",
         "--export-metadata=false",
         "--span-mode=relative",
+        "--root-path-relative-from-output=.",
         "--check-why3=false",
     ]);
     cmd.args(&[


### PR DESCRIPTION
This is an attempt at fixing #944 , along the lines mentioned in the issue.

This PR adds an option to creusot-rustc to specify the relative location of the project's root with respect to creusot's output. This option is used by the test harness, which uses a different file layout than 'cargo creusot'. ('cargo creusot' then simply uses the default value of the option, which matches its usecase: the default value is `../..` to match the `target/debug` directories where `cargo creusot` stores generated mlcfg files.)