### PR TITLE
Allow creusot-contracts to build locally

### DIFF
--- a/creusot-contracts/Cargo.toml
+++ b/creusot-contracts/Cargo.toml
@@ -21,3 +21,6 @@ contracts = []
 
 [package.metadata.release]
 pre-release-replacements = [ ]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(creusot)'] }

--- a/creusot-contracts/build.rs
+++ b/creusot-contracts/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("cargo::rustc-check-cfg=cfg(creusot)");
-}


### PR DESCRIPTION
This provides a patch to the problem encountered by making `creusot-contracts` a hard error.
