### PR TITLE
Non Prusti specific changes that are helpful for adding Prusi-ish syntax

### DIFF
--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -13,121 +13,28 @@
 extern crate self as creusot_contracts;
 
 #[cfg(creusot)]
-mod macros {
-    /// A pre-condition of a function or trait item
-    pub use creusot_contracts_proc::requires;
-
-    /// A post-condition of a function or trait item
-    pub use creusot_contracts_proc::ensures;
-
-    pub use creusot_contracts_proc::snapshot;
-
-    /// A loop invariant
-    /// The first argument should be a name for the invariant
-    /// The second argument is the Pearlite expression for the loop invariant
-    pub use creusot_contracts_proc::invariant;
-
-    /// Declares a trait item as being a law which is autoloaded as soon another
-    /// trait item is used in a function
-    pub use creusot_contracts_proc::law;
-
-    /// Declare a function as being a logical function, this declaration must be pure and
-    /// total. It cannot be called from Rust programs, but in exchange it can use logical
-    /// operations and syntax with the help of the [`pearlite!`] macro.
-    ///
-    /// # `prophetic`
-    ///
-    /// If you wish to use the `^` operator on mutable borrows to get the final value, you need to
-    /// specify that the function is _prophetic_, like so:
-    /// ```ignore
-    /// #[logic(prophetic)]
-    /// fn uses_prophecies(x: &mut Int) -> Int {
-    ///     pearlite! { if ^x == 0 { 0 } else { 1 } }
-    /// }
-    /// ```
-    /// Such a logic function cannot be used in [`snapshot!`] anymore, and cannot be
-    /// called from a regular [`logic`] or [`predicate`] function.
-    pub use creusot_contracts_proc::logic;
-
-    /// Declare a function as being a logical function, this declaration must be pure and
-    /// total. It cannot be called from Rust programs as it is *ghost*, in exchange it can
-    /// use logical operations and syntax with the help of the [`pearlite!`] macro.
-    ///
-    /// It **must** return a boolean.
-    ///
-    /// # `prophetic`
-    ///
-    /// If you wish to use the `^` operator on mutable borrows to get the final value, you need to
-    /// specify that the function is _prophetic_, like so:
-    /// ```ignore
-    /// #[predicate(prophetic)]
-    /// fn uses_prophecies(x: &mut Int) -> bool {
-    ///     pearlite! { ^x == 0 }
-    /// }
-    /// ```
-    /// Such a predicate function cannot be used in [`snapshot!`] anymore, and cannot be
-    /// called from a regular [`logic`] or [`predicate`] function.
-    pub use creusot_contracts_proc::predicate;
-
-    /// Inserts a *logical* assertion into the code. This assertion will not be checked at runtime
-    /// but only during proofs. However, it has access to the ghost context and can use logical operations
-    /// and syntax.
-    pub use creusot_contracts_proc::proof_assert;
-
-    /// Instructs Pearlite to ignore the body of a declaration, assuming any contract the declaration has is
-    /// valid.
-    pub use creusot_contracts_proc::trusted;
-
-    /// Declares a variant for a function, this is primarily used in combination with logical functions
-    /// The variant must be an expression which returns a type implementing [WellFounded]
-    pub use creusot_contracts_proc::variant;
-
-    /// Enables Pearlite syntax, granting access to Pearlite specific operators and syntax
-    pub use creusot_contracts_proc::pearlite;
-
-    /// Allows specifications to be attached to functions coming from external crates
-    /// TODO: Document syntax
-    pub use creusot_contracts_proc::extern_spec;
-
-    /// Allows specifying both a pre- and post-condition in a single statement.
-    /// Expects an expression in either the form of a method or function call
-    /// Arguments to the call can be prefixed with `mut` to indicate that they are mutable borrows.
-    ///
-    /// Generates a `requires` and `ensures` clause in the shape of the input expression, with
-    /// `mut` replaced by `*` in the `requires` and `^` in the ensures.
-    pub use creusot_contracts_proc::maintains;
-
-    /// Allows the body of a logical definition to be made visible to provers. An optional visibility modifier can be
-    /// provided to restrict the context in whcih the obdy is opened.
-    /// By default bodies are *opaque*: they are only visible to definitions in the same module (like `pub(self)` for visibility).
-    ///
-    /// A body can only be visible in contexts where all the symbols used in the body are also visible.
-    /// This means you cannot `#[open]` a body which refers to a `pub(crate)` symbol.
-    pub use creusot_contracts_proc::open;
-
-    pub use creusot_contracts_proc::DeepModel;
-
-    pub use creusot_contracts_proc::Resolve;
-}
+extern crate creusot_contracts_proc as base_macros;
 
 #[cfg(not(creusot))]
+extern crate creusot_contracts_dummy as base_macros;
+
 mod macros {
     /// A pre-condition of a function or trait item
-    pub use creusot_contracts_dummy::requires;
+    pub use base_macros::requires;
 
     /// A post-condition of a function or trait item
-    pub use creusot_contracts_dummy::ensures;
+    pub use base_macros::ensures;
 
-    pub use creusot_contracts_dummy::snapshot;
+    pub use base_macros::snapshot;
 
     /// A loop invariant
     /// The first argument should be a name for the invariant
     /// The second argument is the Pearlite expression for the loop invariant
-    pub use creusot_contracts_dummy::invariant;
+    pub use base_macros::invariant;
 
     /// Declares a trait item as being a law which is autoloaded as soon another
     /// trait item is used in a function
-    pub use creusot_contracts_dummy::law;
+    pub use base_macros::law;
 
     /// Declare a function as being a logical function, this declaration must be pure and
     /// total. It cannot be called from Rust programs, but in exchange it can use logical
@@ -145,7 +52,7 @@ mod macros {
     /// ```
     /// Such a logic function cannot be used in [`snapshot!`] anymore, and cannot be
     /// called from a regular [`logic`] or [`predicate`] function.
-    pub use creusot_contracts_dummy::logic;
+    pub use base_macros::logic;
 
     /// Declare a function as being a logical function, this declaration must be pure and
     /// total. It cannot be called from Rust programs as it is *ghost*, in exchange it can
@@ -165,27 +72,27 @@ mod macros {
     /// ```
     /// Such a predicate function cannot be used in [`snapshot!`] anymore, and cannot be
     /// called from a regular [`logic`] or [`predicate`] function.
-    pub use creusot_contracts_dummy::predicate;
+    pub use base_macros::predicate;
 
     /// Inserts a *logical* assertion into the code. This assertion will not be checked at runtime
     /// but only during proofs. However, it has access to the ghost context and can use logical operations
     /// and syntax.
-    pub use creusot_contracts_dummy::proof_assert;
+    pub use base_macros::proof_assert;
 
     /// Instructs Pearlite to ignore the body of a declaration, assuming any contract the declaration has is
     /// valid.
-    pub use creusot_contracts_dummy::trusted;
+    pub use base_macros::trusted;
 
     /// Declares a variant for a function, this is primarily used in combination with logical functions
     /// The variant must be an expression which returns a type implementing [WellFounded]
-    pub use creusot_contracts_dummy::variant;
+    pub use base_macros::variant;
 
     /// Enables Pearlite syntax, granting access to Pearlite specific operators and syntax
-    pub use creusot_contracts_dummy::pearlite;
+    pub use base_macros::pearlite;
 
     /// Allows specifications to be attached to functions coming from external crates
     /// TODO: Document syntax
-    pub use creusot_contracts_dummy::extern_spec;
+    pub use base_macros::extern_spec;
 
     /// Allows specifying both a pre- and post-condition in a single statement.
     /// Expects an expression in either the form of a method or function call
@@ -193,19 +100,15 @@ mod macros {
     ///
     /// Generates a `requires` and `ensures` clause in the shape of the input expression, with
     /// `mut` replaced by `*` in the `requires` and `^` in the ensures.
-    pub use creusot_contracts_dummy::maintains;
+    pub use base_macros::maintains;
 
     /// Allows the body of a logical definition to be made visible to provers. An optional visibility modifier can be
     /// provided to restrict the context in whcih the obdy is opened.
-    /// By default bodies are *opaque*: they are only visible to definitions in the same module (like `pub(self)` for visibility).
+    /// By default, bodies are *opaque*: they are only visible to definitions in the same module (like `pub(self)` for visibility).
     ///
     /// A body can only be visible in contexts where all the symbols used in the body are also visible.
     /// This means you cannot `#[open]` a body which refers to a `pub(crate)` symbol.
-    pub use creusot_contracts_dummy::open;
-
-    pub use creusot_contracts_dummy::DeepModel;
-
-    pub use creusot_contracts_dummy::Resolve;
+    pub use base_macros::open;
 }
 
 #[cfg(creusot)]
@@ -252,34 +155,40 @@ pub mod util;
 pub mod well_founded;
 
 // We add some common things at the root of the creusot-contracts library
-pub use crate::{
-    logic::{IndexLogic as _, Int, OrdLogic, Seq},
-    macros::*,
-    model::{DeepModel, ShallowModel},
-    resolve::Resolve,
-    snapshot::Snapshot,
-    std::{
-        // Shadow std::prelude by our version.
-        // For Clone and PartialEq, this is important for the derive macro.
-        // If the user write the glob pattern "use creusot_contracts::*", then
-        // rustc will either shadow the old identifier or complain about the
-        // ambiguïty (ex: for the derive macros Clone and PartialEq, a glob
-        // pattern is not enough to force rustc to use our version, but at least
-        // we get an error message).
-        clone::Clone,
-        cmp::PartialEq,
-        default::Default,
-        iter::{FromIterator, IntoIterator, Iterator},
-    },
-    well_founded::WellFounded,
-};
+mod base_prelude {
+    pub use crate::{
+        logic::{IndexLogic as _, Int, OrdLogic, Seq},
+        model::{DeepModel, ShallowModel},
+        resolve::Resolve,
+        snapshot::Snapshot,
+        std::{
+            // Shadow std::prelude by our version.
+            // For Clone and PartialEq, this is important for the derive macro.
+            // If the user write the glob pattern "use creusot_contracts::*", then
+            // rustc will either shadow the old identifier or complain about the
+            // ambiguïty (ex: for the derive macros Clone and PartialEq, a glob
+            // pattern is not enough to force rustc to use our version, but at least
+            // we get an error message).
+            clone::Clone,
+            cmp::PartialEq,
+            default::Default,
+            iter::{FromIterator, IntoIterator, Iterator},
+        },
+        well_founded::WellFounded,
+    };
 
-// Export extension traits anonymously
-pub use crate::std::{
-    iter::{SkipExt as _, TakeExt as _},
-    ops::{FnExt as _, FnMutExt as _, FnOnceExt as _, RangeInclusiveExt as _},
-    slice::SliceExt as _,
-};
+    // Export extension traits anonymously
+    pub use crate::std::{
+        iter::{SkipExt as _, TakeExt as _},
+        ops::{FnExt as _, FnMutExt as _, FnOnceExt as _, RangeInclusiveExt as _},
+        slice::SliceExt as _,
+    };
+}
+pub mod prelude {
+    pub use crate::{base_prelude::*, macros::*};
+}
+
+pub use prelude::*;
 
 // The std vec macro uses special magic to construct the array argument
 // to Box::new directly on the heap. Because the generated MIR is hard

--- a/creusot-contracts/src/model.rs
+++ b/creusot-contracts/src/model.rs
@@ -12,11 +12,7 @@ pub trait ShallowModel {
     fn shallow_model(self) -> Self::ShallowModelTy;
 }
 
-#[cfg(creusot)]
-pub use creusot_contracts_proc::DeepModel;
-
-#[cfg(not(creusot))]
-pub use creusot_contracts_dummy::DeepModel;
+pub use crate::base_macros::DeepModel;
 
 /// The deep model corresponds to the model used for specifying
 /// operations such as equality, hash function or ordering, which are

--- a/creusot-contracts/src/resolve.rs
+++ b/creusot-contracts/src/resolve.rs
@@ -1,3 +1,4 @@
+pub use crate::base_macros::Resolve;
 use crate::*;
 
 #[cfg_attr(creusot, rustc_diagnostic_item = "creusot_resolve")]

--- a/creusot/src/backend/logic/vcgen.rs
+++ b/creusot/src/backend/logic/vcgen.rs
@@ -325,7 +325,7 @@ impl<'a, 'tcx> VCGen<'a, 'tcx> {
             // Same as for tuples
             TermKind::Constructor { typ, variant, fields } => {
                 self.build_vc_slice(fields, &|args| {
-                    let TyKind::Adt(_, subst) = t.ty.kind() else { unreachable!() };
+                    let TyKind::Adt(_, subst) = t.creusot_ty().kind() else { unreachable!() };
 
                     let ctor = self.names.borrow_mut().constructor(
                         self.ctx.borrow().adt_def(typ).variants()[*variant].def_id,
@@ -366,7 +366,7 @@ impl<'a, 'tcx> VCGen<'a, 'tcx> {
             }),
             // VC(A.f, Q) = VC(A, |a| Q(a.f))
             TermKind::Projection { lhs, name } => {
-                let accessor = match lhs.ty.kind() {
+                let accessor = match lhs.creusot_ty().kind() {
                     TyKind::Closure(did, substs) => {
                         self.names.borrow_mut().accessor(*did, substs, 0, *name)
                     }
@@ -464,10 +464,10 @@ impl<'a, 'tcx> VCGen<'a, 'tcx> {
         let orig_variant = self.self_sig().contract.variant.remove(0);
         let mut rec_var_exp = orig_variant.clone();
         rec_var_exp.subst(&subst);
-        if is_int(self.ctx.borrow().tcx, variant.ty) {
+        if is_int(self.ctx.borrow().tcx, variant.creusot_ty()) {
             Ok(Exp::int(0).leq(orig_variant.clone()).log_and(rec_var_exp.lt(orig_variant)))
         } else {
-            Err(VCError::UnsupportedVariant(variant.ty, variant.span))
+            Err(VCError::UnsupportedVariant(variant.creusot_ty(), variant.span))
         }
     }
 

--- a/creusot/src/backend/term.rs
+++ b/creusot/src/backend/term.rs
@@ -100,7 +100,7 @@ impl<'tcx, N: Namer<'tcx>> Lower<'_, 'tcx, N> {
             }
             TermKind::Constructor { typ, variant, fields } => {
                 self.ctx.translate(*typ);
-                let TyKind::Adt(_, subst) = term.ty.kind() else { unreachable!() };
+                let TyKind::Adt(_, subst) = term.creusot_ty().kind() else { unreachable!() };
                 let args = fields.into_iter().map(|f| self.lower_term(f)).collect();
 
                 let ctor = self
@@ -109,7 +109,7 @@ impl<'tcx, N: Namer<'tcx>> Lower<'_, 'tcx, N> {
                 Exp::Constructor { ctor, args }
             }
             TermKind::Cur { box term } => {
-                if term.ty.is_mutable_ptr() {
+                if term.creusot_ty().is_mutable_ptr() {
                     self.names.import_prelude_module(PreludeModule::Borrow);
                     Exp::Current(Box::new(self.lower_term(term)))
                 } else {
@@ -169,7 +169,7 @@ impl<'tcx, N: Namer<'tcx>> Lower<'_, 'tcx, N> {
                 Exp::qvar(accessor).app(vec![lhs])
             }
             TermKind::Closure { body } => {
-                let TyKind::Closure(id, subst) = term.ty.kind() else {
+                let TyKind::Closure(id, subst) = term.creusot_ty().kind() else {
                     unreachable!("closure has non closure type")
                 };
                 let body = self.lower_term(&*body);

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -66,6 +66,10 @@ impl<'tcx> TranslationCtx<'tcx> {
                 continue;
             }
 
+            let subst = GenericArgs::identity_for_item(self.tcx, impl_item);
+
+            let refn_subst = subst.rebase_onto(self.tcx, impl_id, trait_ref.skip_binder().args);
+
             // If there is no contract to refine, skip this item
             if !self.tcx.def_kind(trait_item).is_fn_like()
                 || (self.sig(trait_item).contract.is_empty()
@@ -73,10 +77,6 @@ impl<'tcx> TranslationCtx<'tcx> {
             {
                 continue;
             }
-
-            let subst = GenericArgs::identity_for_item(self.tcx, impl_item);
-
-            let refn_subst = subst.rebase_onto(self.tcx, impl_id, trait_ref.skip_binder().args);
 
             // TODO: Clean up and abstract
             let predicates = self

--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
@@ -106,7 +106,7 @@ module C01ResolveUnsoundness_MakeVecOfSize
   function shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global))) : Seq.seq bool
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global))) : Seq.seq bool
     ensures { result = shallow_model2 self }
     

--- a/creusot/tests/should_fail/bug/222.mlcfg
+++ b/creusot/tests/should_fail/bug/222.mlcfg
@@ -64,7 +64,7 @@ module C222_UsesInvariant
     ensures { result = invariant0 self }
     
   predicate resolve1 (self : borrowed (C222_Once_Type.t_once t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (C222_Once_Type.t_once t)) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_fail/bug/492.mlcfg
+++ b/creusot/tests/should_fail/bug/492.mlcfg
@@ -31,7 +31,7 @@ module C492_ReborrowTuple
     
   axiom inv0 : forall x : t . inv0 x = true
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -85,17 +85,17 @@ module C492_Test
     
   axiom inv0 : forall x : borrowed int32 . inv0 x = true
   predicate resolve1 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed int32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve2 (self : uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : uint32) : bool
     ensures { result = resolve2 self }
     
   predicate resolve0 (self : (borrowed int32, uint32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (borrowed int32, uint32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_fail/bug/692.mlcfg
+++ b/creusot/tests/should_fail/bug/692.mlcfg
@@ -114,7 +114,7 @@ module C692_Incorrect
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 145 33 145 36] inv4 res)
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 144 14 144 101] postcondition_once0 self args res = (resolve1 self /\ postcondition0 self args res))
   predicate resolve2 (self : borrowed c) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed c) : bool
     ensures { result = resolve2 self }
     
@@ -215,7 +215,7 @@ module C692_ValidNormal_Closure2
    =
      ^ field_00 _2 =  ^ field_00 self
   predicate resolve0 (self : borrowed C692_ValidNormal_Closure2.c692_validnormal_closure2) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed C692_ValidNormal_Closure2.c692_validnormal_closure2) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_fail/bug/695.mlcfg
+++ b/creusot/tests/should_fail/bug/695.mlcfg
@@ -133,7 +133,7 @@ module C695_InversedIf
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 145 33 145 36] inv4 res)
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 144 14 144 101] postcondition_once1 self args res = (resolve0 self /\ postcondition0 self args res))
   predicate resolve1 (self : borrowed c) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed c) : bool
     ensures { result = resolve1 self }
     
@@ -283,7 +283,7 @@ module C695_Valid_Closure2
    =
      ^ field_00 _2 =  ^ field_00 self
   predicate resolve0 (self : borrowed C695_Valid_Closure2.c695_valid_closure2) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed C695_Valid_Closure2.c695_valid_closure2) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_fail/bug/869.mlcfg
+++ b/creusot/tests/should_fail/bug/869.mlcfg
@@ -6,7 +6,7 @@ module C869_Unsound
   use prelude.Snapshot
   use prelude.Snapshot
   predicate resolve0 (self : borrowed (Snapshot.snap_ty bool)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Snapshot.snap_ty bool)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_fail/final_borrows.mlcfg
+++ b/creusot/tests/should_fail/final_borrows.mlcfg
@@ -21,7 +21,7 @@ module FinalBorrows_NotFinalBorrow
     
   axiom inv0 : forall x : t . inv0 x = true
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -81,7 +81,7 @@ module FinalBorrows_StoreChangesProphecy
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -145,7 +145,7 @@ module FinalBorrows_CallChangesProphecy
   use prelude.Int
   val inner0 [#"../final_borrows.rs" 19 4 19 21] (_1 : ()) : int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -207,12 +207,12 @@ module FinalBorrows_UnnestingFails
     
   axiom inv0 : forall x : t . inv0 x = true
   predicate resolve1 (self : borrowed (borrowed (t, t))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (borrowed (t, t))) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -330,7 +330,7 @@ module FinalBorrows_Indexing
     ensures { result = index_logic1 self ix }
     
   function shallow_model0 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -345,12 +345,12 @@ module FinalBorrows_Indexing
    ->  ^ Seq.get (to_mut_seq0 self) i = index_logic1 ( ^ self) i) && ([#"../../../../creusot-contracts/src/std/slice.rs" 80 4 80 82] forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq0 self)
    ->  * Seq.get (to_mut_seq0 self) i = index_logic1 ( * self) i) && ([#"../../../../creusot-contracts/src/std/slice.rs" 79 14 79 41] Seq.length (to_mut_seq0 self) = Seq.length (shallow_model0 self))
   predicate resolve1 (self : borrowed (slice t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (slice t)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -256,7 +256,7 @@ module C100doors_F
   axiom inv0 : forall x : Core_Ops_Range_Range_Type.t_range usize . inv0 x = true
   use prelude.Snapshot
   predicate resolve3 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : bool) : bool
     ensures { result = resolve3 self }
     
@@ -275,7 +275,7 @@ module C100doors_F
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed bool) : bool
     ensures { result = resolve1 self }
     
@@ -299,7 +299,7 @@ module C100doors_F
   function shallow_model3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global))) : Seq.seq bool
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global))) : Seq.seq bool
     ensures { result = shallow_model3 self }
     
@@ -314,7 +314,7 @@ module C100doors_F
     ensures { inv10 result }
     
   function shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global)) : Seq.seq bool =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global)) : Seq.seq bool
     ensures { result = shallow_model2 self }
     
@@ -327,7 +327,7 @@ module C100doors_F
     
   use seq.Seq
   predicate resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/all_zero.mlcfg
+++ b/creusot/tests/should_succeed/all_zero.mlcfg
@@ -28,18 +28,18 @@ module AllZero_AllZero
   use prelude.Borrow
   use prelude.Snapshot
   predicate resolve2 (self : borrowed (AllZero_List_Type.t_list)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (AllZero_List_Type.t_list)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (AllZero_List_Type.t_list)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (AllZero_List_Type.t_list)) : bool
     ensures { result = resolve1 self }
     
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/bdd.mlcfg
+++ b/creusot/tests/should_succeed/bdd.mlcfg
@@ -81,7 +81,7 @@ module Bdd_Hashmap_Impl2_Hash
     
   use prelude.Borrow
   function deep_model0 (self : (u, v)) : (deep_model_ty0, deep_model_ty1) =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model3 self
   val deep_model0 (self : (u, v)) : (deep_model_ty0, deep_model_ty1)
     ensures { result = deep_model0 self }
     
@@ -112,7 +112,7 @@ module Bdd_Hashmap_Impl2_Hash
      -> (exists k : int . k > 0 /\ UInt64.to_int result = UInt64.to_int self * UInt64.to_int rhs - k * (UInt64.to_int max0 - UInt64.to_int min0 + 1)) }
     
   function deep_model2 (self : v) : deep_model_ty1 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model5 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model5 self
   val deep_model2 (self : v) : deep_model_ty1
     ensures { result = deep_model2 self }
     
@@ -125,7 +125,7 @@ module Bdd_Hashmap_Impl2_Hash
     ensures { result = resolve0 self }
     
   function deep_model1 (self : u) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model4 self
   val deep_model1 (self : u) : deep_model_ty0
     ensures { result = deep_model1 self }
     
@@ -245,7 +245,7 @@ module Bdd_Impl7_Eq
     
   use prelude.Borrow
   function shallow_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64
     ensures { result = shallow_model0 self }
     
@@ -289,7 +289,7 @@ module Bdd_Impl13_Eq
     
   use prelude.Borrow
   function deep_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model2 self
   val deep_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = deep_model0 self }
     
@@ -303,7 +303,7 @@ module Bdd_Impl13_Eq
     ensures { result = deep_model3 self }
     
   function deep_model1 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model3 self
   val deep_model1 (self : uint64) : int
     ensures { result = deep_model1 self }
     
@@ -321,7 +321,7 @@ module Bdd_Impl13_Eq
     ensures { result = shallow_model1 self }
     
   function shallow_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64
     ensures { result = shallow_model0 self }
     
