### PR TITLE
Update coma branch

### DIFF
--- a/creusot-deps.opam
+++ b/creusot-deps.opam
@@ -4,8 +4,8 @@ opam-version: "2.0"
 maintainer: "Armaël Guéneau <armael.gueneau@inria.fr>"
 authors: "the creusot authors"
 depends: [
-  "why3" {= "git-6736"}
-  "why3-ide" {= "git-6736" & !?in-creusot-ci}
+  "why3" {= "git-6d61"}
+  "why3-ide" {= "git-6d61" & !?in-creusot-ci}
 # optional dependencies of why3
   "ocamlgraph"
   "camlzip"
@@ -16,6 +16,6 @@ depends: [
 # When updating the hash and git-XXX below, don't forget to update them in the
 # depends: field above!
 pin-depends: [
-  [ "why3.git-6736" "git+https://gitlab.inria.fr/why3/why3.git#67362b1" ]
-  [ "why3-ide.git-6736" "git+https://gitlab.inria.fr/why3/why3.git#67362b1" ]
+  [ "why3.git-6d61" "git+https://gitlab.inria.fr/why3/why3.git#6d615e178" ]
+  [ "why3-ide.git-6d61" "git+https://gitlab.inria.fr/why3/why3.git#6d615e178" ]
 ]


### PR DESCRIPTION
@dewert99 reported that the README was broken. This is because the coma branch of why3 was rebased off why3 master and the previous commit no longer exists. 
