### PR TITLE
Why3find integration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,7 @@ jobs:
         opam --cli=2.1 var --global in-creusot-ci=true
         opam install .
         mkdir /tmp/to-delete
-        opam info --list-files why3 > keep
+        opam info --list-files why3 why3find > keep
         sed -i 's/^.*\/_opam\///' keep
         rsync -a -r --remove-source-files --exclude-from=keep _opam/ /tmp/to-delete
     - name: setup opam PATH

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ _opam
 *.bak
 *~
 
+# why3find
+META.json
+dune
+dune.why3find
+
 # macOS
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ More examples are found in [creusot/tests/should_succeed](creusot/tests/should_s
     $ git clone https://github.com/creusot-rs/creusot
     $ cd creusot
     ```
-4. Set up **Why3**. Create a local `opam` switch with why3:
+4. Set up **Why3** and **Why3find**. Create a local `opam` switch with why3:
    ```
    $ opam switch create -y . ocaml.4.14.1
    $ eval $(opam env)
    ```
-   This will build why3 and its ocaml dependencies in a local `_opam` directory.
+   This will build `why3`, `why3find`, and their ocaml dependencies in a local `_opam` directory.
 5. Build **Creusot**:
     ```
     $ cargo install --path creusot-rustc

--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -10,11 +10,16 @@ mod helpers;
 use helpers::*;
 mod why3_launcher;
 use why3_launcher::*;
+mod why3find_wrapper;
+use why3find_wrapper::{why3find_config, why3find_prove};
+
 enum Subcommand {
     // subcommand to pass on to creusot-rustc
     Creusot(Option<CreusotSubCommand>),
-    // subcommand to handle in cargo-creusot
+    // subcommands to handle in cargo-creusot
     Setup(SetupSubCommand),
+    Config(ConfigArgs),
+    Prove(ProveArgs),
 }
 use Subcommand::*;
 
@@ -26,6 +31,8 @@ fn main() -> Result<()> {
         None => Creusot(None),
         Some(CargoCreusotSubCommand::Creusot(cmd)) => Creusot(Some(cmd)),
         Some(CargoCreusotSubCommand::Setup { command }) => Setup(command),
+        Some(CargoCreusotSubCommand::Config(args)) => Config(args),
+        Some(CargoCreusotSubCommand::Prove(args)) => Prove(args),
     };
 
     match subcommand {
@@ -97,6 +104,7 @@ fn main() -> Result<()> {
             let flags = setup::InstallFlags {
                 provers_parallelism,
                 why3: extflag(SetupTool::Why3),
+                why3find: extflag(SetupTool::Why3find),
                 altergo: managedflag(SetupTool::AltErgo, SetupManagedTool::AltErgo),
                 z3: managedflag(SetupTool::Z3, SetupManagedTool::Z3),
                 cvc4: managedflag(SetupTool::CVC4, SetupManagedTool::CVC4),
@@ -104,6 +112,8 @@ fn main() -> Result<()> {
             };
             setup::install(flags)
         }
+        Config(args) => why3find_config(args),
+        Prove(args) => why3find_prove(args),
     }
 }
 

--- a/cargo-creusot/src/why3find_wrapper.rs
+++ b/cargo-creusot/src/why3find_wrapper.rs
@@ -1,0 +1,70 @@
+use anyhow::Result;
+use creusot_args::options::*;
+use creusot_setup::{get_why3_config_file, PROVERS};
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    str::FromStr,
+};
+
+fn why3find_json_exists() -> bool {
+    Path::new("why3find.json").exists()
+}
+
+fn raw_config(args: &Vec<String>, why3_config_file: &PathBuf) -> Result<()> {
+    let mut why3find = Command::new("why3find");
+    why3find
+        .arg("config")
+        .arg("--quiet")
+        .arg("--why3-warn-off")
+        .arg("unused_variable,axiom_abstract")
+        .arg("--package")
+        .arg("prelude");
+    for prover in PROVERS {
+        why3find.arg("--prover").arg(format!("+{}", prover.bin.binary_name));
+    }
+    for arg in args {
+        why3find.arg(arg);
+    }
+    why3find
+        .env("WHY3CONFIG", &why3_config_file)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|e| anyhow::Error::new(e).context("why3find config failed"))
+        .map(|_| ())
+}
+
+fn raw_prove(args: ProveArgs, why3_config_file: &PathBuf) -> Result<()> {
+    let mut why3find = Command::new("why3find");
+    why3find.arg("prove");
+    if args.ide {
+        why3find.arg("-i");
+    }
+    // If there are no file arguments, default to `verif/` to avoid accidentally including random Why3 files elsewhere.
+    let files =
+        if args.files.len() == 0 { vec![PathBuf::from_str("verif").unwrap()] } else { args.files };
+    for file in files {
+        why3find.arg(file);
+    }
+    why3find
+        .env("WHY3CONFIG", &why3_config_file)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|e| anyhow::Error::new(e).context("why3find prove failed"))
+        .map(|_| ())
+}
+
+pub fn why3find_config(args: ConfigArgs) -> Result<()> {
+    let paths = get_why3_config_file()?;
+    raw_config(&args.args, &paths)
+}
+
+pub fn why3find_prove(args: ProveArgs) -> Result<()> {
+    let paths = get_why3_config_file()?;
+    if !why3find_json_exists() {
+        return Err(anyhow::anyhow!("why3find.json not found. Perhaps you are in the wrong directory, or you need to run `cargo creusot config`."));
+    }
+    raw_prove(args, &paths)
+}

