### PR TITLE
Demote `Expr::Call` to `Statement::Call`

### DIFF
--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -100,7 +100,7 @@ pub(crate) fn after_analysis(ctx: TranslationCtx) -> Result<(), Box<dyn Error>> 
                 let outputs = why3.output_filenames(());
                 let crate_name = why3.crate_name(LOCAL_CRATE);
 
-                let libname = format!("{}-{}.mlcfg", crate_name.as_str(), why3.crate_types()[0]);
+                let libname = format!("{}-{}.coma", crate_name.as_str(), why3.crate_types()[0]);
 
                 let directory = if why3.opts.in_cargo {
                     let mut dir = outputs.out_directory.clone();

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -348,8 +348,8 @@ impl<'body, 'tcx> BodyTranslator<'body, 'tcx> {
     // Useful helper to translate an operand
     pub(crate) fn translate_operand(&mut self, operand: &Operand<'tcx>) -> Expr<'tcx> {
         let kind = match operand {
-            Operand::Copy(pl) => ExprKind::Copy(self.translate_place(*pl)),
-            Operand::Move(pl) => ExprKind::Move(self.translate_place(*pl)),
+            Operand::Copy(pl) => ExprKind::Operand(fmir::Operand::Copy(self.translate_place(*pl))),
+            Operand::Move(pl) => ExprKind::Operand(fmir::Operand::Move(self.translate_place(*pl))),
             Operand::Constant(c) => {
                 return crate::constant::from_mir_constant(self.param_env(), self.ctx, c)
             }

--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -1,6 +1,7 @@
 use super::BodyTranslator;
 use crate::{
     analysis::NotFinalPlaces,
+    fmir::Operand,
     translation::{
         fmir::{self, Expr, ExprKind, RValue},
         specification::inv_subst,
@@ -90,7 +91,8 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                         return;
                     }
 
-                    ExprKind::Copy(self.translate_place(self.compute_ref_place(*pl, loc)))
+                    let op = Operand::Copy(self.translate_place(self.compute_ref_place(*pl, loc)));
+                    ExprKind::Operand(op)
                 }
                 Mut { .. } => {
                     if self.erased_locals.contains(pl.local) {
@@ -158,7 +160,7 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
             }
             Rvalue::Len(pl) => {
                 let e = Expr {
-                    kind: ExprKind::Copy(self.translate_place(*pl)),
+                    kind: ExprKind::Operand(Operand::Copy(self.translate_place(*pl))),
                     ty: pl.ty(self.body, self.tcx).ty,
                     span: DUMMY_SP,
                 };

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -375,7 +375,7 @@ module C100doors_F
     goto BB0
   }
   BB0 {
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] door_open <- ([#"../100doors.rs" 19 35 19 51] from_elem0 ([#"../100doors.rs" 19 40 19 45] [#"../100doors.rs" 19 40 19 45] false) ([#"../100doors.rs" 19 47 19 50] [#"../100doors.rs" 19 47 19 50] (100 : usize)));
+    [#"../100doors.rs" 19 35 19 51] door_open <- ([#"../100doors.rs" 19 35 19 51] from_elem0 ([#"../100doors.rs" 19 40 19 45] [#"../100doors.rs" 19 40 19 45] false) ([#"../100doors.rs" 19 47 19 50] [#"../100doors.rs" 19 47 19 50] (100 : usize)));
     goto BB1
   }
   BB1 {

--- a/creusot/tests/should_succeed/bug/874.mlcfg
+++ b/creusot/tests/should_succeed/bug/874.mlcfg
@@ -290,7 +290,7 @@ module C874_CanExtend
     goto BB2
   }
   BB2 {
-    [#"../../../../../creusot-contracts/src/lib.rs" 254 8 254 58] v <- ([#"../874.rs" 5 16 5 29] into_vec0 ([#"../../../../../creusot-contracts/src/lib.rs" 254 47 254 56] let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 5 21 5 22] [#"../874.rs" 5 21 5 22] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 5 24 5 25] [#"../874.rs" 5 24 5 25] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 5 27 5 28] [#"../874.rs" 5 27 5 28] (3 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp));
+    [#"../874.rs" 5 16 5 29] v <- ([#"../874.rs" 5 16 5 29] into_vec0 ([#"../../../../../creusot-contracts/src/lib.rs" 254 47 254 56] let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 5 21 5 22] [#"../874.rs" 5 21 5 22] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 5 24 5 25] [#"../874.rs" 5 24 5 25] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 5 27 5 28] [#"../874.rs" 5 27 5 28] (3 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp));
     goto BB3
   }
   BB3 {
@@ -300,7 +300,7 @@ module C874_CanExtend
     goto BB5
   }
   BB5 {
-    [#"../../../../../creusot-contracts/src/lib.rs" 254 8 254 58] w <- ([#"../874.rs" 6 12 6 25] into_vec0 ([#"../../../../../creusot-contracts/src/lib.rs" 254 47 254 56] let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 6 17 6 18] [#"../874.rs" 6 17 6 18] (4 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 6 20 6 21] [#"../874.rs" 6 20 6 21] (5 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 6 23 6 24] [#"../874.rs" 6 23 6 24] (6 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp));
+    [#"../874.rs" 6 12 6 25] w <- ([#"../874.rs" 6 12 6 25] into_vec0 ([#"../../../../../creusot-contracts/src/lib.rs" 254 47 254 56] let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 6 17 6 18] [#"../874.rs" 6 17 6 18] (4 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 6 20 6 21] [#"../874.rs" 6 20 6 21] (5 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 6 23 6 24] [#"../874.rs" 6 23 6 24] (6 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp));
     goto BB6
   }
   BB6 {
@@ -319,7 +319,7 @@ module C874_CanExtend
     goto BB9
   }
   BB9 {
-    [#"../../../../../creusot-contracts/src/lib.rs" 254 8 254 58] z <- ([#"../874.rs" 9 12 9 34] into_vec0 ([#"../../../../../creusot-contracts/src/lib.rs" 254 47 254 56] let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 9 17 9 18] [#"../874.rs" 9 17 9 18] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 9 20 9 21] [#"../874.rs" 9 20 9 21] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 9 23 9 24] [#"../874.rs" 9 23 9 24] (3 : int32))}; assume {Seq.get (__arr_temp.elts) 3 = ([#"../874.rs" 9 26 9 27] [#"../874.rs" 9 26 9 27] (4 : int32))}; assume {Seq.get (__arr_temp.elts) 4 = ([#"../874.rs" 9 29 9 30] [#"../874.rs" 9 29 9 30] (5 : int32))}; assume {Seq.get (__arr_temp.elts) 5 = ([#"../874.rs" 9 32 9 33] [#"../874.rs" 9 32 9 33] (6 : int32))}; assume {Slice.length __arr_temp = 6}; __arr_temp));
+    [#"../874.rs" 9 12 9 34] z <- ([#"../874.rs" 9 12 9 34] into_vec0 ([#"../../../../../creusot-contracts/src/lib.rs" 254 47 254 56] let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 9 17 9 18] [#"../874.rs" 9 17 9 18] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 9 20 9 21] [#"../874.rs" 9 20 9 21] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 9 23 9 24] [#"../874.rs" 9 23 9 24] (3 : int32))}; assume {Seq.get (__arr_temp.elts) 3 = ([#"../874.rs" 9 26 9 27] [#"../874.rs" 9 26 9 27] (4 : int32))}; assume {Seq.get (__arr_temp.elts) 4 = ([#"../874.rs" 9 29 9 30] [#"../874.rs" 9 29 9 30] (5 : int32))}; assume {Seq.get (__arr_temp.elts) 5 = ([#"../874.rs" 9 32 9 33] [#"../874.rs" 9 32 9 33] (6 : int32))}; assume {Slice.length __arr_temp = 6}; __arr_temp));
     goto BB10
   }
   BB10 {

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -382,7 +382,7 @@ module FilterPositive_M
     goto BB3
   }
   BB11 {
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] u <- ([#"../filter_positive.rs" 95 26 95 40] from_elem0 ([#"../filter_positive.rs" 95 31 95 32] [#"../filter_positive.rs" 95 31 95 32] (0 : int32)) ([#"../filter_positive.rs" 95 34 95 39] count));
+    [#"../filter_positive.rs" 95 26 95 40] u <- ([#"../filter_positive.rs" 95 26 95 40] from_elem0 ([#"../filter_positive.rs" 95 31 95 32] [#"../filter_positive.rs" 95 31 95 32] (0 : int32)) ([#"../filter_positive.rs" 95 34 95 39] count));
     goto BB12
   }
   BB12 {

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -289,7 +289,7 @@ module Hashmap_Impl5_New
     goto BB0
   }
   BB0 {
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] _6 <- ([#"../hashmap.rs" 99 39 99 60] from_elem0 ([#"../hashmap.rs" 99 44 99 53] Hashmap_List_Type.C_Nil) ([#"../hashmap.rs" 99 55 99 59] size));
+    [#"../hashmap.rs" 99 39 99 60] _6 <- ([#"../hashmap.rs" 99 39 99 60] from_elem0 ([#"../hashmap.rs" 99 44 99 53] Hashmap_List_Type.C_Nil) ([#"../hashmap.rs" 99 55 99 59] size));
     goto BB1
   }
   BB1 {

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -644,7 +644,7 @@ module Knapsack_Knapsack01Dyn
     goto BB0
   }
   BB0 {
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] _7 <- ([#"../knapsack.rs" 49 30 49 53] from_elem0 ([#"../knapsack.rs" 49 35 49 36] [#"../knapsack.rs" 49 35 49 36] (0 : usize)) ([#"../knapsack.rs" 49 38 49 52] ([#"../knapsack.rs" 49 38 49 48] max_weight) + ([#"../knapsack.rs" 49 51 49 52] [#"../knapsack.rs" 49 51 49 52] (1 : usize))));
+    [#"../knapsack.rs" 49 30 49 53] _7 <- ([#"../knapsack.rs" 49 30 49 53] from_elem0 ([#"../knapsack.rs" 49 35 49 36] [#"../knapsack.rs" 49 35 49 36] (0 : usize)) ([#"../knapsack.rs" 49 38 49 52] ([#"../knapsack.rs" 49 38 49 48] max_weight) + ([#"../knapsack.rs" 49 51 49 52] [#"../knapsack.rs" 49 51 49 52] (1 : usize))));
     goto BB1
   }
   BB1 {
@@ -652,7 +652,7 @@ module Knapsack_Knapsack01Dyn
     goto BB2
   }
   BB2 {
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] best_value <- ([#"../knapsack.rs" 49 25 49 71] from_elem1 _7 ([#"../knapsack.rs" 49 55 49 70] _11 + ([#"../knapsack.rs" 49 69 49 70] [#"../knapsack.rs" 49 69 49 70] (1 : usize))));
+    [#"../knapsack.rs" 49 25 49 71] best_value <- ([#"../knapsack.rs" 49 25 49 71] from_elem1 _7 ([#"../knapsack.rs" 49 55 49 70] _11 + ([#"../knapsack.rs" 49 69 49 70] [#"../knapsack.rs" 49 69 49 70] (1 : usize))));
     _7 <- any Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global);
     _11 <- any usize;
     goto BB3

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -1095,7 +1095,7 @@ module KnapsackFull_Knapsack01Dyn
     goto BB0
   }
   BB0 {
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] _10 <- ([#"../knapsack_full.rs" 86 30 86 53] from_elem0 ([#"../knapsack_full.rs" 86 35 86 36] [#"../knapsack_full.rs" 86 35 86 36] (0 : usize)) ([#"../knapsack_full.rs" 86 38 86 52] ([#"../knapsack_full.rs" 86 38 86 48] max_weight) + ([#"../knapsack_full.rs" 86 51 86 52] [#"../knapsack_full.rs" 86 51 86 52] (1 : usize))));
+    [#"../knapsack_full.rs" 86 30 86 53] _10 <- ([#"../knapsack_full.rs" 86 30 86 53] from_elem0 ([#"../knapsack_full.rs" 86 35 86 36] [#"../knapsack_full.rs" 86 35 86 36] (0 : usize)) ([#"../knapsack_full.rs" 86 38 86 52] ([#"../knapsack_full.rs" 86 38 86 48] max_weight) + ([#"../knapsack_full.rs" 86 51 86 52] [#"../knapsack_full.rs" 86 51 86 52] (1 : usize))));
     goto BB1
   }
   BB1 {
@@ -1103,7 +1103,7 @@ module KnapsackFull_Knapsack01Dyn
     goto BB2
   }
   BB2 {
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] best_value <- ([#"../knapsack_full.rs" 86 25 86 71] from_elem1 _10 ([#"../knapsack_full.rs" 86 55 86 70] _14 + ([#"../knapsack_full.rs" 86 69 86 70] [#"../knapsack_full.rs" 86 69 86 70] (1 : usize))));
+    [#"../knapsack_full.rs" 86 25 86 71] best_value <- ([#"../knapsack_full.rs" 86 25 86 71] from_elem1 _10 ([#"../knapsack_full.rs" 86 55 86 70] _14 + ([#"../knapsack_full.rs" 86 69 86 70] [#"../knapsack_full.rs" 86 69 86 70] (1 : usize))));
     _10 <- any Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global);
     _14 <- any usize;
     goto BB3

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -1132,15 +1132,15 @@ module SparseArray_Create
   BB0 {
     assert { [@expl:type invariant] inv0 dummy };
     assume { resolve0 dummy };
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] _6 <- ([#"../sparse_array.rs" 135 37 135 52] from_elem0 ([#"../sparse_array.rs" 135 42 135 47] dummy) ([#"../sparse_array.rs" 135 49 135 51] sz));
+    [#"../sparse_array.rs" 135 37 135 52] _6 <- ([#"../sparse_array.rs" 135 37 135 52] from_elem0 ([#"../sparse_array.rs" 135 42 135 47] dummy) ([#"../sparse_array.rs" 135 49 135 51] sz));
     goto BB1
   }
   BB1 {
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] _9 <- ([#"../sparse_array.rs" 135 59 135 70] from_elem1 ([#"../sparse_array.rs" 135 64 135 65] [#"../sparse_array.rs" 135 64 135 65] (0 : usize)) ([#"../sparse_array.rs" 135 67 135 69] sz));
+    [#"../sparse_array.rs" 135 59 135 70] _9 <- ([#"../sparse_array.rs" 135 59 135 70] from_elem1 ([#"../sparse_array.rs" 135 64 135 65] [#"../sparse_array.rs" 135 64 135 65] (0 : usize)) ([#"../sparse_array.rs" 135 67 135 69] sz));
     goto BB2
   }
   BB2 {
-    [#"../../../../creusot-contracts/src/lib.rs" 251 8 251 40] _11 <- ([#"../sparse_array.rs" 135 78 135 89] from_elem1 ([#"../sparse_array.rs" 135 83 135 84] [#"../sparse_array.rs" 135 83 135 84] (0 : usize)) ([#"../sparse_array.rs" 135 86 135 88] sz));
+    [#"../sparse_array.rs" 135 78 135 89] _11 <- ([#"../sparse_array.rs" 135 78 135 89] from_elem1 ([#"../sparse_array.rs" 135 83 135 84] [#"../sparse_array.rs" 135 83 135 84] (0 : usize)) ([#"../sparse_array.rs" 135 86 135 88] sz));
     goto BB3
   }
   BB3 {

--- a/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
+++ b/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
@@ -213,7 +213,7 @@ module C13VecMacro_X
     goto BB0
   }
   BB0 {
-    [#"../../../../../creusot-contracts/src/lib.rs" 248 8 248 30] v0 <- ([#"../13_vec_macro.rs" 6 23 6 29] new0 ());
+    [#"../13_vec_macro.rs" 6 23 6 29] v0 <- ([#"../13_vec_macro.rs" 6 23 6 29] new0 ());
     goto BB1
   }
   BB1 {
@@ -222,7 +222,7 @@ module C13VecMacro_X
     goto BB2
   }
   BB2 {
-    [#"../../../../../creusot-contracts/src/lib.rs" 251 8 251 40] v1 <- ([#"../13_vec_macro.rs" 9 13 9 23] from_elem0 ([#"../13_vec_macro.rs" 9 18 9 19] [#"../13_vec_macro.rs" 9 18 9 19] (0 : int32)) ([#"../13_vec_macro.rs" 9 21 9 22] [#"../13_vec_macro.rs" 9 21 9 22] (2 : usize)));
+    [#"../13_vec_macro.rs" 9 13 9 23] v1 <- ([#"../13_vec_macro.rs" 9 13 9 23] from_elem0 ([#"../13_vec_macro.rs" 9 18 9 19] [#"../13_vec_macro.rs" 9 18 9 19] (0 : int32)) ([#"../13_vec_macro.rs" 9 21 9 22] [#"../13_vec_macro.rs" 9 21 9 22] (2 : usize)));
     goto BB3
   }
   BB3 {
@@ -237,7 +237,7 @@ module C13VecMacro_X
     goto BB6
   }
   BB6 {
-    [#"../../../../../creusot-contracts/src/lib.rs" 254 8 254 58] v2 <- ([#"../13_vec_macro.rs" 12 13 12 26] into_vec0 ([#"../../../../../creusot-contracts/src/lib.rs" 254 47 254 56] let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../13_vec_macro.rs" 12 18 12 19] [#"../13_vec_macro.rs" 12 18 12 19] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../13_vec_macro.rs" 12 21 12 22] [#"../13_vec_macro.rs" 12 21 12 22] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../13_vec_macro.rs" 12 24 12 25] [#"../13_vec_macro.rs" 12 24 12 25] (3 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp));
+    [#"../13_vec_macro.rs" 12 13 12 26] v2 <- ([#"../13_vec_macro.rs" 12 13 12 26] into_vec0 ([#"../../../../../creusot-contracts/src/lib.rs" 254 47 254 56] let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../13_vec_macro.rs" 12 18 12 19] [#"../13_vec_macro.rs" 12 18 12 19] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../13_vec_macro.rs" 12 21 12 22] [#"../13_vec_macro.rs" 12 21 12 22] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../13_vec_macro.rs" 12 24 12 25] [#"../13_vec_macro.rs" 12 24 12 25] (3 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp));
     goto BB7
   }
   BB7 {

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -277,7 +277,7 @@ module C06KnightsTour_Impl1_New_Closure3
   }
   BB0 {
     assume { resolve0 _1 };
-    [#"../../../../../creusot-contracts/src/lib.rs" 251 8 251 40] res <- ([#"../06_knights_tour.rs" 44 23 44 36] from_elem0 ([#"../06_knights_tour.rs" 44 28 44 29] [#"../06_knights_tour.rs" 44 28 44 29] (0 : usize)) ([#"../06_knights_tour.rs" 44 31 44 35] field_00 ( * _1)));
+    [#"../06_knights_tour.rs" 44 23 44 36] res <- ([#"../06_knights_tour.rs" 44 23 44 36] from_elem0 ([#"../06_knights_tour.rs" 44 28 44 29] [#"../06_knights_tour.rs" 44 28 44 29] (0 : usize)) ([#"../06_knights_tour.rs" 44 31 44 35] field_00 ( * _1)));
     goto BB1
   }
   BB1 {

--- a/why3/src/coma.rs
+++ b/why3/src/coma.rs
@@ -235,16 +235,6 @@ impl Print for Expr {
     }
 }
 
-fn braces<'a, A: pretty::DocAllocator<'a>>(
-    doc: pretty::DocBuilder<'a, A>,
-) -> pretty::DocBuilder<'a, A> {
-    if !matches!(&*doc.1, pretty::Doc::Nil) {
-        doc.braces()
-    } else {
-        doc
-    }
-}
-
 fn brackets<'a, A: pretty::DocAllocator<'a>>(
     doc: pretty::DocBuilder<'a, A>,
 ) -> pretty::DocBuilder<'a, A> {


### PR DESCRIPTION
This PR reifies a data invariant in the types, namely that function calls are always at the 'head' level. 
This will be useful when switching to coma as it simplifies the handling of control flow required. 

I also performed some very *minor* cleanups of `fmir` types, but much more work is required on that front. 

A nice side-effect is that we visibly fix some spans related to `extern_specs`. 
