### PR TITLE
documents specifications of functions with `cargo creusot doc`

### DIFF
--- a/creusot-args/src/lib.rs
+++ b/creusot-args/src/lib.rs
@@ -1,1 +1,18 @@
 pub mod options;
+
+/// Args that activate features needed by creusot.
+pub const CREUSOT_RUSTC_ARGS: &[&str] = &[
+    "-Cpanic=abort",
+    "-Coverflow-checks=off",
+    "-Zcrate-attr=feature(register_tool)",
+    "-Zcrate-attr=register_tool(creusot)",
+    "-Zcrate-attr=register_tool(why3)",
+    "-Zcrate-attr=feature(stmt_expr_attributes)",
+    "-Zcrate-attr=feature(proc_macro_hygiene)",
+    "-Zcrate-attr=feature(rustc_attrs)",
+    "-Zcrate-attr=feature(unsized_fn_params)",
+    "--allow=internal_features",
+    "-Zdump-mir=speccleanup",
+    "--cfg",
+    "creusot",
+];

--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -66,6 +66,12 @@ pub enum CreusotSubCommand {
         #[clap(last = true)]
         rust_flags: Vec<String>,
     },
+    /// Generates the documentation, including specs, logical functions, etc.
+    Doc {
+        /// Arguments to forward to `cargo doc`.
+        #[clap(trailing_var_arg = true)]
+        rust_flags: Vec<String>,
+    },
 }
 
 #[derive(Debug, Parser)]