--- a/ci/creusot-config-dummy.toml
+++ b/ci/creusot-config-dummy.toml
@@ -5,6 +5,10 @@ provers_parallelism = 1
 path = "why3"
 check_version = false
 
+[why3find]
+path = "why3find"
+check_version = false
+
 [altergo]
 mode = "builtin"
 check_version = false

--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -97,6 +97,8 @@ pub enum CargoCreusotSubCommand {
     },
     #[command(flatten)]
     Creusot(CreusotSubCommand),
+    Config(ConfigArgs),
+    Prove(ProveArgs),
 }
 
 #[derive(Debug, ValueEnum, Serialize, Deserialize, Clone)]
@@ -117,6 +119,7 @@ pub enum SetupManagedTool {
 #[derive(Debug, ValueEnum, Serialize, Deserialize, Clone, PartialEq)]
 pub enum SetupTool {
     Why3,
+    Why3find,
     AltErgo,
     Z3,
     CVC4,
@@ -177,4 +180,20 @@ pub enum SpanMode {
     Relative,
     Absolute,
     Off,
+}
+
+#[derive(Debug, Parser)]
+pub struct ProveArgs {
+    /// Run Why3 IDE on next unproved goal.
+    #[clap(short = 'i', default_value_t = false, action = clap::ArgAction::SetTrue)]
+    pub ide: bool,
+    /// Files to prove; default to everything in `verif/`.
+    pub files: Vec<PathBuf>,
+}
+
+#[derive(Debug, Parser)]
+pub struct ConfigArgs {
+    /// All arguments are forwarded to `why3find config`; see `why3find config --help` for a list of options.
+    #[clap(allow_hyphen_values = true)]
+    pub args: Vec<String>,
 }

--- a/creusot-deps.opam
+++ b/creusot-deps.opam
@@ -6,6 +6,7 @@ authors: "the creusot authors"
 depends: [
   "why3" {= "git-ec97"}
   "why3-ide" {= "git-ec97" & !?in-creusot-ci}
+  "why3find" {= "git-09c1"}
 # optional dependencies of why3
   "ocamlgraph"
   "camlzip"
@@ -16,4 +17,5 @@ depends: [
 pin-depends: [
   [ "why3.git-ec97" "git+https://gitlab.inria.fr/why3/why3.git#ec97d9abc" ]
   [ "why3-ide.git-ec97" "git+https://gitlab.inria.fr/why3/why3.git#ec97d9abc" ]
+  [ "why3find.git-09c1" "git+https://git.frama-c.com/pub/why3find.git#09c1d15" ]
 ]

--- a/creusot-setup/src/config.rs
+++ b/creusot-setup/src/config.rs
@@ -32,6 +32,7 @@ pub enum ManagedTool {
 pub struct Config {
     pub provers_parallelism: usize,
     pub why3: ExternalTool,
+    pub why3find: ExternalTool,
     pub altergo: ManagedTool,
     pub z3: ManagedTool,
     pub cvc4: ManagedTool,

--- a/creusot-setup/src/tools.rs
+++ b/creusot-setup/src/tools.rs
@@ -20,6 +20,13 @@ pub const WHY3: Binary = Binary {
     detect_version: detect_why3_version,
 };
 
+pub const WHY3FIND: Binary = Binary {
+    display_name: "why3find",
+    binary_name: "why3find",
+    version: WHY3FIND_VERSION,
+    detect_version: detect_why3find_version,
+};
+
 pub const ALTERGO: ManagedBinary = ManagedBinary {
     bin: Binary {
         display_name: "Alt-Ergo",
@@ -63,6 +70,8 @@ pub const CVC5: ManagedBinary = ManagedBinary {
     url: &URLS.cvc5,
     download_with: download_from_url_with_cache,
 };
+
+pub const PROVERS: &[ManagedBinary] = &[ALTERGO, Z3, CVC4, CVC5];
 
 // ----
 
@@ -256,6 +265,18 @@ fn generate_strategy(f: &mut dyn Write) -> anyhow::Result<()> {
     Ok(())
 }
 
+// helpers: why3find
+
+pub fn detect_why3find_version(why3find: &Path) -> Option<String> {
+    let output = Command::new(&why3find).arg("--version").output().ok()?;
+    let version_full = String::from_utf8(output.stdout).ok()?;
+    let version = version_full.strip_prefix("why3find v");
+    version.map(|ver| {
+        let parts: Vec<_> = ver.trim_end().split(|c| c == '.' || c == '+').collect();
+        String::from(&parts[..3].join("."))
+    })
+}
+
 // helpers: alt-ergo
 
 fn detect_altergo_version(altergo: &Path) -> Option<String> {
@@ -348,4 +369,8 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> std
     {
         std::os::windows::fs::symlink_file(original, link)
     }
+}
+
+pub fn why3find_install() {
+    Command::new("why3find").arg("install").arg("prelude").status().unwrap();
 }

--- a/creusot-setup/src/tools_versions_urls.rs
+++ b/creusot-setup/src/tools_versions_urls.rs
@@ -8,6 +8,7 @@
 // tools without binary releases
 pub const WHY3_VERSION: &'static str = "1.7.2";
 pub const WHY3_CONFIG_MAGIC_NUMBER: &'static str = "14";
+pub const WHY3FIND_VERSION: &'static str = "1.0.0";
 // tools with binary releases
 pub const ALTERGO_VERSION: &'static str = "2.6.0";
 pub const Z3_VERSION: &'static str = "4.12.4";

--- a/guide/src/quickstart.md
+++ b/guide/src/quickstart.md
@@ -50,3 +50,40 @@ We also recommend section 2.3 of this [thesis](https://sarsko.github.io/_pages/S
 
 We plan to improve this part of the user experience, but that will have to wait until Creusot gets more stable and complete.
 If you'd like to help, a prototype VSCode plugin for Why3 is [in development](https://github.com/xldenis/whycode), it should make the experience much smoother when complete.
+
+## Prove with Why3find
+
+### Configure
+
+```sh
+$ cargo creusot config
+```
+
+The configuration is stored in `why3find.json`.
+
+### Prove
+
+1. Run the Creusot translation.
+
+    ```sh
+    $ cargo creusot
+    ```
+
+2. Run the Why3find prover.
+
+    ```sh
+    $ cargo creusot prove
+    ```
+
+    Run the Why3find prover on specific files:
+
+    ```sh
+    $ cargo creusot prove verif/[COMA_FILES]
+    ```
+
+3. Launch Why3 IDE on unproved goals (this will only open one file even if there are many listed with unproved goals).
+
+    ```sh
+    $ cargo creusot prove -i
+    $ cargo creusot prove -i verif/[COMA_FILES]
+    ```


### PR DESCRIPTION
Add scripts to install why3find in `creusot-setup` and to run it in `cargo-creusot`.

```
cargo creusot config
cargo creusot prove
```

I wrote some instructions in `quickstart.md`.