### PR TITLE
creusot setup v2: more flexible per-tool settings for managed/external status and version checking

### DIFF
--- a/.creusot-config.sample/Config.toml
+++ b/.creusot-config.sample/Config.toml
@@ -1,6 +1,0 @@
-version = 1
-
-[tools]
-mode = "external"
-why3_path = "why3"
-altergo_path = "alt-ergo"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,6 +34,6 @@ jobs:
     - name: run cargo creusot setup install
       if: steps.cache-creusot-setup.outputs.cache-hit != 'true'
       run: |
-        cargo run --bin cargo-creusot creusot setup install
+        cargo run --bin cargo-creusot creusot setup install --no-check-version why3
     - run: cargo test --test why3 "" -- --replay=none --diff-from=origin/master
     - run: cargo test --test why3 "" -- --skip-unstable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,9 @@ jobs:
     - name: Build
       run: cargo build
     - name: dummy creusot setup
-      run: cp -r .creusot-config.sample .creusot-config
+      run: |
+        mkdir -p ~/.config/creusot
+        cp ci/creusot-config-dummy.toml ~/.config/creusot/Config.toml
     - name: Run tests
       run: cargo test
   why3:

--- a/HACKING.md
+++ b/HACKING.md
@@ -5,32 +5,20 @@ working on the Creusot codebase.
 
 ## Setup
 
-The "Creusot developer setup" sometimes requires more flexibility in how it
-looks up why3 and related solvers, compared to the standard "user" workflow
-provided by `cargo creusot setup install`. You have two options:
+The testsuite will use the global Creusot configuration managed by 
+`cargo creusot setup`. 
+You first need to have successfully run `cargo creusot setup install` as
+detailed in the README installation instructions.
 
-- **By default** the testsuite will use the global Creusot configuration managed
-  by `cargo creusot setup`. You first need to have successfully run `cargo
-  creusot setup install` (or `cargo creusot setup install-external`).
-- **Alternatively** you can set a custom "developer" Creusot configuration in
-  `.creusot-config/` at the root of the git repo. Start by running `cp -r
-  .creusot-config.sample .creusot-config`. This will tell the testsuite to use
-  whichever `why3` binary is in the PATH, but you can also tweak
-  `.creusot-config/Config.toml` to point to a specific binary.
+**To be able to use custom versions of Why3 or the solvers** (instead of the
+built-in ones expected by Creusot), one can pass extra flags to 
+`cargo creusot setup install` (see also `--help`):
+- `--external <TOOL>` to specify that a solver should be looked up from the path
+- `--no-check-version <TOOL>` to allow unexpected versions of a given tool
 
