### PR TITLE
Make TranslationCtx::error/warn return a DiagnosticBuilder

### DIFF
--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -243,16 +243,20 @@ impl<'tcx, 'sess> TranslationCtx<'tcx> {
         )
     }
 
-    pub(crate) fn error(&self, span: Span, msg: &str) {
-        self.tcx.sess.span_err_with_code(
+    pub(crate) fn error(
+        &self,
+        span: Span,
+        msg: &str,
+    ) -> DiagnosticBuilder<'tcx, rustc_errors::ErrorGuaranteed> {
+        self.tcx.sess.struct_span_err_with_code(
             span,
             msg.to_string(),
             DiagnosticId::Error(String::from("creusot")),
         )
     }
 
-    pub(crate) fn warn(&self, span: Span, msg: &str) {
-        self.tcx.sess.span_warn_with_code(
+    pub(crate) fn warn(&self, span: Span, msg: &str) -> DiagnosticBuilder<'tcx, ()> {
+        self.tcx.sess.struct_span_warn_with_code(
             span,
             msg.to_string(),
             DiagnosticId::Lint {

--- a/creusot/src/run_why3.rs
+++ b/creusot/src/run_why3.rs
@@ -76,7 +76,7 @@ pub(super) fn run_why3<'tcx>(ctx: &Why3Generator<'tcx>, file: Option<PathBuf>) {
                             "Prover reported {answer:?} (time: {time:?}, steps: {step:?}) when trying to solve goal {:?} {:?}",
                             x.term.goal_name, x.term.explanations
                         );
-                        ctx.error(span.unwrap_or_default(), &msg);
+                        ctx.error(span.unwrap_or_default(), &msg).emit();
                         for model in x.prover_result.model_elems() {
                             let span = span_map.decode_span(&model.location);
                             let mut msg = format!("Model Element for {}\n", model.lsymbol.name);
@@ -94,7 +94,7 @@ pub(super) fn run_why3<'tcx>(ctx: &Why3Generator<'tcx>, file: Option<PathBuf>) {
                 }
                 Err(err) => {
                     let msg = format!("error parsing why3 output {err:?}");
-                    ctx.error(DUMMY_SP, &msg)
+                    ctx.error(DUMMY_SP, &msg).emit();
                 }
             }
         }

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -202,7 +202,7 @@ pub(crate) fn resolve_function<'tcx>(
                 .expect("could not find instance");
 
             if !method.0.is_local() && ctx.sig(method.0).contract.is_false() {
-                ctx.warn(sp, "calling an external function with no contract will yield an impossible precondition");
+                ctx.warn(sp, "calling an external function with no contract will yield an impossible precondition").emit();
             }
 
             return method;
@@ -213,7 +213,8 @@ pub(crate) fn resolve_function<'tcx>(
         ctx.warn(
             sp,
             "calling an external function with no contract will yield an impossible precondition",
-        );
+        )
+        .emit();
     }
     // ctx.translate(def_id);
 

--- a/creusot/src/validate.rs
+++ b/creusot/src/validate.rs
@@ -33,7 +33,7 @@ pub(crate) fn validate_opacity(ctx: &mut TranslationCtx, item: DefId) -> Option<
                     "Cannot make `{:?}` transparent in `{:?}` as it would call a less-visible item.",
                     self.ctx.def_path_str(id), self.ctx.def_path_str(self.source_item)
                 ),
-            )
+            ).emit();
         }
     }
 
@@ -69,7 +69,7 @@ pub(crate) fn validate_opacity(ctx: &mut TranslationCtx, item: DefId) -> Option<
     if ctx.visibility(item) != Visibility::Restricted(parent_module(ctx.tcx, item))
         && util::opacity_witness_name(ctx.tcx, item).is_none()
     {
-        ctx.error(ctx.def_span(item), "Non private definitions must have an explicit transparency. Please add #[open(..)] to your definition", );
+        ctx.error(ctx.def_span(item), "Non private definitions must have an explicit transparency. Please add #[open(..)] to your definition").emit();
     }
 
     let opacity = ctx.opacity(item).scope();
@@ -93,7 +93,7 @@ pub(crate) fn validate_traits(ctx: &mut TranslationCtx) {
     }
 
     for (_, sp) in law_violations {
-        ctx.error(sp, "Laws cannot have additional generic parameters");
+        ctx.error(sp, "Laws cannot have additional generic parameters").emit();
     }
 }
 
@@ -120,7 +120,7 @@ pub(crate) fn validate_impls(ctx: &TranslationCtx) {
                     trait_ref.print_only_trait_name()
                 )
             };
-            ctx.error(ctx.def_span(impl_id.to_def_id()), &msg)
+            ctx.error(ctx.def_span(impl_id.to_def_id()), &msg).emit();
         }
 
         let implementors = ctx.impl_item_implementor_ids(impl_id.to_def_id());
@@ -145,7 +145,8 @@ pub(crate) fn validate_impls(ctx: &TranslationCtx) {
                         ctx.item_name(*impl_item),
                         util::item_type(ctx.tcx, *impl_item).to_str()
                     ),
-                );
+                )
+                .emit();
             }
         }
     }


### PR DESCRIPTION
This adds more control to the display of errors/warnings, like notes, 'help' sections...

I want to use this for a future PR, so here it is.