### PR TITLE
Output crates of different types in separate directories

### DIFF
--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -35,10 +35,16 @@ fn main() -> Result<()> {
         coma_glob = None;
     } else {
         // default to --output-dir=target/creusot
-        let dir = make_coma_target(&cargo_md)?;
-        coma_src = dir.clone();
-        cargs.options.output_dir = Some(dir);
-        coma_glob = coma_src.to_str().map(|s| s.to_string() + "/**/*.coma");
+        let dir = match &cargs.options.output_dir {
+            Some(dir) => dir.clone(),
+            None => {
+                let dir = make_coma_target(&cargo_md)?;
+                cargs.options.output_dir = Some(dir.clone());
+                dir
+            }
+        };
+        coma_glob = dir.to_str().map(|s| s.to_string() + "/**/*.coma");
+        coma_src = dir;
     }
 
     let subcommand = match cargs.subcommand {

--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -35,6 +35,9 @@ pub struct CommonOptions {
     pub output_file: Option<PathBuf>,
     #[clap(group = "output", long, env, conflicts_with = "output_file", conflicts_with = "stdout")]
     pub output_dir: Option<PathBuf>,
+    /// Output the generated code in a single file in output_dir.
+    #[clap(long, default_value_t = false, action = clap::ArgAction::SetTrue)]
+    pub monolithic: bool,
     /// Specify locations of metadata for external crates. The format is the same as rustc's `--extern` flag.
     #[clap(long = "creusot-extern", value_parser= parse_key_val::<String, String>, required=false)]
     pub extern_paths: Vec<(String, String)>,

--- a/creusot-rustc/src/options.rs
+++ b/creusot-rustc/src/options.rs
@@ -63,6 +63,7 @@ impl CreusotArgsExt for CreusotArgs {
             output,
             in_cargo: cargo_creusot,
             span_mode,
+            monolithic: self.options.monolithic,
             match_str: self.options.focus_on,
             simple_triggers: self.options.simple_triggers,
             why3_cmd: match self.subcommand {

--- a/creusot/src/options.rs
+++ b/creusot/src/options.rs
@@ -29,6 +29,7 @@ pub struct Options {
     pub export_metadata: bool,
     pub should_output: bool,
     pub output: Output,
+    pub monolithic: bool,
     pub in_cargo: bool,
     pub span_mode: SpanMode,
     pub match_str: Option<String>,

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -155,10 +155,13 @@ fn print_crate<I: Iterator<Item = FileModule>>(
 ) -> std::io::Result<Option<PathBuf>> {
     let (root, mut output) = match output_target {
         Output::Directory(dir) => (Some(dir.clone()), OutputHandle::Directory(dir)),
-        Output::File(ref f) => (
-            Some(f.clone()),
-            OutputHandle::File(Box::new(std::io::BufWriter::new(File::create(f)?))),
-        ),
+        Output::File(ref f) => {
+            std::fs::create_dir_all(f.parent().unwrap()).unwrap();
+            (
+                Some(f.clone()),
+                OutputHandle::File(Box::new(std::io::BufWriter::new(File::create(f)?))),
+            )
+        }
         Output::Stdout => (None, OutputHandle::File(Box::new(std::io::stdout()))),
     };
     let alloc = mlcfg::printer::ALLOC;

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -318,10 +318,6 @@ pub(crate) fn module_path_with_suffix(
     }
 }
 
-pub(crate) fn module_path(tcx: TyCtxt, modular: bool, def_id: DefId) -> why3::QName {
-    module_path_with_suffix(tcx, modular, def_id, "")
-}
-
 // Translate a name to be a valid fragment of a Why3 identifier
 // Escape initial and final underscores, double underscores, non-ascii characters,
 // and "qy" sequences (because "qy" is the escape sequence).


### PR DESCRIPTION
This fixes the issue for both multi-file and single-file workflows. Closes #1178.

`creusot-rustc` now chooses the output location under `--output-dir` depending on whether the crate is a lib (`target/creusot/mycrate`) or bin (`target/creusot/bin/mycrate`) or other. (That used to be done in `cargo-creusot` instead of `creusot-rustc` before #1172 but didn't really work; [more details here](https://github.com/creusot-rs/creusot/issues/1178#issuecomment-2427501817))

For single-file output, a new flag `--monolithic` is added.

Basically there are the following output modes:

- User calls `cargo creusot`, which defaults to multi-file output (calls `creusot-rustc` with `--output-dir=target/creusot/`).
- User calls `cargo creusot --monolithic` for single-file output (calls `creusot-rustc` with `--monolithic --output-dir=target/creusot/`, and it's `creusot-rustc` which sets the file name to `crate_name.coma`, possibly with a `bin/` directory in the middle); we keep this option around while we fix issues with the multi-file workflow (or in case we decide to revert back to single-file).
- Creusot's test suite calls `creusot-rustc --stdout`, no changes there.
- The option `--output-file=${FILE}` previously used for single-file output is now unused (but it uses the same code as `--stdout` so it doesn't hurt to keep it).