@@ -156,6 +162,7 @@ impl CreusotArgs {
         let rust_flags = match &mut self.subcommand {
             None => return,
             Some(CreusotSubCommand::Why3 { rust_flags, .. }) => rust_flags,
+            Some(CreusotSubCommand::Doc { rust_flags }) => rust_flags,
         };
         let rust_flags = std::mem::take(rust_flags);
         assert!(self.rust_flags.is_empty());
@@ -175,6 +182,9 @@ impl CargoCreusotArgs {
             Some(CargoCreusotSubCommand::Creusot(CreusotSubCommand::Why3 {
                 rust_flags, ..
             })) => rust_flags,
+            Some(CargoCreusotSubCommand::Creusot(CreusotSubCommand::Doc { rust_flags })) => {
+                rust_flags
+            }
             _ => return,
         };
         let rust_flags = std::mem::take(rust_flags);

--- a/creusot-contracts-dummy/src/lib.rs
+++ b/creusot-contracts-dummy/src/lib.rs
@@ -6,16 +6,11 @@ use proc_macro::TokenStream as TS1;
 pub fn requires(precondition: TS1, tokens: TS1) -> TS1 {
     let tokens = proc_macro2::TokenStream::from(tokens);
     let mut precondition = precondition.to_string();
-    precondition = if precondition.contains('\n') {
-        precondition = precondition.replace('\n', "\n> > ");
-        format!("> > ```pearlite\n> > {precondition}\n> > ```")
-    } else {
-        format!("> > `{precondition}`")
-    };
+    precondition = precondition.replace('\n', "\n> > ");
+    precondition = format!("> > ```\n> > {precondition}\n> > ```");
     quote::quote! {
-        #[doc = "> <span style=\"color:Tomato;\">requires</span>"]
-        #[doc = #precondition]
-        #[doc = ""]
+        #[cfg_attr(not(doctest), doc = "> <span style=\"color:Tomato;\">requires</span>")]
+        #[cfg_attr(not(doctest), doc = #precondition)]
         #tokens
     }
     .into()
@@ -25,16 +20,11 @@ pub fn requires(precondition: TS1, tokens: TS1) -> TS1 {
 pub fn ensures(postcondition: TS1, tokens: TS1) -> TS1 {
     let tokens = proc_macro2::TokenStream::from(tokens);
     let mut postcondition = postcondition.to_string();
-    postcondition = if postcondition.contains('\n') {
-        postcondition = postcondition.replace('\n', "\n> > ");
-        format!("> > ```pearlite\n> > {postcondition}\n> > ```")
-    } else {
-        format!("> > `{postcondition}`")
-    };
+    postcondition = postcondition.replace('\n', "\n> > ");
+    postcondition = format!("> > ```\n> > {postcondition}\n> > ```");
     quote::quote! {
-        #[doc = "> <span style=\"color:MediumSeaGreen;\">ensures</span>"]
-        #[doc = #postcondition]
-        #[doc = ""]
+        #[cfg_attr(not(doctest), doc = "> <span style=\"color:DodgerBlue;\">ensures</span>")]
+        #[cfg_attr(not(doctest), doc = #postcondition)]
         #tokens
     }
     .into()

--- a/creusot-contracts-dummy/src/lib.rs
+++ b/creusot-contracts-dummy/src/lib.rs
@@ -3,31 +3,13 @@ extern crate proc_macro;
 use proc_macro::TokenStream as TS1;
 
 #[proc_macro_attribute]
-pub fn requires(precondition: TS1, tokens: TS1) -> TS1 {
-    let tokens = proc_macro2::TokenStream::from(tokens);
-    let mut precondition = precondition.to_string();
-    precondition = precondition.replace('\n', "\n> > ");
-    precondition = format!("> > ```\n> > {precondition}\n> > ```");
-    quote::quote! {
-        #[cfg_attr(not(doctest), doc = "> <span style=\"color:Tomato;\">requires</span>")]
-        #[cfg_attr(not(doctest), doc = #precondition)]
-        #tokens
-    }
-    .into()
+pub fn requires(_: TS1, tokens: TS1) -> TS1 {
+    tokens
 }
 
 #[proc_macro_attribute]
-pub fn ensures(postcondition: TS1, tokens: TS1) -> TS1 {
-    let tokens = proc_macro2::TokenStream::from(tokens);
-    let mut postcondition = postcondition.to_string();
-    postcondition = postcondition.replace('\n', "\n> > ");
-    postcondition = format!("> > ```\n> > {postcondition}\n> > ```");
-    quote::quote! {
-        #[cfg_attr(not(doctest), doc = "> <span style=\"color:DodgerBlue;\">ensures</span>")]
-        #[cfg_attr(not(doctest), doc = #postcondition)]
-        #tokens
-    }
-    .into()
+pub fn ensures(_: TS1, tokens: TS1) -> TS1 {
+    tokens
 }
 
 #[proc_macro_attribute]

--- a/creusot-contracts-dummy/src/lib.rs
+++ b/creusot-contracts-dummy/src/lib.rs
@@ -3,13 +3,41 @@ extern crate proc_macro;
 use proc_macro::TokenStream as TS1;
 
 #[proc_macro_attribute]
-pub fn requires(_: TS1, tokens: TS1) -> TS1 {
-    tokens
+pub fn requires(precondition: TS1, tokens: TS1) -> TS1 {
+    let tokens = proc_macro2::TokenStream::from(tokens);
+    let mut precondition = precondition.to_string();
+    precondition = if precondition.contains('\n') {
+        precondition = precondition.replace('\n', "\n> > ");
+        format!("> > ```pearlite\n> > {precondition}\n> > ```")
+    } else {
+        format!("> > `{precondition}`")
+    };
+    quote::quote! {
+        #[doc = "> <span style=\"color:Tomato;\">requires</span>"]
+        #[doc = #precondition]
+        #[doc = ""]
+        #tokens
+    }
+    .into()
 }
 
 #[proc_macro_attribute]
-pub fn ensures(_: TS1, tokens: TS1) -> TS1 {
-    tokens
+pub fn ensures(postcondition: TS1, tokens: TS1) -> TS1 {
+    let tokens = proc_macro2::TokenStream::from(tokens);
+    let mut postcondition = postcondition.to_string();
+    postcondition = if postcondition.contains('\n') {
+        postcondition = postcondition.replace('\n', "\n> > ");
+        format!("> > ```pearlite\n> > {postcondition}\n> > ```")
+    } else {
+        format!("> > `{postcondition}`")
+    };
+    quote::quote! {
+        #[doc = "> <span style=\"color:MediumSeaGreen;\">ensures</span>"]
+        #[doc = #postcondition]
+        #[doc = ""]
+        #tokens
+    }
+    .into()
 }
 
 #[proc_macro_attribute]
@@ -40,13 +68,13 @@ pub fn ghost(body: TS1) -> TS1 {
 }
 
 #[proc_macro_attribute]
-pub fn terminates(_: TS1, _: TS1) -> TS1 {
-    TS1::new()
+pub fn terminates(_: TS1, tokens: TS1) -> TS1 {
+    tokens
 }
 
 #[proc_macro_attribute]
-pub fn pure(_: TS1, _: TS1) -> TS1 {
-    TS1::new()
+pub fn pure(_: TS1, tokens: TS1) -> TS1 {
+    tokens
 }
 
 #[proc_macro_attribute]

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -170,6 +170,7 @@ fn spec_attrs(tag: &Ident) -> TokenStream {
          #[creusot::no_translate]
          #[creusot::item=#name_tag]
          #[creusot::spec]
+         #[doc(hidden)]
     }
 }
 

--- a/creusot-contracts/src/ghost_ptr.rs
+++ b/creusot-contracts/src/ghost_ptr.rs
@@ -6,8 +6,8 @@ use ::std::{
 };
 
 /// Models a fragment of the heap that maps the [`GhostPtr`]s it has permission to their value.
-/// At most one [`GhostToken`] has permission to each [`GhostPtr`]
-/// No [`GhostToken`] has permission to a dangling [`GhostPtr`]
+/// At most one [`GhostPtrToken`] has permission to each [`GhostPtr`]
+/// No [`GhostPtrToken`] has permission to a dangling [`GhostPtr`]
 #[trusted]
 pub struct GhostPtrToken<T: ?Sized>(PhantomData<T>);
 
@@ -62,7 +62,7 @@ impl<T: ?Sized> GhostPtrToken<T> {
     }
 
     /// Casts `val` into a raw pointer and gives `self` permission to it
-    // Safety this pointer was owned by a box so no other GhostToken could have permission to it
+    // Safety this pointer was owned by a box so no other GhostPtrToken could have permission to it
     #[trusted]
     #[ensures(!(*self)@.contains(result))]
     // Since we had full permission to `val` and all of the entries in `self` simultaneously,
@@ -304,8 +304,8 @@ extern_spec! {
 
     mod std {
         mod ptr {
-            /// Creates a null pointer that no GhostToken has permission to
-            // Safety even though this pointer is dangling no GhostToken has permission to it so it's okay
+            /// Creates a null pointer that no GhostPtrToken has permission to
+            // Safety even though this pointer is dangling no GhostPtrToken has permission to it so it's okay
             #[trusted]
             #[ensures(result == GhostPtr::<T>::null_logic())]
             fn null<T>() -> *const T

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -144,7 +144,8 @@ mod macros {
     pub use base_macros::trusted;
 
     /// Declares a variant for a function, this is primarily used in combination with logical functions
-    /// The variant must be an expression which returns a type implementing [WellFounded]
+    /// The variant must be an expression which returns a type implementing
+    /// [`WellFounded`](crate::WellFounded).
     pub use base_macros::variant;
 
     /// Enables Pearlite syntax, granting access to Pearlite specific operators and syntax

--- a/creusot-rustc/src/main.rs
+++ b/creusot-rustc/src/main.rs
@@ -12,6 +12,7 @@ use options::CreusotArgsExt as _;
 extern crate log;
 
 use creusot::callbacks::*;
+use creusot_args::CREUSOT_RUSTC_ARGS;
 use options::CreusotArgs;
 use rustc_driver::RunCompiler;
 use rustc_session::{config::ErrorOutputType, EarlyDiagCtxt};
@@ -68,18 +69,9 @@ fn setup_plugin() {
     if normal_rustc || !(user_asked_for || has_contracts) {
         return RunCompiler::new(&args, &mut DefaultCallbacks {}).run().unwrap();
     } else {
-        args.push("-Cpanic=abort".to_owned());
-        args.push("-Coverflow-checks=off".to_owned());
-        args.push("-Zcrate-attr=feature(register_tool)".to_owned());
-        args.push("-Zcrate-attr=register_tool(creusot)".to_owned());
-        args.push("-Zcrate-attr=register_tool(why3)".to_owned());
-        args.push("-Zcrate-attr=feature(stmt_expr_attributes)".to_owned());
-        args.push("-Zcrate-attr=feature(proc_macro_hygiene)".to_owned());
-        args.push("-Zcrate-attr=feature(rustc_attrs)".to_owned());
-        args.push("-Zcrate-attr=feature(unsized_fn_params)".to_owned());
-        args.push("--allow=internal_features".to_owned());
-        args.push("-Zdump-mir=speccleanup".to_owned());
-        args.extend(["--cfg", "creusot"].into_iter().map(str::to_owned));
+        for &arg in CREUSOT_RUSTC_ARGS {
+            args.push(arg.to_owned());
+        }
         debug!("creusot args={:?}", args);
 
         let opts = match CreusotArgs::to_options(creusot) {

--- a/creusot-rustc/src/options.rs
+++ b/creusot-rustc/src/options.rs
@@ -11,7 +11,9 @@ fn why3_command(
     config_file: PathBuf,
     cmd: CreusotSubCommand,
 ) -> options::Why3Command {
-    let CreusotSubCommand::Why3 { command, args, .. } = cmd;
+    let CreusotSubCommand::Why3 { command, args, .. } = cmd else {
+        unreachable!();
+    };
     let sub = match command {
         Why3SubCommand::Prove => options::Why3Sub::Prove,
         Why3SubCommand::Ide => options::Why3Sub::Ide,
@@ -58,9 +60,12 @@ impl CreusotArgsExt for CreusotArgs {
             span_mode,
             match_str: self.options.focus_on,
             simple_triggers: self.options.simple_triggers,
-            why3_cmd: self
-                .subcommand
-                .map(|cmd| why3_command(self.why3_path, self.why3_config_file, cmd)),
+            why3_cmd: match self.subcommand {
+                Some(cmd @ CreusotSubCommand::Why3 { .. }) => {
+                    Some(why3_command(self.why3_path, self.why3_config_file, cmd))
+                }
+                _ => None,
+            },
         })
     }
 }

--- a/creusot/tests/should_succeed/syntax/13_vec_macro.coma
+++ b/creusot/tests/should_succeed/syntax/13_vec_macro.coma
@@ -109,7 +109,7 @@ module Alloc_Boxed_Box_Type
   function any_l (_ : 'b) : 'a
 end
 module C13VecMacro_X
-  let%span slib0 = "../../../../../creusot-contracts/src/lib.rs" 285 8 285 30
+  let%span slib0 = "../../../../../creusot-contracts/src/lib.rs" 286 8 286 30
   
   let%span s13_vec_macro1 = "../13_vec_macro.rs" 7 20 7 34
   


### PR DESCRIPTION
This is just a fun little thing, inspired by the way Verus doc appears.

To see the effects, do `cargo doc -p creusot-contracts --open`, and look at
- `GhostPtrToken` for an example of pre and post conditions
- `GhostMap` for a multiline postcondition

Edit: now the command is `cargo creusot doc`, see <https://arnaudgolfouse.gitlab.io/creusot-test/creusot_test/> for an example