### PR TITLE
Refactor generation of `use` declarations

### DIFF
--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -392,12 +392,8 @@ impl<'tcx> Why3Generator<'tcx> {
         }
     }
 
-    pub(crate) fn module_path_with_suffix(&self, def_id: DefId, suffix: &str) -> why3::QName {
-        util::module_path_with_suffix(self.tcx, self.is_modular(), def_id, suffix)
-    }
-
-    pub(crate) fn module_path(&self, def_id: DefId) -> why3::QName {
-        self.module_path_with_suffix(def_id, "")
+    pub(crate) fn module_path(&self, def_id: DefId, namespace: util::NS) -> util::ModulePath {
+        util::ModulePath::new(self.tcx, def_id, namespace)
     }
 
     pub fn is_modular(&self) -> bool {

--- a/creusot/src/backend/logic.rs
+++ b/creusot/src/backend/logic.rs
@@ -9,7 +9,7 @@ use rustc_hir::def_id::DefId;
 use why3::{
     declaration::*,
     exp::{super_visit_mut, BinOp, Binder, Exp, ExpMutVisitor, Trigger},
-    Ident, QName,
+    Ident,
 };
 
 mod vcgen;
@@ -264,7 +264,8 @@ fn proof_module(ctx: &mut Why3Generator, def_id: DefId) -> Option<FileModule> {
 
     let attrs = Vec::from_iter(ctx.span_attr(ctx.def_span(def_id)));
     let meta = ctx.display_impl_of(def_id);
-    let QName { module: path, name } = ctx.module_path(def_id);
+    let path = ctx.module_path(def_id, util::NS::M);
+    let name = path.why3_ident();
     Some(FileModule { path, modl: Module { name, decls, attrs, meta } })
 }
 

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -64,7 +64,8 @@ fn closure_ty<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefId) -> FileModule 
 
     let attrs = Vec::from_iter(ctx.span_attr(ctx.def_span(def_id)));
     let meta = ctx.display_impl_of(def_id);
-    let QName { module: path, name } = ctx.module_path_with_suffix(def_id, "_Type");
+    let path = ctx.module_path(def_id, util::NS::T);
+    let name = path.why3_ident();
     FileModule { path, modl: Module { name, decls, attrs, meta } }
 }
 
@@ -107,7 +108,8 @@ pub(crate) fn translate_function<'tcx, 'sess>(
 
     let attrs = Vec::from_iter(ctx.span_attr(ctx.def_span(def_id)));
     let meta = ctx.display_impl_of(def_id);
-    let QName { module: path, name } = ctx.module_path(def_id);
+    let path = ctx.module_path(def_id, util::NS::M);
+    let name = path.why3_ident();
     Some(FileModule { path, modl: Module { name, decls, attrs, meta } })
 }
 

--- a/creusot/src/backend/traits.rs
+++ b/creusot/src/backend/traits.rs
@@ -39,7 +39,8 @@ pub(crate) fn lower_impl<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefId) -> 
 
     let attrs = Vec::from_iter(ctx.span_attr(ctx.def_span(def_id)));
     let meta = ctx.display_impl_of(def_id);
-    let why3::QName { module: path, name } = ctx.module_path(def_id);
+    let path = ctx.module_path(def_id, util::NS::M);
+    let name = path.why3_ident();
     FileModule { path, modl: Module { name, decls, attrs, meta } }
 }
 

--- a/creusot/src/translated_item.rs
+++ b/creusot/src/translated_item.rs
@@ -1,16 +1,13 @@
 use indexmap::IndexMap;
 use rustc_hir::def_id::DefId;
 
-use why3::{
-    declaration::{Decl, Module},
-    Ident,
-};
+use why3::declaration::{Decl, Module};
 
 /// Module with a path to the file it is defined in.
 /// We use this for modular translation (one file per module).
 /// In monolithic translation, the path is left empty.
 pub struct FileModule {
-    pub path: Vec<Ident>,
+    pub path: crate::util::ModulePath,
     pub modl: Module,
 }
 

--- a/creusot/tests/should_fail/bug/692.coma
+++ b/creusot/tests/should_fail/bug/692.coma
@@ -96,7 +96,7 @@ module M_692__incorrect [#"692.rs" 8 0 8 76]
     [ return' (result:())-> {[@expl:postcondition] [%#s6923] false} (! return' {result}) ]
     
 end
