### PR TITLE
Fix why3 pin version

### DIFF
--- a/creusot-deps.opam
+++ b/creusot-deps.opam
@@ -4,8 +4,8 @@ opam-version: "2.0"
 maintainer: "Armaël Guéneau <armael.gueneau@inria.fr>"
 authors: "the creusot authors"
 depends: [
-  "why3" {= "git-40a7"}
-  "why3-ide" {= "git-40a7" & !?in-creusot-ci}
+  "why3" {= "git-9371"}
+  "why3-ide" {= "git-9371" & !?in-creusot-ci}
 # optional dependencies of why3
   "ocamlgraph"
   "camlzip"
@@ -16,6 +16,6 @@ depends: [
 # When updating the hash and git-XXX below, don't forget to update them in the
 # depends: field above!
 pin-depends: [
-  [ "why3.git-40a7" "git+https://gitlab.inria.fr/why3/why3.git#40a7b4fc" ]
-  [ "why3-ide.git-40a7" "git+https://gitlab.inria.fr/why3/why3.git#40a7b4fc" ]
+  [ "why3.git-9371" "git+https://gitlab.inria.fr/why3/why3.git#9371ad18" ]
+  [ "why3-ide.git-9371" "git+https://gitlab.inria.fr/why3/why3.git#9371ad18" ]
 ]


### PR DESCRIPTION
Coma is now merged into the Why3 master branch.
The previous pinned commit no longer exists.