### PR TITLE
Fix the `mlcfg` script

### DIFF
--- a/mlcfg
+++ b/mlcfg
@@ -6,7 +6,9 @@ OUTDIR=$(pwd)
 popd > /dev/null
 SCRIPTPATH=$(dirname "$BASH_SOURCE")
 pushd $SCRIPTPATH > /dev/null
-cargo run --bin creusot-rustc --  \
+eval $(cargo run --bin dev-env)
+cargo run --bin creusot-rustc -- \
+  --why3-config-file $WHY3CONFIG \
   --output-file="${INPUTPATH%.*}.mlcfg" \
   --span-mode=absolute \
   -- -Zno-codegen \


### PR DESCRIPTION
The `mlcfg` script at the root of the repo was failing with the error
```
error: the following required arguments were not provided:
  --why3-config-file <WHY3_CONFIG_FILE>

Usage: creusot-rustc --why3-config-file <WHY3_CONFIG_FILE> --output-file <OUTPUT_FILE> --span-mode <SPAN_MODE> -- <RUST_FLAGS>...

For more information, try '--help'.
```

@Armael is that the correct fix ?