@@ -329,12 +329,12 @@ module Bdd_Impl13_Eq
     ensures { [#"../bdd.rs" 201 14 201 37] result = (shallow_model0 self = shallow_model0 o) }
     
   predicate resolve1 (self : Bdd_Node_Type.t_node) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : Bdd_Node_Type.t_node) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (Bdd_Node_Type.t_node, Bdd_Node_Type.t_node)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (Bdd_Node_Type.t_node, Bdd_Node_Type.t_node)) : bool
     ensures { result = resolve0 self }
     
@@ -623,7 +623,7 @@ module Bdd_Impl1_Hash
     
   use prelude.Borrow
   function shallow_model1 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model1 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model1 self }
     
@@ -745,7 +745,7 @@ module Bdd_Impl2_Hash
     
   use prelude.Borrow
   function shallow_model1 (self : Bdd_Bdd_Type.t_bdd) : uint64 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model1 (self : Bdd_Bdd_Type.t_bdd) : uint64
     ensures { result = shallow_model1 self }
     
@@ -847,7 +847,7 @@ module Bdd_Impl10_GrowsIsValidBdd_Impl
   use prelude.Int
   use prelude.UInt64
   function shallow_model6 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model6 (self : uint64) : int
     ensures { result = shallow_model6 self }
     
@@ -893,7 +893,7 @@ module Bdd_Impl10_GrowsIsValidBdd_Impl
     ensures { result = shallow_model3 self }
     
   function shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model2 self }
     
@@ -990,7 +990,7 @@ module Bdd_Impl10_GrowsTrans_Impl
   use prelude.Int
   use prelude.UInt64
   function shallow_model6 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model6 (self : uint64) : int
     ensures { result = shallow_model6 self }
     
@@ -1036,7 +1036,7 @@ module Bdd_Impl10_GrowsTrans_Impl
     ensures { result = shallow_model5 self }
     
   function shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model5 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model5 self
   val shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model2 self }
     
@@ -1138,7 +1138,7 @@ module Bdd_Impl10_SetIrreleventVar_Impl
   use prelude.Int
   use prelude.UInt64
   function shallow_model3 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model3 (self : uint64) : int
     ensures { result = shallow_model3 self }
     
@@ -1184,7 +1184,7 @@ module Bdd_Impl10_SetIrreleventVar_Impl
     ensures { result = shallow_model4 self }
     
   function shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model2 self }
     
@@ -1273,7 +1273,7 @@ module Bdd_Impl10_DiscrValuation_Impl
   use prelude.Int
   use prelude.UInt64
   function shallow_model3 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model3 (self : uint64) : int
     ensures { result = shallow_model3 self }
     
@@ -1319,7 +1319,7 @@ module Bdd_Impl10_DiscrValuation_Impl
     ensures { result = shallow_model4 self }
     
   function shallow_model1 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model1 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model1 self }
     
@@ -1463,7 +1463,7 @@ module Bdd_Impl10_BddCanonical_Impl
   use prelude.Int
   use prelude.UInt64
   function shallow_model4 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model4 (self : uint64) : int
     ensures { result = shallow_model4 self }
     
@@ -1509,7 +1509,7 @@ module Bdd_Impl10_BddCanonical_Impl
     ensures { result = shallow_model2 self }
     
   function shallow_model1 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model1 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model1 self }
     
@@ -1667,7 +1667,7 @@ module Bdd_Impl11_New
   use prelude.Int
   use prelude.UInt64
   function shallow_model6 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model6 (self : uint64) : int
     ensures { result = shallow_model6 self }
     
@@ -1713,7 +1713,7 @@ module Bdd_Impl11_New
     ensures { result = shallow_model4 self }
     
   function shallow_model3 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model3 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model3 self }
     
@@ -1845,7 +1845,7 @@ module Bdd_Impl11_Hashcons
   use prelude.Int
   use prelude.UInt64
   function shallow_model6 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model6 (self : uint64) : int
     ensures { result = shallow_model6 self }
     
@@ -1891,7 +1891,7 @@ module Bdd_Impl11_Hashcons
     ensures { result = shallow_model1 self }
     
   function shallow_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model0 self }
     
@@ -2022,7 +2022,7 @@ module Bdd_Impl11_Hashcons
   function shallow_model4 (self : borrowed (Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Node_Type.t_node) (Bdd_Bdd_Type.t_bdd))) : Map.map (Bdd_NodeLog_Type.t_nodelog) (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model4 (self : borrowed (Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Node_Type.t_node) (Bdd_Bdd_Type.t_bdd))) : Map.map (Bdd_NodeLog_Type.t_nodelog) (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     ensures { result = shallow_model4 self }
     
@@ -2037,7 +2037,7 @@ module Bdd_Impl11_Hashcons
     ) }
     
   predicate resolve1 (self : borrowed (Bdd_Node_Type.t_node)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Bdd_Node_Type.t_node)) : bool
     ensures { result = resolve1 self }
     
@@ -2048,19 +2048,19 @@ module Bdd_Impl11_Hashcons
     ensures { [#"../bdd.rs" 18 42 18 48] inv4 result }
     
   predicate resolve0 (self : borrowed (Bdd_Context_Type.t_context)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Bdd_Context_Type.t_context)) : bool
     ensures { result = resolve0 self }
     
   function deep_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = deep_model0 self }
     
   function shallow_model2 (self : Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Node_Type.t_node) (Bdd_Bdd_Type.t_bdd)) : Map.map (Bdd_NodeLog_Type.t_nodelog) (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model2 (self : Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Node_Type.t_node) (Bdd_Bdd_Type.t_bdd)) : Map.map (Bdd_NodeLog_Type.t_nodelog) (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     ensures { result = shallow_model2 self }
     
@@ -2207,7 +2207,7 @@ module Bdd_Impl11_Node
   use prelude.Int
   use prelude.UInt64
   function shallow_model4 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model4 (self : uint64) : int
     ensures { result = shallow_model4 self }
     
@@ -2253,7 +2253,7 @@ module Bdd_Impl11_Node
     ensures { result = shallow_model6 self }
     
   function shallow_model3 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model3 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model3 self }
     
@@ -2304,7 +2304,7 @@ module Bdd_Impl11_Node
     ensures { result = grows0 self }
     
   predicate resolve0 (self : borrowed (Bdd_Context_Type.t_context)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Bdd_Context_Type.t_context)) : bool
     ensures { result = resolve0 self }
     
@@ -2326,7 +2326,7 @@ module Bdd_Impl11_Node
     ensures { result = shallow_model5 self }
     
   function shallow_model1 (self : Bdd_Bdd_Type.t_bdd) : uint64 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model5 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model5 self
   val shallow_model1 (self : Bdd_Bdd_Type.t_bdd) : uint64
     ensures { result = shallow_model1 self }
     
@@ -2434,7 +2434,7 @@ module Bdd_Impl11_True
   use prelude.Int
   use prelude.UInt64
   function shallow_model3 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model3 (self : uint64) : int
     ensures { result = shallow_model3 self }
     
@@ -2480,7 +2480,7 @@ module Bdd_Impl11_True
     ensures { result = shallow_model4 self }
     
   function shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model2 self }
     
@@ -2531,7 +2531,7 @@ module Bdd_Impl11_True
     ensures { result = grows0 self }
     
   predicate resolve0 (self : borrowed (Bdd_Context_Type.t_context)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Bdd_Context_Type.t_context)) : bool
     ensures { result = resolve0 self }
     
@@ -2613,7 +2613,7 @@ module Bdd_Impl11_False
   use prelude.Int
   use prelude.UInt64
   function shallow_model3 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model3 (self : uint64) : int
     ensures { result = shallow_model3 self }
     
@@ -2659,7 +2659,7 @@ module Bdd_Impl11_False
     ensures { result = shallow_model4 self }
     
   function shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model2 self }
     
@@ -2710,7 +2710,7 @@ module Bdd_Impl11_False
     ensures { result = grows0 self }
     
   predicate resolve0 (self : borrowed (Bdd_Context_Type.t_context)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Bdd_Context_Type.t_context)) : bool
     ensures { result = resolve0 self }
     
@@ -2792,7 +2792,7 @@ module Bdd_Impl11_V
   use prelude.Int
   use prelude.UInt64
   function shallow_model3 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model3 (self : uint64) : int
     ensures { result = shallow_model3 self }
     
@@ -2838,7 +2838,7 @@ module Bdd_Impl11_V
     ensures { result = shallow_model4 self }
     
   function shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model2 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model2 self }
     
@@ -2889,7 +2889,7 @@ module Bdd_Impl11_V
     ensures { result = grows0 self }
     
   predicate resolve0 (self : borrowed (Bdd_Context_Type.t_context)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Bdd_Context_Type.t_context)) : bool
     ensures { result = resolve0 self }
     
@@ -3034,7 +3034,7 @@ module Bdd_Impl11_Not
   use prelude.Int
   use prelude.UInt64
   function shallow_model6 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model6 (self : uint64) : int
     ensures { result = shallow_model6 self }
     
@@ -3080,7 +3080,7 @@ module Bdd_Impl11_Not
     ensures { result = shallow_model7 self }
     
   function shallow_model5 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model7 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model7 self
   val shallow_model5 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model5 self }
     
@@ -3158,7 +3158,7 @@ module Bdd_Impl11_Not
   function shallow_model3 (self : borrowed (Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd))) : Map.map uint64 (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model3 (self : borrowed (Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd))) : Map.map uint64 (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     ensures { result = shallow_model3 self }
     
@@ -3206,19 +3206,19 @@ module Bdd_Impl11_Not
     ensures { [#"../bdd.rs" 483 14 483 46] UInt64.to_int max0 + 1 = leastvar0 result }
     
   predicate resolve0 (self : borrowed (Bdd_Context_Type.t_context)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Bdd_Context_Type.t_context)) : bool
     ensures { result = resolve0 self }
     
   function deep_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64
     ensures { result = deep_model0 self }
     
   function shallow_model0 (self : Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd)) : Map.map uint64 (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model0 (self : Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd)) : Map.map uint64 (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     ensures { result = shallow_model0 self }
     
@@ -3491,7 +3491,7 @@ module Bdd_Impl11_And
   use prelude.Int
   use prelude.UInt64
   function shallow_model6 (self : uint64) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt64.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt64.to_int self
   val shallow_model6 (self : uint64) : int
     ensures { result = shallow_model6 self }
     
@@ -3536,7 +3536,7 @@ module Bdd_Impl11_And
     ensures { result = shallow_model7 self }
     
   function shallow_model5 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model7 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model7 self
   val shallow_model5 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model5 self }
     
@@ -3614,7 +3614,7 @@ module Bdd_Impl11_And
   function shallow_model3 (self : borrowed (Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd, Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd))) : Map.map (uint64, uint64) (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model3 (self : borrowed (Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd, Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd))) : Map.map (uint64, uint64) (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     ensures { result = shallow_model3 self }
     
@@ -3677,39 +3677,39 @@ module Bdd_Impl11_And
     ensures { [#"../bdd.rs" 483 14 483 46] UInt64.to_int max0 + 1 = leastvar0 result }
     
   predicate resolve4 (self : Bdd_Node_Type.t_node) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve4 (self : Bdd_Node_Type.t_node) : bool
     ensures { result = resolve4 self }
     
   predicate resolve2 (self : (Bdd_Node_Type.t_node, Bdd_Node_Type.t_node)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve4 (let (a, _) = self in a) /\ resolve4 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve4 (let (a, _) = self in a) /\ resolve4 (let (_, a) = self in a)
   val resolve2 (self : (Bdd_Node_Type.t_node, Bdd_Node_Type.t_node)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (Bdd_Context_Type.t_context)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Bdd_Context_Type.t_context)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve3 (self : Bdd_Bdd_Type.t_bdd) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : Bdd_Bdd_Type.t_bdd) : bool
     ensures { result = resolve3 self }
     
   predicate resolve0 (self : (Bdd_Bdd_Type.t_bdd, Bdd_Bdd_Type.t_bdd)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve0 (self : (Bdd_Bdd_Type.t_bdd, Bdd_Bdd_Type.t_bdd)) : bool
     ensures { result = resolve0 self }
     
   function deep_model0 (self : (Bdd_Bdd_Type.t_bdd, Bdd_Bdd_Type.t_bdd)) : (uint64, uint64) =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model2 self
   val deep_model0 (self : (Bdd_Bdd_Type.t_bdd, Bdd_Bdd_Type.t_bdd)) : (uint64, uint64)
     ensures { result = deep_model0 self }
     
   function shallow_model0 (self : Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd, Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd)) : Map.map (uint64, uint64) (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model0 (self : Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd, Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd)) : Map.map (uint64, uint64) (Core_Option_Option_Type.t_option (Bdd_Bdd_Type.t_bdd))
     ensures { result = shallow_model0 self }
     
@@ -4073,7 +4073,7 @@ module Bdd_Hashmap_Impl2
     
   use prelude.Borrow
   function deep_model0 (self : (u, v)) : (deep_model_ty0, deep_model_ty1) =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : (u, v)) : (deep_model_ty0, deep_model_ty1)
     ensures { result = deep_model0 self }
     
@@ -4106,7 +4106,7 @@ module Bdd_Impl1
     
   use prelude.Borrow
   function deep_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = deep_model0 self }
     
@@ -4130,7 +4130,7 @@ module Bdd_Impl1
     ensures { result = shallow_model2 self }
     
   function shallow_model1 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model1 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = shallow_model1 self }
     
@@ -4159,7 +4159,7 @@ module Bdd_Impl2
     
   use prelude.Borrow
   function deep_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64
     ensures { result = deep_model0 self }
     
@@ -4175,7 +4175,7 @@ module Bdd_Impl2
     ensures { result = shallow_model2 self }
     
   function shallow_model1 (self : Bdd_Bdd_Type.t_bdd) : uint64 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model1 (self : Bdd_Bdd_Type.t_bdd) : uint64
     ensures { result = shallow_model1 self }
     
@@ -4214,7 +4214,7 @@ module Bdd_Impl13
     
   use prelude.Borrow
   function deep_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : Bdd_Node_Type.t_node) : Bdd_NodeLog_Type.t_nodelog
     ensures { result = deep_model0 self }
     
@@ -4243,7 +4243,7 @@ module Bdd_Impl7
     
   use prelude.Borrow
   function deep_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64
     ensures { result = deep_model0 self }
     
@@ -4253,7 +4253,7 @@ module Bdd_Impl7
     ensures { result = shallow_model1 self }
     
   function shallow_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model0 (self : Bdd_Bdd_Type.t_bdd) : uint64
     ensures { result = shallow_model0 self }
     

--- a/creusot/tests/should_succeed/bug/552.mlcfg
+++ b/creusot/tests/should_succeed/bug/552.mlcfg
@@ -42,7 +42,7 @@ module C552_Impl0_Step
   use C552_Transition_Type as C552_Transition_Type
   use prelude.Borrow
   predicate resolve0 (self : borrowed (C552_Machine_Type.t_machine)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C552_Machine_Type.t_machine)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/bug/594.mlcfg
+++ b/creusot/tests/should_succeed/bug/594.mlcfg
@@ -3,12 +3,12 @@ module C594_TestProgram
   use prelude.UInt32
   use prelude.Int
   predicate resolve1 (self : uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint32, uint32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (uint32, uint32)) : bool
     ensures { result = resolve0 self }
     
@@ -44,12 +44,12 @@ module C594_TestClosure_Closure0
   use prelude.Borrow
   use prelude.Int
   predicate resolve1 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int32, int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (int32, int32)) : bool
     ensures { result = resolve0 self }
     
@@ -89,12 +89,12 @@ module C594_TestClosure_Closure1
   use prelude.Borrow
   use prelude.Int
   predicate resolve1 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int32, int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (int32, int32)) : bool
     ensures { result = resolve0 self }
     
@@ -129,12 +129,12 @@ module C594_TestClosure
   use prelude.Borrow
   use prelude.Int
   predicate resolve3 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : int32) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : (int32, int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve2 (self : (int32, int32)) : bool
     ensures { result = resolve2 self }
     
@@ -199,12 +199,12 @@ module C594_Impl0_TestMethod
   use prelude.UInt32
   use prelude.Int
   predicate resolve1 (self : uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint32, uint32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (uint32, uint32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/bug/682.mlcfg
+++ b/creusot/tests/should_succeed/bug/682.mlcfg
@@ -6,7 +6,7 @@ module C682_AddSome
     (18446744073709551615 : uint64)
   use prelude.Borrow
   predicate resolve0 (self : borrowed uint64) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint64) : bool
     ensures { result = resolve0 self }
     
@@ -34,7 +34,7 @@ module C682_Foo
   use prelude.Snapshot
   use prelude.Borrow
   predicate resolve0 (self : borrowed uint64) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint64) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/bug/766.mlcfg
+++ b/creusot/tests/should_succeed/bug/766.mlcfg
@@ -26,7 +26,7 @@ module C766_Trait_Goo
     
   axiom inv0 : forall x : self . inv0 x = true
   predicate resolve0 (self : borrowed self) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed self) : bool
     ensures { result = resolve0 self }
     
@@ -40,7 +40,7 @@ module C766_Trait_Goo
   function deep_model0 (self : borrowed self) : CreusotContracts_Logic_Fmap_FMap_Type.t_fmap deep_model_ty0 deep_model_ty1
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 92 8 92 28] deep_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 88 8 88 28] deep_model1 ( * self)
   val deep_model0 (self : borrowed self) : CreusotContracts_Logic_Fmap_FMap_Type.t_fmap deep_model_ty0 deep_model_ty1
     ensures { result = deep_model0 self }
     

--- a/creusot/tests/should_succeed/bug/874.mlcfg
+++ b/creusot/tests/should_succeed/bug/874.mlcfg
@@ -207,7 +207,7 @@ module C874_CanExtend
   axiom inv0 : forall x : slice int32 . inv0 x = true
   use seq.Seq
   predicate resolve1 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int32) : bool
     ensures { result = resolve1 self }
     
@@ -228,21 +228,21 @@ module C874_CanExtend
   function shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model2 self }
     
   function shallow_model6 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model5 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model5 ( * self)
   val shallow_model6 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model6 self }
     
   predicate resolve2 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global)))
     
    =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve2 self }
     
