### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/pearlite-syn/Cargo.toml
+++ b/pearlite-syn/Cargo.toml
@@ -3,7 +3,7 @@ name = "pearlite-syn"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-homepage = "https://github.com/creusot-rs/creusot"
+repository = "https://github.com/creusot-rs/creusot"
 description = "A syn parser for the Pearlite specification language"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.