### PR TITLE
consistently pass coma_no_trivial to why3

### DIFF
--- a/cargo-creusot/src/why3_launcher.rs
+++ b/cargo-creusot/src/why3_launcher.rs
@@ -50,6 +50,7 @@ impl Why3Launcher {
                 "--warn-off=unused_variable",
                 "--warn-off=clone_not_abstract",
                 "--warn-off=axiom_abstract",
+                "--debug=coma_no_trivial",
                 &mode,
                 "-L",
             ])

--- a/creusot/src/run_why3.rs
+++ b/creusot/src/run_why3.rs
@@ -59,6 +59,7 @@ pub(super) fn run_why3<'tcx>(ctx: &Why3Generator<'tcx>, file: Option<PathBuf>) {
             "--warn-off=unused_variable",
             "--warn-off=clone_not_abstract",
             "--warn-off=axiom_abstract",
+            "--debug=coma_no_trivial",
             &why3_cmd.sub.to_string(),
             "-L",
         ])


### PR DESCRIPTION
The option (which avoids trivial `true` goals) is already passed in the testsuite and in `./ide`, this passes it everywhere else.