@@ -304,7 +304,7 @@ module C874_CanExtend
     goto BB0
   }
   BB0 {
-    [#"../../../../../creusot-contracts/src/lib.rs" 296 47 296 56] _4 <- (let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 5 21 5 22] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 5 24 5 25] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 5 27 5 28] (3 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp);
+    [#"../../../../../creusot-contracts/src/lib.rs" 205 47 205 56] _4 <- (let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 5 21 5 22] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 5 24 5 25] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 5 27 5 28] (3 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp);
     goto BB1
   }
   BB1 {
@@ -316,7 +316,7 @@ module C874_CanExtend
     goto BB3
   }
   BB3 {
-    [#"../../../../../creusot-contracts/src/lib.rs" 296 47 296 56] _8 <- (let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 6 17 6 18] (4 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 6 20 6 21] (5 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 6 23 6 24] (6 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp);
+    [#"../../../../../creusot-contracts/src/lib.rs" 205 47 205 56] _8 <- (let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 6 17 6 18] (4 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 6 20 6 21] (5 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 6 23 6 24] (6 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp);
     goto BB4
   }
   BB4 {
@@ -337,7 +337,7 @@ module C874_CanExtend
   }
   BB7 {
     assume { resolve0 v };
-    [#"../../../../../creusot-contracts/src/lib.rs" 296 47 296 56] _15 <- (let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 9 17 9 18] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 9 20 9 21] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 9 23 9 24] (3 : int32))}; assume {Seq.get (__arr_temp.elts) 3 = ([#"../874.rs" 9 26 9 27] (4 : int32))}; assume {Seq.get (__arr_temp.elts) 4 = ([#"../874.rs" 9 29 9 30] (5 : int32))}; assume {Seq.get (__arr_temp.elts) 5 = ([#"../874.rs" 9 32 9 33] (6 : int32))}; assume {Slice.length __arr_temp = 6}; __arr_temp);
+    [#"../../../../../creusot-contracts/src/lib.rs" 205 47 205 56] _15 <- (let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../874.rs" 9 17 9 18] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../874.rs" 9 20 9 21] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../874.rs" 9 23 9 24] (3 : int32))}; assume {Seq.get (__arr_temp.elts) 3 = ([#"../874.rs" 9 26 9 27] (4 : int32))}; assume {Seq.get (__arr_temp.elts) 4 = ([#"../874.rs" 9 29 9 30] (5 : int32))}; assume {Seq.get (__arr_temp.elts) 5 = ([#"../874.rs" 9 32 9 33] (6 : int32))}; assume {Slice.length __arr_temp = 6}; __arr_temp);
     goto BB8
   }
   BB8 {

--- a/creusot/tests/should_succeed/bug/922.mlcfg
+++ b/creusot/tests/should_succeed/bug/922.mlcfg
@@ -4,22 +4,22 @@ module C922_G
   use prelude.Int
   use prelude.Borrow
   predicate resolve3 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : int32) : bool
     ensures { result = resolve3 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
   predicate resolve2 (self : (int32, borrowed int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve0 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve0 (let (_, a) = self in a)
   val resolve2 (self : (int32, borrowed int32)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : ((int32, borrowed int32), int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve1 (self : ((int32, borrowed int32), int32)) : bool
     ensures { result = resolve1 self }
     
@@ -53,12 +53,12 @@ module C922_F1
   use prelude.Int
   use prelude.Borrow
   predicate resolve1 (self : borrowed (int32, borrowed int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (int32, borrowed int32)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -94,12 +94,12 @@ module C922_F2
   use prelude.Int
   use prelude.Borrow
   predicate resolve1 (self : borrowed (int32, borrowed int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (int32, borrowed int32)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -135,12 +135,12 @@ module C922_F3
   use prelude.Int
   use prelude.Borrow
   predicate resolve1 (self : borrowed (int32, borrowed int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (int32, borrowed int32)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -176,12 +176,12 @@ module C922_F4
   use prelude.Int
   use prelude.Borrow
   predicate resolve1 (self : borrowed (int32, borrowed int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (int32, borrowed int32)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/bug/949.mlcfg
+++ b/creusot/tests/should_succeed/bug/949.mlcfg
@@ -118,12 +118,12 @@ module C949_Main
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   axiom inv0 : forall x : int32 . inv0 x = true
   predicate resolve1 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve1 self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve1 self
   val resolve0 (self : int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/bug/box_borrow_resolve.mlcfg
+++ b/creusot/tests/should_succeed/bug/box_borrow_resolve.mlcfg
@@ -4,12 +4,12 @@ module BoxBorrowResolve_BorrowInBox
   use prelude.Int
   use prelude.Borrow
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
   predicate resolve1 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve0 self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve0 self
   val resolve1 (self : borrowed int32) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/bug/eq_panic.mlcfg
+++ b/creusot/tests/should_succeed/bug/eq_panic.mlcfg
@@ -30,12 +30,12 @@ module EqPanic_Omg
     ensures { result = deep_model2 self }
     
   function deep_model1 (self : t) : deep_model_ty0 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model2 self
   val deep_model1 (self : t) : deep_model_ty0
     ensures { result = deep_model1 self }
     
   function deep_model0 (self : t) : deep_model_ty0 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : t) : deep_model_ty0
     ensures { result = deep_model0 self }
     

--- a/creusot/tests/should_succeed/bug/final_borrows.mlcfg
+++ b/creusot/tests/should_succeed/bug/final_borrows.mlcfg
@@ -21,7 +21,7 @@ module FinalBorrows_ReborrowId
     
   axiom inv0 : forall x : t . inv0 x = true
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -74,7 +74,7 @@ module FinalBorrows_Select
     
   axiom inv0 : forall x : borrowed t . inv0 x = true
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -172,12 +172,12 @@ module FinalBorrows_ReborrowField
     
   axiom inv0 : forall x : t . inv0 x = true
   predicate resolve1 (self : borrowed (t, t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (t, t)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -263,17 +263,17 @@ module FinalBorrows_NestedFields
     
   axiom inv0 : forall x : (t, t) . inv0 x = true
   predicate resolve2 (self : borrowed ((t, t), t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed ((t, t), t)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed t) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (t, t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (t, t)) : bool
     ensures { result = resolve0 self }
     
@@ -351,17 +351,17 @@ module FinalBorrows_ReallyNestedFields
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed (t, t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (t, t)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : (borrowed (t, t), t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve1 (self : (borrowed (t, t), t)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -465,17 +465,17 @@ module FinalBorrows_SelectField
     
   axiom inv0 : forall x : Core_Option_Option_Type.t_option t . inv0 x = true
   predicate resolve2 (self : borrowed (Core_Option_Option_Type.t_option t, t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Core_Option_Option_Type.t_option t, t)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed t) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (Core_Option_Option_Type.t_option t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Option_Option_Type.t_option t)) : bool
     ensures { result = resolve0 self }
     
@@ -554,7 +554,7 @@ module FinalBorrows_Set7
   use prelude.Borrow
   use prelude.Int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -581,7 +581,7 @@ module FinalBorrows_NotFinalBorrowWorks
   use prelude.Borrow
   use prelude.Int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -630,7 +630,7 @@ module FinalBorrows_Branching
   use prelude.Borrow
   use prelude.Int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -725,12 +725,12 @@ module FinalBorrows_UnnestingNonExtensional
     
   axiom inv0 : forall x : t . inv0 x = true
   predicate resolve1 (self : borrowed (borrowed t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (borrowed t)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -823,7 +823,7 @@ module FinalBorrows_BoxDeref
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve1 self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve1 self
   val resolve0 (self : t) : bool
     ensures { result = resolve0 self }
     
@@ -889,12 +889,12 @@ module FinalBorrows_BoxReborrowDirect
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve2 self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve2 self
   val resolve1 (self : t) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -966,12 +966,12 @@ module FinalBorrows_BoxReborrowIndirect
     
   axiom inv0 : forall x : t . inv0 x = true
   predicate resolve1 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed t) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -1012,12 +1012,12 @@ module FinalBorrows_BoxReborrowInStruct
   use prelude.Int32
   use prelude.Int
   predicate resolve1 (self : borrowed (int32, borrowed int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (int32, borrowed int32)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -1078,12 +1078,12 @@ module FinalBorrows_BorrowInBox
     
   axiom inv0 : forall x : t . inv0 x = true
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
   predicate resolve1 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve0 self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve0 self
   val resolve1 (self : borrowed t) : bool
     ensures { result = resolve1 self }
     
@@ -1129,22 +1129,22 @@ module FinalBorrows_BorrowInBoxTuple1
   use prelude.Int32
   use prelude.Int
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
   predicate resolve3 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : int32) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : (int32, borrowed int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve0 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve0 (let (_, a) = self in a)
   val resolve2 (self : (int32, borrowed int32)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : (int32, borrowed int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve2 self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve2 self
   val resolve1 (self : (int32, borrowed int32)) : bool
     ensures { result = resolve1 self }
     
@@ -1185,22 +1185,22 @@ module FinalBorrows_BorrowInBoxTuple2
   use prelude.Int32
   use prelude.Int
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
   predicate resolve3 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve0 self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve0 self
   val resolve3 (self : borrowed int32) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : int32) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : (int32, borrowed int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve1 (self : (int32, borrowed int32)) : bool
     ensures { result = resolve1 self }
     
@@ -1270,7 +1270,7 @@ module FinalBorrows_SharedBorrowNoGen
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -1325,7 +1325,7 @@ module FinalBorrows_InspectNoGen
     
   axiom inv0 : forall x : Core_Option_Option_Type.t_option t . inv0 x = true
   predicate resolve0 (self : borrowed (Core_Option_Option_Type.t_option t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Option_Option_Type.t_option t)) : bool
     ensures { result = resolve0 self }
     
@@ -1407,7 +1407,7 @@ module FinalBorrows_PlaceMentionNoGen
     
   axiom inv0 : forall x : Core_Option_Option_Type.t_option t . inv0 x = true
   predicate resolve0 (self : borrowed (Core_Option_Option_Type.t_option t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Option_Option_Type.t_option t)) : bool
     ensures { result = resolve0 self }
     
@@ -1441,7 +1441,7 @@ module FinalBorrows_ShallowBorrowNoGen
   use prelude.Int
   use Core_Option_Option_Type as Core_Option_Option_Type
   predicate resolve0 (self : borrowed (Core_Option_Option_Type.t_option int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Option_Option_Type.t_option int32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/bug/two_phase.mlcfg
+++ b/creusot/tests/should_succeed/bug/two_phase.mlcfg
@@ -123,12 +123,12 @@ module TwoPhase_Test
   function shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     ensures { result = shallow_model0 self }
     
   predicate resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve0 self }
     
@@ -139,7 +139,7 @@ module TwoPhase_Test
     ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 78 26 78 51] shallow_model3 ( ^ self) = Seq.snoc (shallow_model0 self) value }
     
   function shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize
     ensures { result = shallow_model2 self }
     

--- a/creusot/tests/should_succeed/cell/02.mlcfg
+++ b/creusot/tests/should_succeed/cell/02.mlcfg
@@ -217,7 +217,7 @@ module C02_FibMemo
   function shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec (C02_Cell_Type.t_cell (Core_Option_Option_Type.t_option usize) (C02_Fib_Type.t_fib)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (C02_Cell_Type.t_cell (Core_Option_Option_Type.t_option usize) (C02_Fib_Type.t_fib))
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec (C02_Cell_Type.t_cell (Core_Option_Option_Type.t_option usize) (C02_Fib_Type.t_fib)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (C02_Cell_Type.t_cell (Core_Option_Option_Type.t_option usize) (C02_Fib_Type.t_fib))
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/checked_ops.mlcfg
+++ b/creusot/tests/should_succeed/checked_ops.mlcfg
@@ -40,17 +40,17 @@ module CheckedOps_TestU8AddExample
   axiom inv0 : forall x : Core_Option_Option_Type.t_option uint8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -320,17 +320,17 @@ module CheckedOps_TestU8AddOverflow
   use prelude.UInt8
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -580,17 +580,17 @@ module CheckedOps_TestU8OverflowingAdd
      -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int max0 - UInt8.to_int min0 + 1)) }
     
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -707,17 +707,17 @@ module CheckedOps_TestU8SubExample
   axiom inv0 : forall x : Core_Option_Option_Type.t_option uint8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -987,17 +987,17 @@ module CheckedOps_TestU8SubOverflow
   use prelude.UInt8
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -1253,17 +1253,17 @@ module CheckedOps_TestU8OverflowingSub
      -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int max0 - UInt8.to_int min0 + 1)) }
     
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -1380,17 +1380,17 @@ module CheckedOps_TestU8MulExample
   axiom inv0 : forall x : Core_Option_Option_Type.t_option uint8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -1669,17 +1669,17 @@ module CheckedOps_TestU8MulZero
   axiom inv0 : forall x : Core_Option_Option_Type.t_option uint8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -1886,17 +1886,17 @@ module CheckedOps_TestU8OverflowingMul
      -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int max0 - UInt8.to_int min0 + 1)) }
     
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -2013,17 +2013,17 @@ module CheckedOps_TestU8DivExample
   axiom inv0 : forall x : Core_Option_Option_Type.t_option uint8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -2218,17 +2218,17 @@ module CheckedOps_TestU8DivNoOverflow
   use prelude.UInt8
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : uint8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (uint8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -2518,17 +2518,17 @@ module CheckedOps_TestI8AddExample
   axiom inv0 : forall x : Core_Option_Option_Type.t_option int8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -2887,17 +2887,17 @@ module CheckedOps_TestI8AddOverflowPos
   use prelude.Int8
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -3081,17 +3081,17 @@ module CheckedOps_TestI8AddOverflowNeg
   use prelude.Int8
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -3347,17 +3347,17 @@ module CheckedOps_TestI8OverflowingAdd
      -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int max0 - Int8.to_int min0 + 1)) }
     
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -3474,17 +3474,17 @@ module CheckedOps_TestI8SubExample
   axiom inv0 : forall x : Core_Option_Option_Type.t_option int8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -3847,17 +3847,17 @@ module CheckedOps_TestI8SubOverflowPos
   use prelude.Int8
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -4041,17 +4041,17 @@ module CheckedOps_TestI8SubOverflowNeg
   use prelude.Int8
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -4313,17 +4313,17 @@ module CheckedOps_TestI8OverflowingSub
      -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int max0 - Int8.to_int min0 + 1)) }
     
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -4440,17 +4440,17 @@ module CheckedOps_TestI8MulExample
   axiom inv0 : forall x : Core_Option_Option_Type.t_option int8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -4818,17 +4818,17 @@ module CheckedOps_TestI8MulZero
   axiom inv0 : forall x : Core_Option_Option_Type.t_option int8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -5035,17 +5035,17 @@ module CheckedOps_TestI8OverflowingMul
      -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int max0 - Int8.to_int min0 + 1)) }
     
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -5162,17 +5162,17 @@ module CheckedOps_TestI8DivExample
   axiom inv0 : forall x : Core_Option_Option_Type.t_option int8 . inv0 x = true
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     
@@ -5549,17 +5549,17 @@ module CheckedOps_TestI8DivNoOverflow
   use prelude.Int8
   use prelude.Bool
   predicate resolve2 (self : bool) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : bool) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : int8) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int8) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (int8, bool)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (int8, bool)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/closures/01_basic.mlcfg
+++ b/creusot/tests/should_succeed/closures/01_basic.mlcfg
@@ -150,7 +150,7 @@ module C01Basic_MoveClosure_Closure0
    =
     true
   predicate resolve0 (self : borrowed C01Basic_MoveClosure_Closure0.c01basic_moveclosure_closure0) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed C01Basic_MoveClosure_Closure0.c01basic_moveclosure_closure0) : bool
     ensures { result = resolve0 self }
     
@@ -183,7 +183,7 @@ module C01Basic_MoveClosure
   use prelude.Borrow
   use prelude.Int32
   predicate resolve2 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed int32) : bool
     ensures { result = resolve2 self }
     
@@ -205,7 +205,7 @@ module C01Basic_MoveClosure
    =
     true
   predicate resolve1 (self : borrowed C01Basic_MoveClosure_Closure0.c01basic_moveclosure_closure0) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed C01Basic_MoveClosure_Closure0.c01basic_moveclosure_closure0) : bool
     ensures { result = resolve1 self }
     
@@ -286,7 +286,7 @@ module C01Basic_MoveMut_Closure0
    =
     true
   predicate resolve1 (self : borrowed C01Basic_MoveMut_Closure0.c01basic_movemut_closure0) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed C01Basic_MoveMut_Closure0.c01basic_movemut_closure0) : bool
     ensures { result = resolve1 self }
     
@@ -299,7 +299,7 @@ module C01Basic_MoveMut_Closure0
     ensures { result = field_00 self }
     
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -348,7 +348,7 @@ module C01Basic_MoveMut
     
   axiom inv0 : forall x : borrowed uint32 . inv0 x = true
   predicate resolve1 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed uint32) : bool
     ensures { result = resolve1 self }
     
@@ -369,7 +369,7 @@ module C01Basic_MoveMut
    =
     true
   predicate resolve2 (self : borrowed C01Basic_MoveMut_Closure0.c01basic_movemut_closure0) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed C01Basic_MoveMut_Closure0.c01basic_movemut_closure0) : bool
     ensures { result = resolve2 self }
     

--- a/creusot/tests/should_succeed/closures/03_generic_bound.mlcfg
+++ b/creusot/tests/should_succeed/closures/03_generic_bound.mlcfg
@@ -108,7 +108,7 @@ module C03GenericBound_ClosureParam
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 145 33 145 36] inv3 res)
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 144 14 144 101] postcondition_once0 self args res = (resolve0 self /\ postcondition0 self args res))
   predicate resolve1 (self : borrowed f) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed f) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/closures/04_generic_closure.mlcfg
+++ b/creusot/tests/should_succeed/closures/04_generic_closure.mlcfg
@@ -103,7 +103,7 @@ module C04GenericClosure_GenericClosure
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 145 33 145 36] inv2 res)
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 144 14 144 101] postcondition_once0 self args res = (resolve0 self /\ postcondition0 self args res))
   predicate resolve1 (self : borrowed f) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed f) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/closures/05_map.mlcfg
+++ b/creusot/tests/should_succeed/closures/05_map.mlcfg
@@ -138,7 +138,7 @@ module C05Map_Impl0_Next
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 145 33 145 36] inv7 res)
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 144 14 144 101] postcondition_once0 self args res = (resolve3 self /\ postcondition0 self args res))
   predicate resolve2 (self : borrowed f) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed f) : bool
     ensures { result = resolve2 self }
     
@@ -226,7 +226,7 @@ module C05Map_Impl0_Next
     ensures { inv7 result }
     
   predicate resolve1 (self : borrowed (C05Map_Map_Type.t_map i f)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (C05Map_Map_Type.t_map i f)) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/closures/06_fn_specs.mlcfg
+++ b/creusot/tests/should_succeed/closures/06_fn_specs.mlcfg
@@ -342,7 +342,7 @@ module C06FnSpecs_Weaken
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 61 33 61 36] inv2 res)
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 60 14 60 101] postcondition_once0 self args res = (resolve0 self /\ postcondition0 self args res))
   predicate resolve1 (self : borrowed f) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed f) : bool
     ensures { result = resolve1 self }
     
@@ -758,7 +758,7 @@ module C06FnSpecs_WeakenStd
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 145 33 145 36] inv2 res)
    -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 144 14 144 101] postcondition_once0 self args res = (resolve0 self /\ postcondition0 self args res))
   predicate resolve1 (self : borrowed f) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed f) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.mlcfg
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.mlcfg
@@ -29,7 +29,7 @@ module C07MutableCapture_TestFnmut_Closure1
      ^ field_00 _2 =  ^ field_00 self
   use prelude.UInt32
   predicate resolve0 (self : borrowed C07MutableCapture_TestFnmut_Closure1.c07mutablecapture_testfnmut_closure1) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed C07MutableCapture_TestFnmut_Closure1.c07mutablecapture_testfnmut_closure1) : bool
     ensures { result = resolve0 self }
     
@@ -62,7 +62,7 @@ module C07MutableCapture_TestFnmut
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve2 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed uint32) : bool
     ensures { result = resolve2 self }
     
@@ -85,7 +85,7 @@ module C07MutableCapture_TestFnmut
    =
      ^ field_00 _2 =  ^ field_00 self
   predicate resolve1 (self : borrowed C07MutableCapture_TestFnmut_Closure1.c07mutablecapture_testfnmut_closure1) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed C07MutableCapture_TestFnmut_Closure1.c07mutablecapture_testfnmut_closure1) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/constrained_types.mlcfg
+++ b/creusot/tests/should_succeed/constrained_types.mlcfg
@@ -58,12 +58,12 @@ module ConstrainedTypes_UsesConcreteInstance
   axiom inv0 : forall x : (uint32, uint32) . inv0 x = true
   use prelude.Int
   predicate resolve1 (self : uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint32, uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (uint32, uint32)) : bool
     ensures { result = resolve0 self }
     
@@ -86,7 +86,7 @@ module ConstrainedTypes_UsesConcreteInstance
     ensures { result = deep_model1 self }
     
   function deep_model0 (self : (uint32, uint32)) : (int, int) =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : (uint32, uint32)) : (int, int)
     ensures { result = deep_model0 self }
     

--- a/creusot/tests/should_succeed/drop_pair.mlcfg
+++ b/creusot/tests/should_succeed/drop_pair.mlcfg
@@ -4,12 +4,12 @@ module DropPair_DropPair
   use prelude.Int
   use prelude.Borrow
   predicate resolve1 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (borrowed uint32, borrowed uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (borrowed uint32, borrowed uint32)) : bool
     ensures { result = resolve0 self }
     
@@ -36,12 +36,12 @@ module DropPair_DropPair2
   use prelude.Int
   use prelude.Borrow
   predicate resolve1 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (borrowed uint32, borrowed uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (borrowed uint32, borrowed uint32)) : bool
     ensures { result = resolve0 self }
     
@@ -65,7 +65,7 @@ module DropPair_Drop
   use prelude.Int
   use prelude.Borrow
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/duration.mlcfg
+++ b/creusot/tests/should_succeed/duration.mlcfg
@@ -116,7 +116,7 @@ module Duration_TestDuration
     ensures { result = nanos_to_micros0 nanos }
     
   function shallow_model4 (self : Core_Time_Duration_Type.t_duration) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model4 (self : Core_Time_Duration_Type.t_duration) : int
     ensures { result = shallow_model4 self }
     

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -213,7 +213,7 @@ module FilterPositive_M
     
   axiom inv0 : forall x : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global) . inv0 x = true
   predicate resolve1 (self : borrowed int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed int32) : bool
     ensures { result = resolve1 self }
     
@@ -238,7 +238,7 @@ module FilterPositive_M
   function shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model4 self }
     
@@ -288,7 +288,7 @@ module FilterPositive_M
    -> ([#"../filter_positive.rs" 77 11 77 20] Int32.to_int (Seq.get t i) > 0)
    -> ([#"../filter_positive.rs" 78 10 78 49] num_of_pos0 0 i t < num_of_pos0 0 (i + 1) t)
   function shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32
     ensures { result = shallow_model3 self }
     
@@ -300,7 +300,7 @@ module FilterPositive_M
     ensures { inv5 result }
     
   predicate resolve2 (self : int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : int32) : bool
     ensures { result = resolve2 self }
     

--- a/creusot/tests/should_succeed/ghost_ptr_token.mlcfg
+++ b/creusot/tests/should_succeed/ghost_ptr_token.mlcfg
@@ -198,7 +198,7 @@ module GhostPtrToken_Test
   function shallow_model1 (self : CreusotContracts_GhostPtr_GhostPtrToken_Type.t_ghostptrtoken int32) : CreusotContracts_Logic_Fmap_FMap_Type.t_fmap opaque_ptr int32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model1 (self : CreusotContracts_GhostPtr_GhostPtrToken_Type.t_ghostptrtoken int32) : CreusotContracts_Logic_Fmap_FMap_Type.t_fmap opaque_ptr int32
     ensures { result = shallow_model1 self }
     
@@ -215,17 +215,17 @@ module GhostPtrToken_Test
     
   use Core_Panicking_AssertKind_Type as Core_Panicking_AssertKind_Type
   predicate resolve2 (self : borrowed int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed int32) : bool
     ensures { result = resolve2 self }
     
   predicate resolve3 (self : int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : int32) : bool
     ensures { result = resolve3 self }
     
   predicate resolve1 (self : (int32, int32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve1 (self : (int32, int32)) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -38,7 +38,7 @@ module Hashmap_Impl2_Hash
   use prelude.Int
   use prelude.Borrow
   function deep_model0 (self : usize) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : usize) : int
     ensures { result = deep_model0 self }
     
@@ -579,7 +579,7 @@ module Hashmap_Impl5_Add
   function shallow_model2 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model2 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model2 self }
     
@@ -611,7 +611,7 @@ module Hashmap_Impl5_Add
     ensures { result = hashmap_inv0 self }
     
   predicate resolve8 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve8 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : bool
     ensures { result = resolve8 self }
     
@@ -624,22 +624,22 @@ module Hashmap_Impl5_Add
     ensures { result = resolve6 self }
     
   predicate resolve5 (self : borrowed (Hashmap_List_Type.t_list (k, v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve5 (self : borrowed (Hashmap_List_Type.t_list (k, v))) : bool
     ensures { result = resolve5 self }
     
   predicate resolve4 (self : borrowed k) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed k) : bool
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed v) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed v) : bool
     ensures { result = resolve3 self }
     
   function deep_model1 (self : k) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model0 self
   val deep_model1 (self : k) : deep_model_ty0
     ensures { result = deep_model1 self }
     
@@ -657,7 +657,7 @@ module Hashmap_Impl5_Add
     
   use prelude.Snapshot
   predicate resolve1 (self : borrowed (Hashmap_List_Type.t_list (k, v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Hashmap_List_Type.t_list (k, v))) : bool
     ensures { result = resolve1 self }
     
@@ -685,7 +685,7 @@ module Hashmap_Impl5_Add
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model6 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model6 ( * self)
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     ensures { result = shallow_model5 self }
     
@@ -708,7 +708,7 @@ module Hashmap_Impl5_Add
   function shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     ensures { result = shallow_model3 self }
     
@@ -1149,7 +1149,7 @@ module Hashmap_Impl5_Get
   function shallow_model0 (self : Hashmap_MyHashMap_Type.t_myhashmap k v) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model5 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model5 self
   val shallow_model0 (self : Hashmap_MyHashMap_Type.t_myhashmap k v) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model0 self }
     
@@ -1188,7 +1188,7 @@ module Hashmap_Impl5_Get
     ensures { result = resolve3 self }
     
   function deep_model1 (self : k) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model0 self
   val deep_model1 (self : k) : deep_model_ty0
     ensures { result = deep_model1 self }
     
@@ -1221,7 +1221,7 @@ module Hashmap_Impl5_Get
   function shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     ensures { result = shallow_model3 self }
     
@@ -1585,7 +1585,7 @@ module Hashmap_Impl5_Resize
   function shallow_model4 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model4 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model4 self }
     
@@ -1594,7 +1594,7 @@ module Hashmap_Impl5_Resize
     ensures { result = resolve4 self }
     
   predicate resolve7 (self : Hashmap_List_Type.t_list (k, v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve4 self
+    [#"../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve4 self
   val resolve7 (self : Hashmap_List_Type.t_list (k, v)) : bool
     ensures { result = resolve7 self }
     
@@ -1643,7 +1643,7 @@ module Hashmap_Impl5_Resize
     ensures { result = resolve5 self }
     
   predicate resolve3 (self : borrowed (Hashmap_List_Type.t_list (k, v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Hashmap_List_Type.t_list (k, v))) : bool
     ensures { result = resolve3 self }
     
@@ -1678,7 +1678,7 @@ module Hashmap_Impl5_Resize
   function shallow_model7 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model7 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     ensures { result = shallow_model7 self }
     
@@ -1693,7 +1693,7 @@ module Hashmap_Impl5_Resize
     ensures { inv6 result }
     
   predicate resolve2 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : bool
     ensures { result = resolve2 self }
     
@@ -1705,7 +1705,7 @@ module Hashmap_Impl5_Resize
   function shallow_model6 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model6 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model6 self }
     
@@ -1727,7 +1727,7 @@ module Hashmap_Impl5_Resize
   function shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Hashmap_List_Type.t_list (k, v))
     ensures { result = shallow_model5 self }
     
@@ -2145,7 +2145,7 @@ module Hashmap_Main
   function shallow_model3 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap usize isize)) : Map.map int (Core_Option_Option_Type.t_option isize)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model3 (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap usize isize)) : Map.map int (Core_Option_Option_Type.t_option isize)
     ensures { result = shallow_model3 self }
     
@@ -2188,7 +2188,7 @@ module Hashmap_Main
   function shallow_model2 (self : Hashmap_MyHashMap_Type.t_myhashmap usize isize) : Map.map int (Core_Option_Option_Type.t_option isize)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model2 (self : Hashmap_MyHashMap_Type.t_myhashmap usize isize) : Map.map int (Core_Option_Option_Type.t_option isize)
     ensures { result = shallow_model2 self }
     
@@ -2384,7 +2384,7 @@ module Hashmap_Impl2
   use prelude.Int
   use prelude.Borrow
   function deep_model0 (self : usize) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : usize) : int
     ensures { result = deep_model0 self }
     

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -477,12 +477,12 @@ module HeapsortGeneric_SiftDown
     ensures { result = heap_frag0 s start end' }
     
   predicate resolve3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed (slice t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (slice t)) : bool
     ensures { result = resolve2 self }
     
@@ -496,7 +496,7 @@ module HeapsortGeneric_SiftDown
   axiom shallow_model7_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 19 21 19 25] inv4 self)
    -> ([#"../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv10 (shallow_model7 self)) && ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model7 self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model7 self) <= UIntSize.to_int max0)
   function shallow_model6 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model7 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model7 ( * self)
   val shallow_model6 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model6 self }
     
@@ -508,7 +508,7 @@ module HeapsortGeneric_SiftDown
     
   function shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -519,7 +519,7 @@ module HeapsortGeneric_SiftDown
     ensures { inv5 result }
     
   function deep_model2 (self : t) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model3 self
   val deep_model2 (self : t) : deep_model_ty0
     ensures { result = deep_model2 self }
     
@@ -548,7 +548,7 @@ module HeapsortGeneric_SiftDown
     ensures { result = in_bounds0 self seq }
     
   function shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model5 self }
     
