### PR TITLE
Support type annotations in pearlite

### DIFF
--- a/creusot/src/translation/pearlite.rs
+++ b/creusot/src/translation/pearlite.rs
@@ -858,6 +858,10 @@ impl<'a, 'tcx> ThirTerm<'a, 'tcx> {
                 }
                 Ok(Pattern::Boolean(value.try_to_bool().unwrap()))
             }
+            // TODO: this simply ignores type annotations, maybe we should actually support them
+            PatKind::AscribeUserType { ascription: _, subpattern } => {
+                self.pattern_term(subpattern, mut_allowed)
+            }
             ref pk => todo!("lower_pattern: unsupported pattern kind {:?}", pk),
         }
     }


### PR DESCRIPTION
Fixes #1171.

This simply ignores type annotations, ideally we should try to support them somehow.