-module M_692__valid_normal__qyClosure1_Type [#"692.rs" 13 15 13 47]
+module T_692__valid_normal__qyClosure1 [#"692.rs" 13 15 13 47]
   use prelude.prelude.UInt32
   
   use prelude.prelude.Int
@@ -120,7 +120,7 @@ module M_692__valid_normal__qyClosure1 [#"692.rs" 13 15 13 47]
   
   use prelude.prelude.Borrow
   
-  use M_692__valid_normal__qyClosure1_Type as Closure'0
+  use T_692__valid_normal__qyClosure1 as Closure'0
   
   function field_0'0 [#"692.rs" 13 15 13 47] (self : Closure'0.m_692__valid_normal__qyClosure1) : uint32 =
     let Closure'0.M_692__valid_normal__qyClosure1 a = self in a
@@ -141,7 +141,7 @@ module M_692__valid_normal__qyClosure1 [#"692.rs" 13 15 13 47]
       (! return' {result}) ]
     
 end
-module M_692__valid_normal__qyClosure2_Type [#"692.rs" 15 17 15 64]
+module T_692__valid_normal__qyClosure2 [#"692.rs" 15 17 15 64]
   use prelude.prelude.UInt32
   
   use prelude.prelude.Int
@@ -167,7 +167,7 @@ module M_692__valid_normal__qyClosure2 [#"692.rs" 15 17 15 64]
   
   use prelude.prelude.Borrow
   
-  use M_692__valid_normal__qyClosure2_Type as Closure'0
+  use T_692__valid_normal__qyClosure2 as Closure'0
   
   function field_0'0 [#"692.rs" 15 17 15 64] (self : Closure'0.m_692__valid_normal__qyClosure2) : borrowed uint32 =
     let Closure'0.M_692__valid_normal__qyClosure2 a = self in a
@@ -220,13 +220,13 @@ module M_692__valid_normal [#"692.rs" 11 0 11 34]
   let%span s6925 = "692.rs" 7 10 7 15
   let%span s6926 = "692.rs" 13 25 13 45
   
-  use M_692__valid_normal__qyClosure2_Type as Closure'1
+  use T_692__valid_normal__qyClosure2 as Closure'1
   
   predicate inv'1 (_1 : Closure'1.m_692__valid_normal__qyClosure2)
   
   axiom inv_axiom'1 [@rewrite] : forall x : Closure'1.m_692__valid_normal__qyClosure2 [inv'1 x] . inv'1 x = true
   
-  use M_692__valid_normal__qyClosure1_Type as Closure'0
+  use T_692__valid_normal__qyClosure1 as Closure'0
   
   predicate inv'0 (_1 : Closure'0.m_692__valid_normal__qyClosure1)
   

--- a/creusot/tests/should_fail/bug/695.coma
+++ b/creusot/tests/should_fail/bug/695.coma
@@ -151,7 +151,7 @@ module M_695__inversed_if [#"695.rs" 6 0 6 78]
       (! return' {result}) ]
     
 end
-module M_695__valid__qyClosure1_Type [#"695.rs" 17 15 17 47]
+module T_695__valid__qyClosure1 [#"695.rs" 17 15 17 47]
   use prelude.prelude.UInt32
   
   use prelude.prelude.Int
@@ -175,7 +175,7 @@ module M_695__valid__qyClosure1 [#"695.rs" 17 15 17 47]
   
   use prelude.prelude.Borrow
   
-  use M_695__valid__qyClosure1_Type as Closure'0
+  use T_695__valid__qyClosure1 as Closure'0
   
   function field_0'0 [#"695.rs" 17 15 17 47] (self : Closure'0.m_695__valid__qyClosure1) : uint32 =
     let Closure'0.M_695__valid__qyClosure1 a = self in a
@@ -196,7 +196,7 @@ module M_695__valid__qyClosure1 [#"695.rs" 17 15 17 47]
       (! return' {result}) ]
     
 end
-module M_695__valid__qyClosure2_Type [#"695.rs" 19 17 19 64]
+module T_695__valid__qyClosure2 [#"695.rs" 19 17 19 64]
   use prelude.prelude.UInt32
   
   use prelude.prelude.Int
@@ -222,7 +222,7 @@ module M_695__valid__qyClosure2 [#"695.rs" 19 17 19 64]
   
   use prelude.prelude.Borrow
   
-  use M_695__valid__qyClosure2_Type as Closure'0
+  use T_695__valid__qyClosure2 as Closure'0
   
   function field_0'0 [#"695.rs" 19 17 19 64] (self : Closure'0.m_695__valid__qyClosure2) : borrowed uint32 =
     let Closure'0.M_695__valid__qyClosure2 a = self in a
@@ -277,13 +277,13 @@ module M_695__valid [#"695.rs" 15 0 15 27]
   let%span s6957 = "695.rs" 17 25 17 45
   let%span s6958 = "695.rs" 19 27 19 62
   
-  use M_695__valid__qyClosure2_Type as Closure'1
+  use T_695__valid__qyClosure2 as Closure'1
   
   predicate inv'1 (_1 : Closure'1.m_695__valid__qyClosure2)
   
   axiom inv_axiom'1 [@rewrite] : forall x : Closure'1.m_695__valid__qyClosure2 [inv'1 x] . inv'1 x = true
   
-  use M_695__valid__qyClosure1_Type as Closure'0
+  use T_695__valid__qyClosure1 as Closure'0
   
   predicate inv'0 (_1 : Closure'0.m_695__valid__qyClosure1)
   

--- a/creusot/tests/should_succeed/bug/463.coma
+++ b/creusot/tests/should_succeed/bug/463.coma
@@ -1,4 +1,4 @@
-module M_463__test__qyClosure0_Type [#"463.rs" 6 8 6 37]
+module T_463__test__qyClosure0 [#"463.rs" 6 8 6 37]
   type m_463__test__qyClosure0  =
     | M_463__test__qyClosure0
   
@@ -11,7 +11,7 @@ module M_463__test__qyClosure0 [#"463.rs" 6 8 6 37]
   let%span s4631 = "463.rs" 5 19 5 28
   let%span s4632 = "463.rs" 6 18 6 35
   
-  use M_463__test__qyClosure0_Type as Closure'0
+  use T_463__test__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -51,7 +51,7 @@ module M_463__test [#"463.rs" 3 0 3 13]
   
   use prelude.prelude.UIntSize
   
-  use M_463__test__qyClosure0_Type as Closure'0
+  use T_463__test__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   

--- a/creusot/tests/should_succeed/bug/594.coma
+++ b/creusot/tests/should_succeed/bug/594.coma
@@ -15,7 +15,7 @@ module M_594__test_program [#"594.rs" 11 0 11 46]
     [ return' (result:uint32)-> {[@expl:postcondition] [%#s5940] let (x, _) = _1 in result = x} (! return' {result}) ]
     
 end
-module M_594__test_closure__qyClosure0_Type [#"594.rs" 16 14 16 37]
+module T_594__test_closure__qyClosure0 [#"594.rs" 16 14 16 37]
   type m_594__test_closure__qyClosure0  =
     | M_594__test_closure__qyClosure0
   
@@ -26,7 +26,7 @@ end
 module M_594__test_closure__qyClosure0 [#"594.rs" 16 14 16 37]
   let%span s5940 = "594.rs" 16 24 16 35
   
-  use M_594__test_closure__qyClosure0_Type as Closure'0
+  use T_594__test_closure__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -54,7 +54,7 @@ module M_594__test_closure__qyClosure0 [#"594.rs" 16 14 16 37]
     | & res : int32 = any_l () ]
      [ return' (result:int32)-> {[@expl:postcondition] [%#s5940] let (_a, b) = _3 in result = b} (! return' {result}) ] 
 end
-module M_594__test_closure__qyClosure1_Type [#"594.rs" 18 14 18 37]
+module T_594__test_closure__qyClosure1 [#"594.rs" 18 14 18 37]
   type m_594__test_closure__qyClosure1  =
     | M_594__test_closure__qyClosure1
   
@@ -65,7 +65,7 @@ end
 module M_594__test_closure__qyClosure1 [#"594.rs" 18 14 18 37]
   let%span s5940 = "594.rs" 18 24 18 35
   
-  use M_594__test_closure__qyClosure1_Type as Closure'0
+  use T_594__test_closure__qyClosure1 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -108,7 +108,7 @@ module M_594__test_closure [#"594.rs" 15 0 15 21]
   
   use prelude.prelude.Int
   
-  use M_594__test_closure__qyClosure1_Type as Closure'1
+  use T_594__test_closure__qyClosure1 as Closure'1
   
   use prelude.prelude.Borrow
   
@@ -116,7 +116,7 @@ module M_594__test_closure [#"594.rs" 15 0 15 21]
     [ return' (result:int32)-> {[%#s5946] let (_a, b) = _2 in result = b} (! return' {result}) ]
     
   
-  use M_594__test_closure__qyClosure0_Type as Closure'0
+  use T_594__test_closure__qyClosure0 as Closure'0
   
   let rec closure0'0 (_1:Closure'0.m_594__test_closure__qyClosure0) (_c:int32) (_3:(int32, int32)) (return'  (ret:int32))= any
     [ return' (result:int32)-> {[%#s5945] let (_a, b) = _3 in result = b} (! return' {result}) ]

--- a/creusot/tests/should_succeed/bug/691.coma
+++ b/creusot/tests/should_succeed/bug/691.coma
@@ -30,7 +30,7 @@ module M_691__example [#"691.rs" 8 0 8 16]
     [ bb0 = s0 [ s0 =  [ &c <- Foo'0.C_Foo ([%#s6910] (2 : uint32)) ] s1 | s1 = return' {_0} ]  ]
     ) [ & _0 : () = any_l () | & c : Foo'0.t_Foo = any_l () ]  [ return' (result:())-> (! return' {result}) ] 
 end
-module M_691__example__qyClosure0_Type [#"691.rs" 10 12 10 39]
+module T_691__example__qyClosure0 [#"691.rs" 10 12 10 39]
   use T_691__Foo as Foo'0
   
   use prelude.prelude.Borrow
@@ -45,7 +45,7 @@ end
 module M_691__example__qyClosure0 [#"691.rs" 10 12 10 39]
   let%span s6910 = "691.rs" 10 24 10 37
   
-  use M_691__example__qyClosure0_Type as Closure'0
+  use T_691__example__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   

--- a/creusot/tests/should_succeed/closures/01_basic.coma
+++ b/creusot/tests/should_succeed/closures/01_basic.coma
@@ -1,4 +1,4 @@
-module M_01_basic__uses_closure__qyClosure0_Type [#"01_basic.rs" 8 14 8 16]
+module T_01_basic__uses_closure__qyClosure0 [#"01_basic.rs" 8 14 8 16]
   use prelude.prelude.Borrow
   
   type m_01_basic__uses_closure__qyClosure0  =
@@ -13,7 +13,7 @@ module M_01_basic__uses_closure__qyClosure0 [#"01_basic.rs" 8 14 8 16]
   
   use prelude.prelude.Borrow
   
-  use M_01_basic__uses_closure__qyClosure0_Type as Closure'0
+  use T_01_basic__uses_closure__qyClosure0 as Closure'0
   
   meta "compute_max_steps" 1000000
   
@@ -31,7 +31,7 @@ module M_01_basic__uses_closure [#"01_basic.rs" 6 0 6 21]
   
   use prelude.prelude.Intrinsic
   
-  use M_01_basic__uses_closure__qyClosure0_Type as Closure'0
+  use T_01_basic__uses_closure__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -57,7 +57,7 @@ module M_01_basic__uses_closure [#"01_basic.rs" 6 0 6 21]
     | & _6 : () = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_01_basic__multi_arg__qyClosure0_Type [#"01_basic.rs" 12 12 12 18]
+module T_01_basic__multi_arg__qyClosure0 [#"01_basic.rs" 12 12 12 18]
   type m_01_basic__multi_arg__qyClosure0  =
     | M_01_basic__multi_arg__qyClosure0
   
@@ -66,7 +66,7 @@ module M_01_basic__multi_arg__qyClosure0_Type [#"01_basic.rs" 12 12 12 18]
     
 end
 module M_01_basic__multi_arg__qyClosure0 [#"01_basic.rs" 12 12 12 18]
-  use M_01_basic__multi_arg__qyClosure0_Type as Closure'0
+  use T_01_basic__multi_arg__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -94,7 +94,7 @@ module M_01_basic__multi_arg [#"01_basic.rs" 11 0 11 18]
   
   use prelude.prelude.Int
   
-  use M_01_basic__multi_arg__qyClosure0_Type as Closure'0
+  use T_01_basic__multi_arg__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -120,7 +120,7 @@ module M_01_basic__multi_arg [#"01_basic.rs" 11 0 11 18]
     | & _4 : (int32, int32) = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_01_basic__move_closure__qyClosure0_Type [#"01_basic.rs" 21 16 21 23]
+module T_01_basic__move_closure__qyClosure0 [#"01_basic.rs" 21 16 21 23]
   use prelude.prelude.Int32
   
   use prelude.prelude.Int
@@ -138,7 +138,7 @@ module M_01_basic__move_closure__qyClosure0 [#"01_basic.rs" 21 16 21 23]
   let%span s01_basic0 = "01_basic.rs" 22 14 22 15
   let%span sresolve1 = "../../../../creusot-contracts/src/resolve.rs" 41 20 41 34
   
-  use M_01_basic__move_closure__qyClosure0_Type as Closure'0
+  use T_01_basic__move_closure__qyClosure0 as Closure'0
   
   predicate unnest'0 [#"01_basic.rs" 21 16 21 23] (self : Closure'0.m_01_basic__move_closure__qyClosure0) (_2 : Closure'0.m_01_basic__move_closure__qyClosure0)
     
@@ -198,7 +198,7 @@ module M_01_basic__move_closure [#"01_basic.rs" 18 0 18 21]
   predicate resolve'2 (_1 : borrowed int32) =
     resolve'3 _1
   
-  use M_01_basic__move_closure__qyClosure0_Type as Closure'0
+  use T_01_basic__move_closure__qyClosure0 as Closure'0
   
   function field_0'0 [#"01_basic.rs" 21 16 21 23] (self : Closure'0.m_01_basic__move_closure__qyClosure0) : borrowed int32
     
@@ -258,7 +258,7 @@ module M_01_basic__move_closure [#"01_basic.rs" 18 0 18 21]
     | & _9 : () = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_01_basic__move_mut__qyClosure0_Type [#"01_basic.rs" 37 16 37 23]
+module T_01_basic__move_mut__qyClosure0 [#"01_basic.rs" 37 16 37 23]
   use prelude.prelude.UInt32
   
   use prelude.prelude.Int
@@ -287,7 +287,7 @@ module M_01_basic__move_mut__qyClosure0 [#"01_basic.rs" 37 16 37 23]
   
   axiom inv_axiom'0 [@rewrite] : forall x : borrowed uint32 [inv'0 x] . inv'0 x = true
   
-  use M_01_basic__move_mut__qyClosure0_Type as Closure'0
+  use T_01_basic__move_mut__qyClosure0 as Closure'0
   
   predicate unnest'0 [#"01_basic.rs" 37 16 37 23] (self : Closure'0.m_01_basic__move_mut__qyClosure0) (_2 : Closure'0.m_01_basic__move_mut__qyClosure0)
     
@@ -357,7 +357,7 @@ module M_01_basic__move_mut [#"01_basic.rs" 34 0 34 17]
   predicate resolve'2 (_1 : borrowed uint32) =
     resolve'3 _1
   
-  use M_01_basic__move_mut__qyClosure0_Type as Closure'0
+  use T_01_basic__move_mut__qyClosure0 as Closure'0
   
   function field_0'0 [#"01_basic.rs" 37 16 37 23] (self : Closure'0.m_01_basic__move_mut__qyClosure0) : borrowed uint32
    =

--- a/creusot/tests/should_succeed/closures/02_nested.coma
+++ b/creusot/tests/should_succeed/closures/02_nested.coma
@@ -1,4 +1,4 @@
-module M_02_nested__nested_closure__qyClosure0__qyClosure0_Type [#"02_nested.rs" 6 18 6 20]
+module T_02_nested__nested_closure__qyClosure0__qyClosure0 [#"02_nested.rs" 6 18 6 20]
   use prelude.prelude.Borrow
   
   type m_02_nested__nested_closure__qyClosure0__qyClosure0  =
@@ -13,7 +13,7 @@ module M_02_nested__nested_closure__qyClosure0__qyClosure0 [#"02_nested.rs" 6 18
   
   use prelude.prelude.Borrow
   
-  use M_02_nested__nested_closure__qyClosure0__qyClosure0_Type as Closure'0
+  use T_02_nested__nested_closure__qyClosure0__qyClosure0 as Closure'0
   
   meta "compute_max_steps" 1000000
   
@@ -26,7 +26,7 @@ module M_02_nested__nested_closure__qyClosure0__qyClosure0 [#"02_nested.rs" 6 18
     [ return' (result:bool)-> (! return' {result}) ]
     
 end
-module M_02_nested__nested_closure__qyClosure0_Type [#"02_nested.rs" 5 14 5 16]
+module T_02_nested__nested_closure__qyClosure0 [#"02_nested.rs" 5 14 5 16]
   use prelude.prelude.Borrow
   
   type m_02_nested__nested_closure__qyClosure0  =
@@ -39,7 +39,7 @@ end
 module M_02_nested__nested_closure__qyClosure0 [#"02_nested.rs" 5 14 5 16]
   use prelude.prelude.Intrinsic
   
-  use M_02_nested__nested_closure__qyClosure0__qyClosure0_Type as Closure'1
+  use T_02_nested__nested_closure__qyClosure0__qyClosure0 as Closure'1
   
   use prelude.prelude.Borrow
   
@@ -47,7 +47,7 @@ module M_02_nested__nested_closure__qyClosure0 [#"02_nested.rs" 5 14 5 16]
     [ return' (result:bool)-> (! return' {result}) ]
     
   
-  use M_02_nested__nested_closure__qyClosure0_Type as Closure'0
+  use T_02_nested__nested_closure__qyClosure0 as Closure'0
   
   meta "compute_max_steps" 1000000
   
@@ -71,7 +71,7 @@ module M_02_nested__nested_closure [#"02_nested.rs" 3 0 3 23]
   
   use prelude.prelude.Intrinsic
   
-  use M_02_nested__nested_closure__qyClosure0_Type as Closure'0
+  use T_02_nested__nested_closure__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   

--- a/creusot/tests/should_succeed/closures/03_generic_bound.coma
+++ b/creusot/tests/should_succeed/closures/03_generic_bound.coma
@@ -104,7 +104,7 @@ module M_03_generic_bound__closure_param [#"03_generic_bound.rs" 5 0 5 34]
     | bb2 = return' {_0} ]
     ) [ & _0 : () = any_l () | & f : f = f | & _3 : uint32 = any_l () ]  [ return' (result:())-> (! return' {result}) ] 
 end
-module M_03_generic_bound__caller__qyClosure0_Type [#"03_generic_bound.rs" 10 18 10 27]
+module T_03_generic_bound__caller__qyClosure0 [#"03_generic_bound.rs" 10 18 10 27]
   type m_03_generic_bound__caller__qyClosure0  =
     | M_03_generic_bound__caller__qyClosure0
   
@@ -117,7 +117,7 @@ module M_03_generic_bound__caller__qyClosure0 [#"03_generic_bound.rs" 10 18 10 2
   
   use prelude.prelude.Int
   
-  use M_03_generic_bound__caller__qyClosure0_Type as Closure'0
+  use T_03_generic_bound__caller__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -132,7 +132,7 @@ end
 module M_03_generic_bound__caller [#"03_generic_bound.rs" 9 0 9 15]
   let%span s03_generic_bound0 = "03_generic_bound.rs" 5 29 5 30
   
-  use M_03_generic_bound__caller__qyClosure0_Type as Closure'0
+  use T_03_generic_bound__caller__qyClosure0 as Closure'0
   
   predicate inv'0 (_1 : Closure'0.m_03_generic_bound__caller__qyClosure0)
   

--- a/creusot/tests/should_succeed/closures/04_generic_closure.coma
+++ b/creusot/tests/should_succeed/closures/04_generic_closure.coma
@@ -106,7 +106,7 @@ module M_04_generic_closure__generic_closure [#"04_generic_closure.rs" 5 0 5 56]
     [ return' (result:b)-> {[@expl:postcondition] [%#s04_generic_closure2] inv'2 result} (! return' {result}) ]
     
 end
-module M_04_generic_closure__mapper__qyClosure0_Type [#"04_generic_closure.rs" 10 28 10 32]
+module T_04_generic_closure__mapper__qyClosure0 [#"04_generic_closure.rs" 10 28 10 32]
   type m_04_generic_closure__mapper__qyClosure0 'a =
     | M_04_generic_closure__mapper__qyClosure0
   
@@ -119,7 +119,7 @@ module M_04_generic_closure__mapper__qyClosure0 [#"04_generic_closure.rs" 10 28 
   
   let%span s04_generic_closure0 = "04_generic_closure.rs" 10 29 10 31
   
-  use M_04_generic_closure__mapper__qyClosure0_Type as Closure'0
+  use T_04_generic_closure__mapper__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -149,7 +149,7 @@ module M_04_generic_closure__mapper [#"04_generic_closure.rs" 9 0 9 22]
   
   axiom inv_axiom'1 [@rewrite] : forall x : () [inv'2 x] . inv'2 x = true
   
-  use M_04_generic_closure__mapper__qyClosure0_Type as Closure'0
+  use T_04_generic_closure__mapper__qyClosure0 as Closure'0
   
   predicate inv'1 (_1 : Closure'0.m_04_generic_closure__mapper__qyClosure0 a)
   

--- a/creusot/tests/should_succeed/closures/06_fn_specs.coma
+++ b/creusot/tests/should_succeed/closures/06_fn_specs.coma
@@ -559,7 +559,7 @@ module M_06_fn_specs__fn_once_user [#"06_fn_specs.rs" 44 0 44 43]
     | bb3 = return' {_0} ]
     ) [ & _0 : () = any_l () | & f : f = f | & _4 : usize = any_l () ]  [ return' (result:())-> (! return' {result}) ] 
 end
-module M_06_fn_specs__caller__qyClosure0_Type [#"06_fn_specs.rs" 49 17 49 20]
+module T_06_fn_specs__caller__qyClosure0 [#"06_fn_specs.rs" 49 17 49 20]
   type m_06_fn_specs__caller__qyClosure0  =
     | M_06_fn_specs__caller__qyClosure0
   
@@ -572,7 +572,7 @@ module M_06_fn_specs__caller__qyClosure0 [#"06_fn_specs.rs" 49 17 49 20]
   
   use prelude.prelude.Int
   
-  use M_06_fn_specs__caller__qyClosure0_Type as Closure'0
+  use T_06_fn_specs__caller__qyClosure0 as Closure'0
   
   use prelude.prelude.Intrinsic
   
@@ -586,7 +586,7 @@ module M_06_fn_specs__caller [#"06_fn_specs.rs" 48 0 48 15]
   let%span s06_fn_specs0 = "06_fn_specs.rs" 43 11 43 36
   let%span s06_fn_specs1 = "06_fn_specs.rs" 44 38 44 39
   
-  use M_06_fn_specs__caller__qyClosure0_Type as Closure'0
+  use T_06_fn_specs__caller__qyClosure0 as Closure'0
   
   predicate inv'0 (_1 : Closure'0.m_06_fn_specs__caller__qyClosure0)
   

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.coma
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.coma
@@ -1,4 +1,4 @@
-module M_07_mutable_capture__test_fnmut__qyClosure1_Type [#"07_mutable_capture.rs" 8 8 8 37]
+module T_07_mutable_capture__test_fnmut__qyClosure1 [#"07_mutable_capture.rs" 8 8 8 37]
   use prelude.prelude.UInt32
   
   use prelude.prelude.Int
@@ -25,7 +25,7 @@ module M_07_mutable_capture__test_fnmut__qyClosure1 [#"07_mutable_capture.rs" 8 
   
   use prelude.prelude.Borrow
   
-  use M_07_mutable_capture__test_fnmut__qyClosure1_Type as Closure'0
+  use T_07_mutable_capture__test_fnmut__qyClosure1 as Closure'0
   
   function field_0'0 [#"07_mutable_capture.rs" 8 8 8 37] (self : Closure'0.m_07_mutable_capture__test_fnmut__qyClosure1) : borrowed uint32
     
@@ -106,7 +106,7 @@ module M_07_mutable_capture__test_fnmut [#"07_mutable_capture.rs" 5 0 5 29]
   predicate resolve'2 (_1 : borrowed uint32) =
     resolve'3 _1
   
-  use M_07_mutable_capture__test_fnmut__qyClosure1_Type as Closure'0
+  use T_07_mutable_capture__test_fnmut__qyClosure1 as Closure'0
   
   function field_0'0 [#"07_mutable_capture.rs" 8 8 8 37] (self : Closure'0.m_07_mutable_capture__test_fnmut__qyClosure1) : borrowed uint32
     

--- a/creusot/tests/should_succeed/closures/08_multiple_calls.coma
+++ b/creusot/tests/should_succeed/closures/08_multiple_calls.coma
@@ -1,4 +1,4 @@
-module M_08_multiple_calls__multi_use__qyClosure0_Type [#"08_multiple_calls.rs" 5 12 5 31]
+module T_08_multiple_calls__multi_use__qyClosure0 [#"08_multiple_calls.rs" 5 12 5 31]
   use prelude.prelude.Borrow
   
   type m_08_multiple_calls__multi_use__qyClosure0 't =
@@ -33,7 +33,7 @@ module M_08_multiple_calls__multi_use__qyClosure0 [#"08_multiple_calls.rs" 5 12 
   
   axiom inv_axiom'2 [@rewrite] : forall x : t [inv'2 x] . inv'2 x = invariant'1 x
   
-  use M_08_multiple_calls__multi_use__qyClosure0_Type as Closure'0
+  use T_08_multiple_calls__multi_use__qyClosure0 as Closure'0
   
   predicate inv'1 (_1 : Closure'0.m_08_multiple_calls__multi_use__qyClosure0 t)
   
@@ -90,7 +90,7 @@ module M_08_multiple_calls__multi_use [#"08_multiple_calls.rs" 4 0 4 26]
   
   axiom inv_axiom'2 [@rewrite] : forall x : t [inv'2 x] . inv'2 x = invariant'1 x
   
-  use M_08_multiple_calls__multi_use__qyClosure0_Type as Closure'0
+  use T_08_multiple_calls__multi_use__qyClosure0 as Closure'0
   
   predicate inv'1 (_1 : Closure'0.m_08_multiple_calls__multi_use__qyClosure0 t)
   

--- a/creusot/tests/should_succeed/closures/09_fnonce_resolve.coma
+++ b/creusot/tests/should_succeed/closures/09_fnonce_resolve.coma
@@ -1,4 +1,4 @@
-module M_09_fnonce_resolve__f__qyClosure0_Type [#"09_fnonce_resolve.rs" 10 4 10 39]
+module T_09_fnonce_resolve__f__qyClosure0 [#"09_fnonce_resolve.rs" 10 4 10 39]
   use prelude.prelude.Int32
   
   use prelude.prelude.Int
@@ -27,7 +27,7 @@ module M_09_fnonce_resolve__f__qyClosure0 [#"09_fnonce_resolve.rs" 10 4 10 39]
   
   use prelude.prelude.Borrow
   
-  use M_09_fnonce_resolve__f__qyClosure0_Type as Closure'0
+  use T_09_fnonce_resolve__f__qyClosure0 as Closure'0
   
   function field_2'0 [#"09_fnonce_resolve.rs" 10 4 10 39] (self : Closure'0.m_09_fnonce_resolve__f__qyClosure0) : borrowed int32
     
@@ -123,7 +123,7 @@ module M_09_fnonce_resolve__f [#"09_fnonce_resolve.rs" 4 0 4 17]
   
   use prelude.prelude.Int32
   
-  use M_09_fnonce_resolve__f__qyClosure0_Type as Closure'0
+  use T_09_fnonce_resolve__f__qyClosure0 as Closure'0
   
   use prelude.prelude.Int
   

--- a/creusot/tests/should_succeed/closures/10_proof_assert_in_closure.coma
+++ b/creusot/tests/should_succeed/closures/10_proof_assert_in_closure.coma
@@ -1,4 +1,4 @@
-module M_10_proof_assert_in_closure__immutable_capture__qyClosure0_Type [#"10_proof_assert_in_closure.rs" 7 4 7 6]
+module T_10_proof_assert_in_closure__immutable_capture__qyClosure0 [#"10_proof_assert_in_closure.rs" 7 4 7 6]
   use prelude.prelude.Int32
   
   use prelude.prelude.Int
@@ -16,7 +16,7 @@ module M_10_proof_assert_in_closure__immutable_capture__qyClosure0 [#"10_proof_a
   let%span s10_proof_assert_in_closure0 = "10_proof_assert_in_closure.rs" 8 22 8 31
   let%span s10_proof_assert_in_closure1 = "10_proof_assert_in_closure.rs" 6 16 6 25
   
-  use M_10_proof_assert_in_closure__immutable_capture__qyClosure0_Type as Closure'0
+  use T_10_proof_assert_in_closure__immutable_capture__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -49,7 +49,7 @@ module M_10_proof_assert_in_closure__immutable_capture [#"10_proof_assert_in_clo
   
   use prelude.prelude.Intrinsic
   
-  use M_10_proof_assert_in_closure__immutable_capture__qyClosure0_Type as Closure'0
+  use T_10_proof_assert_in_closure__immutable_capture__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -84,7 +84,7 @@ module M_10_proof_assert_in_closure__immutable_capture [#"10_proof_assert_in_clo
     | & _6 : () = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_10_proof_assert_in_closure__mutable_capture__qyClosure0_Type [#"10_proof_assert_in_closure.rs" 15 4 15 6]
+module T_10_proof_assert_in_closure__mutable_capture__qyClosure0 [#"10_proof_assert_in_closure.rs" 15 4 15 6]
   use prelude.prelude.Int32
   
   use prelude.prelude.Int
@@ -111,7 +111,7 @@ module M_10_proof_assert_in_closure__mutable_capture__qyClosure0 [#"10_proof_ass
   
   use prelude.prelude.Borrow
   
-  use M_10_proof_assert_in_closure__mutable_capture__qyClosure0_Type as Closure'0
+  use T_10_proof_assert_in_closure__mutable_capture__qyClosure0 as Closure'0
   
   function field_0'0 [#"10_proof_assert_in_closure.rs" 15 4 15 6] (self : Closure'0.m_10_proof_assert_in_closure__mutable_capture__qyClosure0) : borrowed int32
     
@@ -171,7 +171,7 @@ module M_10_proof_assert_in_closure__mutable_capture [#"10_proof_assert_in_closu
   predicate resolve'2 (_1 : borrowed int32) =
     resolve'3 _1
   
-  use M_10_proof_assert_in_closure__mutable_capture__qyClosure0_Type as Closure'0
+  use T_10_proof_assert_in_closure__mutable_capture__qyClosure0 as Closure'0
   
   function field_0'0 [#"10_proof_assert_in_closure.rs" 15 4 15 6] (self : Closure'0.m_10_proof_assert_in_closure__mutable_capture__qyClosure0) : borrowed int32
     
@@ -221,7 +221,7 @@ module M_10_proof_assert_in_closure__mutable_capture [#"10_proof_assert_in_closu
     | & _6 : () = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_10_proof_assert_in_closure__captures_and_call__qyClosure0_Type [#"10_proof_assert_in_closure.rs" 32 4 32 25]
+module T_10_proof_assert_in_closure__captures_and_call__qyClosure0 [#"10_proof_assert_in_closure.rs" 32 4 32 25]
   use prelude.prelude.Int32
   
   use prelude.prelude.Int
@@ -249,7 +249,7 @@ module M_10_proof_assert_in_closure__captures_and_call__qyClosure0 [#"10_proof_a
   
   use prelude.prelude.Borrow
   
-  use M_10_proof_assert_in_closure__captures_and_call__qyClosure0_Type as Closure'0
+  use T_10_proof_assert_in_closure__captures_and_call__qyClosure0 as Closure'0
   
   function field_0'0 [#"10_proof_assert_in_closure.rs" 32 4 32 25] (self : Closure'0.m_10_proof_assert_in_closure__captures_and_call__qyClosure0) : borrowed int32
     
@@ -304,7 +304,7 @@ module M_10_proof_assert_in_closure__captures_and_call [#"10_proof_assert_in_clo
   let%span s10_proof_assert_in_closure5 = "10_proof_assert_in_closure.rs" 31 26 31 35
   let%span s10_proof_assert_in_closure6 = "10_proof_assert_in_closure.rs" 32 14 32 23
   
-  use M_10_proof_assert_in_closure__captures_and_call__qyClosure0_Type as Closure'0
+  use T_10_proof_assert_in_closure__captures_and_call__qyClosure0 as Closure'0
   
   predicate inv'0 (_1 : Closure'0.m_10_proof_assert_in_closure__captures_and_call__qyClosure0)
   

--- a/creusot/tests/should_succeed/closures/10_tyinv.coma
+++ b/creusot/tests/should_succeed/closures/10_tyinv.coma
@@ -15,7 +15,7 @@ module T_10_tyinv__Zero [#"10_tyinv.rs" 4 0 4 18]
       | C_Zero a _ -> a
       end
 end
-module M_10_tyinv__f__qyClosure0__qyClosure1_Type [#"10_tyinv.rs" 18 20 18 44]
+module T_10_tyinv__f__qyClosure0__qyClosure1 [#"10_tyinv.rs" 18 20 18 44]
   use T_10_tyinv__Zero as Zero'0
   
   use prelude.prelude.Borrow
@@ -63,7 +63,7 @@ module M_10_tyinv__f__qyClosure0__qyClosure1 [#"10_tyinv.rs" 18 20 18 44]
   
   axiom inv_axiom'2 [@rewrite] : forall x : Zero'0.t_Zero t [inv'2 x] . inv'2 x = invariant'1 x
   
-  use M_10_tyinv__f__qyClosure0__qyClosure1_Type as Closure'0
+  use T_10_tyinv__f__qyClosure0__qyClosure1 as Closure'0
   
   predicate inv'1 (_1 : Closure'0.m_10_tyinv__f__qyClosure0__qyClosure1 t)
   
@@ -106,7 +106,7 @@ module M_10_tyinv__f__qyClosure0__qyClosure1 [#"10_tyinv.rs" 18 20 18 44]
     | & res : uint32 = any_l () ]
      [ return' (result:uint32)-> {[@expl:postcondition] [%#s10_tyinv1] UInt32.to_int result = 0} (! return' {result}) ] 
 end
-module M_10_tyinv__f__qyClosure0_Type [#"10_tyinv.rs" 15 15 15 39]
+module T_10_tyinv__f__qyClosure0 [#"10_tyinv.rs" 15 15 15 39]
   use T_10_tyinv__Zero as Zero'0
   
   use prelude.prelude.Borrow
@@ -155,14 +155,14 @@ module M_10_tyinv__f__qyClosure0 [#"10_tyinv.rs" 15 15 15 39]
   
   axiom inv_axiom'4 [@rewrite] : forall x : Zero'0.t_Zero t [inv'4 x] . inv'4 x = invariant'2 x
   
-  use M_10_tyinv__f__qyClosure0__qyClosure1_Type as Closure'1
+  use T_10_tyinv__f__qyClosure0__qyClosure1 as Closure'1
   
   predicate inv'3 (_1 : Closure'1.m_10_tyinv__f__qyClosure0__qyClosure1 t)
   
   axiom inv_axiom'3 [@rewrite] : forall x : Closure'1.m_10_tyinv__f__qyClosure0__qyClosure1 t [inv'3 x] . inv'3 x
   = (let Closure'1.M_10_tyinv__f__qyClosure0__qyClosure1 a = x in inv'4 a)
   
-  use M_10_tyinv__f__qyClosure0_Type as Closure'0
+  use T_10_tyinv__f__qyClosure0 as Closure'0
   
   predicate inv'2 (_1 : Closure'0.m_10_tyinv__f__qyClosure0 t)
   
@@ -247,7 +247,7 @@ module M_10_tyinv__f [#"10_tyinv.rs" 14 0 14 35]
   
   axiom inv_axiom'3 [@rewrite] : forall x : Zero'0.t_Zero t [inv'4 x] . inv'4 x = invariant'2 x
   
-  use M_10_tyinv__f__qyClosure0_Type as Closure'0
+  use T_10_tyinv__f__qyClosure0 as Closure'0
   
   predicate inv'3 (_1 : Closure'0.m_10_tyinv__f__qyClosure0 t)
   

--- a/creusot/tests/should_succeed/ghost/assert_in_ghost.coma
+++ b/creusot/tests/should_succeed/ghost/assert_in_ghost.coma
@@ -11,7 +11,7 @@ module T_creusot_contracts__ghost__GhostBox [#"../../../../creusot-contracts/src
       | C_GhostBox a -> a
       end
 end
-module M_assert_in_ghost__ghost_only__qyClosure0_Type [#"assert_in_ghost.rs" 5 4 8 5]
+module T_assert_in_ghost__ghost_only__qyClosure0 [#"assert_in_ghost.rs" 5 4 8 5]
   type m_assert_in_ghost__ghost_only__qyClosure0  =
     | M_assert_in_ghost__ghost_only__qyClosure0
   
@@ -36,7 +36,7 @@ module M_assert_in_ghost__ghost_only__qyClosure0 [#"assert_in_ghost.rs" 5 4 8 5]
   
   axiom inv_axiom'0 [@rewrite] : forall x : () [inv'0 x] . inv'0 x = true
   
-  use M_assert_in_ghost__ghost_only__qyClosure0_Type as Closure'0
+  use T_assert_in_ghost__ghost_only__qyClosure0 as Closure'0
   
   use prelude.prelude.Intrinsic
   
@@ -99,7 +99,7 @@ module M_assert_in_ghost__ghost_only [#"assert_in_ghost.rs" 4 0 4 19]
   
   use prelude.prelude.Int
   
-  use M_assert_in_ghost__ghost_only__qyClosure0_Type as Closure'0
+  use T_assert_in_ghost__ghost_only__qyClosure0 as Closure'0
   
   let rec closure0'0 (_1:Closure'0.m_assert_in_ghost__ghost_only__qyClosure0) (return'  (ret:GhostBox'0.t_GhostBox ()))= bb0
     [ bb0 = s0
@@ -130,7 +130,7 @@ module M_assert_in_ghost__ghost_only [#"assert_in_ghost.rs" 4 0 4 19]
     | & _3 : () = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_assert_in_ghost__ghost_capture__qyClosure0_Type [#"assert_in_ghost.rs" 14 4 17 5]
+module T_assert_in_ghost__ghost_capture__qyClosure0 [#"assert_in_ghost.rs" 14 4 17 5]
   use prelude.prelude.Int32
   
   use prelude.prelude.Int
@@ -177,7 +177,7 @@ module M_assert_in_ghost__ghost_capture__qyClosure0 [#"assert_in_ghost.rs" 14 4 
   
   use prelude.prelude.Borrow
   
-  use M_assert_in_ghost__ghost_capture__qyClosure0_Type as Closure'0
+  use T_assert_in_ghost__ghost_capture__qyClosure0 as Closure'0
   
   meta "compute_max_steps" 1000000
   
@@ -230,7 +230,7 @@ module M_assert_in_ghost__ghost_capture [#"assert_in_ghost.rs" 11 0 11 22]
   
   use prelude.prelude.Borrow
   
-  use M_assert_in_ghost__ghost_capture__qyClosure0_Type as Closure'0
+  use T_assert_in_ghost__ghost_capture__qyClosure0 as Closure'0
   
   let rec closure0'0 (_1:Closure'0.m_assert_in_ghost__ghost_capture__qyClosure0) (return'  (ret:GhostBox'0.t_GhostBox ()))= bb0
     [ bb0 = s0
@@ -266,7 +266,7 @@ module M_assert_in_ghost__ghost_capture [#"assert_in_ghost.rs" 11 0 11 22]
     | & _5 : () = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_assert_in_ghost__ghost_mutate__qyClosure0_Type [#"assert_in_ghost.rs" 21 16 21 37]
+module T_assert_in_ghost__ghost_mutate__qyClosure0 [#"assert_in_ghost.rs" 21 16 21 37]
   type m_assert_in_ghost__ghost_mutate__qyClosure0  =
     | M_assert_in_ghost__ghost_mutate__qyClosure0
   
@@ -295,7 +295,7 @@ module M_assert_in_ghost__ghost_mutate__qyClosure0 [#"assert_in_ghost.rs" 21 16 
   
   axiom inv_axiom'0 [@rewrite] : forall x : (int32, int32) [inv'0 x] . inv'0 x = true
   
-  use M_assert_in_ghost__ghost_mutate__qyClosure0_Type as Closure'0
+  use T_assert_in_ghost__ghost_mutate__qyClosure0 as Closure'0
   
   use prelude.prelude.Intrinsic
   
@@ -321,7 +321,7 @@ module M_assert_in_ghost__ghost_mutate__qyClosure0 [#"assert_in_ghost.rs" 21 16 
     [ return' (result:GhostBox'0.t_GhostBox (int32, int32))-> return' {result} ]
     
 end
-module M_assert_in_ghost__ghost_mutate__qyClosure1_Type [#"assert_in_ghost.rs" 23 4 25 5]
+module T_assert_in_ghost__ghost_mutate__qyClosure1 [#"assert_in_ghost.rs" 23 4 25 5]
   use prelude.prelude.Int32
   
   use prelude.prelude.Int
@@ -391,7 +391,7 @@ module M_assert_in_ghost__ghost_mutate__qyClosure1 [#"assert_in_ghost.rs" 23 4 2
   predicate resolve'4 (_1 : borrowed (GhostBox'0.t_GhostBox (int32, int32))) =
     resolve'5 _1
   
-  use M_assert_in_ghost__ghost_mutate__qyClosure1_Type as Closure'0
+  use T_assert_in_ghost__ghost_mutate__qyClosure1 as Closure'0
   
   function field_0'0 [#"assert_in_ghost.rs" 23 4 25 5] (self : Closure'0.m_assert_in_ghost__ghost_mutate__qyClosure1) : borrowed (GhostBox'0.t_GhostBox (int32, int32))
     
@@ -455,7 +455,7 @@ module M_assert_in_ghost__ghost_mutate__qyClosure1 [#"assert_in_ghost.rs" 23 4 2
     | & _4 : borrowed (GhostBox'0.t_GhostBox (int32, int32)) = any_l () ]
      [ return' (result:GhostBox'0.t_GhostBox ())-> return' {result} ] 
 end
-module M_assert_in_ghost__ghost_mutate__qyClosure2_Type [#"assert_in_ghost.rs" 27 4 30 5]
+module T_assert_in_ghost__ghost_mutate__qyClosure2 [#"assert_in_ghost.rs" 27 4 30 5]
   use prelude.prelude.Int32
   
   use prelude.prelude.Int
@@ -490,7 +490,7 @@ module M_assert_in_ghost__ghost_mutate__qyClosure2 [#"assert_in_ghost.rs" 27 4 3
   
   axiom inv_axiom'0 [@rewrite] : forall x : () [inv'0 x] . inv'0 x = true
   
-  use M_assert_in_ghost__ghost_mutate__qyClosure2_Type as Closure'0
+  use T_assert_in_ghost__ghost_mutate__qyClosure2 as Closure'0
   
   use prelude.prelude.Intrinsic
   
@@ -602,7 +602,7 @@ module M_assert_in_ghost__ghost_mutate [#"assert_in_ghost.rs" 20 0 20 21]
   function inner_logic'0 (self : GhostBox'0.t_GhostBox (int32, int32)) : (int32, int32) =
     [%#sghost11] T_creusot_contracts__ghost__GhostBox.t_GhostBox__0 self
   
-  use M_assert_in_ghost__ghost_mutate__qyClosure2_Type as Closure'2
+  use T_assert_in_ghost__ghost_mutate__qyClosure2 as Closure'2
   
   function field_0'0 [#"assert_in_ghost.rs" 27 4 30 5] (self : Closure'2.m_assert_in_ghost__ghost_mutate__qyClosure2) : GhostBox'0.t_GhostBox (int32, int32)
     
@@ -629,7 +629,7 @@ module M_assert_in_ghost__ghost_mutate [#"assert_in_ghost.rs" 20 0 20 21]
   predicate resolve'4 (_1 : borrowed (GhostBox'0.t_GhostBox (int32, int32))) =
     resolve'5 _1
   
-  use M_assert_in_ghost__ghost_mutate__qyClosure1_Type as Closure'1
+  use T_assert_in_ghost__ghost_mutate__qyClosure1 as Closure'1
   
   function field_0'1 [#"assert_in_ghost.rs" 23 4 25 5] (self : Closure'1.m_assert_in_ghost__ghost_mutate__qyClosure1) : borrowed (GhostBox'0.t_GhostBox (int32, int32))
     
@@ -696,7 +696,7 @@ module M_assert_in_ghost__ghost_mutate [#"assert_in_ghost.rs" 20 0 20 21]
       (! return' {result}) ]
     
   
-  use M_assert_in_ghost__ghost_mutate__qyClosure0_Type as Closure'0
+  use T_assert_in_ghost__ghost_mutate__qyClosure0 as Closure'0
   
   let rec closure0'0 (_1:Closure'0.m_assert_in_ghost__ghost_mutate__qyClosure0) (return'  (ret:GhostBox'0.t_GhostBox (int32, int32)))= bb0
     [ bb0 = s0

--- a/creusot/tests/should_succeed/ghost/typing.coma
+++ b/creusot/tests/should_succeed/ghost/typing.coma
@@ -28,7 +28,7 @@ module T_creusot_contracts__ghost__GhostBox [#"../../../../creusot-contracts/src
       | C_GhostBox a -> a
       end
 end
-module M_typing__ghost_enter_ghost__qyClosure0_Type [#"typing.rs" 15 17 15 35]
+module T_typing__ghost_enter_ghost__qyClosure0 [#"typing.rs" 15 17 15 35]
   type m_typing__ghost_enter_ghost__qyClosure0  =
     | M_typing__ghost_enter_ghost__qyClosure0
   
@@ -54,7 +54,7 @@ module M_typing__ghost_enter_ghost__qyClosure0 [#"typing.rs" 15 17 15 35]
   
   axiom inv_axiom'0 [@rewrite] : forall x : NonCopy'0.t_NonCopy [inv'0 x] . inv'0 x = true
   
-  use M_typing__ghost_enter_ghost__qyClosure0_Type as Closure'0
+  use T_typing__ghost_enter_ghost__qyClosure0 as Closure'0
   
   use prelude.prelude.Intrinsic
   
@@ -84,7 +84,7 @@ module M_typing__ghost_enter_ghost__qyClosure0 [#"typing.rs" 15 17 15 35]
     [ return' (result:GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy))-> return' {result} ]
     
 end
-module M_typing__ghost_enter_ghost__qyClosure1_Type [#"typing.rs" 16 17 16 35]
+module T_typing__ghost_enter_ghost__qyClosure1 [#"typing.rs" 16 17 16 35]
   type m_typing__ghost_enter_ghost__qyClosure1  =
     | M_typing__ghost_enter_ghost__qyClosure1
   
@@ -110,7 +110,7 @@ module M_typing__ghost_enter_ghost__qyClosure1 [#"typing.rs" 16 17 16 35]
   
   axiom inv_axiom'0 [@rewrite] : forall x : NonCopy'0.t_NonCopy [inv'0 x] . inv'0 x = true
   
-  use M_typing__ghost_enter_ghost__qyClosure1_Type as Closure'0
+  use T_typing__ghost_enter_ghost__qyClosure1 as Closure'0
   
   use prelude.prelude.Intrinsic
   
@@ -140,7 +140,7 @@ module M_typing__ghost_enter_ghost__qyClosure1 [#"typing.rs" 16 17 16 35]
     [ return' (result:GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy))-> return' {result} ]
     
 end
-module M_typing__ghost_enter_ghost__qyClosure2_Type [#"typing.rs" 17 20 17 38]
+module T_typing__ghost_enter_ghost__qyClosure2 [#"typing.rs" 17 20 17 38]
   type m_typing__ghost_enter_ghost__qyClosure2  =
     | M_typing__ghost_enter_ghost__qyClosure2
   
@@ -166,7 +166,7 @@ module M_typing__ghost_enter_ghost__qyClosure2 [#"typing.rs" 17 20 17 38]
   
   axiom inv_axiom'0 [@rewrite] : forall x : NonCopy'0.t_NonCopy [inv'0 x] . inv'0 x = true
   
-  use M_typing__ghost_enter_ghost__qyClosure2_Type as Closure'0
+  use T_typing__ghost_enter_ghost__qyClosure2 as Closure'0
   
   use prelude.prelude.Intrinsic
   
@@ -196,7 +196,7 @@ module M_typing__ghost_enter_ghost__qyClosure2 [#"typing.rs" 17 20 17 38]
     [ return' (result:GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy))-> return' {result} ]
     
 end
-module M_typing__ghost_enter_ghost__qyClosure3_Type [#"typing.rs" 19 4 23 5]
+module T_typing__ghost_enter_ghost__qyClosure3 [#"typing.rs" 19 4 23 5]
   use T_typing__NonCopy as NonCopy'0
   
   use T_creusot_contracts__ghost__GhostBox as GhostBox'0
@@ -275,7 +275,7 @@ module M_typing__ghost_enter_ghost__qyClosure3 [#"typing.rs" 19 4 23 5]
   predicate resolve'4 (_1 : borrowed (GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy))) =
     resolve'5 _1
   
-  use M_typing__ghost_enter_ghost__qyClosure3_Type as Closure'0
+  use T_typing__ghost_enter_ghost__qyClosure3 as Closure'0
   
   function field_1'0 [#"typing.rs" 19 4 23 5] (self : Closure'0.m_typing__ghost_enter_ghost__qyClosure3) : borrowed (GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy))
     
@@ -452,7 +452,7 @@ module M_typing__ghost_enter_ghost [#"typing.rs" 14 0 14 26]
   predicate resolve'4 (_1 : borrowed (GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy))) =
     resolve'5 _1
   
-  use M_typing__ghost_enter_ghost__qyClosure3_Type as Closure'3
+  use T_typing__ghost_enter_ghost__qyClosure3 as Closure'3
   
   function field_1'0 [#"typing.rs" 19 4 23 5] (self : Closure'3.m_typing__ghost_enter_ghost__qyClosure3) : borrowed (GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy))
     
@@ -534,7 +534,7 @@ module M_typing__ghost_enter_ghost [#"typing.rs" 14 0 14 26]
       (! return' {result}) ]
     
   
-  use M_typing__ghost_enter_ghost__qyClosure2_Type as Closure'2
+  use T_typing__ghost_enter_ghost__qyClosure2 as Closure'2
   
   let rec closure2'0 (_1:Closure'2.m_typing__ghost_enter_ghost__qyClosure2) (return'  (ret:GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy)))= bb0
     [ bb0 = s0
@@ -547,7 +547,7 @@ module M_typing__ghost_enter_ghost [#"typing.rs" 14 0 14 26]
     [ return' (result:GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy))-> return' {result} ]
     
   
-  use M_typing__ghost_enter_ghost__qyClosure1_Type as Closure'1
+  use T_typing__ghost_enter_ghost__qyClosure1 as Closure'1
   
   let rec closure1'0 (_1:Closure'1.m_typing__ghost_enter_ghost__qyClosure1) (return'  (ret:GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy)))= bb0
     [ bb0 = s0
@@ -560,7 +560,7 @@ module M_typing__ghost_enter_ghost [#"typing.rs" 14 0 14 26]
     [ return' (result:GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy))-> return' {result} ]
     
   
-  use M_typing__ghost_enter_ghost__qyClosure0_Type as Closure'0
+  use T_typing__ghost_enter_ghost__qyClosure0 as Closure'0
   
   let rec closure0'0 (_1:Closure'0.m_typing__ghost_enter_ghost__qyClosure0) (return'  (ret:GhostBox'0.t_GhostBox (NonCopy'0.t_NonCopy)))= bb0
     [ bb0 = s0
@@ -625,7 +625,7 @@ module M_typing__ghost_enter_ghost [#"typing.rs" 14 0 14 26]
     | & _15 : () = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_typing__copy_enter_ghost__qyClosure0_Type [#"typing.rs" 34 4 38 5]
+module T_typing__copy_enter_ghost__qyClosure0 [#"typing.rs" 34 4 38 5]
   use prelude.prelude.Int32
   
   use prelude.prelude.Int
@@ -672,7 +672,7 @@ module M_typing__copy_enter_ghost__qyClosure0 [#"typing.rs" 34 4 38 5]
   
   use prelude.prelude.Borrow
   
-  use M_typing__copy_enter_ghost__qyClosure0_Type as Closure'0
+  use T_typing__copy_enter_ghost__qyClosure0 as Closure'0
   
   meta "compute_max_steps" 1000000
   
@@ -733,7 +733,7 @@ module M_typing__copy_enter_ghost [#"typing.rs" 29 0 29 25]
   
   use prelude.prelude.Borrow
   
-  use M_typing__copy_enter_ghost__qyClosure0_Type as Closure'0
+  use T_typing__copy_enter_ghost__qyClosure0 as Closure'0
   
   let rec closure0'0 (_1:Closure'0.m_typing__copy_enter_ghost__qyClosure0) (return'  (ret:GhostBox'0.t_GhostBox ()))= bb0
     [ bb0 = s0

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.coma
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.coma
@@ -1458,7 +1458,7 @@ module T_creusot_contracts__stdqy35z1__iter__map_inv__MapInv [#"../../../../creu
       | C_MapInv _ a _ -> a
       end
 end
-module M_03_std_iterators__counter__qyClosure0_Type [#"03_std_iterators.rs" 48 12 48 91]
+module T_03_std_iterators__counter__qyClosure0 [#"03_std_iterators.rs" 48 12 48 91]
   use prelude.prelude.UIntSize
   
   use prelude.prelude.Int
@@ -1488,7 +1488,7 @@ module M_03_std_iterators__counter__qyClosure0 [#"03_std_iterators.rs" 48 12 48 
   
   use prelude.prelude.Borrow
   
-  use M_03_std_iterators__counter__qyClosure0_Type as Closure'0
+  use T_03_std_iterators__counter__qyClosure0 as Closure'0
   
   function field_0'0 [#"03_std_iterators.rs" 48 12 48 91] (self : Closure'0.m_03_std_iterators__counter__qyClosure0) : borrowed usize
     
@@ -1605,7 +1605,7 @@ module M_03_std_iterators__counter [#"03_std_iterators.rs" 41 0 41 27]
   let%span smodel46 = "../../../../creusot-contracts/src/model.rs" 109 8 109 22
   let%span sinvariant47 = "../../../../creusot-contracts/src/invariant.rs" 34 20 34 44
   
-  use M_03_std_iterators__counter__qyClosure0_Type as Closure'0
+  use T_03_std_iterators__counter__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   

--- a/creusot/tests/should_succeed/iterators/06_map_precond.coma
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.coma
@@ -1956,7 +1956,7 @@ module M_06_map_precond__map [#"06_map_precond.rs" 191 0 194 17]
       (! return' {result}) ]
     
 end
-module M_06_map_precond__identity__qyClosure0_Type [#"06_map_precond.rs" 199 14 199 20]
+module T_06_map_precond__identity__qyClosure0 [#"06_map_precond.rs" 199 14 199 20]
   type m_06_map_precond__identity__qyClosure0 'i =
     | M_06_map_precond__identity__qyClosure0
   
@@ -2007,7 +2007,7 @@ module M_06_map_precond__identity__qyClosure0 [#"06_map_precond.rs" 199 14 199 2
   
   use prelude.prelude.Snapshot
   
-  use M_06_map_precond__identity__qyClosure0_Type as Closure'0
+  use T_06_map_precond__identity__qyClosure0 as Closure'0
   
   predicate unnest'0 [#"06_map_precond.rs" 199 14 199 20] (self : Closure'0.m_06_map_precond__identity__qyClosure0 i) (_2 : Closure'0.m_06_map_precond__identity__qyClosure0 i)
     
@@ -2079,7 +2079,7 @@ module M_06_map_precond__identity [#"06_map_precond.rs" 198 0 198 37]
   
   axiom inv_axiom'5 [@rewrite] : forall x : t_Item'0 [inv'7 x] . inv'7 x = invariant'3 x
   
-  use M_06_map_precond__identity__qyClosure0_Type as Closure'0
+  use T_06_map_precond__identity__qyClosure0 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -2258,7 +2258,7 @@ module M_06_map_precond__identity [#"06_map_precond.rs" 198 0 198 37]
     | & _4 : Closure'0.m_06_map_precond__identity__qyClosure0 i = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_06_map_precond__increment__qyClosure2_Type [#"06_map_precond.rs" 210 8 210 35]
+module T_06_map_precond__increment__qyClosure2 [#"06_map_precond.rs" 210 8 210 35]
   type m_06_map_precond__increment__qyClosure2 'u =
     | M_06_map_precond__increment__qyClosure2
   
@@ -2278,7 +2278,7 @@ module M_06_map_precond__increment__qyClosure2 [#"06_map_precond.rs" 210 8 210 3
   
   use prelude.prelude.Snapshot
   
-  use M_06_map_precond__increment__qyClosure2_Type as Closure'0
+  use T_06_map_precond__increment__qyClosure2 as Closure'0
   
   predicate unnest'0 [#"06_map_precond.rs" 210 8 210 35] (self : Closure'0.m_06_map_precond__increment__qyClosure2 u) (_2 : Closure'0.m_06_map_precond__increment__qyClosure2 u)
     
@@ -2367,7 +2367,7 @@ module M_06_map_precond__increment [#"06_map_precond.rs" 206 0 206 50]
   let%span s06_map_precond36 = "06_map_precond.rs" 102 4 102 83
   let%span s06_map_precond37 = "06_map_precond.rs" 104 8 112 9
   
-  use M_06_map_precond__increment__qyClosure2_Type as Closure'0
+  use T_06_map_precond__increment__qyClosure2 as Closure'0
   
   use prelude.prelude.Borrow
   
@@ -2621,7 +2621,7 @@ module M_06_map_precond__increment [#"06_map_precond.rs" 206 0 206 50]
     | & _6 : Closure'0.m_06_map_precond__increment__qyClosure2 u = any_l () ]
      [ return' (result:())-> (! return' {result}) ] 
 end
-module M_06_map_precond__counter__qyClosure2_Type [#"06_map_precond.rs" 227 8 227 41]
+module T_06_map_precond__counter__qyClosure2 [#"06_map_precond.rs" 227 8 227 41]
   use prelude.prelude.UIntSize
   
   use prelude.prelude.Int
@@ -2653,7 +2653,7 @@ module M_06_map_precond__counter__qyClosure2 [#"06_map_precond.rs" 227 8 227 41]
   
   use prelude.prelude.Borrow
   
-  use M_06_map_precond__counter__qyClosure2_Type as Closure'0
+  use T_06_map_precond__counter__qyClosure2 as Closure'0
   
   function field_0'0 [#"06_map_precond.rs" 227 8 227 41] (self : Closure'0.m_06_map_precond__counter__qyClosure2 i) : borrowed usize
     
@@ -2750,7 +2750,7 @@ module M_06_map_precond__counter [#"06_map_precond.rs" 222 0 222 48]
   let%span s06_map_precond25 = "06_map_precond.rs" 102 4 102 83
   let%span s06_map_precond26 = "06_map_precond.rs" 104 8 112 9
   
-  use M_06_map_precond__counter__qyClosure2_Type as Closure'0
+  use T_06_map_precond__counter__qyClosure2 as Closure'0
   
   use prelude.prelude.Borrow
   

--- a/creusot/tests/should_succeed/iterators/17_filter.coma
+++ b/creusot/tests/should_succeed/iterators/17_filter.coma
@@ -898,7 +898,7 @@ module T_core__iter__adapters__filter__Filter
     [ good (iter:'i) (predicate':'p)-> {C_Filter iter predicate' = input} (! ret {iter} {predicate'}) ]
     
 end
-module M_17_filter__less_than__qyClosure2_Type [#"17_filter.rs" 133 12 133 42]
+module T_17_filter__less_than__qyClosure2 [#"17_filter.rs" 133 12 133 42]
   use prelude.prelude.UInt32
   
   use prelude.prelude.Int
@@ -922,7 +922,7 @@ module M_17_filter__less_than__qyClosure2 [#"17_filter.rs" 133 12 133 42]
   
   use prelude.prelude.Borrow
   
-  use M_17_filter__less_than__qyClosure2_Type as Closure'0
+  use T_17_filter__less_than__qyClosure2 as Closure'0
   
   function field_0'0 [#"17_filter.rs" 133 12 133 42] (self : Closure'0.m_17_filter__less_than__qyClosure2) : uint32 =
     let Closure'0.M_17_filter__less_than__qyClosure2 a = self in a
@@ -1059,7 +1059,7 @@ module M_17_filter__less_than [#"17_filter.rs" 130 0 130 49]
   let%span sresolve41 = "../../../../creusot-contracts/src/resolve.rs" 41 20 41 34
   let%span smodel42 = "../../../../creusot-contracts/src/model.rs" 109 8 109 22
   
-  use M_17_filter__less_than__qyClosure2_Type as Closure'0
+  use T_17_filter__less_than__qyClosure2 as Closure'0
   
   use prelude.prelude.Borrow
   

--- a/creusot/tests/should_succeed/vector/06_knights_tour.coma
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.coma
@@ -275,7 +275,7 @@ module T_core__ops__range__Range
       | C_Range a _ -> a
       end
 end
-module M_06_knights_tour__qyi4580598960913230815__new__qyClosure3_Type [#"06_knights_tour.rs" 43 16 43 50] (* Board *)
+module T_06_knights_tour__qyi4580598960913230815__new__qyClosure3 [#"06_knights_tour.rs" 43 16 43 50] (* Board *)
   use prelude.prelude.UIntSize
   
   use prelude.prelude.Int
@@ -320,7 +320,7 @@ module M_06_knights_tour__qyi4580598960913230815__new__qyClosure3 [#"06_knights_
   
   use prelude.prelude.Borrow
   
-  use M_06_knights_tour__qyi4580598960913230815__new__qyClosure3_Type as Closure'0
+  use T_06_knights_tour__qyi4580598960913230815__new__qyClosure3 as Closure'0
   
   function field_0'0 [#"06_knights_tour.rs" 43 16 43 50] (self : Closure'0.m_06_knights_tour__qyi4580598960913230815__new__qyClosure3) : usize
     
@@ -433,7 +433,7 @@ module M_06_knights_tour__qyi4580598960913230815__new [#"06_knights_tour.rs" 40 
   let%span sresolve41 = "../../../../creusot-contracts/src/resolve.rs" 41 20 41 34
   let%span sinvariant42 = "../../../../creusot-contracts/src/invariant.rs" 34 20 34 44
   
-  use M_06_knights_tour__qyi4580598960913230815__new__qyClosure3_Type as Closure'0
+  use T_06_knights_tour__qyi4580598960913230815__new__qyClosure3 as Closure'0
   
   use prelude.prelude.Borrow
   

--- a/why3/src/declaration.rs
+++ b/why3/src/declaration.rs
@@ -59,6 +59,7 @@ pub enum Decl {
     Coma(coma::Defn),
     LetSpans(Vec<Span>),
     Meta(Meta),
+    Comment(String),
 }
 
 impl Decl {

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -113,6 +113,7 @@ impl Print for Decl {
                 alloc.intersperse(spans.iter().map(|span| span.pretty(alloc)), alloc.hardline())
             }
             Decl::Meta(meta) => meta.pretty(alloc),
+            Decl::Comment(c) => alloc.text("(* ").append(c).append(" *)"),
         }
     }
 }
@@ -135,18 +136,25 @@ impl Print for Module {
                 None => alloc.nil(),
             })
             .append(alloc.hardline())
-            .append(
-                alloc
-                    .intersperse(
-                        self.decls.iter().map(|decl| decl.pretty(alloc)),
-                        alloc.hardline().append(alloc.hardline()),
-                    )
-                    .indent(2),
-            )
+            .append(pretty_blocks(&self.decls, alloc).indent(2))
             .append(alloc.hardline())
             .append("end");
         doc
     }
+}
+
+// Items separated by empty lines
+pub fn pretty_blocks<'a, T: Print, A: DocAllocator<'a>>(
+    items: &'a Vec<T>,
+    alloc: &'a A,
+) -> DocBuilder<'a, A>
+where
+    A::Doc: Clone,
+{
+    alloc.intersperse(
+        items.iter().map(|item| item.pretty(alloc)),
+        alloc.hardline().append(alloc.hardline()),
+    )
 }
 
 impl Print for Scope {


### PR DESCRIPTION
While reworking the structure of the generated modules, I kept getting lost in the logic of `clone_map.rs` and `clone_map/elaborator.rs`, because there are some module names that are computed in two ways.

For example in `impl DepElab for TyElab`:

- we call `names.insert(dep)` which computes modules names one way
- we discard the result
- then we recompute the module names from scratch to fill the `as_` and `name` fields of `UseDecl`.

So when changing the shape of module names I was never sure whether I've forgotten a branch somewhere. This PR tries to unify that logic by preserving the structure of the module names returned by `names.insert()` (not flattened to a `Symbol`) so we can reuse it.

- This PR also makes it more explicit which modules are prefixed with `M_` and which are `T_`
- For closure types, instead of adding a `_Type` suffix, we change the prefix from `M_` to `T_`
- In one-file-per-module mode we remove the now redundant `module` declaration. Why3 then implicitly wraps it in `Coma` so that changes how it is imported by other files.

- [x] ~~I still need to update the why3sessions~~ There are no proofs in `qyClosure*_Type` modules, so no changes to why3sessions are needed.