@@ -562,7 +562,7 @@ module HeapsortGeneric_SiftDown
   function deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 92 8 92 28] deep_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 88 8 88 28] deep_model1 ( * self)
   val deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     ensures { result = deep_model0 self }
     
@@ -575,7 +575,7 @@ module HeapsortGeneric_SiftDown
     
   function shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model4 self }
     
@@ -1049,7 +1049,7 @@ module HeapsortGeneric_HeapSort
     
   function shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -1067,7 +1067,7 @@ module HeapsortGeneric_HeapSort
   function deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 92 8 92 28] deep_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 88 8 88 28] deep_model1 ( * self)
   val deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     ensures { result = deep_model0 self }
     
@@ -1104,7 +1104,7 @@ module HeapsortGeneric_HeapSort
    -> ([#"../heapsort_generic.rs" 25 30 25 31] inv6 s)
    -> ([#"../heapsort_generic.rs" 23 10 23 22] le_log0 (Seq.get s i) (Seq.get s 0))
   predicate resolve2 (self : borrowed (slice t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (slice t)) : bool
     ensures { result = resolve2 self }
     
@@ -1118,7 +1118,7 @@ module HeapsortGeneric_HeapSort
   axiom shallow_model7_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 19 21 19 25] inv3 self)
    -> ([#"../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv8 (shallow_model7 self)) && ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model7 self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model7 self) <= UIntSize.to_int max1)
   function shallow_model6 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model7 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model7 ( * self)
   val shallow_model6 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model6 self }
     
@@ -1135,13 +1135,13 @@ module HeapsortGeneric_HeapSort
     ensures { inv4 result }
     
   predicate resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve1 self }
     
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model5 self }
     
@@ -1154,7 +1154,7 @@ module HeapsortGeneric_HeapSort
     ensures { result = shallow_model1 self }
     
   function shallow_model4 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model4 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model4 self }
     

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -123,7 +123,7 @@ module Hillel_RightPad
   use seq.Seq
   function shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model1 self }
     
@@ -133,7 +133,7 @@ module Hillel_RightPad
     ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 78 26 78 51] shallow_model3 ( ^ self) = Seq.snoc (shallow_model1 self) value }
     
   predicate resolve2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve2 self }
     
@@ -142,7 +142,7 @@ module Hillel_RightPad
     ensures { result = resolve1 self }
     
   function shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model5 self }
     
@@ -161,7 +161,7 @@ module Hillel_RightPad
     
   function shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model4 self }
     
@@ -346,7 +346,7 @@ module Hillel_LeftPad
     
   function shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model4 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model4 ( * self)
   val shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model1 self }
     
@@ -361,7 +361,7 @@ module Hillel_LeftPad
      -> index_logic0 ( ^ self) i = index_logic0 ( * self) (i - 1) }
     
   predicate resolve2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve2 self }
     
@@ -370,7 +370,7 @@ module Hillel_LeftPad
     ensures { result = resolve1 self }
     
   function shallow_model7 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model7 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model7 self }
     
@@ -381,7 +381,7 @@ module Hillel_LeftPad
   use prelude.Snapshot
   use prelude.Int
   function shallow_model6 (self : usize) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UIntSize.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UIntSize.to_int self
   val shallow_model6 (self : usize) : int
     ensures { result = shallow_model6 self }
     
@@ -392,7 +392,7 @@ module Hillel_LeftPad
     
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model5 self }
     
@@ -710,7 +710,7 @@ module Hillel_InsertUnique
     
   use seq.Seq
   function shallow_model0 (self : slice t) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model5 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model5 self
   val shallow_model0 (self : slice t) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -818,7 +818,7 @@ module Hillel_InsertUnique
   use seq.Seq
   function shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model4 self }
     
@@ -839,7 +839,7 @@ module Hillel_InsertUnique
     ensures { result = contains0 seq elem }
     
   predicate resolve10 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve10 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve10 self }
     
@@ -852,12 +852,12 @@ module Hillel_InsertUnique
     ensures { result = resolve8 self }
     
   function deep_model2 (self : t) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model2 (self : t) : deep_model_ty0
     ensures { result = deep_model2 self }
     
   function deep_model4 (self : t) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model2 self
   val deep_model4 (self : t) : deep_model_ty0
     ensures { result = deep_model4 self }
     
@@ -877,13 +877,13 @@ module Hillel_InsertUnique
     ensures { result = resolve6 self }
     
   predicate resolve5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : bool
     ensures { result = resolve5 self }
     
   use seq.Seq
   function shallow_model6 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : slice t =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model6 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : slice t
     ensures { result = shallow_model6 self }
     
@@ -942,7 +942,7 @@ module Hillel_InsertUnique
     ensures { result = resolve2 self }
     
   function shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model1 self }
     
@@ -965,7 +965,7 @@ module Hillel_InsertUnique
   function deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 92 8 92 28] deep_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 88 8 88 28] deep_model3 ( * self)
   val deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     ensures { result = deep_model0 self }
     
@@ -1407,7 +1407,7 @@ module Hillel_Unique
   axiom shallow_model3_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 19 21 19 25] inv11 self)
    -> ([#"../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv9 (shallow_model3 self)) && ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model3 self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model3 self) <= UIntSize.to_int max0)
   function shallow_model0 (self : slice t) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model0 (self : slice t) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -1418,7 +1418,7 @@ module Hillel_Unique
   use seq.Seq
   use prelude.Snapshot
   predicate resolve3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve3 self }
     
@@ -1456,7 +1456,7 @@ module Hillel_Unique
   function deep_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 92 8 92 28] deep_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 88 8 88 28] deep_model0 ( * self)
   val deep_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     ensures { result = deep_model5 self }
     
@@ -1471,7 +1471,7 @@ module Hillel_Unique
     
   use seq.Seq
   predicate resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve1 self }
     
@@ -1504,7 +1504,7 @@ module Hillel_Unique
    -> ([#"../../../../creusot-contracts/src/std/slice.rs" 32 4 32 44] inv6 (deep_model4 self)) && ([#"../../../../creusot-contracts/src/std/slice.rs" 31 4 31 98] forall i : int . 0 <= i /\ i < Seq.length (deep_model4 self)
    -> Seq.get (deep_model4 self) i = deep_model3 (index_logic4 self i)) && ([#"../../../../creusot-contracts/src/std/slice.rs" 30 14 30 44] Seq.length (shallow_model0 self) = Seq.length (deep_model4 self))
   function deep_model1 (self : slice t) : Seq.seq deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model4 self
   val deep_model1 (self : slice t) : Seq.seq deep_model_ty0
     ensures { result = deep_model1 self }
     
@@ -1976,7 +1976,7 @@ module Hillel_Fulcrum
     
   use seq.Seq
   function shallow_model1 (self : slice uint32) : Seq.seq uint32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model1 (self : slice uint32) : Seq.seq uint32
     ensures { result = shallow_model1 self }
     
@@ -2045,7 +2045,7 @@ module Hillel_Fulcrum
     
   use seq.Seq
   predicate resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve1 self }
     
@@ -2125,13 +2125,13 @@ module Hillel_Fulcrum
     
   use seq.Seq
   predicate resolve0 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32)) : bool
     ensures { result = resolve0 self }
     
   use seq.Seq
   function shallow_model5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32)) : slice uint32 =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32)) : slice uint32
     ensures { result = shallow_model5 self }
     

--- a/creusot/tests/should_succeed/immut.mlcfg
+++ b/creusot/tests/should_succeed/immut.mlcfg
@@ -3,7 +3,7 @@ module Immut_F
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -116,7 +116,7 @@ module IndexRange_CreateArr
   function shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model2 self }
     
@@ -370,7 +370,7 @@ module IndexRange_TestRange
     ensures { result = in_bounds1 self seq }
     
   function shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32
     ensures { result = shallow_model2 self }
     
@@ -386,7 +386,7 @@ module IndexRange_TestRange
     ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 75 26 75 48] UIntSize.to_int result = Seq.length (shallow_model2 self) }
     
   predicate resolve1 (self : borrowed (slice int32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (slice int32)) : bool
     ensures { result = resolve1 self }
     
@@ -420,7 +420,7 @@ module IndexRange_TestRange
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model5 self }
     
@@ -439,7 +439,7 @@ module IndexRange_TestRange
     ensures { [#"../../../../creusot-contracts/src/std/option.rs" 36 26 36 51] result = (self = Core_Option_Option_Type.C_None) }
     
   function shallow_model3 (self : slice int32) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model3 (self : slice int32) : Seq.seq int32
     ensures { result = shallow_model3 self }
     
@@ -457,7 +457,7 @@ module IndexRange_TestRange
     ensures { inv2 result }
     
   predicate resolve2 (self : int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : int32) : bool
     ensures { result = resolve2 self }
     
@@ -1186,7 +1186,7 @@ module IndexRange_TestRangeTo
     ensures { result = in_bounds1 self seq }
     
   function shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32
     ensures { result = shallow_model2 self }
     
@@ -1202,7 +1202,7 @@ module IndexRange_TestRangeTo
     ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 75 26 75 48] UIntSize.to_int result = Seq.length (shallow_model2 self) }
     
   predicate resolve1 (self : borrowed (slice int32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (slice int32)) : bool
     ensures { result = resolve1 self }
     
@@ -1236,7 +1236,7 @@ module IndexRange_TestRangeTo
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model5 self }
     
@@ -1255,7 +1255,7 @@ module IndexRange_TestRangeTo
     ensures { [#"../../../../creusot-contracts/src/std/option.rs" 36 26 36 51] result = (self = Core_Option_Option_Type.C_None) }
     
   function shallow_model3 (self : slice int32) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model3 (self : slice int32) : Seq.seq int32
     ensures { result = shallow_model3 self }
     
@@ -1273,7 +1273,7 @@ module IndexRange_TestRangeTo
     ensures { inv2 result }
     
   predicate resolve2 (self : int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : int32) : bool
     ensures { result = resolve2 self }
     
@@ -1812,7 +1812,7 @@ module IndexRange_TestRangeFrom
     ensures { result = in_bounds1 self seq }
     
   function shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32
     ensures { result = shallow_model2 self }
     
@@ -1828,7 +1828,7 @@ module IndexRange_TestRangeFrom
     ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 75 26 75 48] UIntSize.to_int result = Seq.length (shallow_model2 self) }
     
   predicate resolve1 (self : borrowed (slice int32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (slice int32)) : bool
     ensures { result = resolve1 self }
     
@@ -1864,7 +1864,7 @@ module IndexRange_TestRangeFrom
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model5 self }
     
@@ -1883,7 +1883,7 @@ module IndexRange_TestRangeFrom
     ensures { [#"../../../../creusot-contracts/src/std/option.rs" 36 26 36 51] result = (self = Core_Option_Option_Type.C_None) }
     
   function shallow_model3 (self : slice int32) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model3 (self : slice int32) : Seq.seq int32
     ensures { result = shallow_model3 self }
     
@@ -1901,7 +1901,7 @@ module IndexRange_TestRangeFrom
     ensures { inv2 result }
     
   predicate resolve2 (self : int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : int32) : bool
     ensures { result = resolve2 self }
     
@@ -2445,7 +2445,7 @@ module IndexRange_TestRangeFull
     ensures { result = in_bounds1 self seq }
     
   function shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32
     ensures { result = shallow_model2 self }
     
@@ -2461,7 +2461,7 @@ module IndexRange_TestRangeFull
     ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 75 26 75 48] UIntSize.to_int result = Seq.length (shallow_model2 self) }
     
   predicate resolve1 (self : borrowed (slice int32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (slice int32)) : bool
     ensures { result = resolve1 self }
     
@@ -2493,7 +2493,7 @@ module IndexRange_TestRangeFull
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model5 self }
     
@@ -2508,7 +2508,7 @@ module IndexRange_TestRangeFull
     ensures { inv4 result }
     
   predicate resolve2 (self : int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : int32) : bool
     ensures { result = resolve2 self }
     
@@ -2526,7 +2526,7 @@ module IndexRange_TestRangeFull
     ensures { result = resolve0 self }
     
   function shallow_model3 (self : slice int32) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model3 (self : slice int32) : Seq.seq int32
     ensures { result = shallow_model3 self }
     
@@ -3040,7 +3040,7 @@ module IndexRange_TestRangeToInclusive
     ensures { result = in_bounds1 self seq }
     
   function shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32
     ensures { result = shallow_model2 self }
     
@@ -3056,7 +3056,7 @@ module IndexRange_TestRangeToInclusive
     ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 75 26 75 48] UIntSize.to_int result = Seq.length (shallow_model2 self) }
     
   predicate resolve1 (self : borrowed (slice int32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (slice int32)) : bool
     ensures { result = resolve1 self }
     
@@ -3092,7 +3092,7 @@ module IndexRange_TestRangeToInclusive
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model5 self }
     
@@ -3111,7 +3111,7 @@ module IndexRange_TestRangeToInclusive
     ensures { [#"../../../../creusot-contracts/src/std/option.rs" 36 26 36 51] result = (self = Core_Option_Option_Type.C_None) }
     
   function shallow_model3 (self : slice int32) : Seq.seq int32 =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model3 (self : slice int32) : Seq.seq int32
     ensures { result = shallow_model3 self }
     
@@ -3129,7 +3129,7 @@ module IndexRange_TestRangeToInclusive
     ensures { inv2 result }
     
   predicate resolve2 (self : int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : int32) : bool
     ensures { result = resolve2 self }
     

--- a/creusot/tests/should_succeed/inplace_list_reversal.mlcfg
+++ b/creusot/tests/should_succeed/inplace_list_reversal.mlcfg
@@ -43,7 +43,7 @@ module InplaceListReversal_Rev
     
   axiom inv0 : forall x : Snapshot.snap_ty (borrowed (InplaceListReversal_List_Type.t_list t)) . inv0 x = true
   predicate resolve2 (self : borrowed (InplaceListReversal_List_Type.t_list t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (InplaceListReversal_List_Type.t_list t)) : bool
     ensures { result = resolve2 self }
     

--- a/creusot/tests/should_succeed/instant.mlcfg
+++ b/creusot/tests/should_succeed/instant.mlcfg
@@ -335,7 +335,7 @@ module Instant_TestInstant
     
   axiom shallow_model0_spec : forall self : Std_Time_Instant_Type.t_instant . [#"../../../../creusot-contracts/src/std/time.rs" 57 14 57 25] shallow_model0 self >= 0
   function shallow_model3 (self : Std_Time_Instant_Type.t_instant) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model3 (self : Std_Time_Instant_Type.t_instant) : int
     ensures { result = shallow_model3 self }
     
@@ -372,7 +372,7 @@ module Instant_TestInstant
     
   axiom deep_model3_spec : forall self : Core_Time_Duration_Type.t_duration . ([#"../../../../creusot-contracts/src/std/time.rs" 26 14 26 44] deep_model3 self = shallow_model1 self) && ([#"../../../../creusot-contracts/src/std/time.rs" 25 14 25 77] deep_model3 self >= 0 /\ deep_model3 self <= secs_to_nanos0 (UInt64.to_int max0) + 999999999)
   function deep_model0 (self : Core_Time_Duration_Type.t_duration) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model3 self
   val deep_model0 (self : Core_Time_Duration_Type.t_duration) : int
     ensures { result = deep_model0 self }
     
@@ -424,7 +424,7 @@ module Instant_TestInstant
      -> shallow_model0 self < shallow_model0 result }
     
   function deep_model2 (self : Std_Time_Instant_Type.t_instant) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model4 self
   val deep_model2 (self : Std_Time_Instant_Type.t_instant) : int
     ensures { result = deep_model2 self }
     

--- a/creusot/tests/should_succeed/invariant_moves.mlcfg
+++ b/creusot/tests/should_succeed/invariant_moves.mlcfg
@@ -111,7 +111,7 @@ module InvariantMoves_TestInvariantMove
     
   axiom inv0 : forall x : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) . inv0 x = true
   predicate resolve2 (self : uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : uint32) : bool
     ensures { result = resolve2 self }
     
@@ -130,7 +130,7 @@ module InvariantMoves_TestInvariantMove
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve0 self }
     
@@ -139,7 +139,7 @@ module InvariantMoves_TestInvariantMove
   function shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/ite_normalize.mlcfg
+++ b/creusot/tests/should_succeed/ite_normalize.mlcfg
@@ -358,12 +358,12 @@ module IteNormalize_Impl5_Transpose
     ensures { [#"../ite_normalize.rs" 55 9 55 14] result = self }
     
   predicate resolve1 (self : IteNormalize_Expr_Type.t_expr) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : IteNormalize_Expr_Type.t_expr) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : IteNormalize_Expr_Type.t_expr) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve1 self
+    [#"../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve1 self
   val resolve0 (self : IteNormalize_Expr_Type.t_expr) : bool
     ensures { result = resolve0 self }
     
@@ -759,7 +759,7 @@ module IteNormalize_Impl5_SimplifyHelper
   function shallow_model3 (self : borrowed (IteNormalize_BTreeMap_Type.t_btreemap usize bool)) : Map.map int (Core_Option_Option_Type.t_option bool)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model3 (self : borrowed (IteNormalize_BTreeMap_Type.t_btreemap usize bool)) : Map.map int (Core_Option_Option_Type.t_option bool)
     ensures { result = shallow_model3 self }
     
@@ -783,24 +783,24 @@ module IteNormalize_Impl5_SimplifyHelper
     ensures { [#"../ite_normalize.rs" 38 14 38 29] self = result }
     
   predicate resolve1 (self : IteNormalize_Expr_Type.t_expr) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : IteNormalize_Expr_Type.t_expr) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : IteNormalize_Expr_Type.t_expr) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve1 self
+    [#"../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve1 self
   val resolve0 (self : IteNormalize_Expr_Type.t_expr) : bool
     ensures { result = resolve0 self }
     
   function deep_model0 (self : usize) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : usize) : int
     ensures { result = deep_model0 self }
     
   function shallow_model2 (self : IteNormalize_BTreeMap_Type.t_btreemap usize bool) : Map.map int (Core_Option_Option_Type.t_option bool)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model2 (self : IteNormalize_BTreeMap_Type.t_btreemap usize bool) : Map.map int (Core_Option_Option_Type.t_option bool)
     ensures { result = shallow_model2 self }
     

--- a/creusot/tests/should_succeed/iterators/01_range.mlcfg
+++ b/creusot/tests/should_succeed/iterators/01_range.mlcfg
@@ -96,7 +96,7 @@ module C01Range_Impl0_Next
   use seq.Seq
   use prelude.Borrow
   predicate resolve0 (self : borrowed (C01Range_Range_Type.t_range)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C01Range_Range_Type.t_range)) : bool
     ensures { result = resolve0 self }
     
@@ -214,7 +214,7 @@ module C01Range_SumRange
   use Core_Option_Option_Type as Core_Option_Option_Type
   use prelude.Borrow
   predicate resolve0 (self : borrowed (C01Range_Range_Type.t_range)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C01Range_Range_Type.t_range)) : bool
     ensures { result = resolve0 self }
     
@@ -368,7 +368,7 @@ module C01Range_Impl0
   use seq.Seq
   use prelude.Int
   predicate resolve0 (self : borrowed (C01Range_Range_Type.t_range)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C01Range_Range_Type.t_range)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -87,7 +87,7 @@ module C02IterMut_Impl1_ProducesRefl_Impl
     ensures { result = index_logic1 self ix }
     
   function shallow_model0 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -192,7 +192,7 @@ module C02IterMut_Impl1_ProducesTrans_Impl
     ensures { result = index_logic1 self ix }
     
   function shallow_model0 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -346,7 +346,7 @@ module C02IterMut_Impl1_Next
     ensures { result = index_logic0 self ix }
     
   function shallow_model1 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model1 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model1 self }
     
@@ -372,7 +372,7 @@ module C02IterMut_Impl1_Next
   use seq.Seq
   use seq.Seq
   predicate resolve1 (self : borrowed (slice t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (slice t)) : bool
     ensures { result = resolve1 self }
     
@@ -382,7 +382,7 @@ module C02IterMut_Impl1_Next
     ensures { result = completed0 self }
     
   predicate resolve0 (self : borrowed (C02IterMut_IterMut_Type.t_itermut t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C02IterMut_IterMut_Type.t_itermut t)) : bool
     ensures { result = resolve0 self }
     
@@ -657,22 +657,22 @@ module C02IterMut_IterMut
   axiom inv0 : forall x : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global) . inv0 x = true
   function shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model1 self }
     
   function shallow_model0 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model0 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model0 self }
     
   predicate resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (slice t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (slice t)) : bool
     ensures { result = resolve0 self }
     
@@ -870,7 +870,7 @@ module C02IterMut_AllZero
     ensures { result = index_logic4 self ix }
     
   function shallow_model3 (self : borrowed (slice usize)) : Seq.seq usize =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model4 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model4 ( * self)
   val shallow_model3 (self : borrowed (slice usize)) : Seq.seq usize
     ensures { result = shallow_model3 self }
     
@@ -941,18 +941,18 @@ module C02IterMut_AllZero
   function shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     ensures { result = shallow_model2 self }
     
   use prelude.Snapshot
   predicate resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed usize) : bool
     ensures { result = resolve0 self }
     
@@ -960,7 +960,7 @@ module C02IterMut_AllZero
   use seq.Seq
   use seq.Seq
   predicate resolve2 (self : borrowed (slice usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (slice usize)) : bool
     ensures { result = resolve2 self }
     
@@ -1194,7 +1194,7 @@ module C02IterMut_Impl1
     ensures { result = index_logic1 self ix }
     
   function shallow_model0 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -1220,7 +1220,7 @@ module C02IterMut_Impl1
   use seq.Seq
   use seq.Seq
   predicate resolve0 (self : borrowed (slice t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (slice t)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -105,7 +105,7 @@ module C03StdIterators_SliceIter
     
   use seq.Seq
   function shallow_model1 (self : slice t) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model1 (self : slice t) : Seq.seq t
     ensures { result = shallow_model1 self }
     
@@ -194,13 +194,13 @@ module C03StdIterators_SliceIter
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : bool
     ensures { result = resolve3 self }
     
   use seq.Seq
   function shallow_model4 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : slice t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model4 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : slice t
     ensures { result = shallow_model4 self }
     
@@ -495,7 +495,7 @@ module C03StdIterators_VecIter
     
   use seq.Seq
   function shallow_model4 (self : slice t) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model4 (self : slice t) : Seq.seq t
     ensures { result = shallow_model4 self }
     
@@ -571,7 +571,7 @@ module C03StdIterators_VecIter
     
   axiom inv0 : forall x : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global) . inv0 x = true
   function shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model1 self }
     
@@ -589,13 +589,13 @@ module C03StdIterators_VecIter
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : bool
     ensures { result = resolve3 self }
     
   use seq.Seq
   function shallow_model5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : slice t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : slice t
     ensures { result = shallow_model5 self }
     
@@ -861,7 +861,7 @@ module C03StdIterators_AllZero
     
   use seq.Seq
   function shallow_model3 (self : borrowed (slice usize)) : Seq.seq usize =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model4 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model4 ( * self)
   val shallow_model3 (self : borrowed (slice usize)) : Seq.seq usize
     ensures { result = shallow_model3 self }
     
@@ -930,13 +930,13 @@ module C03StdIterators_AllZero
   function shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     ensures { result = shallow_model2 self }
     
   use prelude.Snapshot
   predicate resolve4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve4 self }
     
