### PR TITLE
Improve the `fmt` script, and make it take arguments for rustfmt

### DIFF
--- a/fmt
+++ b/fmt
@@ -2,7 +2,9 @@
 # We use zsh instead of bash to enable globstar "**".
 # We don't instead run "shopt -s globstar", because shopt is not supported in Mac OS.
 
-SCRIPTPATH=$(dirname "$BASH_SOURCE")
+set -e
+
+SCRIPTPATH=${0:a:h}
 pushd $SCRIPTPATH > /dev/null
-rustfmt **/*.rs
+rustfmt $@ **/*.rs
 popd > /dev/null


### PR DESCRIPTION
I got tired of forgetting to run `./fmt`, so this enables using a (local, non-commited) pre-commit script.
The script I personally use:
```sh
#!/bin/sh
# in .git/hooks/pre-commit

./fmt --check
```

This also correctly detect the script's path in `./fmt`, given that it uses zsh.