### PR TITLE
builtin strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "creusot-args",
  "directories",
  "hex",
+ "indoc",
  "reqwest",
  "serde",
  "sha2",
@@ -998,6 +999,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inout"

--- a/ci/creusot-config-dummy.toml
+++ b/ci/creusot-config-dummy.toml
@@ -1,4 +1,4 @@
-version = 4
+version = 5
 provers_parallelism = 1
 
 [why3]

--- a/creusot-args/src/lib.rs
+++ b/creusot-args/src/lib.rs
@@ -12,7 +12,6 @@ pub const CREUSOT_RUSTC_ARGS: &[&str] = &[
     "-Zcrate-attr=feature(rustc_attrs)",
     "-Zcrate-attr=feature(unsized_fn_params)",
     "--allow=internal_features",
-    "-Zdump-mir=speccleanup",
     "--cfg",
     "creusot",
 ];

--- a/creusot-setup/Cargo.toml
+++ b/creusot-setup/Cargo.toml
@@ -15,6 +15,7 @@ reqwest = { version = "0.11", features = ["blocking"] }
 zip = "0.6"
 hex = "0.4"
 sha2 = "0.10"
+indoc = "2.0.5"
 
 [package.metadata.release]
 pre-release-replacements = [ ]

--- a/creusot-setup/src/config.rs
+++ b/creusot-setup/src/config.rs
@@ -8,7 +8,7 @@ use std::{
 // the goal is to avoid silently mis-interpreting a past or future version of
 // the config file whenever its format changes.
 // NOTE: update ci/creusot-config-dummy.toml whenever you change this.
-pub const CURRENT_CONFIG_VERSION: i64 = 4;
+pub const CURRENT_CONFIG_VERSION: i64 = 5;
 
 // bump CURRENT_CONFIG_VERSION if you change this definition
 #[derive(Serialize, Deserialize)]

--- a/creusot-setup/src/tools.rs
+++ b/creusot-setup/src/tools.rs
@@ -1,5 +1,6 @@
-use crate::{tools_versions_urls::*, Config};
+use crate::tools_versions_urls::*;
 use anyhow::{anyhow, bail, Context};
+use indoc::writedoc;
 use reqwest::blocking::Client;
 use std::{
     fs,
@@ -228,7 +229,7 @@ fn generate_strategy(f: &mut dyn Write) -> anyhow::Result<()> {
     let z3 = format!("Z3,{Z3_VERSION}");
     let cvc5 = format!("CVC5,{CVC5_VERSION}");
     let cvc4 = format!("CVC4,{CVC4_VERSION}");
-    write!(
+    writedoc!(
         f,
         r#"
         [strategy]
@@ -247,8 +248,8 @@ fn generate_strategy(f: &mut dyn Write) -> anyhow::Result<()> {
         c {altergo} 6. 4000 | {cvc5} 6. 4000 | {z3} 6. 4000 | {cvc4} 6. 4000
         "
         desc = "Automatic@ run@ of@ provers@ and@ most@ useful@ transformations"
-        name = "Auto_level_3"
-        shortcut = "3"
+        name = "Creusot_Auto"
+        shortcut = "4"
     "#,
     )?;
 


### PR DESCRIPTION
I've been using custom why3 strategies for ages, which save soooo much time when regenerating proofs. I've put together a template for my "tuned" Auto 3 strategy which reduces useless timeouts and attempts to avoid unnecessary proof tasks. 

When we move to `why3find` this won't be necessary, but this PR was easy to throw up in the meantime. 