@@ -946,19 +946,19 @@ module C03StdIterators_AllZero
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed usize) : bool
     ensures { result = resolve2 self }
     
   use seq.Seq
   predicate resolve1 (self : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize)) : bool
     ensures { result = resolve1 self }
     
   use seq.Seq
   function shallow_model6 (self : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize)) : borrowed (slice usize) =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model5 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model5 ( * self)
   val shallow_model6 (self : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize)) : borrowed (slice usize)
     ensures { result = shallow_model6 self }
     
@@ -987,7 +987,7 @@ module C03StdIterators_AllZero
   use prelude.Snapshot
   use prelude.Snapshot
   predicate resolve0 (self : borrowed (slice usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (slice usize)) : bool
     ensures { result = resolve0 self }
     
@@ -1391,7 +1391,7 @@ module C03StdIterators_SkipTake
   axiom iter_mut0_spec : forall self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i) . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 26 21 26 25] inv5 self)
    -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 26 4 26 36] inv7 (iter_mut0 self)) && ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 25 14 25 68] iter0 ( * self) =  * iter_mut0 self /\ iter0 ( ^ self) =  ^ iter_mut0 self)
   predicate resolve5 (self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve5 (self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i)) : bool
     ensures { result = resolve5 self }
     
@@ -1519,7 +1519,7 @@ module C03StdIterators_Counter_Closure0
   use prelude.Snapshot
   use prelude.UIntSize
   predicate resolve0 (self : borrowed C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) : bool
     ensures { result = resolve0 self }
     
@@ -1725,7 +1725,7 @@ module C03StdIterators_Counter
     ensures { result = index_logic4 self ix }
     
   function shallow_model2 (self : slice uint32) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model5 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model5 self
   val shallow_model2 (self : slice uint32) : Seq.seq uint32
     ensures { result = shallow_model2 self }
     
@@ -1866,12 +1866,12 @@ module C03StdIterators_Counter
    -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 120 4 120 83] produced = Seq.empty 
    -> preservation_inv0 iter func produced = preservation0 iter func)
   function shallow_model6 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32)) : slice uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model4 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model4 ( * self)
   val shallow_model6 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32)) : slice uint32
     ensures { result = shallow_model6 self }
     
   predicate resolve5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32)) : bool
     ensures { result = resolve5 self }
     
@@ -1980,7 +1980,7 @@ module C03StdIterators_Counter
    -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 45] produces0 self (Seq.empty ) self)
   use seq.Seq
   predicate resolve2 (self : uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : uint32) : bool
     ensures { result = resolve2 self }
     
@@ -2012,7 +2012,7 @@ module C03StdIterators_Counter
     ensures { result = completed0 self }
     
   predicate resolve6 (self : borrowed usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve6 (self : borrowed usize) : bool
     ensures { result = resolve6 self }
     
@@ -2021,7 +2021,7 @@ module C03StdIterators_Counter
    =
     resolve6 (field_00 _1)
   predicate resolve3 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) : bool
     ensures { result = resolve3 self }
     
@@ -2052,7 +2052,7 @@ module C03StdIterators_Counter
     ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 238 0 334 1] shallow_model4 result = self }
     
   function shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32
     ensures { result = shallow_model3 self }
     
@@ -2236,7 +2236,7 @@ module C03StdIterators_SumRange
   use prelude.Snapshot
   use seq.Seq
   predicate resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range isize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range isize)) : bool
     ensures { result = resolve0 self }
     
@@ -2541,7 +2541,7 @@ module C03StdIterators_EnumerateRange
   axiom produces_refl0_spec : forall self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize) . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 21 73 25] inv0 self)
    -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 72 14 72 45] produces0 self (Seq.empty ) self)
   predicate resolve5 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve5 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve5 self }
     
@@ -2562,7 +2562,7 @@ module C03StdIterators_EnumerateRange
     end)
   use prelude.Snapshot
   predicate resolve4 (self : Core_Ops_Range_Range_Type.t_range usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve4 (self : Core_Ops_Range_Range_Type.t_range usize) : bool
     ensures { result = resolve4 self }
     
@@ -2574,12 +2574,12 @@ module C03StdIterators_EnumerateRange
     ensures { result = resolve2 self }
     
   predicate resolve3 (self : usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : usize) : bool
     ensures { result = resolve3 self }
     
   predicate resolve1 (self : (usize, usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve1 (self : (usize, usize)) : bool
     ensures { result = resolve1 self }
     
@@ -2587,7 +2587,7 @@ module C03StdIterators_EnumerateRange
   predicate resolve0 (self : borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)))
     
    =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize))) : bool
     ensures { result = resolve0 self }
     
@@ -3002,13 +3002,13 @@ module C03StdIterators_MyReverse
   axiom shallow_model3_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 21 19 25] inv2 self)
    -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv9 (shallow_model3 self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model3 self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model3 self) <= UIntSize.to_int max0)
   predicate resolve3 (self : borrowed (slice t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (slice t)) : bool
     ensures { result = resolve3 self }
     
   use seq.Permut
   function shallow_model1 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model1 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model1 self }
     
@@ -3019,12 +3019,12 @@ module C03StdIterators_MyReverse
     ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 249 8 249 52] Permut.exchange (shallow_model3 ( ^ self)) (shallow_model1 self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
   predicate resolve4 (self : usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve4 (self : usize) : bool
     ensures { result = resolve4 self }
     
   predicate resolve2 (self : (usize, usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve4 (let (a, _) = self in a) /\ resolve4 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve4 (let (a, _) = self in a) /\ resolve4 (let (_, a) = self in a)
   val resolve2 (self : (usize, usize)) : bool
     ensures { result = resolve2 self }
     
@@ -3032,13 +3032,13 @@ module C03StdIterators_MyReverse
   predicate resolve1 (self : borrowed (Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize)))
     
    =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize))) : bool
     ensures { result = resolve1 self }
     
   use seq.Seq
   predicate resolve5 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve5 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve5 self }
     
@@ -3077,7 +3077,7 @@ module C03StdIterators_MyReverse
     
   use prelude.Snapshot
   function shallow_model5 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model5 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model5 self }
     
@@ -3137,7 +3137,7 @@ module C03StdIterators_MyReverse
     
   use prelude.Snapshot
   function shallow_model4 (self : slice t) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model4 (self : slice t) : Seq.seq t
     ensures { result = shallow_model4 self }
     

--- a/creusot/tests/should_succeed/iterators/04_skip.mlcfg
+++ b/creusot/tests/should_succeed/iterators/04_skip.mlcfg
@@ -366,7 +366,7 @@ module C04Skip_Impl0_Next
     ensures { result = completed0 self }
     
   predicate resolve5 (self : borrowed (C04Skip_Skip_Type.t_skip i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve5 (self : borrowed (C04Skip_Skip_Type.t_skip i)) : bool
     ensures { result = resolve5 self }
     
@@ -397,7 +397,7 @@ module C04Skip_Impl0_Next
     
   use prelude.Snapshot
   predicate resolve1 (self : borrowed usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed usize) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/iterators/05_map.mlcfg
+++ b/creusot/tests/should_succeed/iterators/05_map.mlcfg
@@ -1399,7 +1399,7 @@ module C05Map_Impl0_Next
     
   use prelude.Snapshot
   predicate resolve2 (self : borrowed (C05Map_Map_Type.t_map i b f)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (C05Map_Map_Type.t_map i b f)) : bool
     ensures { result = resolve2 self }
     

--- a/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
@@ -1836,7 +1836,7 @@ module C06MapPrecond_Impl0_Next
    -> ([#"../06_map_precond.rs" 132 65 132 69] inv0 iter)
    -> ([#"../06_map_precond.rs" 131 14 131 70] next_precondition0 iter ( ^ f) (Seq.snoc (Snapshot.inner (C06MapPrecond_Map_Type.map_produced self)) e)) && ([#"../06_map_precond.rs" 130 14 130 69] preservation_inv0 iter ( ^ f) (Seq.snoc (Snapshot.inner (C06MapPrecond_Map_Type.map_produced self)) e))
   predicate resolve2 (self : borrowed (C06MapPrecond_Map_Type.t_map i b f item0)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (C06MapPrecond_Map_Type.t_map i b f item0)) : bool
     ensures { result = resolve2 self }
     
@@ -2388,7 +2388,7 @@ module C06MapPrecond_Identity_Closure0
     true
   use prelude.Borrow
   predicate resolve1 (self : borrowed (C06MapPrecond_Identity_Closure0.c06mapprecond_identity_closure0 i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (C06MapPrecond_Identity_Closure0.c06mapprecond_identity_closure0 i)) : bool
     ensures { result = resolve1 self }
     
@@ -2688,7 +2688,7 @@ module C06MapPrecond_Increment_Closure2
   use prelude.Borrow
   use prelude.Int
   predicate resolve0 (self : borrowed (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u)) : bool
     ensures { result = resolve0 self }
     
@@ -3079,7 +3079,7 @@ module C06MapPrecond_Counter_Closure2
   use prelude.Snapshot
   use prelude.UIntSize
   predicate resolve0 (self : borrowed (C06MapPrecond_Counter_Closure2.c06mapprecond_counter_closure2 i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C06MapPrecond_Counter_Closure2.c06mapprecond_counter_closure2 i)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
+++ b/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
@@ -154,7 +154,7 @@ module C07Fuse_Impl0_Next
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed i) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed i) : bool
     ensures { result = resolve2 self }
     
@@ -167,12 +167,12 @@ module C07Fuse_Impl0_Next
     ensures { [#"../common.rs" 27 26 27 44] inv5 result }
     
   predicate resolve1 (self : borrowed (C07Fuse_Fuse_Type.t_fuse i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (C07Fuse_Fuse_Type.t_fuse i)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (Core_Option_Option_Type.t_option i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Option_Option_Type.t_option i)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -206,7 +206,7 @@ module C08CollectExtend_Extend
     ensures { result = completed0 self }
     
   predicate resolve6 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve6 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve6 self }
     
@@ -217,7 +217,7 @@ module C08CollectExtend_Extend
   use seq.Seq
   function shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -232,7 +232,7 @@ module C08CollectExtend_Extend
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed i) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed i) : bool
     ensures { result = resolve3 self }
     
@@ -248,7 +248,7 @@ module C08CollectExtend_Extend
   use prelude.Snapshot
   function shallow_model3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model3 self }
     
@@ -614,7 +614,7 @@ module C08CollectExtend_Collect
   function shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec item0 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq item0
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec item0 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq item0
     ensures { result = shallow_model2 self }
     
@@ -629,7 +629,7 @@ module C08CollectExtend_Collect
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed i) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed i) : bool
     ensures { result = resolve2 self }
     
@@ -1006,7 +1006,7 @@ module C08CollectExtend_ExtendIndex
   axiom shallow_model6_spec : forall self : slice uint32 . ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 21 19 25] inv7 self)
    -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv5 (shallow_model6 self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model6 self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model6 self) <= UIntSize.to_int max0)
   function shallow_model2 (self : slice uint32) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model2 (self : slice uint32) : Seq.seq uint32
     ensures { result = shallow_model2 self }
     
@@ -1017,7 +1017,7 @@ module C08CollectExtend_ExtendIndex
     ensures { result = shallow_model1 self }
     
   predicate resolve2 (self : uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : uint32) : bool
     ensures { result = resolve2 self }
     
@@ -1036,28 +1036,28 @@ module C08CollectExtend_ExtendIndex
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve0 self }
     
   function shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     ensures { result = shallow_model4 self }
     
   function shallow_model8 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model7 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model7 ( * self)
   val shallow_model8 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     ensures { result = shallow_model8 self }
     
   predicate resolve3 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)))
     
    =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve3 self }
     
@@ -1093,7 +1093,7 @@ module C08CollectExtend_ExtendIndex
     
   use prelude.Snapshot
   function shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32
     ensures { result = shallow_model3 self }
     
@@ -1258,7 +1258,7 @@ module C08CollectExtend_CollectExample
     ensures { result = index_logic0 self ix }
     
   predicate resolve1 (self : uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint32) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/iterators/09_empty.mlcfg
+++ b/creusot/tests/should_succeed/iterators/09_empty.mlcfg
@@ -92,7 +92,7 @@ module C09Empty_Impl0_Next
   use seq.Seq
   use prelude.Borrow
   predicate resolve0 (self : borrowed (C09Empty_Empty_Type.t_empty t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C09Empty_Empty_Type.t_empty t)) : bool
     ensures { result = resolve0 self }
     
@@ -166,7 +166,7 @@ module C09Empty_Impl0
   use seq.Seq
   use seq.Seq
   predicate resolve0 (self : borrowed (C09Empty_Empty_Type.t_empty t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C09Empty_Empty_Type.t_empty t)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/iterators/10_once.mlcfg
+++ b/creusot/tests/should_succeed/iterators/10_once.mlcfg
@@ -162,7 +162,7 @@ module C10Once_Impl0_Next
     ensures { result = produces0 self visited o }
     
   predicate resolve0 (self : borrowed (C10Once_Once_Type.t_once t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C10Once_Once_Type.t_once t)) : bool
     ensures { result = resolve0 self }
     
@@ -261,7 +261,7 @@ module C10Once_Impl0
   use seq.Seq
   use seq.Seq
   predicate resolve0 (self : borrowed (C10Once_Once_Type.t_once t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C10Once_Once_Type.t_once t)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/iterators/11_repeat.mlcfg
+++ b/creusot/tests/should_succeed/iterators/11_repeat.mlcfg
@@ -154,7 +154,7 @@ module C11Repeat_Impl0_Next
     ensures { result = completed0 self }
     
   predicate resolve0 (self : borrowed (C11Repeat_Repeat_Type.t_repeat a)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C11Repeat_Repeat_Type.t_repeat a)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/iterators/12_zip.mlcfg
+++ b/creusot/tests/should_succeed/iterators/12_zip.mlcfg
@@ -537,7 +537,7 @@ module C12Zip_Impl0_Next
     ensures { [#"../common.rs" 27 26 27 44] inv4 result }
     
   predicate resolve1 (self : borrowed (C12Zip_Zip_Type.t_zip a b)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (C12Zip_Zip_Type.t_zip a b)) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/iterators/13_cloned.mlcfg
+++ b/creusot/tests/should_succeed/iterators/13_cloned.mlcfg
@@ -332,7 +332,7 @@ module C13Cloned_Impl0_Next
     ensures { inv2 result }
     
   predicate resolve0 (self : borrowed (C13Cloned_Cloned_Type.t_cloned i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C13Cloned_Cloned_Type.t_cloned i)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/iterators/14_copied.mlcfg
+++ b/creusot/tests/should_succeed/iterators/14_copied.mlcfg
@@ -332,7 +332,7 @@ module C14Copied_Impl0_Next
     ensures { inv2 result }
     
   predicate resolve0 (self : borrowed (C14Copied_Copied_Type.t_copied i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C14Copied_Copied_Type.t_copied i)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
@@ -399,7 +399,7 @@ module C15Enumerate_Impl0_Next
     ensures { result = completed0 self }
     
   predicate resolve1 (self : borrowed (C15Enumerate_Enumerate_Type.t_enumerate i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (C15Enumerate_Enumerate_Type.t_enumerate i)) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/iterators/16_take.mlcfg
+++ b/creusot/tests/should_succeed/iterators/16_take.mlcfg
@@ -289,7 +289,7 @@ module C16Take_Impl0_Next
     ensures { result = completed1 self }
     
   predicate resolve0 (self : borrowed (C16Take_Take_Type.t_take i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C16Take_Take_Type.t_take i)) : bool
     ensures { result = resolve0 self }
     
@@ -406,7 +406,7 @@ module C16Take_Impl0
     
   use prelude.Int
   predicate resolve0 (self : borrowed (C16Take_Take_Type.t_take i)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C16Take_Take_Type.t_take i)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -380,12 +380,12 @@ module Knapsack_Knapsack01Dyn
     ensures { result = index_logic2 self ix }
     
   predicate resolve4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed usize) : bool
     ensures { result = resolve3 self }
     
@@ -410,7 +410,7 @@ module Knapsack_Knapsack01Dyn
   function shallow_model10 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model10 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     ensures { result = shallow_model10 self }
     
@@ -450,7 +450,7 @@ module Knapsack_Knapsack01Dyn
   function shallow_model9 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model9 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     ensures { result = shallow_model9 self }
     
@@ -473,7 +473,7 @@ module Knapsack_Knapsack01Dyn
   function shallow_model8 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Knapsack_Item_Type.t_item name)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model5 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model5 ( * self)
   val shallow_model8 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Knapsack_Item_Type.t_item name)
     ensures { result = shallow_model8 self }
     
@@ -483,7 +483,7 @@ module Knapsack_Knapsack01Dyn
     ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 78 26 78 51] shallow_model5 ( ^ self) = Seq.snoc (shallow_model8 self) value }
     
   function shallow_model7 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model7 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize
     ensures { result = shallow_model7 self }
     
@@ -497,7 +497,7 @@ module Knapsack_Knapsack01Dyn
   function shallow_model6 (self : Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model6 (self : Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     ensures { result = shallow_model6 self }
     
@@ -527,7 +527,7 @@ module Knapsack_Knapsack01Dyn
   function shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Knapsack_Item_Type.t_item name)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Knapsack_Item_Type.t_item name)
     ensures { result = shallow_model0 self }
     
@@ -544,7 +544,7 @@ module Knapsack_Knapsack01Dyn
     ensures { result = resolve1 self }
     
   predicate resolve6 (self : usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve6 (self : usize) : bool
     ensures { result = resolve6 self }
     

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -728,7 +728,7 @@ module KnapsackFull_Knapsack01Dyn
   function shallow_model10 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (KnapsackFull_Item_Type.t_item name)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model4 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model4 ( * self)
   val shallow_model10 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (KnapsackFull_Item_Type.t_item name)
     ensures { result = shallow_model10 self }
     
@@ -792,7 +792,7 @@ module KnapsackFull_Knapsack01Dyn
     ensures { result = resolve6 self }
     
   predicate resolve8 (self : usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve8 (self : usize) : bool
     ensures { result = resolve8 self }
     
@@ -826,12 +826,12 @@ module KnapsackFull_Knapsack01Dyn
     ensures { result = resolve5 self }
     
   predicate resolve4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed usize) : bool
     ensures { result = resolve3 self }
     
@@ -855,7 +855,7 @@ module KnapsackFull_Knapsack01Dyn
   function shallow_model9 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model9 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     ensures { result = shallow_model9 self }
     
@@ -894,7 +894,7 @@ module KnapsackFull_Knapsack01Dyn
   function shallow_model8 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model8 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     ensures { result = shallow_model8 self }
     
@@ -913,7 +913,7 @@ module KnapsackFull_Knapsack01Dyn
     ensures { [#"../knapsack_full.rs" 14 10 14 31] UIntSize.to_int result = MinMax.max (UIntSize.to_int a) (UIntSize.to_int b) }
     
   function shallow_model7 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model7 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize
     ensures { result = shallow_model7 self }
     
@@ -927,7 +927,7 @@ module KnapsackFull_Knapsack01Dyn
   function shallow_model6 (self : Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model6 (self : Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     ensures { result = shallow_model6 self }
     
@@ -939,7 +939,7 @@ module KnapsackFull_Knapsack01Dyn
     ensures { inv16 result }
     
   predicate resolve2 (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize)) : bool
     ensures { result = resolve2 self }
     
@@ -1005,7 +1005,7 @@ module KnapsackFull_Knapsack01Dyn
   function shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (KnapsackFull_Item_Type.t_item name)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model5 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model5 self
   val shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (KnapsackFull_Item_Type.t_item name)
     ensures { result = shallow_model0 self }
     
@@ -1017,7 +1017,7 @@ module KnapsackFull_Knapsack01Dyn
     ensures { inv1 result }
     
   predicate resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/lang/branch_borrow_2.mlcfg
+++ b/creusot/tests/should_succeed/lang/branch_borrow_2.mlcfg
@@ -3,7 +3,7 @@ module BranchBorrow2_F
   use prelude.Borrow
   use prelude.Int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -126,22 +126,22 @@ module BranchBorrow2_G
   use prelude.Borrow
   use BranchBorrow2_MyInt_Type as BranchBorrow2_MyInt_Type
   predicate resolve3 (self : BranchBorrow2_MyInt_Type.t_myint) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : BranchBorrow2_MyInt_Type.t_myint) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : (BranchBorrow2_MyInt_Type.t_myint, BranchBorrow2_MyInt_Type.t_myint)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve2 (self : (BranchBorrow2_MyInt_Type.t_myint, BranchBorrow2_MyInt_Type.t_myint)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (BranchBorrow2_MyInt_Type.t_myint, BranchBorrow2_MyInt_Type.t_myint)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (BranchBorrow2_MyInt_Type.t_myint, BranchBorrow2_MyInt_Type.t_myint)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (BranchBorrow2_MyInt_Type.t_myint)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (BranchBorrow2_MyInt_Type.t_myint)) : bool
     ensures { result = resolve0 self }
     
@@ -184,7 +184,7 @@ module BranchBorrow2_H
   use prelude.Borrow
   use prelude.Int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/lang/move_path.mlcfg
+++ b/creusot/tests/should_succeed/lang/move_path.mlcfg
@@ -3,7 +3,7 @@ module MovePath_F
   use prelude.Borrow
   use prelude.Int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/lang/promoted_constants.mlcfg
+++ b/creusot/tests/should_succeed/lang/promoted_constants.mlcfg
@@ -10,12 +10,12 @@ module PromotedConstants_PromotedNone
   use prelude.Int32
   use Core_Option_Option_Type as Core_Option_Option_Type
   predicate resolve1 (self : Core_Option_Option_Type.t_option int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : Core_Option_Option_Type.t_option int32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (Core_Option_Option_Type.t_option int32, Core_Option_Option_Type.t_option int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (Core_Option_Option_Type.t_option int32, Core_Option_Option_Type.t_option int32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/lang/while_let.mlcfg
+++ b/creusot/tests/should_succeed/lang/while_let.mlcfg
@@ -10,7 +10,7 @@ module WhileLet_F
   use prelude.Int32
   use Core_Option_Option_Type as Core_Option_Option_Type
   predicate resolve0 (self : borrowed (Core_Option_Option_Type.t_option int32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Option_Option_Type.t_option int32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/list_index_mut.mlcfg
+++ b/creusot/tests/should_succeed/list_index_mut.mlcfg
@@ -59,7 +59,7 @@ module ListIndexMut_IndexMut
   use prelude.UIntSize
   use prelude.Snapshot
   predicate resolve2 (self : borrowed (ListIndexMut_List_Type.t_list)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (ListIndexMut_List_Type.t_list)) : bool
     ensures { result = resolve2 self }
     
@@ -77,19 +77,19 @@ module ListIndexMut_IndexMut
     ensures { inv2 result }
     
   predicate resolve1 (self : borrowed (ListIndexMut_List_Type.t_list)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (ListIndexMut_List_Type.t_list)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
   use prelude.UIntSize
   use prelude.Int
   function shallow_model2 (self : usize) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] UIntSize.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] UIntSize.to_int self
   val shallow_model2 (self : usize) : int
     ensures { result = shallow_model2 self }
     
@@ -246,12 +246,12 @@ module ListIndexMut_Write
   use prelude.UIntSize
   use prelude.Borrow
   predicate resolve1 (self : borrowed (ListIndexMut_List_Type.t_list)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (ListIndexMut_List_Type.t_list)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -300,7 +300,7 @@ module ListIndexMut_F
   use prelude.Borrow
   use ListIndexMut_List_Type as ListIndexMut_List_Type
   predicate resolve0 (self : borrowed (ListIndexMut_List_Type.t_list)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (ListIndexMut_List_Type.t_list)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
+++ b/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
@@ -161,7 +161,7 @@ module ListReversalLasso_Impl1_Index
     ensures { result = in_bounds0 self seq }
     
   function shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize
     ensures { result = shallow_model0 self }
     
@@ -288,12 +288,12 @@ module ListReversalLasso_Impl2_IndexMut
     ensures { result = nonnull_ptr0 self i }
     
   predicate resolve1 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed usize) : bool
     ensures { result = resolve0 self }
     
@@ -317,7 +317,7 @@ module ListReversalLasso_Impl2_IndexMut
   function shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     ensures { result = shallow_model1 self }
     
@@ -411,7 +411,7 @@ module ListReversalLasso_Impl4_ListReversalSafe
   axiom inv0 : forall x : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global) . inv0 x = true
   use prelude.Borrow
   predicate resolve1 (self : borrowed usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed usize) : bool
     ensures { result = resolve1 self }
     
@@ -451,7 +451,7 @@ module ListReversalLasso_Impl4_ListReversalSafe
     ensures { [#"../list_reversal_lasso.rs" 29 14 29 44] result = index_logic0 self i }
     
   predicate resolve0 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) : bool
     ensures { result = resolve0 self }
     
@@ -635,7 +635,7 @@ module ListReversalLasso_Impl4_ListReversalList
   use prelude.Snapshot
   use prelude.Int
   predicate resolve1 (self : borrowed usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed usize) : bool
     ensures { result = resolve1 self }
     
@@ -655,7 +655,7 @@ module ListReversalLasso_Impl4_ListReversalList
      -> index_logic1 ( ^ self) j = index_logic1 ( * self) j }
     
   predicate resolve0 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) : bool
     ensures { result = resolve0 self }
     
@@ -863,7 +863,7 @@ module ListReversalLasso_Impl4_ListReversalLoop
   use prelude.Snapshot
   use prelude.Int
   predicate resolve1 (self : borrowed usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed usize) : bool
     ensures { result = resolve1 self }
     
@@ -886,7 +886,7 @@ module ListReversalLasso_Impl4_ListReversalLoop
   use seq_ext.SeqExt
   use seq.Seq
   predicate resolve0 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) : bool
     ensures { result = resolve0 self }
     
@@ -1119,7 +1119,7 @@ module ListReversalLasso_Impl4_ListReversalLasso
   use prelude.Snapshot
   use prelude.Int
   predicate resolve1 (self : borrowed usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed usize) : bool
     ensures { result = resolve1 self }
     
@@ -1139,7 +1139,7 @@ module ListReversalLasso_Impl4_ListReversalLasso
      -> index_logic2 ( ^ self) j = index_logic2 ( * self) j }
     
   predicate resolve0 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (ListReversalLasso_Memory_Type.t_memory)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/loop.mlcfg
+++ b/creusot/tests/should_succeed/loop.mlcfg
@@ -3,7 +3,7 @@ module Loop_F
   use prelude.Borrow
   use prelude.Int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/mapping_test.mlcfg
+++ b/creusot/tests/should_succeed/mapping_test.mlcfg
@@ -28,7 +28,7 @@ module MappingTest_Incr
   )
   use prelude.Borrow
   function shallow_model3 (self : borrowed (MappingTest_T_Type.t_t)) : Map.map int int =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model3 (self : borrowed (MappingTest_T_Type.t_t)) : Map.map int int
     ensures { result = shallow_model3 self }
     
@@ -36,7 +36,7 @@ module MappingTest_Incr
   use map.Map
   use prelude.Snapshot
   function shallow_model4 (self : borrowed (MappingTest_T_Type.t_t)) : Map.map int int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model4 (self : borrowed (MappingTest_T_Type.t_t)) : Map.map int int
     ensures { result = shallow_model4 self }
     
@@ -46,7 +46,7 @@ module MappingTest_Incr
     ensures { result = shallow_model1 self }
     
   predicate resolve0 (self : borrowed (MappingTest_T_Type.t_t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (MappingTest_T_Type.t_t)) : bool
     ensures { result = resolve0 self }
     
@@ -81,7 +81,7 @@ module MappingTest_F
   use prelude.Borrow
   use MappingTest_T_Type as MappingTest_T_Type
   predicate resolve0 (self : borrowed (MappingTest_T_Type.t_t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (MappingTest_T_Type.t_t)) : bool
     ensures { result = resolve0 self }
     
@@ -101,7 +101,7 @@ module MappingTest_F
     0
   )
   function shallow_model2 (self : borrowed (MappingTest_T_Type.t_t)) : Map.map int int =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model2 (self : borrowed (MappingTest_T_Type.t_t)) : Map.map int int
     ensures { result = shallow_model2 self }
     

--- a/creusot/tests/should_succeed/mutex.mlcfg
+++ b/creusot/tests/should_succeed/mutex.mlcfg
@@ -383,7 +383,7 @@ module Mutex_Concurrent
     ensures { [#"../mutex.rs" 133 5 133 36] inv7 result }
     
   predicate resolve0 (self : borrowed (Mutex_Mutex_Type.t_mutex uint32 (Mutex_Even_Type.t_even))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Mutex_Mutex_Type.t_mutex uint32 (Mutex_Even_Type.t_even))) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/one_side_update.mlcfg
+++ b/creusot/tests/should_succeed/one_side_update.mlcfg
@@ -10,7 +10,7 @@ module OneSideUpdate_F
   use prelude.Borrow
   use OneSideUpdate_MyInt_Type as OneSideUpdate_MyInt_Type
   predicate resolve0 (self : borrowed (OneSideUpdate_MyInt_Type.t_myint)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (OneSideUpdate_MyInt_Type.t_myint)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/option.mlcfg
+++ b/creusot/tests/should_succeed/option.mlcfg
@@ -116,7 +116,7 @@ module Option_TestOption
     ensures { inv1 result }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/ord_trait.mlcfg
+++ b/creusot/tests/should_succeed/ord_trait.mlcfg
@@ -157,12 +157,12 @@ module OrdTrait_X
     ensures { result = deep_model2 self }
     
   function deep_model1 (self : t) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model2 self
   val deep_model1 (self : t) : deep_model_ty0
     ensures { result = deep_model1 self }
     
   function deep_model0 (self : t) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : t) : deep_model_ty0
     ensures { result = deep_model0 self }
     
@@ -343,12 +343,12 @@ module OrdTrait_GtOrLe
     
   use prelude.Borrow
   function deep_model2 (self : t) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model0 self
   val deep_model2 (self : t) : deep_model_ty0
     ensures { result = deep_model2 self }
     
   function deep_model1 (self : t) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model2 self
   val deep_model1 (self : t) : deep_model_ty0
     ensures { result = deep_model1 self }
     

--- a/creusot/tests/should_succeed/projection_toggle.mlcfg
+++ b/creusot/tests/should_succeed/projection_toggle.mlcfg
@@ -21,7 +21,7 @@ module ProjectionToggle_ProjToggle
     
   axiom inv0 : forall x : borrowed t . inv0 x = true
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -106,7 +106,7 @@ module ProjectionToggle_F
     
   axiom inv0 : forall x : borrowed int32 . inv0 x = true
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/projections.mlcfg
+++ b/creusot/tests/should_succeed/projections.mlcfg
@@ -37,7 +37,7 @@ module Projections_CopyOutOfSum
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -101,12 +101,12 @@ module Projections_WriteIntoSum
   use prelude.UInt32
   use Core_Option_Option_Type as Core_Option_Option_Type
   predicate resolve1 (self : borrowed (Core_Option_Option_Type.t_option uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Option_Option_Type.t_option uint32)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/prophecy.mlcfg
+++ b/creusot/tests/should_succeed/prophecy.mlcfg
@@ -3,7 +3,7 @@ module Prophecy_F
   use prelude.Borrow
   use prelude.Int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -1599,7 +1599,7 @@ module RedBlackTree_Impl14_RotateRight
     ensures { result = internal_invariant0 self }
     
   predicate resolve6 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve6 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve6 self }
     
@@ -1609,7 +1609,7 @@ module RedBlackTree_Impl14_RotateRight
     
   use prelude.Snapshot
   predicate resolve4 (self : borrowed (RedBlackTree_Color_Type.t_color)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (RedBlackTree_Color_Type.t_color)) : bool
     ensures { result = resolve4 self }
     
@@ -1620,7 +1620,7 @@ module RedBlackTree_Impl14_RotateRight
     ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 12 22 12 30]  ^ y =  * x }
     
   predicate resolve3 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve3 self }
     
@@ -1631,7 +1631,7 @@ module RedBlackTree_Impl14_RotateRight
     ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 12 22 12 30]  ^ y =  * x }
     
   predicate resolve2 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve2 self }
     
@@ -1648,7 +1648,7 @@ module RedBlackTree_Impl14_RotateRight
     ensures { inv6 result }
     
   predicate resolve1 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve1 self }
     
