### PR TITLE
Merge `BorrowFinal` and `Borrow`.

### DIFF
--- a/creusot/src/backend/optimization.rs
+++ b/creusot/src/backend/optimization.rs
@@ -109,7 +109,7 @@ impl<'a, 'tcx> LocalUsage<'a, 'tcx> {
     fn visit_rvalue(&mut self, r: &RValue<'tcx>) {
         match r {
             RValue::Ghost(t) => self.visit_term(t),
-            RValue::FinalBorrow(p, _) | RValue::Borrow(p) => {
+            RValue::Borrow(_, p) => {
                 self.read_place(p);
                 self.read_place(p)
             }
@@ -291,7 +291,7 @@ impl<'tcx> SimplePropagator<'tcx> {
     fn visit_rvalue(&mut self, r: &mut RValue<'tcx>) {
         match r {
             RValue::Ghost(t) => self.visit_term(t),
-            RValue::FinalBorrow(p, _) | RValue::Borrow(p) => {
+            RValue::Borrow(_, p) => {
                 assert!(self.prop.get(&p.local).is_none(), "Trying to propagate borrowed variable")
             }
             RValue::Expr(e) => self.visit_expr(e),

--- a/creusot/src/translation/fmir.rs
+++ b/creusot/src/translation/fmir.rs
@@ -47,21 +47,27 @@ pub enum Statement<'tcx> {
     Call(Place<'tcx>, DefId, GenericArgsRef<'tcx>, Vec<Operand<'tcx>>, Span),
 }
 
-// Re-organize this completely
-// Get rid of Expr and reimpose a more traditional statement-rvalue-operand setup
-#[derive(Clone, Debug)]
-pub enum RValue<'tcx> {
-    Ghost(Term<'tcx>),
-    Borrow(Place<'tcx>),
+// TODO: Add shared borrows?
+#[derive(Clone, Copy, Debug)]
+pub enum BorrowKind {
+    /// Ordinary mutable borrows
+    Mut,
     /// The source of this borrow is not used after the reborrow, and thus we can
     /// inherit the prophecy identifier.
     ///
     /// The second field is an index in `place.projection`: see
     /// [`NotFinalPlaces::is_final_at`](crate::analysis::NotFinalPlaces::is_final_at).
-    FinalBorrow(Place<'tcx>, usize),
+    Final(usize),
+}
+
+#[derive(Clone, Debug)]
+pub enum RValue<'tcx> {
+    Ghost(Term<'tcx>),
+    Borrow(BorrowKind, Place<'tcx>),
     Expr(Expr<'tcx>),
 }
 
+// TODO Inline `Expr` in to `RValue`
 #[derive(Clone, Debug)]
 pub struct Expr<'tcx> {
     pub kind: ExprKind<'tcx>,

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -263,9 +263,9 @@ impl<'body, 'tcx> BodyTranslator<'body, 'tcx> {
         self.emit_assignment(
             lhs,
             if let Some(deref_index) = is_final {
-                fmir::RValue::FinalBorrow(p, deref_index)
+                fmir::RValue::Borrow(fmir::BorrowKind::Final(deref_index), p)
             } else {
-                fmir::RValue::Borrow(p)
+                fmir::RValue::Borrow(fmir::BorrowKind::Mut, p)
             },
             span,
         );


### PR DESCRIPTION
Another small cleanup: this merges the `Borrow` and `BorrowFinal` cases of RValue by using a `BorrowKind` enum to discriminate between them. 
