### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/creusot-contracts-proc/Cargo.toml
+++ b/creusot-contracts-proc/Cargo.toml
@@ -3,7 +3,7 @@ name = "creusot-contracts-proc"
 version = "0.1.0"
 authors = ["Xavier Denis <xldenis@gmail.com>"]
 edition = "2018"
-homepage = "https://github.com/creusot-rs/creusot"
+repository = "https://github.com/creusot-rs/creusot"
 license = "LGPL-2.1-or-later"
 description = "Proc macro crate for creusot-contracts"
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.