@@ -2172,7 +2172,7 @@ module RedBlackTree_Impl14_RotateLeft
     ensures { result = internal_invariant0 self }
     
   predicate resolve6 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve6 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve6 self }
     
@@ -2182,7 +2182,7 @@ module RedBlackTree_Impl14_RotateLeft
     
   use prelude.Snapshot
   predicate resolve4 (self : borrowed (RedBlackTree_Color_Type.t_color)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (RedBlackTree_Color_Type.t_color)) : bool
     ensures { result = resolve4 self }
     
@@ -2193,7 +2193,7 @@ module RedBlackTree_Impl14_RotateLeft
     ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 12 22 12 30]  ^ y =  * x }
     
   predicate resolve3 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve3 self }
     
@@ -2204,7 +2204,7 @@ module RedBlackTree_Impl14_RotateLeft
     ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 12 22 12 30]  ^ y =  * x }
     
   predicate resolve2 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve2 self }
     
@@ -2221,7 +2221,7 @@ module RedBlackTree_Impl14_RotateLeft
     ensures { inv6 result }
     
   predicate resolve1 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve1 self }
     
@@ -2735,12 +2735,12 @@ module RedBlackTree_Impl14_FlipColors
     ensures { result = internal_invariant0 self }
     
   predicate resolve2 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (RedBlackTree_Color_Type.t_color)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Color_Type.t_color)) : bool
     ensures { result = resolve1 self }
     
@@ -2751,7 +2751,7 @@ module RedBlackTree_Impl14_FlipColors
     ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 12 22 12 30]  ^ y =  * x }
     
   predicate resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve0 self }
     
@@ -3246,7 +3246,7 @@ module RedBlackTree_Impl14_Balance
     ensures { [#"../red_black_tree.rs" 483 4 485 90] exists r2 : RedBlackTree_Node_Type.t_node k v . exists r1 : RedBlackTree_Node_Type.t_node k v . inv4 r2 /\ inv4 r1 /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)) = Core_Option_Option_Type.C_Some r1 /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( ^ self)) = Core_Option_Option_Type.C_Some r2 /\ RedBlackTree_Node_Type.node_left r1 = RedBlackTree_Node_Type.node_left r2 /\ RedBlackTree_Node_Type.node_right r1 = RedBlackTree_Node_Type.node_right r2 /\ RedBlackTree_Node_Type.node_key r1 = RedBlackTree_Node_Type.node_key r2 /\ RedBlackTree_Node_Type.node_color ( * self) = RedBlackTree_Node_Type.node_color r2 /\ RedBlackTree_Node_Type.node_color ( ^ self) = RedBlackTree_Node_Type.node_color r1 /\ RedBlackTree_Node_Type.node_key r1 = RedBlackTree_Node_Type.node_key r2 }
     
   predicate resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve1 self }
     
@@ -3869,7 +3869,7 @@ module RedBlackTree_Impl14_MoveRedLeft
     ensures { result = internal_invariant0 self }
     
   predicate resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve1 self }
     
@@ -3906,7 +3906,7 @@ module RedBlackTree_Impl14_MoveRedLeft
     ensures { [#"../red_black_tree.rs" 408 4 411 36] exists r : RedBlackTree_Node_Type.t_node k v . exists l : RedBlackTree_Node_Type.t_node k v . inv6 r /\ inv6 l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)) = Core_Option_Option_Type.C_Some l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( ^ self)) = Core_Option_Option_Type.C_Some r /\ (RedBlackTree_Node_Type.node_left ( ^ self), RedBlackTree_Node_Type.node_left r, RedBlackTree_Node_Type.node_right r) = (RedBlackTree_Node_Type.node_left l, RedBlackTree_Node_Type.node_right l, RedBlackTree_Node_Type.node_right ( * self)) /\ RedBlackTree_Node_Type.node_key r = RedBlackTree_Node_Type.node_key ( * self) }
     
   predicate resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve0 self }
     
@@ -4481,7 +4481,7 @@ module RedBlackTree_Impl14_MoveRedRight
     ensures { result = internal_invariant0 self }
     
   predicate resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve1 self }
     
@@ -4506,7 +4506,7 @@ module RedBlackTree_Impl14_MoveRedRight
     ensures { [#"../red_black_tree.rs" 408 4 411 36] exists r : RedBlackTree_Node_Type.t_node k v . exists l : RedBlackTree_Node_Type.t_node k v . inv6 r /\ inv6 l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)) = Core_Option_Option_Type.C_Some l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( ^ self)) = Core_Option_Option_Type.C_Some r /\ (RedBlackTree_Node_Type.node_left ( ^ self), RedBlackTree_Node_Type.node_left r, RedBlackTree_Node_Type.node_right r) = (RedBlackTree_Node_Type.node_left l, RedBlackTree_Node_Type.node_right l, RedBlackTree_Node_Type.node_right ( * self)) /\ RedBlackTree_Node_Type.node_key r = RedBlackTree_Node_Type.node_key ( * self) }
     
   predicate resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve0 self }
     
@@ -5384,17 +5384,17 @@ module RedBlackTree_Impl15_InsertRec
      -> match_n0 (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Red)) ( ^ self) }
     
   predicate resolve5 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve5 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve5 self }
     
   predicate resolve4 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve3 self }
     
@@ -5896,7 +5896,7 @@ module RedBlackTree_Impl15_Insert
   function shallow_model1 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model1 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model1 self }
     
@@ -6051,12 +6051,12 @@ module RedBlackTree_Impl15_Insert
    -> ([#"../red_black_tree.rs" 109 4 109 80] forall v : v . inv5 v
    -> has_mapping0 self k v = (Map.get (shallow_model0 self) k = Core_Option_Option_Type.C_Some v))
   predicate resolve1 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve0 self }
     
@@ -6686,7 +6686,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
     ensures { result = resolve6 self }
     
   predicate resolve4 (self : RedBlackTree_Node_Type.t_node k v) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve6 self
+    [#"../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve6 self
   val resolve4 (self : RedBlackTree_Node_Type.t_node k v) : bool
     ensures { result = resolve4 self }
     
@@ -6697,12 +6697,12 @@ module RedBlackTree_Impl15_DeleteMaxRec
     ensures { inv1 result }
     
   predicate resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve2 self }
     
@@ -6718,7 +6718,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
     ensures { inv0 result }
     
   predicate resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve1 self }
     
@@ -6739,7 +6739,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
     ensures { [#"../red_black_tree.rs" 387 14 387 45] result = (color0 self = RedBlackTree_Color_Type.C_Red) }
     
   predicate resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve0 self }
     
@@ -7275,7 +7275,7 @@ module RedBlackTree_Impl15_DeleteMax
   function shallow_model0 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model0 self }
     
@@ -7441,7 +7441,7 @@ module RedBlackTree_Impl15_DeleteMax
     ensures { inv12 result }
     
   predicate resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve3 self }
     
@@ -7490,12 +7490,12 @@ module RedBlackTree_Impl15_DeleteMax
     
   use prelude.Snapshot
   predicate resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve1 self }
     
@@ -8181,7 +8181,7 @@ module RedBlackTree_Impl15_DeleteMinRec
     ensures { result = resolve6 self }
     
   predicate resolve4 (self : RedBlackTree_Node_Type.t_node k v) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve6 self
+    [#"../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve6 self
   val resolve4 (self : RedBlackTree_Node_Type.t_node k v) : bool
     ensures { result = resolve4 self }
     
@@ -8192,12 +8192,12 @@ module RedBlackTree_Impl15_DeleteMinRec
     ensures { inv1 result }
     
   predicate resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve2 self }
     
@@ -8213,12 +8213,12 @@ module RedBlackTree_Impl15_DeleteMinRec
     ensures { inv0 result }
     
   predicate resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve0 self }
     
@@ -8716,7 +8716,7 @@ module RedBlackTree_Impl15_DeleteMin
   function shallow_model0 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model0 self }
     
@@ -8826,7 +8826,7 @@ module RedBlackTree_Impl15_DeleteMin
     ensures { inv11 result }
     
   predicate resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve3 self }
     
@@ -8866,12 +8866,12 @@ module RedBlackTree_Impl15_DeleteMin
     ensures { [#"../red_black_tree.rs" 696 36 696 42] inv10 result }
     
   predicate resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve1 self }
     
@@ -9446,7 +9446,7 @@ module RedBlackTree_Impl15_DeleteRec
     ensures { result = has_mapping0 self k v }
     
   function deep_model0 (self : k) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : k) : deep_model_ty0
     ensures { result = deep_model0 self }
     
@@ -9627,7 +9627,7 @@ module RedBlackTree_Impl15_DeleteRec
     ensures { result = resolve10 self }
     
   predicate resolve9 (self : RedBlackTree_Node_Type.t_node k v) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 34 8 34 31] resolve10 self
+    [#"../../../../creusot-contracts/src/resolve.rs" 35 8 35 31] resolve10 self
   val resolve9 (self : RedBlackTree_Node_Type.t_node k v) : bool
     ensures { result = resolve9 self }
     
@@ -9638,7 +9638,7 @@ module RedBlackTree_Impl15_DeleteRec
     ensures { inv1 result }
     
   predicate resolve8 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve8 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve8 self }
     
@@ -9654,7 +9654,7 @@ module RedBlackTree_Impl15_DeleteRec
     ensures { inv0 result }
     
   predicate resolve7 (self : borrowed v) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve7 (self : borrowed v) : bool
     ensures { result = resolve7 self }
     
@@ -9665,7 +9665,7 @@ module RedBlackTree_Impl15_DeleteRec
     ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 12 22 12 30]  ^ y =  * x }
     
   predicate resolve6 (self : borrowed k) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve6 (self : borrowed k) : bool
     ensures { result = resolve6 self }
     
@@ -9820,12 +9820,12 @@ module RedBlackTree_Impl15_DeleteRec
     ensures { [#"../red_black_tree.rs" 571 36 571 45] inv6 result }
     
   predicate resolve4 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve3 self }
     
@@ -9890,7 +9890,7 @@ module RedBlackTree_Impl15_DeleteRec
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve0 self }
     
@@ -10708,12 +10708,12 @@ module RedBlackTree_Impl15_Delete
   function shallow_model0 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model0 self }
     
   function deep_model1 (self : k) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model0 self
   val deep_model1 (self : k) : deep_model_ty0
     ensures { result = deep_model1 self }
     
@@ -10823,7 +10823,7 @@ module RedBlackTree_Impl15_Delete
     ensures { inv11 result }
     
   predicate resolve4 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve4 self }
     
@@ -10868,12 +10868,12 @@ module RedBlackTree_Impl15_Delete
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve1 self }
     
@@ -11330,7 +11330,7 @@ module RedBlackTree_Impl15_Get
   function shallow_model0 (self : RedBlackTree_Tree_Type.t_tree k v) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model0 (self : RedBlackTree_Tree_Type.t_tree k v) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model0 self }
     
@@ -11448,7 +11448,7 @@ module RedBlackTree_Impl15_Get
     ensures { result = resolve2 self }
     
   function deep_model0 (self : k) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : k) : deep_model_ty0
     ensures { result = deep_model0 self }
     
@@ -11919,7 +11919,7 @@ module RedBlackTree_Impl15_GetMut
   function shallow_model0 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Map.map deep_model_ty0 (Core_Option_Option_Type.t_option v)
     ensures { result = shallow_model0 self }
     
@@ -12015,22 +12015,22 @@ module RedBlackTree_Impl15_GetMut
     ensures { result = invariant0 self }
     
   predicate resolve6 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve6 (self : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))) : bool
     ensures { result = resolve6 self }
     
   predicate resolve5 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve5 (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : bool
     ensures { result = resolve5 self }
     
   predicate resolve4 (self : borrowed v) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed v) : bool
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : bool
     ensures { result = resolve3 self }
     
@@ -12056,7 +12056,7 @@ module RedBlackTree_Impl15_GetMut
     
   use prelude.Snapshot
   function deep_model0 (self : k) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : k) : deep_model_ty0
     ensures { result = deep_model0 self }
     

--- a/creusot/tests/should_succeed/resolve_uninit.mlcfg
+++ b/creusot/tests/should_succeed/resolve_uninit.mlcfg
@@ -89,7 +89,7 @@ module ResolveUninit_InitJoin
   use prelude.Borrow
   use prelude.Int32
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/result/own.mlcfg
+++ b/creusot/tests/should_succeed/result/own.mlcfg
@@ -578,17 +578,17 @@ module Own_Impl0_AsMut
     
   axiom inv0 : forall x : t . inv0 x = true
   predicate resolve2 (self : borrowed (Own_OwnResult_Type.t_ownresult t e)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Own_OwnResult_Type.t_ownresult t e)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed e) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed e) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed t) : bool
     ensures { result = resolve0 self }
     
@@ -1845,7 +1845,7 @@ module Own_Impl2_Copied
     
   axiom inv0 : forall x : Own_OwnResult_Type.t_ownresult (borrowed t) e . inv0 x = true
   predicate resolve1 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed t) : bool
     ensures { result = resolve1 self }
     
@@ -1991,7 +1991,7 @@ module Own_Impl2_Cloned
     
   axiom inv0 : forall x : Own_OwnResult_Type.t_ownresult (borrowed t) e . inv0 x = true
   predicate resolve1 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed t) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/result/result.mlcfg
+++ b/creusot/tests/should_succeed/result/result.mlcfg
@@ -189,7 +189,7 @@ module Result_TestResult
     ensures { inv13 result }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_max.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max.mlcfg
@@ -3,7 +3,7 @@ module IncMax_TakeMax
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -65,7 +65,7 @@ module IncMax_IncMax
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_max_3.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_3.mlcfg
@@ -3,12 +3,12 @@ module IncMax3_IncMax3
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve1 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (borrowed uint32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (borrowed uint32)) : bool
     ensures { result = resolve0 self }
     
@@ -158,7 +158,7 @@ module IncMax3_TestIncMax3
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_max_many.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_many.mlcfg
@@ -3,7 +3,7 @@ module IncMaxMany_TakeMax
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -65,7 +65,7 @@ module IncMaxMany_IncMaxMany
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
@@ -3,7 +3,7 @@ module IncMaxRepeat_TakeMax
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -181,7 +181,7 @@ module IncMaxRepeat_IncMaxRepeat
   axiom inv0 : forall x : Core_Ops_Range_Range_Type.t_range uint32 . inv0 x = true
   use prelude.Snapshot
   predicate resolve1 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed uint32) : bool
     ensures { result = resolve1 self }
     
@@ -194,7 +194,7 @@ module IncMaxRepeat_IncMaxRepeat
     
   use seq.Seq
   predicate resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range uint32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range uint32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
@@ -104,7 +104,7 @@ module IncSome2List_Impl0_TakeSomeRest
   use prelude.Borrow
   use prelude.UInt32
   function shallow_model1 (self : borrowed uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] UInt32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] UInt32.to_int ( * self)
   val shallow_model1 (self : borrowed uint32) : int
     ensures { result = shallow_model1 self }
     
@@ -120,17 +120,17 @@ module IncSome2List_Impl0_TakeSomeRest
     
   use prelude.Snapshot
   predicate resolve2 (self : borrowed (IncSome2List_List_Type.t_list)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (IncSome2List_List_Type.t_list)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (IncSome2List_List_Type.t_list)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (IncSome2List_List_Type.t_list)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -248,24 +248,24 @@ module IncSome2List_IncSome2List
     
   use prelude.Borrow
   predicate resolve2 (self : borrowed (IncSome2List_List_Type.t_list)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (IncSome2List_List_Type.t_list)) : bool
     ensures { result = resolve2 self }
     
   use prelude.UInt32
   predicate resolve1 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (borrowed uint32, borrowed (IncSome2List_List_Type.t_list))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (borrowed uint32, borrowed (IncSome2List_List_Type.t_list))) : bool
     ensures { result = resolve0 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] UInt32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] UInt32.to_int ( * self)
   val shallow_model1 (self : borrowed uint32) : int
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
@@ -131,7 +131,7 @@ module IncSome2Tree_Impl0_TakeSomeRest
   use prelude.Borrow
   use prelude.UInt32
   function shallow_model1 (self : borrowed uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] UInt32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] UInt32.to_int ( * self)
   val shallow_model1 (self : borrowed uint32) : int
     ensures { result = shallow_model1 self }
     
