### PR TITLE
Move all the special cases of dependencies to Dependency::new.

### DIFF
--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -22,7 +22,7 @@ use std::{
 use crate::{options::SpanMode, run_why3::SpanMap};
 pub(crate) use clone_map::*;
 
-use self::dependency::{Dependency, ExtendedId};
+use self::dependency::{ClosureSpecKind, Dependency};
 
 pub(crate) mod clone_map;
 pub(crate) mod constant;
@@ -45,7 +45,7 @@ pub(crate) enum TransId<'tcx> {
     Item(DefId),
     TyInv(Ty<'tcx>),
     StructuralResolve(Ty<'tcx>),
-    Hacked(ExtendedId, DefId),
+    Hacked(ClosureSpecKind, DefId),
 }
 
 impl<'tcx> From<DefId> for TransId<'tcx> {
@@ -99,13 +99,13 @@ impl<'tcx> Why3Generator<'tcx> {
             TransId::Hacked(h, id) => {
                 let c = self.ctx.closure_contract(id);
                 match h {
-                    ExtendedId::PostconditionOnce => Some(&c.postcond_once.as_ref()?.1),
-                    ExtendedId::PostconditionMut => Some(&c.postcond_mut.as_ref()?.1),
-                    ExtendedId::Postcondition => Some(&c.postcond.as_ref()?.1),
-                    ExtendedId::Precondition => Some(&c.precond.1),
-                    ExtendedId::Unnest => Some(&c.unnest.as_ref()?.1),
-                    ExtendedId::Resolve => Some(&c.resolve.1),
-                    ExtendedId::Accessor(ix) => Some(&c.accessors[ix as usize].1),
+                    ClosureSpecKind::PostconditionOnce => Some(&c.postcond_once.as_ref()?.1),
+                    ClosureSpecKind::PostconditionMut => Some(&c.postcond_mut.as_ref()?.1),
+                    ClosureSpecKind::Postcondition => Some(&c.postcond.as_ref()?.1),
+                    ClosureSpecKind::Precondition => Some(&c.precond.1),
+                    ClosureSpecKind::Unnest => Some(&c.unnest.as_ref()?.1),
+                    ClosureSpecKind::Resolve => Some(&c.resolve.1),
+                    ClosureSpecKind::Accessor(ix) => Some(&c.accessors[ix as usize].1),
                 }
             }
             TransId::StructuralResolve(_) => unreachable!(),
@@ -382,7 +382,7 @@ impl<'tcx> Why3Generator<'tcx> {
 
     fn is_accessor(&self, item: TransId) -> bool {
         match item {
-            TransId::Hacked(ExtendedId::Accessor(_), _) => true,
+            TransId::Hacked(ClosureSpecKind::Accessor(_), _) => true,
             TransId::Item(id) => self.def_kind(id) == DefKind::Field,
             _ => false,
         }

--- a/creusot/src/backend/clone_map.rs
+++ b/creusot/src/backend/clone_map.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 use rustc_macros::{TyDecodable, TyEncodable, TypeFoldable, TypeVisitable};
 
-use super::{dependency::ExtendedId, TransId, Why3Generator};
+use super::{dependency::ClosureSpecKind, TransId, Why3Generator};
 
 mod elaborator;
 mod expander;
@@ -148,7 +148,7 @@ pub(crate) trait Namer<'tcx> {
         let tcx = self.tcx();
         let node = match util::item_type(tcx, def_id) {
             ItemType::Closure => {
-                Dependency::Hacked(ExtendedId::Accessor(ix.as_u32() as u8), def_id, subst)
+                Dependency::ClosureSpec(ClosureSpecKind::Accessor(ix.as_u32() as u8), def_id, subst)
             }
             ItemType::Type => {
                 let adt = tcx.adt_def(def_id);
@@ -236,7 +236,7 @@ impl<'tcx> Namer<'tcx> for Dependencies<'tcx> {
     }
 
     fn insert(&mut self, key: Dependency<'tcx>) -> Kind {
-        let key = key.erase_regions(self.tcx).identify_overloads(self.tcx);
+        let key = key.erase_regions(self.tcx);
         self.levels
             .entry(key)
             .and_modify(|l| {

--- a/creusot/src/backend/dependency.rs
+++ b/creusot/src/backend/dependency.rs
@@ -28,14 +28,14 @@ pub(crate) enum Dependency<'tcx> {
     // 'skeleton type' (aka type with identity substs).
     TyInv(Ty<'tcx>),
     StructuralResolve(Ty<'tcx>),
-    Hacked(ExtendedId, DefId, GenericArgsRef<'tcx>),
+    ClosureSpec(ClosureSpecKind, DefId, GenericArgsRef<'tcx>),
     Builtin(PreludeModule),
 }
 
 /// Due to how rustc keeps closures hidden from us, some key symbols of creusot don't get their own def ids.
 /// Instead, we use this enumerator combined with the closure's defid to distinguish these symbols.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
-pub(crate) enum ExtendedId {
+pub(crate) enum ClosureSpecKind {
     PostconditionOnce,
     PostconditionMut,
     Postcondition,
@@ -45,13 +45,13 @@ pub(crate) enum ExtendedId {
     Accessor(u8),
 }
 
-impl<'tcx, I: Interner> TypeVisitable<I> for ExtendedId {
+impl<'tcx, I: Interner> TypeVisitable<I> for ClosureSpecKind {
     fn visit_with<V: rustc_type_ir::visit::TypeVisitor<I>>(&self, _: &mut V) -> V::Result {
         V::Result::output()
     }
 }
 
-impl<'tcx, I: Interner> TypeFoldable<I> for ExtendedId {
+impl<'tcx, I: Interner> TypeFoldable<I> for ClosureSpecKind {
     fn try_fold_with<F: rustc_type_ir::fold::FallibleTypeFolder<I>>(
         self,
         _: &mut F,
@@ -65,7 +65,44 @@ impl<'tcx> Dependency<'tcx> {
         match util::item_type(tcx, did) {
             ItemType::Type => Dependency::Type(Ty::new_adt(tcx, tcx.adt_def(did), subst)),
             ItemType::AssocTy => Dependency::Type(Ty::new_projection(tcx, did, subst)),
-            _ => Dependency::Item(did, subst),
+            _ => {
+                // We need to "overload" certain identifiers in rustc so that we can distinguish them while
+                // rustc doesn't. In particular, closures act as both a type and a function and are missing many
+                // identifiers for things like accessors.
+                //
+                // We also use this to overload "structural resolution" for types
+
+                let closure_spec = if tcx
+                    .is_diagnostic_item(Symbol::intern("fn_once_impl_precond"), did)
+                {
+                    Some((ClosureSpecKind::Precondition, 1))
+                } else if tcx.is_diagnostic_item(Symbol::intern("fn_once_impl_postcond"), did) {
+                    Some((ClosureSpecKind::PostconditionOnce, 1))
+                } else if tcx.is_diagnostic_item(Symbol::intern("fn_mut_impl_postcond"), did) {
+                    Some((ClosureSpecKind::PostconditionMut, 1))
+                } else if tcx.is_diagnostic_item(Symbol::intern("fn_impl_postcond"), did) {
+                    Some((ClosureSpecKind::Postcondition, 1))
+                } else if tcx.is_diagnostic_item(Symbol::intern("fn_mut_impl_unnest"), did) {
+                    Some((ClosureSpecKind::Unnest, 1))
+                } else if tcx.is_diagnostic_item(Symbol::intern("creusot_resolve_method"), did) {
+                    Some((ClosureSpecKind::Resolve, 0))
+                } else {
+                    None
+                };
+
+                if let Some((closure_spec, param_id)) = closure_spec {
+                    let self_ty = subst.types().nth(param_id).unwrap();
+                    if let TyKind::Closure(id, csubst) = self_ty.kind() {
+                        return Dependency::ClosureSpec(closure_spec, *id, csubst);
+                    }
+                }
+
+                if let Some(ty) = structural_resolve(tcx, (did, subst)) {
+                    Dependency::StructuralResolve(ty)
+                } else {
+                    Dependency::Item(did, subst)
+                }
+            }
         }
     }
 
@@ -91,7 +128,7 @@ impl<'tcx> Dependency<'tcx> {
                     },
                     _ => unreachable!(),
                 };
-                Dependency::Hacked(h, self_id, subst).erase_regions(tcx)
+                Dependency::ClosureSpec(h, self_id, subst).erase_regions(tcx)
             }
             TransId::StructuralResolve(ty) => Dependency::StructuralResolve(ty),
         }
@@ -109,7 +146,7 @@ impl<'tcx> Dependency<'tcx> {
                 let ty = tyinv_head_and_subst(tcx, ty, param_env).0;
                 Some(TransId::TyInv(ty))
             }
-            Dependency::Hacked(h, id, _) => Some(TransId::Hacked(h, id)),
+            Dependency::ClosureSpec(h, id, _) => Some(TransId::Hacked(h, id)),
             Dependency::Builtin(_) => None,
             Dependency::StructuralResolve(ty) => {
                 let ty = structural_resolve::head_and_subst(tcx, ty).0;
@@ -139,14 +176,14 @@ impl<'tcx> Dependency<'tcx> {
                 TyKind::Alias(AliasTyKind::Projection, aty) => Some((aty.def_id, aty.args)),
                 _ => None,
             },
-            Dependency::Hacked(_, id, substs) => Some((id, substs)),
+            Dependency::ClosureSpec(_, id, substs) => Some((id, substs)),
             Dependency::TyInv(_) | Dependency::Builtin(_) => None,
             Dependency::StructuralResolve(_) => None,
         }
     }
 
-    pub(crate) fn is_hacked(&self) -> bool {
-        matches!(self, Dependency::Hacked(_, _, _))
+    pub(crate) fn is_closure_spec(&self) -> bool {
+        matches!(self, Dependency::ClosureSpec(_, _, _))
     }
 
     #[inline]
@@ -172,29 +209,6 @@ impl<'tcx> Dependency<'tcx> {
         };
 
         EarlyBinder::bind(self).instantiate(tcx, substs)
-    }
-
-    /// We need to "overload" certain identifiers in rustc so that we can distinguish them while
-    /// rustc doesn't. In particular, closures act as both a type and a function and are missing many
-    /// identifiers for things like accessors.
-    ///
-    /// We also use this to overload "structural resolution" for types
-    #[inline]
-    pub(crate) fn identify_overloads(self, tcx: TyCtxt<'tcx>) -> Self {
-        match self {
-            Dependency::Item(did, subst) => {
-                let (hacked_id, id, subst) = closure_hack(tcx, did, subst);
-                if let Some(hacked_id) = hacked_id {
-                    Dependency::Hacked(hacked_id, id, subst)
-                } else if let Some(ty) = structural_resolve(tcx, (id, subst)) {
-                    Dependency::StructuralResolve(ty)
-                } else {
-                    Dependency::new(tcx, (id, subst))
-                }
-            }
-
-            _ => self,
-        }
     }
 
     pub(crate) fn base_ident(self, tcx: TyCtxt<'tcx>) -> Symbol {
@@ -228,14 +242,14 @@ impl<'tcx> Dependency<'tcx> {
                     _ => Symbol::intern(&value_name(tcx.item_name(did).as_str())),
                 }
             }
-            Dependency::Hacked(hacked_id, _, _) => match hacked_id {
-                ExtendedId::PostconditionOnce => Symbol::intern("postcondition_once"),
-                ExtendedId::PostconditionMut => Symbol::intern("postcondition_mut"),
-                ExtendedId::Postcondition => Symbol::intern("postcondition"),
-                ExtendedId::Precondition => Symbol::intern("precondition"),
-                ExtendedId::Unnest => Symbol::intern("unnest"),
-                ExtendedId::Resolve => Symbol::intern("resolve"),
-                ExtendedId::Accessor(ix) => Symbol::intern(&format!("field_{ix}")),
+            Dependency::ClosureSpec(hacked_id, _, _) => match hacked_id {
+                ClosureSpecKind::PostconditionOnce => Symbol::intern("postcondition_once"),
+                ClosureSpecKind::PostconditionMut => Symbol::intern("postcondition_mut"),
+                ClosureSpecKind::Postcondition => Symbol::intern("postcondition"),
+                ClosureSpecKind::Precondition => Symbol::intern("precondition"),
+                ClosureSpecKind::Unnest => Symbol::intern("unnest"),
+                ClosureSpecKind::Resolve => Symbol::intern("resolve"),
+                ClosureSpecKind::Accessor(ix) => Symbol::intern(&format!("field_{ix}")),
             },
             Dependency::TyInv(..) => Symbol::intern("tyinv_should_not_appear"),
             Dependency::Builtin(_) => Symbol::intern("builtin_should_not_appear"),
@@ -250,25 +264,16 @@ fn resolve_item<'tcx>(
     tcx: TyCtxt<'tcx>,
     param_env: ParamEnv<'tcx>,
 ) -> Dependency<'tcx> {
-    let resolved = if tcx.trait_of_item(item).is_some()
+    if tcx.trait_of_item(item).is_some()
         && let traits::TraitResol::Instance(did, subst) =
             traits::resolve_assoc_item_opt(tcx, param_env, item, substs)
     {
-        (did, subst)
+        Dependency::new(tcx, (did, subst))
     } else {
         // May happen:
         //    - if this is not a trait method, or
         //    - if don't know the instance
-        (item, substs)
-    };
-
-    let (hacked_id, id, subst) = closure_hack(tcx, resolved.0, resolved.1);
-    if let Some(hacked_id) = hacked_id {
-        Dependency::Hacked(hacked_id, id, subst)
-    } else if let Some(ty) = structural_resolve(tcx, resolved) {
-        Dependency::StructuralResolve(ty)
-    } else {
-        Dependency::new(tcx, (id, subst))
+        Dependency::new(tcx, (item, substs))
     }
 }
 
@@ -281,42 +286,4 @@ fn structural_resolve<'tcx>(
     } else {
         None
     }
-}
-
-pub(crate) fn closure_hack<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    def_id: DefId,
-    subst: GenericArgsRef<'tcx>,
-) -> (Option<ExtendedId>, DefId, GenericArgsRef<'tcx>) {
-    let hacked = if tcx.is_diagnostic_item(Symbol::intern("fn_once_impl_precond"), def_id) {
-        Some(ExtendedId::Precondition)
-    } else if tcx.is_diagnostic_item(Symbol::intern("fn_once_impl_postcond"), def_id) {
-        Some(ExtendedId::PostconditionOnce)
-    } else if tcx.is_diagnostic_item(Symbol::intern("fn_mut_impl_postcond"), def_id) {
-        Some(ExtendedId::PostconditionMut)
-    } else if tcx.is_diagnostic_item(Symbol::intern("fn_impl_postcond"), def_id) {
-        Some(ExtendedId::Postcondition)
-    } else if tcx.is_diagnostic_item(Symbol::intern("fn_mut_impl_unnest"), def_id) {
-        Some(ExtendedId::Unnest)
-    } else if tcx.is_diagnostic_item(Symbol::intern("fn_impl_resolve"), def_id) {
-        Some(ExtendedId::Resolve)
-    } else {
-        None
-    };
-
-    if hacked.is_some() {
-        let self_ty = subst.types().nth(1).unwrap();
-        if let TyKind::Closure(id, csubst) = self_ty.kind() {
-            return (hacked, *id, csubst);
-        }
-    };
-
-    if tcx.is_diagnostic_item(Symbol::intern("creusot_resolve_method"), def_id) {
-        let self_ty = subst.types().nth(0).unwrap();
-        if let TyKind::Closure(id, csubst) = self_ty.kind() {
-            return (Some(ExtendedId::Resolve), *id, csubst);
-        }
-    }
-
-    (None, def_id, subst)
 }

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -1,6 +1,6 @@
 use super::{
     clone_map::PreludeModule,
-    dependency::ExtendedId,
+    dependency::ClosureSpecKind,
     is_trusted_function,
     place::rplace_to_expr,
     signature::{sig_to_why3, signature_of},
@@ -77,7 +77,7 @@ pub(crate) fn closure_aux_defs<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefI
     lower_pure(ctx, &mut names, &contract.resolve.1);
 
     let (_, deps) = names.provide_deps(ctx, GraphDepth::Shallow);
-    ctx.dependencies.insert(TransId::Hacked(ExtendedId::Resolve, def_id), deps);
+    ctx.dependencies.insert(TransId::Hacked(ClosureSpecKind::Resolve, def_id), deps);
 
     // HACK PRECOND
     let mut names = Dependencies::new(ctx.tcx, [def_id]);
@@ -85,7 +85,7 @@ pub(crate) fn closure_aux_defs<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefI
     lower_pure(ctx, &mut names, &contract.precond.1);
 
     let (_, deps) = names.provide_deps(ctx, GraphDepth::Shallow);
-    ctx.dependencies.insert(TransId::Hacked(ExtendedId::Precondition, def_id), deps);
+    ctx.dependencies.insert(TransId::Hacked(ClosureSpecKind::Precondition, def_id), deps);
 
     // HACK POST ONCE
     if let Some((sig, term)) = contract.postcond_once {
@@ -94,7 +94,7 @@ pub(crate) fn closure_aux_defs<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefI
         lower_pure(ctx, &mut names, &term);
 
         let (_, deps) = names.provide_deps(ctx, GraphDepth::Shallow);
-        ctx.dependencies.insert(TransId::Hacked(ExtendedId::PostconditionOnce, def_id), deps);
+        ctx.dependencies.insert(TransId::Hacked(ClosureSpecKind::PostconditionOnce, def_id), deps);
     }
 
     // HACK POST MUT
@@ -104,7 +104,7 @@ pub(crate) fn closure_aux_defs<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefI
         lower_pure(ctx, &mut names, &term);
 
         let (_, deps) = names.provide_deps(ctx, GraphDepth::Shallow);
-        ctx.dependencies.insert(TransId::Hacked(ExtendedId::PostconditionMut, def_id), deps);
+        ctx.dependencies.insert(TransId::Hacked(ClosureSpecKind::PostconditionMut, def_id), deps);
     }
     // HACK POST
     if let Some((sig, term)) = contract.postcond {
@@ -113,7 +113,7 @@ pub(crate) fn closure_aux_defs<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefI
         lower_pure(ctx, &mut names, &term);
 
         let (_, deps) = names.provide_deps(ctx, GraphDepth::Shallow);
-        ctx.dependencies.insert(TransId::Hacked(ExtendedId::Postcondition, def_id), deps);
+        ctx.dependencies.insert(TransId::Hacked(ClosureSpecKind::Postcondition, def_id), deps);
     }
     // HACK UNNEst
     if let Some((sig, term)) = contract.unnest {
@@ -122,7 +122,7 @@ pub(crate) fn closure_aux_defs<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefI
         lower_pure(ctx, &mut names, &term);
 
         let (_, deps) = names.provide_deps(ctx, GraphDepth::Shallow);
-        ctx.dependencies.insert(TransId::Hacked(ExtendedId::Unnest, def_id), deps);
+        ctx.dependencies.insert(TransId::Hacked(ClosureSpecKind::Unnest, def_id), deps);
     } // END COMPLETE HACK
       // decls.extend(contract);
       // decls
@@ -132,7 +132,7 @@ pub(crate) fn closure_aux_defs<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefI
         lower_pure(ctx, &mut names, &term);
 
         let (_, deps) = names.provide_deps(ctx, GraphDepth::Shallow);
-        ctx.dependencies.insert(TransId::Hacked(ExtendedId::Accessor(ix as u8), def_id), deps);
+        ctx.dependencies.insert(TransId::Hacked(ClosureSpecKind::Accessor(ix as u8), def_id), deps);
     }
 }
 


### PR DESCRIPTION
Also, refactor the "hacked" names to more meaningful names.