### PR TITLE
Simplify `Term::Call`

### DIFF
--- a/creusot/src/backend/term.rs
+++ b/creusot/src/backend/term.rs
@@ -128,13 +128,7 @@ impl<'tcx, N: Namer<'tcx>> Lower<'_, 'tcx, N> {
                 };
                 Exp::UnaryOp(op, Box::new(self.lower_term(arg)))
             }
-            TermKind::Call {
-                id,
-                subst,
-                // fun: box Term { kind: TermKind::Item(id, subst), .. },
-                args,
-                ..
-            } => {
+            TermKind::Call { id, subst, args, .. } => {
                 let mut args: Vec<_> = args.into_iter().map(|arg| self.lower_term(arg)).collect();
 
                 if args.is_empty() {

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -677,12 +677,7 @@ fn closure_resolve<'tcx>(
         if let Some((id, subst)) = resolve_predicate_of(ctx, param_env, ty) {
             resolve = Term {
                 ty: ctx.types.bool,
-                kind: TermKind::Call {
-                    id: id.into(),
-                    subst,
-                    fun: Box::new(Term::item(ctx.tcx, id, subst)),
-                    args: vec![proj],
-                },
+                kind: TermKind::Call { id: id.into(), subst, args: vec![proj] },
                 span: DUMMY_SP,
             }
             .conj(resolve);


### PR DESCRIPTION
The `Term::Call` node was always this weird hybrid between first-order
and higher-order. This just commits to being first-order making our
lives way simpler.