@@ -146,17 +146,17 @@ module IncSome2Tree_Impl0_TakeSomeRest
     ensures { result = sum0 self }
     
   predicate resolve2 (self : borrowed (IncSome2Tree_Tree_Type.t_tree)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (IncSome2Tree_Tree_Type.t_tree)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (IncSome2Tree_Tree_Type.t_tree)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (IncSome2Tree_Tree_Type.t_tree)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -329,24 +329,24 @@ module IncSome2Tree_IncSome2Tree
     
   use prelude.Borrow
   predicate resolve2 (self : borrowed (IncSome2Tree_Tree_Type.t_tree)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (IncSome2Tree_Tree_Type.t_tree)) : bool
     ensures { result = resolve2 self }
     
   use prelude.UInt32
   predicate resolve1 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (borrowed uint32, borrowed (IncSome2Tree_Tree_Type.t_tree))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (borrowed uint32, borrowed (IncSome2Tree_Tree_Type.t_tree))) : bool
     ensures { result = resolve0 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] UInt32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] UInt32.to_int ( * self)
   val shallow_model1 (self : borrowed uint32) : int
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
@@ -104,7 +104,7 @@ module IncSomeList_Impl0_TakeSome
   use prelude.Borrow
   use prelude.UInt32
   function shallow_model1 (self : borrowed uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] UInt32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] UInt32.to_int ( * self)
   val shallow_model1 (self : borrowed uint32) : int
     ensures { result = shallow_model1 self }
     
@@ -120,17 +120,17 @@ module IncSomeList_Impl0_TakeSome
     
   use prelude.Snapshot
   predicate resolve2 (self : borrowed (IncSomeList_List_Type.t_list)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (IncSomeList_List_Type.t_list)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (IncSomeList_List_Type.t_list)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (IncSomeList_List_Type.t_list)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -266,13 +266,13 @@ module IncSomeList_IncSomeList
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] UInt32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] UInt32.to_int ( * self)
   val shallow_model1 (self : borrowed uint32) : int
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
@@ -131,7 +131,7 @@ module IncSomeTree_Impl0_TakeSome
   use prelude.Borrow
   use prelude.UInt32
   function shallow_model1 (self : borrowed uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] UInt32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] UInt32.to_int ( * self)
   val shallow_model1 (self : borrowed uint32) : int
     ensures { result = shallow_model1 self }
     
@@ -146,17 +146,17 @@ module IncSomeTree_Impl0_TakeSome
     ensures { result = sum0 self }
     
   predicate resolve2 (self : borrowed (IncSomeTree_Tree_Type.t_tree)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (IncSomeTree_Tree_Type.t_tree)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (IncSomeTree_Tree_Type.t_tree)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (IncSomeTree_Tree_Type.t_tree)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
@@ -327,13 +327,13 @@ module IncSomeTree_IncSomeTree
   use prelude.Borrow
   use prelude.UInt32
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] UInt32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] UInt32.to_int ( * self)
   val shallow_model1 (self : borrowed uint32) : int
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -433,12 +433,12 @@ module SelectionSortGeneric_SelectionSort
    -> ([#"../../../../creusot-contracts/src/std/vec.rs" 33 4 33 44] inv11 (deep_model1 self)) && ([#"../../../../creusot-contracts/src/std/vec.rs" 31 4 32 53] forall i : int . 0 <= i /\ i < Seq.length (shallow_model3 self)
    -> Seq.get (deep_model1 self) i = deep_model4 (index_logic2 self i)) && ([#"../../../../creusot-contracts/src/std/vec.rs" 30 14 30 56] Seq.length (shallow_model3 self) = Seq.length (deep_model1 self))
   predicate resolve4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed (slice t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (slice t)) : bool
     ensures { result = resolve3 self }
     
@@ -452,7 +452,7 @@ module SelectionSortGeneric_SelectionSort
   axiom shallow_model7_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 19 21 19 25] inv4 self)
    -> ([#"../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv12 (shallow_model7 self)) && ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model7 self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model7 self) <= UIntSize.to_int max0)
   function shallow_model6 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model7 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model7 ( * self)
   val shallow_model6 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model6 self }
     
@@ -464,7 +464,7 @@ module SelectionSortGeneric_SelectionSort
     
   function shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -475,7 +475,7 @@ module SelectionSortGeneric_SelectionSort
     ensures { inv5 result }
     
   function deep_model3 (self : t) : deep_model_ty0 =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model4 self
   val deep_model3 (self : t) : deep_model_ty0
     ensures { result = deep_model3 self }
     
@@ -499,7 +499,7 @@ module SelectionSortGeneric_SelectionSort
     ensures { result = in_bounds0 self seq }
     
   function shallow_model4 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model4 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model4 self }
     
@@ -512,7 +512,7 @@ module SelectionSortGeneric_SelectionSort
     
   use seq.Seq
   predicate resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve1 self }
     
@@ -539,7 +539,7 @@ module SelectionSortGeneric_SelectionSort
   function deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 92 8 92 28] deep_model1 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 88 8 88 28] deep_model1 ( * self)
   val deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     ensures { result = deep_model0 self }
     
@@ -551,7 +551,7 @@ module SelectionSortGeneric_SelectionSort
     
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model5 self }
     

--- a/creusot/tests/should_succeed/slices/01.mlcfg
+++ b/creusot/tests/should_succeed/slices/01.mlcfg
@@ -39,7 +39,7 @@ module C01_IndexSlice
    -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv1 (shallow_model1 self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model1 self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model1 self) <= UIntSize.to_int max0)
   use prelude.Borrow
   function shallow_model0 (self : slice uint32) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model0 (self : slice uint32) : Seq.seq uint32
     ensures { result = shallow_model0 self }
     
@@ -115,12 +115,12 @@ module C01_IndexMutSlice
     
   use prelude.Borrow
   function shallow_model0 (self : borrowed (slice uint32)) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model0 (self : borrowed (slice uint32)) : Seq.seq uint32
     ensures { result = shallow_model0 self }
     
   predicate resolve0 (self : borrowed (slice uint32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (slice uint32)) : bool
     ensures { result = resolve0 self }
     
@@ -224,7 +224,7 @@ module C01_SliceFirst
    -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv4 (shallow_model2 self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model2 self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model2 self) <= UIntSize.to_int max0)
   use prelude.Borrow
   function shallow_model0 (self : slice t) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model0 (self : slice t) : Seq.seq t
     ensures { result = shallow_model0 self }
     

--- a/creusot/tests/should_succeed/slices/02_std.mlcfg
+++ b/creusot/tests/should_succeed/slices/02_std.mlcfg
@@ -111,7 +111,7 @@ module C02Std_BinarySearch
     
   use prelude.Borrow
   function shallow_model1 (self : slice uint32) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model1 (self : slice uint32) : Seq.seq uint32
     ensures { result = shallow_model1 self }
     
@@ -128,7 +128,7 @@ module C02Std_BinarySearch
     ensures { result = deep_model3 self }
     
   function deep_model2 (self : uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model3 self
   val deep_model2 (self : uint32) : int
     ensures { result = deep_model2 self }
     
@@ -155,7 +155,7 @@ module C02Std_BinarySearch
     ensures { result = sorted0 self }
     
   function deep_model0 (self : slice uint32) : Seq.seq int =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : slice uint32) : Seq.seq int
     ensures { result = deep_model0 self }
     

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -268,7 +268,7 @@ module SparseArray_Impl2_Get
   axiom inv0 : forall x : SparseArray_Sparse_Type.t_sparse t . inv0 x = inv7 x
   use seq.Seq
   function shallow_model1 (self : SparseArray_Sparse_Type.t_sparse t) : Seq.seq (Core_Option_Option_Type.t_option t) =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model1 (self : SparseArray_Sparse_Type.t_sparse t) : Seq.seq (Core_Option_Option_Type.t_option t)
     ensures { result = shallow_model1 self }
     
@@ -288,7 +288,7 @@ module SparseArray_Impl2_Get
     ensures { result = in_bounds1 self seq }
     
   function shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model3 self }
     
@@ -314,7 +314,7 @@ module SparseArray_Impl2_Get
     ensures { result = in_bounds0 self seq }
     
   function shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model5 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model5 self
   val shallow_model2 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize
     ensures { result = shallow_model2 self }
     
@@ -744,18 +744,18 @@ module SparseArray_Impl2_Set
   function shallow_model1 (self : borrowed (SparseArray_Sparse_Type.t_sparse t)) : Seq.seq (Core_Option_Option_Type.t_option t)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model1 (self : borrowed (SparseArray_Sparse_Type.t_sparse t)) : Seq.seq (Core_Option_Option_Type.t_option t)
     ensures { result = shallow_model1 self }
     
   use prelude.Snapshot
   predicate resolve4 (self : borrowed (SparseArray_Sparse_Type.t_sparse t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve4 (self : borrowed (SparseArray_Sparse_Type.t_sparse t)) : bool
     ensures { result = resolve4 self }
     
   predicate resolve3 (self : borrowed usize) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed usize) : bool
     ensures { result = resolve3 self }
     
@@ -779,7 +779,7 @@ module SparseArray_Impl2_Set
   function shallow_model6 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model7 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model7 ( * self)
   val shallow_model6 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     ensures { result = shallow_model6 self }
     
@@ -812,7 +812,7 @@ module SparseArray_Impl2_Set
    -> ([#"../sparse_array.rs" 102 15 102 39] 0 <= i /\ i < UIntSize.to_int (SparseArray_Sparse_Type.sparse_size self))
    -> ([#"../sparse_array.rs" 104 25 104 29] inv8 self)  -> ([#"../sparse_array.rs" 103 14 103 28] is_elt0 self i)
   function shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model7 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model7 self
   val shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize
     ensures { result = shallow_model5 self }
     
@@ -824,7 +824,7 @@ module SparseArray_Impl2_Set
     ensures { inv7 result }
     
   predicate resolve1 (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed t) : bool
     ensures { result = resolve1 self }
     
@@ -850,7 +850,7 @@ module SparseArray_Impl2_Set
     
   function shallow_model3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model4 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model4 ( * self)
   val shallow_model3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model3 self }
     
@@ -1357,7 +1357,7 @@ module SparseArray_F
   use prelude.Int32
   use prelude.Int
   function shallow_model0 (self : int32) : int =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] Int32.to_int self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] Int32.to_int self
   val shallow_model0 (self : int32) : int
     ensures { result = shallow_model0 self }
     
@@ -1365,7 +1365,7 @@ module SparseArray_F
   function shallow_model4 (self : borrowed (SparseArray_Sparse_Type.t_sparse int32)) : Seq.seq (Core_Option_Option_Type.t_option int32)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model4 (self : borrowed (SparseArray_Sparse_Type.t_sparse int32)) : Seq.seq (Core_Option_Option_Type.t_option int32)
     ensures { result = shallow_model4 self }
     
@@ -1381,7 +1381,7 @@ module SparseArray_F
   function shallow_model3 (self : SparseArray_Sparse_Type.t_sparse int32) : Seq.seq (Core_Option_Option_Type.t_option int32)
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model3 (self : SparseArray_Sparse_Type.t_sparse int32) : Seq.seq (Core_Option_Option_Type.t_option int32)
     ensures { result = shallow_model3 self }
     

--- a/creusot/tests/should_succeed/split_borrow.mlcfg
+++ b/creusot/tests/should_succeed/split_borrow.mlcfg
@@ -23,17 +23,17 @@ module SplitBorrow_F
   use prelude.Borrow
   use SplitBorrow_MyInt_Type as SplitBorrow_MyInt_Type
   predicate resolve2 (self : SplitBorrow_MyInt_Type.t_myint) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : SplitBorrow_MyInt_Type.t_myint) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : (SplitBorrow_MyInt_Type.t_myint, SplitBorrow_MyInt_Type.t_myint)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve2 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve2 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve1 (self : (SplitBorrow_MyInt_Type.t_myint, SplitBorrow_MyInt_Type.t_myint)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (SplitBorrow_MyInt_Type.t_myint, SplitBorrow_MyInt_Type.t_myint)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (SplitBorrow_MyInt_Type.t_myint, SplitBorrow_MyInt_Type.t_myint)) : bool
     ensures { result = resolve0 self }
     
@@ -97,22 +97,22 @@ module SplitBorrow_G
   use prelude.Borrow
   use SplitBorrow_MyInt_Type as SplitBorrow_MyInt_Type
   predicate resolve3 (self : SplitBorrow_MyInt_Type.t_myint) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : SplitBorrow_MyInt_Type.t_myint) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : (SplitBorrow_MyInt_Type.t_myint, SplitBorrow_MyInt_Type.t_myint)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve2 (self : (SplitBorrow_MyInt_Type.t_myint, SplitBorrow_MyInt_Type.t_myint)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (SplitBorrow_MyInt_Type.t_myint, SplitBorrow_MyInt_Type.t_myint)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (SplitBorrow_MyInt_Type.t_myint, SplitBorrow_MyInt_Type.t_myint)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed (SplitBorrow_MyInt_Type.t_myint)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (SplitBorrow_MyInt_Type.t_myint)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/sum.mlcfg
+++ b/creusot/tests/should_succeed/sum.mlcfg
@@ -161,7 +161,7 @@ module Sum_SumFirstN
   use prelude.Snapshot
   use seq.Seq
   predicate resolve0 (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/sum_of_odds.mlcfg
+++ b/creusot/tests/should_succeed/sum_of_odds.mlcfg
@@ -180,7 +180,7 @@ module SumOfOdds_ComputeSumOfOdd
    -> ([#"../sum_of_odds.rs" 28 10 28 33] sum_of_odd0 x = sqr0 x)
   use seq.Seq
   predicate resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range uint32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/swap_borrows.mlcfg
+++ b/creusot/tests/should_succeed/swap_borrows.mlcfg
@@ -15,7 +15,7 @@ module SwapBorrows_Swap
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (t, t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (t, t)) : bool
     ensures { result = resolve0 self }
     
@@ -66,12 +66,12 @@ module SwapBorrows_F
     
   axiom inv0 : forall x : (borrowed uint32, borrowed uint32) . inv0 x = true
   predicate resolve1 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve2 (self : (borrowed uint32, borrowed uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve2 (self : (borrowed uint32, borrowed uint32)) : bool
     ensures { result = resolve2 self }
     
@@ -81,12 +81,12 @@ module SwapBorrows_F
     ensures { [#"../swap_borrows.rs" 5 25 5 31] inv0 result }
     
   predicate resolve3 (self : uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : uint32) : bool
     ensures { result = resolve3 self }
     
   predicate resolve0 (self : (uint32, uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve0 (self : (uint32, uint32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/switch.mlcfg
+++ b/creusot/tests/should_succeed/switch.mlcfg
@@ -54,18 +54,18 @@ module Switch_Test2
   use prelude.UInt32
   use prelude.Int
   predicate resolve2 (self : uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : uint32) : bool
     ensures { result = resolve2 self }
     
   use Switch_Option_Type as Switch_Option_Type
   predicate resolve1 (self : Switch_Option_Type.t_option uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : Switch_Option_Type.t_option uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (Switch_Option_Type.t_option uint32, uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (Switch_Option_Type.t_option uint32, uint32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/syntax/04_assoc_prec.mlcfg
+++ b/creusot/tests/should_succeed/syntax/04_assoc_prec.mlcfg
@@ -3,12 +3,12 @@ module C04AssocPrec_RespectPrec
   use prelude.UInt32
   use prelude.Int
   predicate resolve1 (self : uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint32) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (uint32, uint32)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve1 (let (_, a) = self in a)
   val resolve0 (self : (uint32, uint32)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -39,7 +39,7 @@ module C05Pearlite_HasLen3_Impl
   axiom shallow_model1_spec : forall self : slice uint32 . ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 21 19 25] inv0 self)
    -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv1 (shallow_model1 self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model1 self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model1 self) <= UIntSize.to_int max0)
   function shallow_model0 (self : slice uint32) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model0 (self : slice uint32) : Seq.seq uint32
     ensures { result = shallow_model0 self }
     

--- a/creusot/tests/should_succeed/syntax/09_maintains.mlcfg
+++ b/creusot/tests/should_succeed/syntax/09_maintains.mlcfg
@@ -39,7 +39,7 @@ module C09Maintains_Test2
     
   use prelude.Borrow
   predicate resolve0 (self : borrowed (C09Maintains_A_Type.t_a)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C09Maintains_A_Type.t_a)) : bool
     ensures { result = resolve0 self }
     
@@ -71,12 +71,12 @@ module C09Maintains_Test3
     
   use prelude.Borrow
   predicate resolve1 (self : borrowed (C09Maintains_A_Type.t_a)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (C09Maintains_A_Type.t_a)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed bool) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed bool) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
+++ b/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
@@ -110,7 +110,7 @@ module C12GhostCode_GhostVec
   use prelude.Snapshot
   use prelude.Snapshot
   predicate resolve1 (self : uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : uint32) : bool
     ensures { result = resolve1 self }
     
@@ -199,7 +199,7 @@ module C12GhostCode_GhostIsCopy
   use prelude.Snapshot
   use prelude.Snapshot
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -303,7 +303,7 @@ module C12GhostCode_GhostCheck
   axiom inv0 : forall x : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global) . inv0 x = true
   use prelude.Snapshot
   predicate resolve1 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : int32) : bool
     ensures { result = resolve1 self }
     
@@ -322,7 +322,7 @@ module C12GhostCode_GhostCheck
     ensures { result = resolve0 self }
     
   function shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq int32
     ensures { result = shallow_model3 self }
     
@@ -334,7 +334,7 @@ module C12GhostCode_GhostCheck
   function shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq int32
     ensures { result = shallow_model1 self }
     
@@ -430,7 +430,7 @@ module C12GhostCode_TakesStruct
   use prelude.Int
   use prelude.UInt32
   function shallow_model1 (self : uint32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] UInt32.to_int self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] UInt32.to_int self
   val shallow_model1 (self : uint32) : int
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
+++ b/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
@@ -167,7 +167,7 @@ module C13VecMacro_X
     ensures { inv3 result }
     
   predicate resolve3 (self : int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : int32) : bool
     ensures { result = resolve3 self }
     
@@ -193,7 +193,7 @@ module C13VecMacro_X
     ensures { inv3 result }
     
   predicate resolve2 (self : uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : uint32) : bool
     ensures { result = resolve2 self }
     
@@ -226,7 +226,7 @@ module C13VecMacro_X
     goto BB0
   }
   BB0 {
-    [#"../13_vec_macro.rs" 6 23 6 29] v0 <- ([#"../13_vec_macro.rs" 6 23 6 29] new0 ([#"../../../../../creusot-contracts/src/lib.rs" 290 8 290 30] ()));
+    [#"../13_vec_macro.rs" 6 23 6 29] v0 <- ([#"../13_vec_macro.rs" 6 23 6 29] new0 ([#"../../../../../creusot-contracts/src/lib.rs" 199 8 199 30] ()));
     goto BB1
   }
   BB1 {
@@ -244,7 +244,7 @@ module C13VecMacro_X
     goto BB4
   }
   BB4 {
-    [#"../../../../../creusot-contracts/src/lib.rs" 296 47 296 56] _10 <- (let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../13_vec_macro.rs" 12 18 12 19] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../13_vec_macro.rs" 12 21 12 22] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../13_vec_macro.rs" 12 24 12 25] (3 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp);
+    [#"../../../../../creusot-contracts/src/lib.rs" 205 47 205 56] _10 <- (let __arr_temp = any array int32 in assume {Seq.get (__arr_temp.elts) 0 = ([#"../13_vec_macro.rs" 12 18 12 19] (1 : int32))}; assume {Seq.get (__arr_temp.elts) 1 = ([#"../13_vec_macro.rs" 12 21 12 22] (2 : int32))}; assume {Seq.get (__arr_temp.elts) 2 = ([#"../13_vec_macro.rs" 12 24 12 25] (3 : int32))}; assume {Slice.length __arr_temp = 3}; __arr_temp);
     goto BB5
   }
   BB5 {

--- a/creusot/tests/should_succeed/syntax/derive_macros.mlcfg
+++ b/creusot/tests/should_succeed/syntax/derive_macros.mlcfg
@@ -190,12 +190,12 @@ module DeriveMacros_Impl3_Eq
   function deep_model0 (self : DeriveMacros_Product_Type.t_product a b) : DeriveMacros_Product_Type.t_product deep_model_ty0 deep_model_ty1
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model3 self
   val deep_model0 (self : DeriveMacros_Product_Type.t_product a b) : DeriveMacros_Product_Type.t_product deep_model_ty0 deep_model_ty1
     ensures { result = deep_model0 self }
     
   function deep_model2 (self : b) : deep_model_ty1 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model5 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model5 self
   val deep_model2 (self : b) : deep_model_ty1
     ensures { result = deep_model2 self }
     
@@ -213,7 +213,7 @@ module DeriveMacros_Impl3_Eq
     ensures { result = resolve1 self }
     
   function deep_model1 (self : a) : deep_model_ty0 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model4 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model4 self
   val deep_model1 (self : a) : deep_model_ty0
     ensures { result = deep_model1 self }
     
@@ -545,12 +545,12 @@ module DeriveMacros_Impl5_Eq
   function deep_model0 (self : DeriveMacros_Sum_Type.t_sum a b) : DeriveMacros_Sum_Type.t_sum deep_model_ty0 deep_model_ty1
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model3 self
   val deep_model0 (self : DeriveMacros_Sum_Type.t_sum a b) : DeriveMacros_Sum_Type.t_sum deep_model_ty0 deep_model_ty1
     ensures { result = deep_model0 self }
     
   function deep_model2 (self : b) : deep_model_ty1 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model5 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model5 self
   val deep_model2 (self : b) : deep_model_ty1
     ensures { result = deep_model2 self }
     
@@ -564,7 +564,7 @@ module DeriveMacros_Impl5_Eq
     ensures { result = resolve3 self }
     
   function deep_model1 (self : a) : deep_model_ty0 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model4 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model4 self
   val deep_model1 (self : a) : deep_model_ty0
     ensures { result = deep_model1 self }
     
@@ -582,7 +582,7 @@ module DeriveMacros_Impl5_Eq
     ensures { result = resolve0 self }
     
   predicate resolve1 (self : (DeriveMacros_Sum_Type.t_sum a b, DeriveMacros_Sum_Type.t_sum a b)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve0 (let (a, _) = self in a) /\ resolve0 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve0 (let (a, _) = self in a) /\ resolve0 (let (_, a) = self in a)
   val resolve1 (self : (DeriveMacros_Sum_Type.t_sum a b, DeriveMacros_Sum_Type.t_sum a b)) : bool
     ensures { result = resolve1 self }
     
@@ -910,7 +910,7 @@ module DeriveMacros_Impl3
   function deep_model0 (self : DeriveMacros_Product_Type.t_product a b) : DeriveMacros_Product_Type.t_product deep_model_ty0 deep_model_ty1
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : DeriveMacros_Product_Type.t_product a b) : DeriveMacros_Product_Type.t_product deep_model_ty0 deep_model_ty1
     ensures { result = deep_model0 self }
     
@@ -955,7 +955,7 @@ module DeriveMacros_Impl5
   function deep_model0 (self : DeriveMacros_Sum_Type.t_sum a b) : DeriveMacros_Sum_Type.t_sum deep_model_ty0 deep_model_ty1
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : DeriveMacros_Sum_Type.t_sum a b) : DeriveMacros_Sum_Type.t_sum deep_model_ty0 deep_model_ty1
     ensures { result = deep_model0 self }
     

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -116,17 +116,17 @@ module TakeFirstMut_TakeFirstMut
     ensures { result = index_logic0 self ix }
     
   predicate resolve3 (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed t) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed (slice t)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (slice t)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (borrowed (slice t))) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (borrowed (slice t))) : bool
     ensures { result = resolve1 self }
     
@@ -135,7 +135,7 @@ module TakeFirstMut_TakeFirstMut
     ensures { result = resolve0 self }
     
   function shallow_model1 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model1 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/trait_impl.mlcfg
+++ b/creusot/tests/should_succeed/trait_impl.mlcfg
@@ -21,7 +21,7 @@ module TraitImpl_Impl0_X
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : (t1, t2)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve1 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (t1, t2)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
@@ -70,12 +70,12 @@ module C16ImplCloning_Test
     ensures { result = shallow_model1 self }
     
   function shallow_model0 (self : borrowed (C16ImplCloning_Vec_Type.t_vec t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (C16ImplCloning_Vec_Type.t_vec t)) : Seq.seq t
     ensures { result = shallow_model0 self }
     
   predicate resolve0 (self : borrowed (C16ImplCloning_Vec_Type.t_vec t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (C16ImplCloning_Vec_Type.t_vec t)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/type_invariants/borrows.mlcfg
+++ b/creusot/tests/should_succeed/type_invariants/borrows.mlcfg
@@ -73,12 +73,12 @@ module Borrows_Impl1_InnerMut
   use prelude.Int32
   use prelude.Int
   predicate resolve1 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -119,12 +119,12 @@ module Borrows_Inc
   use prelude.Int
   use prelude.Borrow
   function shallow_model0 (self : borrowed int32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] Int32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] Int32.to_int ( * self)
   val shallow_model0 (self : borrowed int32) : int
     ensures { result = shallow_model0 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -177,18 +177,18 @@ module Borrows_Simple
   let constant max0  : int32 = [@vc:do_not_keep_trace] [@vc:sp]
     (2147483647 : int32)
   predicate resolve1 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed int32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] Int32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] Int32.to_int ( * self)
   val shallow_model1 (self : borrowed int32) : int
     ensures { result = shallow_model1 self }
     
@@ -259,18 +259,18 @@ module Borrows_Hard
   let constant max0  : int32 = [@vc:do_not_keep_trace] [@vc:sp]
     (2147483647 : int32)
   predicate resolve1 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed int32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] Int32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] Int32.to_int ( * self)
   val shallow_model1 (self : borrowed int32) : int
     ensures { result = shallow_model1 self }
     
@@ -363,28 +363,28 @@ module Borrows_Tuple
   let constant max0  : int32 = [@vc:do_not_keep_trace] [@vc:sp]
     (2147483647 : int32)
   predicate resolve3 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : Borrows_NonZero_Type.t_nonzero) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : Borrows_NonZero_Type.t_nonzero) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve1 (self : (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed int32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] Int32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] Int32.to_int ( * self)
   val shallow_model1 (self : borrowed int32) : int
     ensures { result = shallow_model1 self }
     
@@ -466,28 +466,28 @@ module Borrows_PartialMove
   let constant max0  : int32 = [@vc:do_not_keep_trace] [@vc:sp]
     (2147483647 : int32)
   predicate resolve3 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : Borrows_NonZero_Type.t_nonzero) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve2 (self : Borrows_NonZero_Type.t_nonzero) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve2 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve1 (self : (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed int32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] Int32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] Int32.to_int ( * self)
   val shallow_model1 (self : borrowed int32) : int
     ensures { result = shallow_model1 self }
     
@@ -572,18 +572,18 @@ module Borrows_Destruct
   let constant max0  : int32 = [@vc:do_not_keep_trace] [@vc:sp]
     (2147483647 : int32)
   predicate resolve2 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed int32) : bool
     ensures { result = resolve1 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed int32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] Int32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] Int32.to_int ( * self)
   val shallow_model1 (self : borrowed int32) : int
     ensures { result = shallow_model1 self }
     
@@ -592,12 +592,12 @@ module Borrows_Destruct
     ensures { [#"../borrows.rs" 100 10 100 25] Int32.to_int ( ^ x) = shallow_model1 x + 1 }
     
   predicate resolve3 (self : Borrows_NonZero_Type.t_nonzero) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : Borrows_NonZero_Type.t_nonzero) : bool
     ensures { result = resolve3 self }
     
   predicate resolve0 (self : (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve2 (let (_, a) = self in a)
   val resolve0 (self : (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))) : bool
     ensures { result = resolve0 self }
     
@@ -673,13 +673,13 @@ module Borrows_FrozenDead
   let constant max0  : int32 = [@vc:do_not_keep_trace] [@vc:sp]
     (2147483647 : int32)
   predicate resolve1 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed int32) : bool
     ensures { result = resolve1 self }
     
   use prelude.Int
   function shallow_model1 (self : borrowed int32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] Int32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] Int32.to_int ( * self)
   val shallow_model1 (self : borrowed int32) : int
     ensures { result = shallow_model1 self }
     
@@ -688,7 +688,7 @@ module Borrows_FrozenDead
     ensures { [#"../borrows.rs" 100 10 100 25] Int32.to_int ( ^ x) = shallow_model1 x + 1 }
     
   predicate resolve0 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Borrows_NonZero_Type.t_nonzero)) : bool
     ensures { result = resolve0 self }
     
@@ -760,12 +760,12 @@ module Borrows_Dec
   use prelude.Int
   use prelude.Borrow
   function shallow_model0 (self : borrowed int32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] Int32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] Int32.to_int ( * self)
   val shallow_model0 (self : borrowed int32) : int
     ensures { result = shallow_model0 self }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     
@@ -818,7 +818,7 @@ module Borrows_Impl3_Foo
   let constant max0  : int32 = [@vc:do_not_keep_trace] [@vc:sp]
     (2147483647 : int32)
   predicate resolve1 (self : borrowed (Borrows_SumTo10_Type.t_sumto10)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Borrows_SumTo10_Type.t_sumto10)) : bool
     ensures { result = resolve1 self }
     
@@ -826,7 +826,7 @@ module Borrows_Impl3_Foo
   let constant min0  : int32 = [@vc:do_not_keep_trace] [@vc:sp]
     (-2147483648 : int32)
   function shallow_model1 (self : borrowed int32) : int =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] Int32.to_int ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] Int32.to_int ( * self)
   val shallow_model1 (self : borrowed int32) : int
     ensures { result = shallow_model1 self }
     
