### PR TITLE
Ghostptrtoken fixes

### DIFF
--- a/creusot-contracts/src/ghost_ptr.rs
+++ b/creusot-contracts/src/ghost_ptr.rs
@@ -14,7 +14,6 @@ pub struct GhostPtrToken<T: ?Sized>(PhantomData<T>);
 /// ZST equivalent of [`&'a GhostPtrToken<T>`](GhostPtrToken)
 /// Can be created using [`GhostPtrToken::borrow`]
 #[trusted]
-#[derive(Copy, Clone)]
 pub struct GhostPtrTokenRef<'a, T: ?Sized>(PhantomData<&'a T>);
 
 /// ZST equivalent of [`&'a mut GhostPtrToken<T>`](GhostPtrToken)
@@ -161,10 +160,9 @@ impl<'a, T: ?Sized> ShallowModel for GhostPtrTokenRef<'a, T> {
 impl<'a, T: ?Sized> Deref for GhostPtrTokenRef<'a, T> {
     type Target = GhostPtrToken<T>;
 
-    #[trusted]
     #[ensures(result@ == self@)]
     fn deref(&self) -> &Self::Target {
-        &GhostPtrToken(PhantomData)
+        self.to_ref()
     }
 }
 
@@ -176,6 +174,22 @@ impl<'a, T: ?Sized> GhostPtrTokenRef<'a, T> {
     #[allow(unused_variables)]
     pub fn shrink_token_ref(self, new_model: Snapshot<FMap<*const T, T>>) -> Self {
         self
+    }
+
+    #[trusted]
+    #[ensures(result@ == self@)]
+    pub fn to_ref(self) -> &'a GhostPtrToken<T> {
+        &GhostPtrToken(PhantomData)
+    }
+}
+
+impl<'a, T: ?Sized> Copy for GhostPtrTokenRef<'a, T> {}
+
+impl<'a, T: ?Sized> Clone for GhostPtrTokenRef<'a, T> {
+
+    #[ensures(result == *self)]
+    fn clone(&self) -> Self {
+        *self
     }
 }
 