-The first option is recommended if you simply want a working setup to run the
-testsuite.
-
-The second option is useful if you need to try custom versions of Why3 or the
-solvers.
-
-Notes:
-- to avoid first installing the `cargo-creusot` binary before running `cargo
+To avoid first installing the `cargo-creusot` binary before running `cargo
   creusot setup`, one can directly call it from the git repository: `cargo run
   --bin cargo-creusot creusot setup`
-- the format of the `.creusot-config/` directory is simply the same as
-  `~/.config/creusot`, which is where `cargo creusot setup` writes its
-  configuration.
 
 ## Running the testsuite
 

--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -92,11 +92,21 @@ fn main() -> Result<()> {
             Ok(())
         }
         Setup(SetupSubCommand::Status) => setup::status(&cargs.config_dir),
-        Setup(SetupSubCommand::Install) => {
-            setup::install(&cargs.config_dir, setup::InstallMode::Managed)
-        }
-        Setup(SetupSubCommand::InstallExternal { no_resolve_paths }) => {
-            setup::install(&cargs.config_dir, setup::InstallMode::External { no_resolve_paths })
+        Setup(SetupSubCommand::Install { external, no_check_version }) => {
+            let extflag =
+                |name| setup::ExternalFlag { check_version: !no_check_version.contains(&name) };
+            let managedflag = |name, mname| setup::ManagedFlag {
+                check_version: !no_check_version.contains(&name),
+                external: external.contains(&mname),
+            };
+            let flags = setup::InstallFlags {
+                why3: extflag(SetupTool::Why3),
+                altergo: extflag(SetupTool::AltErgo),
+                z3: managedflag(SetupTool::Z3, SetupManagedTool::Z3),
+                cvc4: managedflag(SetupTool::CVC4, SetupManagedTool::CVC4),
+                cvc5: managedflag(SetupTool::CVC5, SetupManagedTool::CVC5),
+            };
+            setup::install(&cargs.config_dir, flags)
         }
     }
 }

--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -55,7 +55,7 @@ fn main() -> Result<()> {
                 (subcmd, false)
             };
 
-            let config_args = setup::status_for_creusot(&cargs.config_dir)?;
+            let config_args = setup::status_for_creusot()?;
             let creusot_args = CreusotArgs {
                 options: cargs.options,
                 why3_path: config_args.why3_path.clone(),
@@ -70,9 +70,7 @@ fn main() -> Result<()> {
                 // why3 configuration
                 let mut b = Why3LauncherBuilder::new();
                 b.why3_path(config_args.why3_path);
-                if let Some(p) = &config_args.why3_config {
-                    b.config_file(p.clone());
-                }
+                b.config_file(config_args.why3_config);
                 b.output_file(mlcfg_filename);
                 // temporary: for the moment we only launch why3 via cargo-creusot in Ide mode
                 b.mode(Why3Mode::Ide);
@@ -91,7 +89,7 @@ fn main() -> Result<()> {
 
             Ok(())
         }
-        Setup(SetupSubCommand::Status) => setup::status(&cargs.config_dir),
+        Setup(SetupSubCommand::Status) => setup::status(),
         Setup(SetupSubCommand::Install { external, no_check_version }) => {
             let extflag =
                 |name| setup::ExternalFlag { check_version: !no_check_version.contains(&name) };
@@ -106,7 +104,7 @@ fn main() -> Result<()> {
                 cvc4: managedflag(SetupTool::CVC4, SetupManagedTool::CVC4),
                 cvc5: managedflag(SetupTool::CVC5, SetupManagedTool::CVC5),
             };
-            setup::install(&cargs.config_dir, flags)
+            setup::install(flags)
         }
     }
 }

--- a/ci/creusot-config-dummy.toml
+++ b/ci/creusot-config-dummy.toml
@@ -1,0 +1,21 @@
+version = 2
+
+[why3]
+path = "why3"
+check_version = false
+
+[altergo]
+path = "alt-ergo"
+check_version = false
+
+[z3]
+mode = "builtin"
+check_version = false
+
+[cvc4]
+mode = "builtin"
+check_version = false
+
+[cvc5]
+mode = "builtin"
+check_version = false

--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -47,7 +47,7 @@ pub struct CreusotArgs {
     pub why3_path: PathBuf,
     /// Specify an alternative location for Why3's configuration
     #[arg(long)]
-    pub why3_config_file: Option<PathBuf>,
+    pub why3_config_file: PathBuf,
     #[command(subcommand)]
     pub subcommand: Option<CreusotSubCommand>,
     #[clap(last = true)]
@@ -72,9 +72,6 @@ pub enum CreusotSubCommand {
 pub struct CargoCreusotArgs {
     #[clap(flatten)]
     pub options: CommonOptions,
-    /// Custom path for Creusot's config directory (managed by 'cargo creusot setup')
-    #[arg(long)]
-    pub config_dir: Option<PathBuf>,
     /// Subcommand: why3, setup
     #[command(subcommand)]
     pub subcommand: Option<CargoCreusotSubCommand>,

--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -101,18 +101,34 @@ pub enum Why3SubCommand {
     Replay,
 }
 
+#[derive(Debug, ValueEnum, Serialize, Deserialize, Clone, PartialEq)]
+pub enum SetupManagedTool {
+    Z3,
+    CVC4,
+    CVC5,
+}
+
+#[derive(Debug, ValueEnum, Serialize, Deserialize, Clone, PartialEq)]
+pub enum SetupTool {
+    Why3,
+    AltErgo,
+    Z3,
+    CVC4,
+    CVC5,
+}
+
 #[derive(Debug, Parser, Clone)]
 pub enum SetupSubCommand {
     /// Show the current status of the Creusot installation
     Status,
     /// Setup Creusot or update an existing installation
-    Install,
-    /// Setup Creusot but use external tools configured manually (not recommended, for experts)
-    InstallExternal {
-        /// Do not lookup and resolve paths to the external binaries (they will
-        /// instead be looked up in PATH at each Creusot invocation)
-        #[arg(long, default_value_t = false)]
-        no_resolve_paths: bool,
+    Install {
+        /// Look-up <TOOL> from PATH instead of using the built-in version
+        #[arg(long, value_name = "TOOL")]
+        external: Vec<SetupManagedTool>,
+        /// Do not error if <TOOL>'s version does not match the one expected by creusot
+        #[arg(long, value_name = "TOOL")]
+        no_check_version: Vec<SetupTool>,
     },
 }
 

--- a/creusot-dev-config/src/bin/dev-env.rs
+++ b/creusot-dev-config/src/bin/dev-env.rs
@@ -18,9 +18,7 @@ pub fn main() -> anyhow::Result<()> {
     };
     println!("PATH={:?}; export PATH;", &new_path);
 
-    if let Some(config) = &paths.why3_config {
-        eprintln!("Using Why3 config at: {}", config.display());
-        println!("WHY3CONFIG='{}'; export WHY3CONFIG;", &config.display());
-    }
+    eprintln!("Using Why3 config at: {}", &paths.why3_config.display());
+    println!("WHY3CONFIG='{}'; export WHY3CONFIG;", &paths.why3_config.display());
     Ok(())
 }

--- a/creusot-dev-config/src/lib.rs
+++ b/creusot-dev-config/src/lib.rs
@@ -4,29 +4,14 @@ use std::{path::PathBuf, process::Command};
 /// calling why3 in development workflows. This is used in particular by the
 /// testsuite.
 
-/// We look for configuration specifying Why3's path and configuration in the
-/// following places:
-/// - in the .creusot-config directory at the root of the git repo, if it exists
-/// - otherwise, in the global config repository used by creusot setup
-
-pub fn custom_config_dir() -> Option<PathBuf> {
-    let local_config = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../.creusot-config");
-    if local_config.is_dir() {
-        Some(std::fs::canonicalize(local_config).unwrap())
-    } else {
-        None
-    }
-}
-
 pub struct Paths {
     pub why3: PathBuf,
-    pub why3_config: Option<PathBuf>,
+    pub why3_config: PathBuf,
 }
 
 /// Fails if the config could not be loaded
 pub fn paths() -> anyhow::Result<Paths> {
-    let custom_config_dir = custom_config_dir();
-    let paths = creusot_setup::status_for_creusot(&custom_config_dir)?;
+    let paths = creusot_setup::status_for_creusot()?;
     Ok(Paths { why3: paths.why3_path, why3_config: paths.why3_config })
 }
 
@@ -36,8 +21,6 @@ pub fn paths() -> anyhow::Result<Paths> {
 pub fn why3_command() -> anyhow::Result<Command> {
     let p = paths()?;
     let mut cmd = Command::new(p.why3.clone());
-    if let Some(ref config) = p.why3_config {
-        cmd.arg("-C").arg(config);
-    }
+    cmd.arg("-C").arg(p.why3_config);
     Ok(cmd)
 }

--- a/creusot-rustc/src/options.rs
+++ b/creusot-rustc/src/options.rs
@@ -8,7 +8,7 @@ pub trait CreusotArgsExt {
 
 fn why3_command(
     path: PathBuf,
-    config_file: Option<PathBuf>,
+    config_file: PathBuf,
     cmd: CreusotSubCommand,
 ) -> options::Why3Command {
     let CreusotSubCommand::Why3 { command, args, .. } = cmd;

--- a/creusot-setup/src/lib.rs
+++ b/creusot-setup/src/lib.rs
@@ -26,14 +26,11 @@ impl fmt::Display for CfgPaths {
     }
 }
 
-fn get_config_paths(custom_config_dir: &Option<PathBuf>) -> anyhow::Result<CfgPaths> {
+fn get_config_paths() -> anyhow::Result<CfgPaths> {
     // arguments: qualifier, organization, application
     let dirs = ProjectDirs::from("", "creusot", "creusot")
         .context("failed to compute configuration paths")?;
-    let config_dir = match custom_config_dir {
-        Some(dir) => dir,
-        None => dirs.config_dir(),
-    };
+    let config_dir = dirs.config_dir();
     Ok(CfgPaths {
         config_dir: PathBuf::from(config_dir),
         config_file: config_dir.join("Config.toml"),
@@ -109,8 +106,8 @@ fn diagnostic_config(paths: &CfgPaths, config: &Config, check_builtins: bool) ->
 }
 
 // display the status of the creusot installation to the user
-pub fn status(custom_config_dir: &Option<PathBuf>) -> anyhow::Result<()> {
-    let paths = get_config_paths(custom_config_dir)?;
+pub fn status() -> anyhow::Result<()> {
+    let paths = get_config_paths()?;
     match Config::read_from_file(&paths.config_file) {
         Err(err) => {
             println!("{err}");
@@ -150,14 +147,14 @@ pub fn status(custom_config_dir: &Option<PathBuf>) -> anyhow::Result<()> {
 
 pub struct CreusotFlags {
     pub why3_path: PathBuf,
-    pub why3_config: Option<PathBuf>,
+    pub why3_config: PathBuf,
 }
 
 /// compute the flags to pass to creusot-rustc.
 /// fail if the installation is not in an acceptable state, which means we will
 /// stop there and do not attempt launching creusot-rustc.
-pub fn status_for_creusot(custom_config_dir: &Option<PathBuf>) -> anyhow::Result<CreusotFlags> {
-    let paths = get_config_paths(custom_config_dir)?;
+pub fn status_for_creusot() -> anyhow::Result<CreusotFlags> {
+    let paths = get_config_paths()?;
     match Config::read_from_file(&paths.config_file) {
         Err(err) => bail!(
             "{err}\n\
@@ -177,7 +174,7 @@ pub fn status_for_creusot(custom_config_dir: &Option<PathBuf>) -> anyhow::Result
             }
             Ok(CreusotFlags {
                 why3_path: cfg.why3.path.to_path_buf(),
-                why3_config: Some(paths.why3_config_file),
+                why3_config: paths.why3_config_file,
             })
         }
     }
@@ -200,8 +197,8 @@ pub struct InstallFlags {
     pub cvc5: ManagedFlag,
 }
 
-pub fn install(custom_config_dir: &Option<PathBuf>, flags: InstallFlags) -> anyhow::Result<()> {
-    let paths = get_config_paths(custom_config_dir)?;
+pub fn install(flags: InstallFlags) -> anyhow::Result<()> {
+    let paths = get_config_paths()?;
 
     // helpers to generate the ExternalTool/ManagedTool config sections
 

--- a/creusot-setup/src/lib.rs
+++ b/creusot-setup/src/lib.rs
@@ -163,10 +163,13 @@ pub fn status_for_creusot() -> anyhow::Result<CreusotFlags> {
         ),
         Ok(cfg) => {
             let issues = diagnostic_config(&paths, &cfg, true);
-            for issue in &issues {
-                println!("{issue}")
-            }
             if issues.iter().any(|issue| issue.error) {
+                // Avoid being too verbose, and only print issues (even
+                // warnings) if there's a hard error. Otherwise we're spamming
+                // testsuite logs, etc.
+                for issue in &issues {
+                    println!("{issue}")
+                }
                 bail!(
                     "Please run 'cargo creusot setup status' \
                      to diagnostic and fix the issue(s)"

--- a/creusot-setup/src/lib.rs
+++ b/creusot-setup/src/lib.rs
@@ -1,17 +1,12 @@
 use anyhow::{anyhow, bail, Context};
 use directories::ProjectDirs;
-use std::{
-    fmt, fs,
-    path::{Path, PathBuf},
-};
+use std::{fmt, fs, path::PathBuf};
 
 mod config;
 mod tools;
 mod tools_versions_urls;
-use config::{Error::*, *};
+use config::*;
 use tools::*;
-use tools_versions_urls::*;
-use ToolsConfig::*;
 
 // CAUTION: on MacOS, [config_dir] and [data_dir] are in fact the same directory
 struct CfgPaths {
@@ -52,73 +47,65 @@ fn get_config_paths(custom_config_dir: &Option<PathBuf>) -> anyhow::Result<CfgPa
 // helpers for diagnostics of a creusot installation.
 // used by the implementation of the various subcommands.
 struct Issue {
+    error: bool,
     tool: String,
     cur_version: Option<String>,
     expected_version: String,
+    builtin_tool: bool,
 }
 
 impl fmt::Display for Issue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Issue { tool, cur_version, expected_version } = self;
+        let Issue { error, tool, cur_version, expected_version, builtin_tool: _ } = self;
         write!(
             f,
-            "{tool} has version {}, but version {expected_version} is expected",
+            "{}: {tool} has version {}, but version {expected_version} is expected",
+            (if *error { "Error" } else { "Warning" }),
             cur_version.as_deref().unwrap_or("(not detected)")
         )
     }
 }
 
-fn diagnostic_config(config: &Config) -> Vec<Issue> {
+fn diagnostic_config(paths: &CfgPaths, config: &Config, check_builtins: bool) -> Vec<Issue> {
     let mut issues: Vec<Issue> = Vec::new();
 
-    // check versions of the external binaries registered in the config (binary
-    // --version vs expected version)
-    let extbins = match &config.tools {
-        Managed { why3_path, altergo_path, .. } => [(WHY3, why3_path), (ALTERGO, altergo_path)],
-        External { why3_path, altergo_path, .. } => [(WHY3, why3_path), (ALTERGO, altergo_path)],
-    };
-    for (bin, path) in extbins {
-        if let DetectedVersion::Bad(ver) = detect_binary_version(&bin, &path) {
+    let mut bins = vec![
+        (WHY3, config.why3.check_version, config.why3.path.clone(), false),
+        (ALTERGO, config.altergo.check_version, config.altergo.path.clone(), false),
+    ];
+    for (bin, cfgbin) in [(Z3.bin, &config.z3), (CVC4.bin, &config.cvc4), (CVC5.bin, &config.cvc5)]
+    {
+        match cfgbin {
+            ManagedTool::Builtin { check_version } => {
+                if check_builtins {
+                    bins.push((
+                        bin,
+                        *check_version,
+                        paths.bin_subdir.clone().join(&bin.binary_name),
+                        true,
+                    ))
+                }
+            }
+            ManagedTool::External(extbin) => {
+                bins.push((bin, extbin.check_version, extbin.path.clone(), false))
+            }
+        }
+    }
+
+    // check versions of binaries (passing --version) vs expected version
+    for (bin, check_version, path, builtin_tool) in bins {
+        if let DetectedVersion::Bad(ver) = bin.detect_version(&path) {
             issues.push(Issue {
+                error: check_version,
                 tool: bin.display_name.to_owned(),
                 cur_version: ver,
                 expected_version: bin.version.to_owned(),
+                builtin_tool,
             })
         }
     }
 
-    // check versions of the managed binaries (version in the config file vs expected version)
-    if let Config { tools: Managed { z3, cvc4, cvc5, .. } } = &config {
-        for (cur_version, bin) in [(z3, Z3), (cvc4, CVC4), (cvc5, CVC5)] {
-            if cur_version != bin.version {
-                issues.push(Issue {
-                    tool: bin.display_name.to_owned(),
-                    cur_version: Some(cur_version.to_owned()),
-                    expected_version: bin.version.to_owned(),
-                })
-            }
-        }
-    };
-
     issues
-}
-
-fn diagnostic_extbinary(bin: ExtBinary, issues: &mut Vec<Issue>) -> anyhow::Result<PathBuf> {
-    let path = detect_binary_path(&bin).ok_or(anyhow!(
-        "{} not found. Please install {} version {}",
-        &bin.display_name,
-        &bin.display_name,
-        &bin.version
-    ))?;
-    println!("Found {} at path: {}", &bin.display_name, &path.display());
-    if let DetectedVersion::Bad(ver) = detect_binary_version(&bin, &path) {
-        issues.push(Issue {
-            tool: bin.display_name.to_owned(),
-            cur_version: ver,
-            expected_version: bin.version.to_owned(),
-        })
-    }
-    Ok(path)
 }
 
 // display the status of the creusot installation to the user
@@ -135,26 +122,26 @@ pub fn status(custom_config_dir: &Option<PathBuf>) -> anyhow::Result<()> {
         Ok(cfg) => {
             println!("Creusot installation found.");
             println!("=== INSTALLATION");
-            print!("{}", cfg.tools);
+            print!("Why3:\n{}", cfg.why3);
+            print!("Alt-Ergo:\n{}", cfg.altergo);
+            print!("Z3:\n{}", cfg.z3);
+            print!("CVC4:\n{}", cfg.cvc4);
+            print!("CVC5:\n{}", cfg.cvc5);
             println!("=== PATHS");
             println!("{}", paths);
-            let issues = diagnostic_config(&cfg);
+            let issues = diagnostic_config(&paths, &cfg, true);
             if !issues.is_empty() {
-                let severity = match cfg.tools {
-                    External { .. } => "Warning",
-                    Managed { .. } => "Error",
-                };
-                println!("");
-                for issue in &issues {
-                    println!("{severity}: {issue}")
-                }
-                if let Managed { .. } = cfg.tools {
-                    println!(
-                        "Hint: for tools installed by Creusot, \
-                              re-run 'cargo creusot setup install' \n\
-                              to upgrade them to the expected version."
-                    )
-                }
+                println!("")
+            }
+            for issue in &issues {
+                println!("{issue}")
+            }
+            if issues.iter().any(|issue| issue.builtin_tool) {
+                println!(
+                    "Hint: for tools installed by Creusot, \
+                     re-run 'cargo creusot setup install' \n\
+                     to upgrade them to the expected version."
+                )
             }
         }
     };
@@ -178,160 +165,133 @@ pub fn status_for_creusot(custom_config_dir: &Option<PathBuf>) -> anyhow::Result
                    how to perform Creusot's initial setup."
         ),
         Ok(cfg) => {
-            match cfg.tools {
-                External { why3_path, .. } =>
-                // in external mode we assume that everything is setup correctly
-                {
-                    Ok(CreusotFlags { why3_path, why3_config: None })
-                }
-                Managed { ref why3_path, .. } => {
-                    let issues = diagnostic_config(&cfg);
-                    if !issues.is_empty() {
-                        for issue in &issues {
-                            println!("Error: {issue}")
-                        }
-                        bail!(
-                            "Please run 'cargo creusot setup status' \
-                               to diagnostic and fix the issue(s)"
-                        )
-                    }
-                    Ok(CreusotFlags {
-                        why3_path: why3_path.to_path_buf(),
-                        why3_config: Some(paths.why3_config_file),
-                    })
-                }
+            let issues = diagnostic_config(&paths, &cfg, true);
+            for issue in &issues {
+                println!("{issue}")
             }
+            if issues.iter().any(|issue| issue.error) {
+                bail!(
+                    "Please run 'cargo creusot setup status' \
+                     to diagnostic and fix the issue(s)"
+                )
+            }
+            Ok(CreusotFlags {
+                why3_path: cfg.why3.path.to_path_buf(),
+                why3_config: Some(paths.why3_config_file),
+            })
         }
     }
 }
 
-pub enum InstallMode {
-    Managed,
-    External { no_resolve_paths: bool },
+pub struct ExternalFlag {
+    pub check_version: bool,
 }
 
-pub fn install(custom_config_dir: &Option<PathBuf>, mode: InstallMode) -> anyhow::Result<()> {
+pub struct ManagedFlag {
+    pub external: bool,
+    pub check_version: bool,
+}
+
+pub struct InstallFlags {
+    pub why3: ExternalFlag,
+    pub altergo: ExternalFlag,
+    pub z3: ManagedFlag,
+    pub cvc4: ManagedFlag,
+    pub cvc5: ManagedFlag,
+}
+
+pub fn install(custom_config_dir: &Option<PathBuf>, flags: InstallFlags) -> anyhow::Result<()> {
     let paths = get_config_paths(custom_config_dir)?;
 
-    // figure out whether we're installing a new configuration from scratch, or
-    // updating an existing configuration
-    let previous_config = match (Config::read_from_file(&paths.config_file), &mode) {
-        (Err(NotFound), _) => None,
-        (Err(Invalid(_) | WrongVersion(_)), _) => {
-            println!("Removing invalid or outdated config...");
-            None
-        }
-        (Ok(Config { tools: Managed { .. } }), InstallMode::External { .. }) => {
-            println!(
-                "Switching to an installation using external tools. \
-                 Erasing current installation..."
-            );
-            None
-        }
-        (Ok(Config { tools: External { .. } }), InstallMode::Managed) => {
-            println!(
-                "Switching to an installation using managed tools. \
-                 Erasing current installation..."
-            );
-            None
-        }
-        (Ok(cfg), _) => {
-            println!("Existing configuration found. Updating.");
-            Some(cfg)
+    // helpers to generate the ExternalTool/ManagedTool config sections
+
+    let getpath = |bin: Binary| -> anyhow::Result<PathBuf> {
+        let path = bin.detect_path().ok_or(anyhow!(
+            "{} not found. Please install {} version {}",
+            &bin.display_name,
+            &bin.display_name,
+            &bin.version
+        ))?;
+        println!("Found {} at path: {}", &bin.display_name, &path.display());
+        Ok(path)
+    };
+
+    let external_tool = |bin: Binary, flag: ExternalFlag| -> anyhow::Result<ExternalTool> {
+        Ok(ExternalTool { path: getpath(bin)?, check_version: flag.check_version })
+    };
+
+    let managed_tool = |bin: Binary, flag: ManagedFlag| -> anyhow::Result<ManagedTool> {
+        if flag.external {
+            Ok(ManagedTool::External(ExternalTool {
+                path: getpath(bin)?,
+                check_version: flag.check_version,
+            }))
+        } else {
+            Ok(ManagedTool::Builtin { check_version: flag.check_version })
         }
     };
 
-    // delete then (re)create the directories we need
-    if previous_config.is_none() {
-        let _ = fs::remove_dir_all(&paths.config_dir);
-        let _ = fs::remove_dir_all(&paths.data_dir);
+    // build the corresponding configuration
+
+    let config = Config {
+        why3: external_tool(WHY3, flags.why3)?,
+        altergo: external_tool(ALTERGO, flags.altergo)?,
+        z3: managed_tool(Z3.bin, flags.z3)?,
+        cvc4: managed_tool(CVC4.bin, flags.cvc4)?,
+        cvc5: managed_tool(CVC5.bin, flags.cvc5)?,
+    };
+
+    // check for issues (incorrect versions of external binaries).
+    // do not attempt checking version of builtin solvers (we haven't installed
+    // them yet, and we know they will be of the expected version).
+
+    let issues = diagnostic_config(&paths, &config, false);
+    for issue in &issues {
+        println!("{issue}")
     }
+    if issues.iter().any(|issue| issue.error) {
+        bail!("Aborting")
+    }
+
+    // apply the configuration to disk
+    apply_config(&paths, &config)
+}
+
+fn apply_config(paths: &CfgPaths, cfg: &Config) -> anyhow::Result<()> {
+    // erase any previous existing config (but not the cache)
+    let _ = fs::remove_dir_all(&paths.config_dir);
+    let _ = fs::remove_dir_all(&paths.data_dir);
+
+    // create directories
     fs::create_dir_all(&paths.config_dir)?;
     fs::create_dir_all(&paths.data_dir)?;
     fs::create_dir_all(&paths.bin_subdir)?;
     fs::create_dir_all(&paths.cache_dir)?;
 
-    match mode {
-        InstallMode::Managed => install_managed(&paths, previous_config)?,
-        InstallMode::External { no_resolve_paths } => install_external(&paths, no_resolve_paths)?,
-    };
-    Ok(println!("Done."))
-}
+    // separate managed tools into "builtin" (we need to download the binary)
+    // and "external" (we have a path to the binary)
+    let mut builtin: Vec<ManagedBinary> = Vec::new();
+    let mut external: Vec<(ManagedBinary, PathBuf)> = Vec::new();
 
-fn install_external(paths: &CfgPaths, no_resolve_paths: bool) -> anyhow::Result<()> {
-    // in external mode, upgrades and fresh installs are equivalent: we
-    // write the paths of external binaries.
-    let mut issues = Vec::new();
-    let why3_path = if no_resolve_paths {
-        PathBuf::from(WHY3.binary_name)
-    } else {
-        diagnostic_extbinary(WHY3, &mut issues)?
-    };
-    let altergo_path = if no_resolve_paths {
-        PathBuf::from(ALTERGO.binary_name)
-    } else {
-        diagnostic_extbinary(ALTERGO, &mut issues)?
-    };
-    // in external mode, only warn about issues
-    for issue in issues {
-        println!("Warning: {issue}")
-    }
-    let config = Config { tools: External { why3_path, altergo_path } };
-    config.write_to_file(&paths.config_file)
-}
-
-fn install_managed(paths: &CfgPaths, previous_config: Option<Config>) -> anyhow::Result<()> {
-    // reread paths to external binaries
-    let mut issues = Vec::new();
-    let why3_path = diagnostic_extbinary(WHY3, &mut issues)?;
-    let altergo_path = diagnostic_extbinary(ALTERGO, &mut issues)?;
-    // in managed mode, issues are failures
-    if !issues.is_empty() {
-        for issue in issues {
-            println!("Error: {issue}")
+    for (bin, mode) in [(Z3, &cfg.z3), (CVC4, &cfg.cvc4), (CVC5, &cfg.cvc5)] {
+        match mode {
+            ManagedTool::Builtin { check_version: _ } => builtin.push(bin),
+            ManagedTool::External(tool) => external.push((bin, tool.path.clone())),
         }
-        bail!("Issues with external binaries.")
     }
-    if let Some(Config { tools: Managed { z3, cvc4, cvc5, .. } }) = previous_config {
-        // we are upgrading an existing configuration
-        let to_upgrade: Vec<_> = [(z3, Z3), (cvc4, CVC4), (cvc5, CVC5)]
-            .into_iter()
-            .filter(|(cur_ver, bin)| cur_ver != bin.version)
-            .map(|(_, bin)| bin)
-            .collect();
-        managed_download_and_generate_config(paths, &why3_path, &altergo_path, &to_upgrade)
-    } else {
-        // otherwise this is a fresh install
-        managed_download_and_generate_config(paths, &why3_path, &altergo_path, &[Z3, CVC4, CVC5])
+
+    // download binaries for builtins
+    download_all(&builtin, &paths.cache_dir, &paths.bin_subdir)?;
+
+    // create symbolic links for external tools so that why3 picks them up
+    symlink_file(&cfg.altergo.path, &paths.bin_subdir.join(ALTERGO.binary_name))?;
+    for (bin, path) in external {
+        symlink_file(path, &paths.bin_subdir.join(bin.bin.binary_name))?;
     }
-}
-
-// in managed mode, download required binaries, then (re)generate configuration
-// files for why3 and creusot
-fn managed_download_and_generate_config(
-    paths: &CfgPaths,
-    why3_path: &Path,
-    altergo_path: &Path,
-    bins: &[Binary],
-) -> anyhow::Result<()> {
-    // download tool binaries
-    download_all(bins, &paths.cache_dir, &paths.bin_subdir)?;
-
-    // create a symbolic link for alt-ergo so that it why3 picks it up
-    symlink_file(altergo_path, &paths.bin_subdir.join(ALTERGO.binary_name))?;
 
     // generate the corresponding .why3.conf
-    generate_why3_conf(why3_path, &paths.bin_subdir, &paths.why3_config_file)?;
+    generate_why3_conf(&cfg.why3.path, &paths.bin_subdir, &paths.why3_config_file)?;
 
-    // write the config file
-    let config = Config {
-        tools: Managed {
-            why3_path: why3_path.to_owned(),
-            altergo_path: altergo_path.to_owned(),
-            z3: Z3_VERSION.to_owned(),
-            cvc4: CVC4_VERSION.to_owned(),
-            cvc5: CVC5_VERSION.to_owned(),
-        },
-    };
-    config.write_to_file(&paths.config_file)
+    // write the config file to disk
+    cfg.write_to_file(&paths.config_file)
 }

--- a/creusot-setup/src/tools.rs
+++ b/creusot-setup/src/tools.rs
@@ -11,40 +11,49 @@ use std::{
 // we should only need to update the [Binary] definitions below whenever the
 // format of a tool binary releases change (unlikely)
 
-pub const WHY3: ExtBinary = ExtBinary {
+pub const WHY3: Binary = Binary {
     display_name: "Why3",
     binary_name: "why3",
     version: WHY3_VERSION,
     detect_version: detect_why3_version,
 };
 
-pub const ALTERGO: ExtBinary = ExtBinary {
+pub const ALTERGO: Binary = Binary {
     display_name: "Alt-Ergo",
     binary_name: "alt-ergo",
     version: ALTERGO_VERSION,
     detect_version: detect_altergo_version,
 };
 
-pub const Z3: Binary = Binary {
-    display_name: "Z3",
-    version: Z3_VERSION,
-    install_as: "z3",
+pub const Z3: ManagedBinary = ManagedBinary {
+    bin: Binary {
+        display_name: "Z3",
+        binary_name: "z3",
+        version: Z3_VERSION,
+        detect_version: detect_z3_version,
+    },
     url: &URLS.z3,
     download_with: download_z3_from_url,
 };
 
-pub const CVC4: Binary = Binary {
-    display_name: "CVC4",
-    version: CVC4_VERSION,
-    install_as: "cvc4",
+pub const CVC4: ManagedBinary = ManagedBinary {
+    bin: Binary {
+        display_name: "CVC4",
+        binary_name: "cvc4",
+        version: CVC4_VERSION,
+        detect_version: detect_cvc4_version,
+    },
     url: &URLS.cvc4,
     download_with: download_from_url_with_cache,
 };
 
-pub const CVC5: Binary = Binary {
-    display_name: "CVC5",
-    version: CVC5_VERSION,
-    install_as: "cvc5",
+pub const CVC5: ManagedBinary = ManagedBinary {
+    bin: Binary {
+        display_name: "CVC5",
+        binary_name: "cvc5",
+        version: CVC5_VERSION,
+        detect_version: detect_cvc5_version,
+    },
     url: &URLS.cvc5,
     download_with: download_from_url_with_cache,
 };
@@ -52,29 +61,31 @@ pub const CVC5: Binary = Binary {
 // ----
 
 #[derive(Clone, Copy)]
-pub struct Binary {
-    pub display_name: &'static str,
-    pub version: &'static str,
-    install_as: &'static str,
+pub struct ManagedBinary {
+    pub bin: Binary,
     url: &'static Url,
     download_with: fn(&Client, &Url, &Path, &Path) -> anyhow::Result<()>,
 }
 
 #[derive(Clone, Copy)]
-pub struct ExtBinary {
+pub struct Binary {
     pub display_name: &'static str,
     pub binary_name: &'static str,
     pub version: &'static str,
     detect_version: fn(&Path) -> Option<String>,
 }
 
-// download a list [Binary]s
+// download a list [ManagedBinary]s
 
-pub fn download_all(bins: &[Binary], cache_dir: &Path, dest_dir: &Path) -> anyhow::Result<()> {
+pub fn download_all(
+    bins: &[ManagedBinary],
+    cache_dir: &Path,
+    dest_dir: &Path,
+) -> anyhow::Result<()> {
     let client = Client::new();
     for bin in bins {
-        println!("Downloading {} {}...", bin.display_name, bin.version);
-        let path = dest_dir.join(bin.install_as);
+        println!("Downloading {} {}...", bin.bin.display_name, bin.bin.version);
+        let path = dest_dir.join(bin.bin.binary_name);
         let dl = bin.download_with;
         dl(&client, bin.url, cache_dir, &path)?;
         set_executable(&path)?;
@@ -147,17 +158,19 @@ pub enum DetectedVersion {
     Bad(Option<String>),
 }
 
-pub fn detect_binary_path(bin: &ExtBinary) -> Option<PathBuf> {
-    use which::which;
-    which(bin.binary_name).ok()
-}
+impl Binary {
+    pub fn detect_path(&self) -> Option<PathBuf> {
+        use which::which;
+        which(self.binary_name).ok()
+    }
 
-pub fn detect_binary_version(bin: &ExtBinary, path: &Path) -> DetectedVersion {
-    let detect_version = bin.detect_version;
-    match detect_version(&path) {
-        None => DetectedVersion::Bad(None),
-        Some(ver) if ver != bin.version => DetectedVersion::Bad(Some(ver)),
-        Some(_) => DetectedVersion::Good,
+    pub fn detect_version(&self, path: &Path) -> DetectedVersion {
+        let detect_version = self.detect_version;
+        match detect_version(&path) {
+            None => DetectedVersion::Bad(None),
+            Some(ver) if ver != self.version => DetectedVersion::Bad(Some(ver)),
+            Some(_) => DetectedVersion::Good,
+        }
     }
 }
 
@@ -209,6 +222,14 @@ fn detect_altergo_version(altergo: &Path) -> Option<String> {
 
 // helpers: Z3
 
+// assumes a version string of the form: "Z3 version 4.12.4 - 64 bit"
+fn detect_z3_version(z3: &Path) -> Option<String> {
+    let output = Command::new(&z3).arg("--version").output().ok()?;
+    let out_s = String::from_utf8(output.stdout).ok()?;
+    let out_s = out_s.strip_prefix("Z3 version ")?;
+    out_s.split_ascii_whitespace().next().map(String::from)
+}
+
 // Z3 releases come as a .zip archive that includes many things. We are only
 // interested in the z3 binary, so we extract it from the archive and throw away
 // the rest.
@@ -239,6 +260,28 @@ fn download_z3_from_url(
     }
     Ok(())
 }
+
+// cvc4
+
+// assumes a version of the form: "This is CVC4 version 1.8 [git HEAD 52479010]\n....."
+fn detect_cvc4_version(cvc4: &Path) -> Option<String> {
+    let output = Command::new(&cvc4).arg("--version").output().ok()?;
+    let out_s = String::from_utf8(output.stdout).ok()?;
+    let out_s = out_s.strip_prefix("This is CVC4 version ")?;
+    out_s.split_ascii_whitespace().next().map(String::from)
+}
+
+// cvc5
+
+// assumes a version of the form: "This is cvc5 version 1.0.5 [git ...]\n....."
+fn detect_cvc5_version(cvc5: &Path) -> Option<String> {
+    let output = Command::new(&cvc5).arg("--version").output().ok()?;
+    let out_s = String::from_utf8(output.stdout).ok()?;
+    let out_s = out_s.strip_prefix("This is cvc5 version ")?;
+    out_s.split_ascii_whitespace().next().map(String::from)
+}
+
+// cross-platform wrappers
 
 fn set_executable(dest: &Path) -> anyhow::Result<()> {
     #[cfg(unix)]

--- a/creusot/src/options.rs
+++ b/creusot/src/options.rs
@@ -17,7 +17,7 @@ pub enum Why3Sub {
 #[derive(Clone)]
 pub struct Why3Command {
     pub path: PathBuf,
-    pub config_file: Option<PathBuf>,
+    pub config_file: PathBuf,
     pub sub: Why3Sub,
     pub args: String,
 }

--- a/creusot/src/run_why3.rs
+++ b/creusot/src/run_why3.rs
@@ -48,11 +48,10 @@ pub(super) fn run_why3<'tcx>(ctx: &Why3Generator<'tcx>, file: Option<PathBuf>) {
     let prelude_dir = TempDir::new("creusot_why3_prelude").expect("could not create temp dir");
     PRELUDE.extract(prelude_dir.path()).expect("could extract prelude into temp dir");
     let mut command = Command::new(&why3_cmd.path);
-    if let Some(cfg) = &why3_cmd.config_file {
-        command.arg("-C").arg(cfg);
-    }
     command
         .args([
+            "-C",
+            &why3_cmd.config_file.to_string_lossy(),
             "--warn-off=unused_variable",
             "--warn-off=clone_not_abstract",
             "--warn-off=axiom_abstract",

--- a/creusot/tests/ui.rs
+++ b/creusot/tests/ui.rs
@@ -47,9 +47,6 @@ fn main() {
         temp_file.as_os_str(),
         "--output-file=/dev/null".as_ref(),
     ]);
-    if let Some(ref dir) = creusot_dev_config::custom_config_dir() {
-        metadata_file.arg("--config-dir").arg(&dir);
-    }
     metadata_file.args(&["--", "--package", "creusot-contracts"]).env("CREUSOT_CONTINUE", "true");
 
     if !metadata_file.status().expect("could not dump metadata for `creusot_contracts`").success() {
@@ -101,9 +98,7 @@ fn run_creusot(
         &format!("creusot_contracts={}", normalize_file_path(contracts)),
     ]);
     cmd.arg("--why3-path").arg(&config_paths.why3);
-    if let Some(why3_config) = &config_paths.why3_config {
-        cmd.arg("--why3-config-file").arg(why3_config);
-    }
+    cmd.arg("--why3-config-file").arg(&config_paths.why3_config);
 
     cmd.args(&["--", "-Zno-codegen", "--crate-type=lib"]);
     cmd.args(&["--extern", &format!("creusot_contracts={}", creusot_contract_path)]);


### PR DESCRIPTION
This is a refactor/overhaul of creusot setup.
The motivation is to provide a better workflow for upgrading tools from one version to the next (why3 and solvers).
(Incidentally this should fix the nightly CI job which currently fails because it detects that why3 has a new "unexpected" version and stops... instead we'd like to still use the bundled solvers, but relax the version checking for why3! this PR makes that possible.)

There are three commits:

Commit 92d9b16 contains the bulk of the work:
    Rework 'creusot setup' to allow toggling "external binary vs downloaded binary" for each tool separately, instead of
    having a global setting that applies to all tools like previously. (And similar for version checking.)
    The new 'creusot setup' cli makes it easy to chose (at the install step) for each tool:
    - whether the tool will be downloaded from a binary release or looked up in the current PATH.
    - whether 'creusot setup' will error and quit when the tool has a different version than expected.

Commit 1bfa0ba cleans up some codepaths left broken by the first commit. The implemented solution is up for discussion: I chose to be somewhat opinionated and cut down the complexity by removing some flexibility.
The commit makes it so the creusot config is always looked up from the "global" config file (removing the ability to use a custom config for running the testsuite), and the why3 config file we use (why3.conf) is always the one generated by creusot setup (removing the ability to use ~/.why3.conf).
Previously there were ways to have creusot use the ~/.why3.conf config file, conditionally on whether one is running the testsuite from the git repo. But I think this was somewhat clunky and I'm not sure anyone actually used these escape hatches...

Commit a6c8d56 unstucks the nightly CI by using the new option `cargo creusot setup install --no-check-version why3`.