@@ -835,7 +835,7 @@ module Borrows_Impl3_Foo
     ensures { [#"../borrows.rs" 106 10 106 25] Int32.to_int ( ^ x) = shallow_model1 x - 1 }
     
   predicate resolve0 (self : borrowed int32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed int32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/type_invariants/vec_inv.mlcfg
+++ b/creusot/tests/should_succeed/type_invariants/vec_inv.mlcfg
@@ -180,7 +180,7 @@ module VecInv_Vec
     ensures { result = index_logic0 self ix }
     
   predicate resolve1 (self : borrowed (VecInv_SumTo10_Type.t_sumto10)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (VecInv_SumTo10_Type.t_sumto10)) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/unnest.mlcfg
+++ b/creusot/tests/should_succeed/unnest.mlcfg
@@ -4,12 +4,12 @@ module Unnest_Unnest
   use prelude.Int
   use prelude.Borrow
   predicate resolve1 (self : borrowed (borrowed uint32)) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (borrowed uint32)) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed uint32) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed uint32) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/vecdeque.mlcfg
+++ b/creusot/tests/should_succeed/vecdeque.mlcfg
@@ -156,7 +156,7 @@ module Vecdeque_TestDeque
   function shallow_model3 (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model3 (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     ensures { result = shallow_model3 self }
     
@@ -198,7 +198,7 @@ module Vecdeque_TestDeque
     ensures { result = deep_model1 self }
     
   function deep_model0 (self : Core_Option_Option_Type.t_option uint32) : Core_Option_Option_Type.t_option int =
-    [#"../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : Core_Option_Option_Type.t_option uint32) : Core_Option_Option_Type.t_option int
     ensures { result = deep_model0 self }
     
@@ -221,7 +221,7 @@ module Vecdeque_TestDeque
   function shallow_model1 (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32
     
    =
-    [#"../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model1 (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -237,12 +237,12 @@ module C01_AllZero
   axiom inv0 : forall x : Core_Ops_Range_Range_Type.t_range usize . inv0 x = true
   use prelude.Snapshot
   predicate resolve2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed uint32) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed uint32) : bool
     ensures { result = resolve1 self }
     
@@ -267,7 +267,7 @@ module C01_AllZero
   function shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     ensures { result = shallow_model0 self }
     
@@ -283,7 +283,7 @@ module C01_AllZero
     
   use seq.Seq
   predicate resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve0 self }
     
@@ -311,7 +311,7 @@ module C01_AllZero
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : Seq.seq uint32
     ensures { result = shallow_model5 self }
     
@@ -346,7 +346,7 @@ module C01_AllZero
     ensures { inv0 result }
     
   function shallow_model4 (self : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model4 (self : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32
     ensures { result = shallow_model4 self }
     

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -320,7 +320,7 @@ module C02Gnome_GnomeSort
    -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 33 4 33 44] inv8 (deep_model1 self)) && ([#"../../../../../creusot-contracts/src/std/vec.rs" 31 4 32 53] forall i : int . 0 <= i /\ i < Seq.length (shallow_model3 self)
    -> Seq.get (deep_model1 self) i = deep_model3 (index_logic1 self i)) && ([#"../../../../../creusot-contracts/src/std/vec.rs" 30 14 30 56] Seq.length (shallow_model3 self) = Seq.length (deep_model1 self))
   predicate resolve3 (self : borrowed (slice t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (slice t)) : bool
     ensures { result = resolve3 self }
     
@@ -334,7 +334,7 @@ module C02Gnome_GnomeSort
   axiom shallow_model7_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 21 19 25] inv4 self)
    -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv9 (shallow_model7 self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model7 self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model7 self) <= UIntSize.to_int max0)
   function shallow_model6 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model7 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model7 ( * self)
   val shallow_model6 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model6 self }
     
@@ -346,7 +346,7 @@ module C02Gnome_GnomeSort
     
   function shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model1 self }
     
@@ -357,7 +357,7 @@ module C02Gnome_GnomeSort
     ensures { inv5 result }
     
   function deep_model2 (self : t) : deep_model_ty0 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model3 self
   val deep_model2 (self : t) : deep_model_ty0
     ensures { result = deep_model2 self }
     
@@ -381,7 +381,7 @@ module C02Gnome_GnomeSort
     ensures { result = in_bounds0 self seq }
     
   function shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model5 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model5 self }
     
@@ -393,7 +393,7 @@ module C02Gnome_GnomeSort
     ensures { inv2 result }
     
   predicate resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve1 self }
     
@@ -409,7 +409,7 @@ module C02Gnome_GnomeSort
     
   function shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model1 self
   val shallow_model4 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model4 self }
     
@@ -424,7 +424,7 @@ module C02Gnome_GnomeSort
   function deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 92 8 92 28] deep_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 88 8 88 28] deep_model1 ( * self)
   val deep_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq deep_model_ty0
     ensures { result = deep_model0 self }
     

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -243,12 +243,12 @@ module C03KnuthShuffle_KnuthShuffle
     
   axiom inv0 : forall x : Snapshot.snap_ty (borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) . inv0 x = true
   predicate resolve3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve3 self }
     
   predicate resolve2 (self : borrowed (slice t)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (slice t)) : bool
     ensures { result = resolve2 self }
     
@@ -262,7 +262,7 @@ module C03KnuthShuffle_KnuthShuffle
   axiom shallow_model7_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 21 19 25] inv3 self)
    -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 19 4 19 50] inv9 (shallow_model7 self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 42] shallow_model7 self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model7 self) <= UIntSize.to_int max0)
   function shallow_model6 (self : borrowed (slice t)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model7 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model7 ( * self)
   val shallow_model6 (self : borrowed (slice t)) : Seq.seq t
     ensures { result = shallow_model6 self }
     
@@ -274,7 +274,7 @@ module C03KnuthShuffle_KnuthShuffle
     
   function shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model0 self }
     
@@ -290,7 +290,7 @@ module C03KnuthShuffle_KnuthShuffle
     
   use seq.Seq
   predicate resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve1 self }
     
@@ -315,7 +315,7 @@ module C03KnuthShuffle_KnuthShuffle
     
   function shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model5 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model5 self }
     
@@ -350,7 +350,7 @@ module C03KnuthShuffle_KnuthShuffle
     ensures { inv1 result }
     
   function shallow_model4 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model4 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model4 self }
     

--- a/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
+++ b/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
@@ -144,7 +144,7 @@ module C04BinarySearch_BinarySearch
     ensures { result = in_bounds0 self seq }
     
   function shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint32
     ensures { result = shallow_model1 self }
     

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
@@ -281,7 +281,7 @@ module C05BinarySearchGeneric_BinarySearch
     ensures { result = deep_model1 self }
     
   function deep_model3 (self : t) : deep_model_ty0 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model3 (self : t) : deep_model_ty0
     ensures { result = deep_model3 self }
     
@@ -317,7 +317,7 @@ module C05BinarySearchGeneric_BinarySearch
     ensures { result = in_bounds0 self seq }
     
   function shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model1 self }
     
@@ -348,7 +348,7 @@ module C05BinarySearchGeneric_BinarySearch
    -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 33 4 33 44] inv6 (deep_model2 self)) && ([#"../../../../../creusot-contracts/src/std/vec.rs" 31 4 32 53] forall i : int . 0 <= i /\ i < Seq.length (shallow_model2 self)
    -> Seq.get (deep_model2 self) i = deep_model1 (index_logic1 self i)) && ([#"../../../../../creusot-contracts/src/std/vec.rs" 30 14 30 56] Seq.length (shallow_model2 self) = Seq.length (deep_model2 self))
   function deep_model0 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq deep_model_ty0 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model2 self
   val deep_model0 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq deep_model_ty0
     ensures { result = deep_model0 self }
     

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -254,7 +254,7 @@ module C06KnightsTour_Impl1_New_Closure3
     ensures { inv1 result }
     
   predicate resolve0 (self : borrowed C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) : bool
     ensures { result = resolve0 self }
     
@@ -580,7 +580,7 @@ module C06KnightsTour_Impl1_New
    -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 120 4 120 83] produced = Seq.empty 
    -> preservation_inv0 iter func produced = preservation0 iter func)
   predicate resolve3 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve3 self }
     
@@ -708,7 +708,7 @@ module C06KnightsTour_Impl1_New
    =
     true
   predicate resolve1 (self : Core_Ops_Range_Range_Type.t_range usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve1 (self : Core_Ops_Range_Range_Type.t_range usize) : bool
     ensures { result = resolve1 self }
     
@@ -925,7 +925,7 @@ module C06KnightsTour_Impl1_Available
     ensures { result = in_bounds2 self seq }
     
   function shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model4 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model4 self
   val shallow_model1 (self : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) : Seq.seq usize
     ensures { result = shallow_model1 self }
     
@@ -953,7 +953,7 @@ module C06KnightsTour_Impl1_Available
   function shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model3 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model3 self
   val shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     ensures { result = shallow_model0 self }
     
@@ -1291,12 +1291,12 @@ module C06KnightsTour_Impl1_CountDegree
     
   use prelude.Snapshot
   predicate resolve3 (self : isize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve3 (self : isize) : bool
     ensures { result = resolve3 self }
     
   predicate resolve1 (self : (isize, isize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve3 (let (a, _) = self in a) /\ resolve3 (let (_, a) = self in a)
   val resolve1 (self : (isize, isize)) : bool
     ensures { result = resolve1 self }
     
@@ -1325,14 +1325,14 @@ module C06KnightsTour_Impl1_CountDegree
   predicate resolve0 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)))
     
    =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve0 self }
     
   function shallow_model6 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (isize, isize)
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model6 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (isize, isize)
     ensures { result = shallow_model6 self }
     
@@ -1654,17 +1654,17 @@ module C06KnightsTour_Impl1_Set
     ensures { result = wf0 self }
     
   predicate resolve2 (self : borrowed (C06KnightsTour_Board_Type.t_board)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve2 (self : borrowed (C06KnightsTour_Board_Type.t_board)) : bool
     ensures { result = resolve2 self }
     
   predicate resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve1 self }
     
   predicate resolve0 (self : borrowed usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed usize) : bool
     ensures { result = resolve0 self }
     
@@ -1689,7 +1689,7 @@ module C06KnightsTour_Impl1_Set
   function shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model3 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model3 ( * self)
   val shallow_model2 (self : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : Seq.seq usize
     ensures { result = shallow_model2 self }
     
@@ -1728,7 +1728,7 @@ module C06KnightsTour_Impl1_Set
   function shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     ensures { result = shallow_model0 self }
     
@@ -1921,7 +1921,7 @@ module C06KnightsTour_Min
   function shallow_model3 (self : slice (usize, C06KnightsTour_Point_Type.t_point)) : Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model6 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model6 self
   val shallow_model3 (self : slice (usize, C06KnightsTour_Point_Type.t_point)) : Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
     ensures { result = shallow_model3 self }
     
@@ -1983,7 +1983,7 @@ module C06KnightsTour_Min
   use prelude.Snapshot
   use seq.Seq
   predicate resolve0 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point))) : bool
     ensures { result = resolve0 self }
     
@@ -1991,7 +1991,7 @@ module C06KnightsTour_Min
   function shallow_model5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point))) : slice (usize, C06KnightsTour_Point_Type.t_point)
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model1 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model1 ( * self)
   val shallow_model5 (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point))) : slice (usize, C06KnightsTour_Point_Type.t_point)
     ensures { result = shallow_model5 self }
     
@@ -2017,7 +2017,7 @@ module C06KnightsTour_Min
   function shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
     ensures { result = shallow_model0 self }
     
@@ -2501,17 +2501,17 @@ module C06KnightsTour_KnightsTour
   use prelude.Snapshot
   use C06KnightsTour_Board_Type as C06KnightsTour_Board_Type
   predicate resolve8 (self : C06KnightsTour_Point_Type.t_point) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve8 (self : C06KnightsTour_Point_Type.t_point) : bool
     ensures { result = resolve8 self }
     
   predicate resolve7 (self : usize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve7 (self : usize) : bool
     ensures { result = resolve7 self }
     
   predicate resolve6 (self : (usize, C06KnightsTour_Point_Type.t_point)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve7 (let (a, _) = self in a) /\ resolve8 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve7 (let (a, _) = self in a) /\ resolve8 (let (_, a) = self in a)
   val resolve6 (self : (usize, C06KnightsTour_Point_Type.t_point)) : bool
     ensures { result = resolve6 self }
     
@@ -2534,7 +2534,7 @@ module C06KnightsTour_KnightsTour
   function shallow_model8 (self : Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model0 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model0 self
   val shallow_model8 (self : Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global)) : Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
     ensures { result = shallow_model8 self }
     
@@ -2543,12 +2543,12 @@ module C06KnightsTour_KnightsTour
      -> (exists i : int . 0 <= i /\ i < Seq.length (shallow_model8 v) /\ index_logic0 v i = r) }
     
   predicate resolve5 (self : isize) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 46 8 46 12] true
   val resolve5 (self : isize) : bool
     ensures { result = resolve5 self }
     
   predicate resolve2 (self : (isize, isize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] resolve5 (let (a, _) = self in a) /\ resolve5 (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 17 8 17 60] resolve5 (let (a, _) = self in a) /\ resolve5 (let (_, a) = self in a)
   val resolve2 (self : (isize, isize)) : bool
     ensures { result = resolve2 self }
     
@@ -2565,7 +2565,7 @@ module C06KnightsTour_KnightsTour
   function shallow_model7 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model7 (self : borrowed (Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
     ensures { result = shallow_model7 self }
     
@@ -2616,14 +2616,14 @@ module C06KnightsTour_KnightsTour
   predicate resolve1 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)))
     
    =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve1 self }
     
   function shallow_model9 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (isize, isize)
     
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model6 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model6 ( * self)
   val shallow_model9 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))) : Seq.seq (isize, isize)
     ensures { result = shallow_model9 self }
     
@@ -2682,7 +2682,7 @@ module C06KnightsTour_KnightsTour
     
   use seq.Seq
   predicate resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/vector/07_read_write.mlcfg
+++ b/creusot/tests/should_succeed/vector/07_read_write.mlcfg
@@ -139,12 +139,12 @@ module C07ReadWrite_ReadWrite
   axiom inv0 : forall x : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global) . inv0 x = true
   function shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model2 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model2 ( * self)
   val shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model1 self }
     
   predicate resolve3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve3 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve3 self }
     
@@ -154,7 +154,7 @@ module C07ReadWrite_ReadWrite
     ensures { result = deep_model1 self }
     
   function deep_model0 (self : t) : deep_model_ty0 =
-    [#"../../../../../creusot-contracts/src/model.rs" 74 8 74 28] deep_model1 self
+    [#"../../../../../creusot-contracts/src/model.rs" 70 8 70 28] deep_model1 self
   val deep_model0 (self : t) : deep_model_ty0
     ensures { result = deep_model0 self }
     
@@ -180,7 +180,7 @@ module C07ReadWrite_ReadWrite
     ensures { result = in_bounds0 self seq }
     
   function shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model3 (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : Seq.seq t
     ensures { result = shallow_model3 self }
     
@@ -192,7 +192,7 @@ module C07ReadWrite_ReadWrite
     ensures { inv3 result }
     
   predicate resolve1 (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed t) : bool
     ensures { result = resolve1 self }
     

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -340,7 +340,7 @@ module C08Haystack_Search
     ensures { result = in_bounds0 self seq }
     
   function shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec uint8 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint8 =
-    [#"../../../../../creusot-contracts/src/model.rs" 83 8 83 31] shallow_model2 self
+    [#"../../../../../creusot-contracts/src/model.rs" 79 8 79 31] shallow_model2 self
   val shallow_model0 (self : Alloc_Vec_Vec_Type.t_vec uint8 (Alloc_Alloc_Global_Type.t_global)) : Seq.seq uint8
     ensures { result = shallow_model0 self }
     
@@ -352,7 +352,7 @@ module C08Haystack_Search
     ensures { inv7 result }
     
   predicate resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve1 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
     ensures { result = resolve1 self }
     
@@ -391,7 +391,7 @@ module C08Haystack_Search
     ensures { inv1 result }
     
   predicate resolve0 (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize)) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize)) : bool
     ensures { result = resolve0 self }
     

--- a/creusot/tests/should_succeed/vector/09_capacity.mlcfg
+++ b/creusot/tests/should_succeed/vector/09_capacity.mlcfg
@@ -101,12 +101,12 @@ module C09Capacity_ChangeCapacity
     
   function shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
    =
-    [#"../../../../../creusot-contracts/src/model.rs" 101 8 101 31] shallow_model0 ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 97 8 97 31] shallow_model0 ( * self)
   val shallow_model1 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : Seq.seq t
     ensures { result = shallow_model1 self }
     
   predicate resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve0 self }
     
@@ -234,7 +234,7 @@ module C09Capacity_ClearVec
     
   axiom inv0 : forall x : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global) . inv0 x = true
   predicate resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 26 20 26 34]  ^ self =  * self
   val resolve0 (self : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : bool
     ensures { result = resolve0 self }
     


### PR DESCRIPTION
In #932 you mentioned it would be useful to extract out some of the changes I made that are not Prusti specific into there own PR.

I reorganized `creusot_contracts` adding `base_macros` which is just a re-export of either `creusot_contracts_proc` or `creusot_contracts_dummy`, and `prelude` which re-exports the items from `creusot_contracts` but not all the modules so that you can `use creusot_contracts::prelude::*` instead of `use creusot_contracts::*`.

I modified the types stored in pearlite `Term`s so that they match the types from THIR, instead of stripping off boxes and shared references. I also added a `creusot_ty` method that returns the type with boxes and shared references removed to use in places creusot was relying on this stripping.