--- a/creusot-contracts/src/ghost_ptr.rs
+++ b/creusot-contracts/src/ghost_ptr.rs
@@ -187,7 +187,6 @@ impl<'a, T: ?Sized> GhostPtrTokenRef<'a, T> {
 impl<'a, T: ?Sized> Copy for GhostPtrTokenRef<'a, T> {}
 
 impl<'a, T: ?Sized> Clone for GhostPtrTokenRef<'a, T> {
-
     #[ensures(result == *self)]
     fn clone(&self) -> Self {
         *self

--- a/creusot-contracts/src/ghost_ptr.rs
+++ b/creusot-contracts/src/ghost_ptr.rs
@@ -188,7 +188,7 @@ impl<'a, T: ?Sized> GhostPtrTokenMut<'a, T> {
     }
 
     #[trusted]
-    #[logic]
+    #[logic(prophetic)]
     #[open(self)]
     pub fn fin(self) -> FMap<GhostPtr<T>, T> {
         absurd
@@ -257,7 +257,7 @@ impl<'a, T> DerefMut for GhostPtrTokenMut<'a, T> {
 
 #[trusted]
 impl<'a, T> Resolve for GhostPtrTokenMut<'a, T> {
-    #[predicate]
+    #[predicate(prophetic)]
     #[open]
     fn resolve(self) -> bool {
         self.cur() == self.fin()

--- a/creusot-contracts/src/ghost_ptr.rs
+++ b/creusot-contracts/src/ghost_ptr.rs
@@ -68,6 +68,7 @@ impl<T: ?Sized> GhostPtrToken<T> {
     // it couldn't have already been contained in `self`
     #[ensures((^self)@ == (*self)@.insert(result, *val))]
     pub fn ptr_from_box(&mut self, val: Box<T>) -> *const T {
+        assert!(core::mem::size_of_val::<T>(&*val) > 0, "GhostPtrToken doesn't support ZSTs");
         Box::into_raw(val)
     }
 

--- a/creusot/tests/should_succeed/bug/949.coma
+++ b/creusot/tests/should_succeed/bug/949.coma
@@ -114,13 +114,13 @@ module C949_Main
   let%span span38 = "../../../../../creusot-contracts/src/logic/fmap.rs" 36 4 36 63
   let%span span39 = "../../../../../creusot-contracts/src/logic/fmap.rs" 37 4 37 68
   let%span span40 = "../../../../../creusot-contracts/src/logic/fmap.rs" 38 4 38 43
-  let%span span41 = "../../../../../creusot-contracts/src/ghost_ptr.rs" 71 35 71 38
-  let%span span42 = "../../../../../creusot-contracts/src/ghost_ptr.rs" 67 4 67 42
-  let%span span43 = "../../../../../creusot-contracts/src/ghost_ptr.rs" 70 14 70 55
+  let%span span41 = "../../../../../creusot-contracts/src/ghost_ptr.rs" 70 35 70 38
+  let%span span42 = "../../../../../creusot-contracts/src/ghost_ptr.rs" 66 4 66 42
+  let%span span43 = "../../../../../creusot-contracts/src/ghost_ptr.rs" 69 14 69 55
   let%span span44 = "../../../../../creusot-contracts/src/logic/fmap.rs" 85 14 85 31
   let%span span45 = "../../../../../creusot-contracts/src/logic/fmap.rs" 86 14 86 49
   let%span span46 = "../../../../../creusot-contracts/src/logic/fmap.rs" 87 4 87 26
-  let%span span47 = "../../../../../creusot-contracts/src/ghost_ptr.rs" 41 14 41 38
+  let%span span47 = "../../../../../creusot-contracts/src/ghost_ptr.rs" 40 14 40 38
   use prelude.Int32
   use Core_Option_Option_Type as Option'0
   predicate invariant'6 (self : Option'0.t_option int32) =

--- a/creusot/tests/should_succeed/ghost_ptr_token.coma
+++ b/creusot/tests/should_succeed/ghost_ptr_token.coma
@@ -130,7 +130,7 @@ module GhostPtrToken_Test
   let%span span34 = "../../../../creusot-contracts/src/std/mem.rs" 14 22 14 30
   let%span span35 = "../../../../creusot-contracts/src/resolve.rs" 46 8 46 12
   let%span span36 = "../../../../creusot-contracts/src/resolve.rs" 17 8 17 60
-  let%span span37 = "../../../../creusot-contracts/src/ghost_ptr.rs" 263 8 263 32
+  let%span span37 = "../../../../creusot-contracts/src/ghost_ptr.rs" 277 8 277 32
   let%span span38 = "../../../../creusot-contracts/src/logic/fmap.rs" 13 15 13 19
   let%span span39 = "../../../../creusot-contracts/src/logic/fmap.rs" 12 14 12 25
   let%span span40 = "../../../../creusot-contracts/src/util.rs" 16 19 16 23
@@ -148,21 +148,21 @@ module GhostPtrToken_Test
   let%span span52 = "../../../../creusot-contracts/src/logic/fmap.rs" 45 14 45 55
   let%span span53 = "../../../../creusot-contracts/src/logic/fmap.rs" 46 14 46 84
   let%span span54 = "../../../../creusot-contracts/src/logic/fmap.rs" 47 4 47 37
-  let%span span55 = "../../../../creusot-contracts/src/ghost_ptr.rs" 229 15 229 42
-  let%span span56 = "../../../../creusot-contracts/src/ghost_ptr.rs" 230 14 230 59
-  let%span span57 = "../../../../creusot-contracts/src/ghost_ptr.rs" 231 14 231 56
-  let%span span58 = "../../../../creusot-contracts/src/ghost_ptr.rs" 232 14 232 65
-  let%span span59 = "../../../../creusot-contracts/src/ghost_ptr.rs" 233 14 233 42
-  let%span span60 = "../../../../creusot-contracts/src/ghost_ptr.rs" 234 4 234 58
+  let%span span55 = "../../../../creusot-contracts/src/ghost_ptr.rs" 243 15 243 42
+  let%span span56 = "../../../../creusot-contracts/src/ghost_ptr.rs" 244 14 244 59
+  let%span span57 = "../../../../creusot-contracts/src/ghost_ptr.rs" 245 14 245 56
+  let%span span58 = "../../../../creusot-contracts/src/ghost_ptr.rs" 246 14 246 65
+  let%span span59 = "../../../../creusot-contracts/src/ghost_ptr.rs" 247 14 247 42
+  let%span span60 = "../../../../creusot-contracts/src/ghost_ptr.rs" 248 4 248 58
   let%span span61 = "../../../../creusot-contracts/src/ghost_ptr.rs" 124 14 124 38
   let%span span62 = "../../../../creusot-contracts/src/ghost_ptr.rs" 125 14 125 38
-  let%span span63 = "../../../../creusot-contracts/src/ghost_ptr.rs" 71 35 71 38
-  let%span span64 = "../../../../creusot-contracts/src/ghost_ptr.rs" 67 4 67 42
-  let%span span65 = "../../../../creusot-contracts/src/ghost_ptr.rs" 70 14 70 55
+  let%span span63 = "../../../../creusot-contracts/src/ghost_ptr.rs" 70 35 70 38
+  let%span span64 = "../../../../creusot-contracts/src/ghost_ptr.rs" 66 4 66 42
+  let%span span65 = "../../../../creusot-contracts/src/ghost_ptr.rs" 69 14 69 55
   let%span span66 = "../../../../creusot-contracts/src/logic/fmap.rs" 85 14 85 31
   let%span span67 = "../../../../creusot-contracts/src/logic/fmap.rs" 86 14 86 49
   let%span span68 = "../../../../creusot-contracts/src/logic/fmap.rs" 87 4 87 26
-  let%span span69 = "../../../../creusot-contracts/src/ghost_ptr.rs" 41 14 41 38
+  let%span span69 = "../../../../creusot-contracts/src/ghost_ptr.rs" 40 14 40 38
   use prelude.Int32
   use Core_Option_Option_Type as Option'0
   predicate invariant'7 (self : Option'0.t_option int32) =


### PR DESCRIPTION
* Makes `GhostPtrToken::fin` `logic(prophetic)`, instead of `logic`.
* Makes the `Copy` implementation of `GhostPtrTokenRef<T>` apply for all `T`.
* Adds `GhostPtrTokenRef::to_ref` to allow accessing references with the longer lifetime.
* Adds a runtime check to make sure no elements in a `GhostPtrToken` are zeros sized.
  - `GhostPtrToken::box_to_ptr` ensures that the returned pointer isn't in the token which might not be true for ZSTs.
  - For statically sized types this check is trivial and should get compiled away.