### PR TITLE
Rework/fix the computation of relative spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "pathdiff",
  "petgraph",
  "serde",
  "serde_json",
@@ -1417,6 +1418,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"

--- a/HACKING.md
+++ b/HACKING.md
@@ -44,6 +44,8 @@ Then, to update an out-of-date reference file:
 cargo test --test ui -- "optional-string" --bless
 ```
 
+(NB: to bless all the tests, you need to pass the empty string `""`)
+
 - Replay proofs:
 ```
 cargo test --test why3

--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -32,7 +32,6 @@ fn main() -> Result<()> {
     } else {
         mlcfg_filename = make_mlcfg_filename(&cargo_md)?;
         cargs.options.output_file = Some(mlcfg_filename.to_string_lossy().into_owned());
-        cargs.options.span_mode = SpanMode::Absolute;
     }
 
     let subcommand = match cargs.subcommand {

--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -10,11 +10,10 @@ pub struct CommonOptions {
     /// [None] provides the clearest diffs.
     #[clap(long, value_enum, default_value_t=SpanMode::Relative)]
     pub span_mode: SpanMode,
-    #[clap(long, default_value_os_t = get_default_root_path_relative_from_output())]
-    /// Relative path of the root of the Rust project relative to the output files
-    /// of Creusot. This is used when producing [Relative] spans, to know the location
-    /// of Rust files corresponding to the generated Why3 files.
-    pub root_path_relative_from_output: PathBuf,
+    #[clap(long)]
+    /// Directory with respect to which (relative) spans should be relative to.
+    /// Necessary when using --stdout with relative spans, not needed otherwise.
+    pub spans_relative_to: Option<PathBuf>,
     #[clap(long)]
     /// Only generate proofs for items matching the provided string. The string is treated
     /// as a Rust qualified path.
@@ -115,13 +114,6 @@ pub enum SetupSubCommand {
         #[arg(long, default_value_t = false)]
         no_resolve_paths: bool,
     },
-}
-
-/// Default relative path of the root project wrt the output.
-/// This corresponds to the default scenario where the user invokes "cargo creusot"
-/// which writes its output in target/debug/
-fn get_default_root_path_relative_from_output() -> PathBuf {
-    [".."].iter().collect()
 }
 
 /// Parse a single key-value pair

--- a/creusot-rustc/src/main.rs
+++ b/creusot-rustc/src/main.rs
@@ -111,7 +111,10 @@ fn setup_plugin() {
         args.extend(["--cfg", "creusot"].into_iter().map(str::to_owned));
         debug!("creusot args={:?}", args);
 
-        let opts = CreusotArgs::to_options(creusot);
+        let opts = match CreusotArgs::to_options(creusot) {
+            Ok(opts) => opts,
+            Err(msg) => panic!("Error: {msg}"),
+        };
         let mut callbacks = ToWhy::new(opts);
 
         RunCompiler::new(&args, &mut callbacks).run().unwrap();

--- a/creusot-rustc/src/options.rs
+++ b/creusot-rustc/src/options.rs
@@ -3,7 +3,7 @@ pub use creusot_args::options::*;
 use std::path::PathBuf;
 
 pub trait CreusotArgsExt {
-    fn to_options(self) -> Options;
+    fn to_options(self) -> Result<Options, String>;
 }
 
 fn why3_command(
@@ -20,7 +20,7 @@ fn why3_command(
     options::Why3Command { path, config_file, sub, args }
 }
 impl CreusotArgsExt for CreusotArgs {
-    fn to_options(self) -> Options {
+    fn to_options(self) -> Result<Options, String> {
         let metadata_path = self.options.metadata_path;
         let extern_paths = self.options.extern_paths.into_iter().collect();
 
@@ -28,18 +28,27 @@ impl CreusotArgsExt for CreusotArgs {
         let should_output = !cargo_creusot || std::env::var("CARGO_PRIMARY_PACKAGE").is_ok();
 
         let output_file = match (self.options.stdout, self.options.output_file) {
-            (true, _) => Some(OutputFile::Stdout),
-            (_, Some(f)) => Some(OutputFile::File(f)),
-            _ => None,
-        };
+            (true, None) => Ok(OutputFile::Stdout),
+            (false, Some(f)) => Ok(OutputFile::File(f)),
+            (true, Some(_)) => Err("--stdout and --output-file are mutually exclusive"),
+            (false, None) => Err("please specify either --output-file or --stdout"),
+        }?;
 
-        let span_mode = match self.options.span_mode {
-            SpanMode::Relative => options::SpanMode::Relative,
-            SpanMode::Absolute => options::SpanMode::Absolute,
-            SpanMode::Off => options::SpanMode::Off,
-        };
+        let span_mode =
+            match (&self.options.span_mode, &output_file, &self.options.spans_relative_to) {
+                (SpanMode::Absolute, _, _) => Ok(options::SpanMode::Absolute),
+                (SpanMode::Off, _, _) => Ok(options::SpanMode::Off),
+                (SpanMode::Relative, _, Some(p)) => Ok(options::SpanMode::Relative(p.to_owned())),
+                (SpanMode::Relative, OutputFile::File(f), None) => {
+                    let p = PathBuf::from(f);
+                    Ok(options::SpanMode::Relative(p.parent().unwrap().to_owned()))
+                }
+                (SpanMode::Relative, OutputFile::Stdout, None) => {
+                    Err("--spans-relative-to is required when using --stdout and relative spans")
+                }
+            }?;
 
-        Options {
+        Ok(Options {
             extern_paths,
             metadata_path,
             export_metadata: self.options.export_metadata,
@@ -47,12 +56,11 @@ impl CreusotArgsExt for CreusotArgs {
             output_file,
             in_cargo: cargo_creusot,
             span_mode,
-            root_path_relative_from_output: self.options.root_path_relative_from_output,
             match_str: self.options.focus_on,
             simple_triggers: self.options.simple_triggers,
             why3_cmd: self
                 .subcommand
                 .map(|cmd| why3_command(self.why3_path, self.why3_config_file, cmd)),
-        }
+        })
     }
 }

--- a/creusot/Cargo.toml
+++ b/creusot/Cargo.toml
@@ -19,6 +19,7 @@ include_dir = "0.7.3"
 tempdir = "0.3.7"
 serde_json = { version = "1.0" }
 lazy_static = "1.4.0"
+pathdiff = "0.2"
 
 [dev-dependencies]
 glob = "*"

--- a/creusot/src/options.rs
+++ b/creusot/src/options.rs
@@ -1,11 +1,8 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, path::PathBuf};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum SpanMode {
-    Relative,
+    Relative(PathBuf),
     Absolute,
     Off,
 }
@@ -31,10 +28,9 @@ pub struct Options {
     pub metadata_path: Option<String>,
     pub export_metadata: bool,
     pub should_output: bool,
-    pub output_file: Option<OutputFile>,
+    pub output_file: OutputFile,
     pub in_cargo: bool,
     pub span_mode: SpanMode,
-    pub root_path_relative_from_output: PathBuf,
     pub match_str: Option<String>,
     pub simple_triggers: bool,
     pub why3_cmd: Option<Why3Command>,
@@ -44,42 +40,4 @@ pub struct Options {
 pub enum OutputFile {
     File(String),
     Stdout,
-}
-
-impl Options {
-    pub fn relative_to_output(&self, p: &Path) -> PathBuf {
-        let mut other = std::env::current_dir().unwrap();
-        match &self.output_file {
-            Some(OutputFile::File(s)) => {
-                if Path::new(s).is_relative() {
-                    other.push(s);
-                }
-            }
-            _ => {
-                other.push("dummy.mlcfg");
-            }
-        };
-
-        let two = other.components();
-        let one = p.components();
-
-        let mut same = 0;
-        one.zip(two).take_while(|(l, r)| l == r).for_each(|_| same += 1);
-        let output_components = other.components().count();
-        let mut buf = PathBuf::new();
-
-        (0..(output_components - same)).for_each(|_| {
-            // Why3 treats the spans as relative to the session, not the source file,
-            // and the session is in a subdirectory next to the mlcfg file, so we need
-            // to add ..
-            buf.push("..");
-            // then add the relative path of the root project with respect to the output
-            // directory (typically some amount of ..)
-            buf.extend(&self.root_path_relative_from_output)
-        });
-        buf.extend(p.components().skip(same));
-        // the roundtrip through [components()] gives us some basic (syntactic)
-        // normalization of the path (e.g. remove /./)
-        buf.components().collect()
-    }
 }

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -93,23 +93,8 @@ pub(crate) fn after_analysis(ctx: TranslationCtx) -> Result<(), Box<dyn Error>> 
         use crate::run_why3::run_why3;
         use std::fs::File;
         let file = match why3.opts.output_file {
-            Some(OutputFile::File(ref f)) => Some(f.clone().into()),
-            Some(OutputFile::Stdout) => None,
-            None => {
-                let outputs = why3.output_filenames(());
-                let crate_name = why3.crate_name(LOCAL_CRATE);
-
-                let libname = format!("{}-{}.mlcfg", crate_name.as_str(), why3.crate_types()[0]);
-
-                let directory = if why3.opts.in_cargo {
-                    let mut dir = outputs.out_directory.clone();
-                    dir.pop();
-                    dir
-                } else {
-                    outputs.out_directory.clone()
-                };
-                Some(directory.join(&libname))
-            }
+            OutputFile::File(ref f) => Some(f.clone().into()),
+            OutputFile::Stdout => None,
         };
         let mut out: Box<dyn Write> = match &file {
             Some(f) => Box::new(std::io::BufWriter::new(File::create(f)?)),

--- a/creusot/tests/ui.rs
+++ b/creusot/tests/ui.rs
@@ -93,7 +93,8 @@ fn run_creusot(
         "--stdout",
         "--export-metadata=false",
         "--span-mode=relative",
-        "--root-path-relative-from-output=.",
+        // we will write the mlcfg output next to the .rs file
+        "--spans-relative-to=.",
     ]);
     cmd.args(&[
         "--creusot-extern",


### PR DESCRIPTION
This PR fixes relative spans in mlcfgs generated by `cargo creusot`. (Following #997 `cargo creusot` hardcodes the use of absolute spans to sidestep this issue; this PR lifts this restriction.)

The handling of file paths and the logic for computing relative spans were subtly broken/inconsistent in a few places.

- --root-path-relative-from-output really only made sense when passing --stdout. Otherwise, we know the path of the output mlcfg file, we don't need it to compute relative spans, and we don't know what to do with it. Furthermore the concept of the "root" of the project seems dubious outside of cargo (but this option is used in creusot-rustc).

- the logic for computing relative spans in creusot::options::relative_to_output was therefore somewhat nonsensical.

This replaces the option with --spans-relative-to which instead indicates a directory path with respect to which spans should be relative to. We then require this option to be passed whenever --stdout is passed and we're using relative spans.

Then, creusot::options::relative_to_output can be simply replaced by a standard "pathdiff" implementation from a crate.

As a extra simplification, in creusot-rustc we require to receive one of --stdout or --output-file, which means we can remove any path-computation logic for .mlcfg from creusot-rustc (everything is done by cargo-creusot).