### PR TITLE
Fix metadata load path

### DIFF
--- a/creusot/src/metadata.rs
+++ b/creusot/src/metadata.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_macros::{TyDecodable, TyEncodable};
 use rustc_middle::ty::TyCtxt;
+use rustc_session::config::OutputType;
 use rustc_span::Symbol;
 use std::{
     collections::HashMap,
@@ -140,12 +141,11 @@ impl<'tcx> BinaryMetadata<'tcx> {
 
 fn export_file(ctx: &TranslationCtx, out: &Option<String>) -> PathBuf {
     out.as_ref().map(|s| s.clone().into()).unwrap_or_else(|| {
-        let outputs = ctx.tcx.output_filenames(());
-
-        // let crate_name = ctx.tcx.crate_name(LOCAL_CRATE);
-
-        outputs.with_extension("cmeta")
-        // .join(&format!("lib{}.cmeta", libname))
+        let outputs = ctx.output_filenames(());
+        let out = outputs.path(OutputType::Metadata);
+        let path = out.as_path().to_owned();
+        let path = path.with_extension("cmeta");
+        path
     })
 }
 


### PR DESCRIPTION
In the recent rustc update, some apis changed with regards to getting output file locations in rustc, as a result I accidentally broke the loading of metadata. We would store to `foo-bar.cmeta` but attempt to load from `libfoo-bar.cmeta`, I've fixed this now, solving #1013. 

Unfortunately this is hard to test since our `ui` tests don't have this issue because they explicitly spell out the path for `creusot-contracts` metadata as an extra parameter. 
