### PR TITLE
Refactor creusot-rustc argument parser

### DIFF
--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -54,10 +54,9 @@ fn main() -> Result<()> {
                 why3_path: config_args.why3_path.clone(),
                 why3_config_file: config_args.why3_config.clone(),
                 subcommand: creusot_rustc_subcmd.clone(),
-                rust_flags: cargs.rust_flags,
             };
 
-            invoke_cargo(&creusot_args);
+            invoke_cargo(&creusot_args, cargs.cargo_flags);
 
             if let Some((mode, coma_src, args)) = launch_why3 {
                 let mut coma_files = vec![coma_src];
@@ -108,7 +107,7 @@ fn main() -> Result<()> {
     }
 }
 
-fn invoke_cargo(args: &CreusotArgs) {
+fn invoke_cargo(args: &CreusotArgs, cargo_flags: Vec<String>) {
     let creusot_rustc_path = std::env::current_exe()
         .expect("current executable path invalid")
         .with_file_name("creusot-rustc");
@@ -129,8 +128,8 @@ fn invoke_cargo(args: &CreusotArgs) {
     let mut cmd = Command::new(cargo_path);
     cmd.arg(format!("+{toolchain}"))
         .arg(&cargo_cmd)
-        .args(args.rust_flags.clone())
-        .env("RUSTC_WRAPPER", creusot_rustc_path)
+        .args(cargo_flags)
+        .env("RUSTC", creusot_rustc_path)
         .env("CARGO_CREUSOT", "1");
 
     // Append flags to any pre-existing ones

--- a/creusot-rustc/src/main.rs
+++ b/creusot-rustc/src/main.rs
@@ -38,58 +38,45 @@ fn main() {
     setup_plugin();
 }
 
+// Usage: creusot-rustc [RUSTC_OPTIONS] -- [CREUSOT_OPTIONS]
+// or     creusot-rustc [RUSTC_OPTIONS] --creusot=JSON_CREUSOT_OPTIONS
 fn setup_plugin() {
     let mut args = env::args().collect::<Vec<_>>();
 
-    let is_wrapper = args.get(1).map(|s| s.contains("rustc")).unwrap_or(false);
-
-    if is_wrapper {
-        args.remove(1);
-    }
-
-    let creusot: Option<CreusotArgs> = if is_wrapper {
-        let creusot = match args.iter().find_map(|arg| arg.strip_prefix("--creusot=")) {
-            Some(arg) => Some(serde_json::from_str(arg).unwrap()),
-            None => None,
-        };
-        args.retain(|arg| !arg.starts_with("--creusot"));
-        creusot
-    } else {
-        let mut all_args = CreusotArgs::parse_from(&args);
-        args = std::mem::take(&mut all_args.rust_flags);
-        Some(all_args)
+    let creusot = match args.iter().find_map(|arg| arg.strip_prefix("--creusot=")) {
+        Some(json) => {
+            let creusot = serde_json::from_str(json).unwrap();
+            args.retain(|arg| !arg.starts_with("--creusot="));
+            Some(creusot)
+        }
+        None => args.iter().rposition(|arg| arg == "--").map(|pos| {
+            let mut creusot_args = args.split_off(pos);
+            creusot_args[0] = "creusot-rustc".to_string();
+            CreusotArgs::parse_from(creusot_args)
+        }),
     };
+
+    let has_contracts =
+        args.iter().any(|arg| arg == "creusot_contracts" || arg.contains("creusot_contracts="));
 
     let sysroot = sysroot_path();
     args.push(format!("--sysroot={}", sysroot));
 
-    let normal_rustc = args.iter().any(|arg| arg.starts_with("--print"));
-    let primary_package = std::env::var("CARGO_PRIMARY_PACKAGE").is_ok();
-    let has_contracts =
-        args.iter().any(|arg| arg == "creusot_contracts" || arg.contains("creusot_contracts="));
-
-    // Did the user ask to compile this crate? Either they explicitly invoked `creusot-rustc` or this is a primary package.
-    let user_asked_for = !is_wrapper || primary_package;
-
-    if normal_rustc || !(user_asked_for || has_contracts) {
-        RunCompiler::new(&args, &mut DefaultCallbacks).run().unwrap()
-    } else {
-        match creusot {
-            Some(creusot) => {
-                for &arg in CREUSOT_RUSTC_ARGS {
-                    args.push(arg.to_owned());
-                }
-                debug!("creusot args={:?}", args);
-
-                let opts = match CreusotArgs::to_options(creusot) {
-                    Ok(opts) => opts,
-                    Err(msg) => panic!("Error: {msg}"),
-                };
-                RunCompiler::new(&args, &mut ToWhy::new(opts)).run().unwrap();
+    match creusot {
+        Some(creusot) if has_contracts => {
+            for &arg in CREUSOT_RUSTC_ARGS {
+                args.push(arg.to_owned());
             }
-            None => RunCompiler::new(&args, &mut DefaultCallbacks).run().unwrap(),
+            debug!("creusot args={:?}", args);
+
+            let opts = match CreusotArgs::to_options(creusot) {
+                Ok(opts) => opts,
+                Err(msg) => panic!("Error: {msg}"),
+            };
+            RunCompiler::new(&args, &mut ToWhy::new(opts)).run().unwrap();
         }
-    };
+        _ => RunCompiler::new(&args, &mut DefaultCallbacks).run().unwrap(),
+    }
 }
 
 fn sysroot_path() -> String {

--- a/creusot/tests/ui.rs
+++ b/creusot/tests/ui.rs
@@ -103,7 +103,16 @@ fn run_creusot(
         })
         .collect();
 
+    cmd.args(&["-Zno-codegen", "--crate-type=lib"]);
+    cmd.args(&["--extern", &format!("creusot_contracts={}", creusot_contract_path)]);
+
+    let mut dep_path = base_path;
+    dep_path.push("deps");
+    cmd.arg(format!("-Ldependency={}/", dep_path.display()));
+    cmd.arg(file.file_name().unwrap());
+
     cmd.args(&[
+        "--",
         "--stdout",
         "--export-metadata=false",
         "--span-mode=relative",
@@ -118,13 +127,6 @@ fn run_creusot(
     cmd.arg("--why3-path").arg(&config_paths.why3);
     cmd.arg("--why3-config-file").arg(&config_paths.why3_config);
 
-    cmd.args(&["--", "-Zno-codegen", "--crate-type=lib"]);
-    cmd.args(&["--extern", &format!("creusot_contracts={}", creusot_contract_path)]);
-
-    let mut dep_path = base_path;
-    dep_path.push("deps");
-    cmd.arg(format!("-Ldependency={}/", dep_path.display()));
-    cmd.arg(file.file_name().unwrap());
     Some(cmd)
 }
 

--- a/mir
+++ b/mir
@@ -7,14 +7,16 @@ SCRIPTPATH=$(dirname "$BASH_SOURCE")
 pushd $SCRIPTPATH > /dev/null
 eval $(cargo run --bin dev-env)
 cargo run --bin creusot-rustc --  \
-  --why3-config-file "$WHY3CONFIG" \
-  --output-file /dev/null \
-  --span-mode=absolute \
-  --creusot-extern creusot_contracts=./target/debug/libcreusot_contracts.rlib \
-  -- -Zno-codegen --crate-type=lib \
+  -Zno-codegen --crate-type=lib \
   --extern creusot_contracts=./target/debug/libcreusot_contracts.rlib \
   -Ldependency=./target/debug/deps/ \
   -Zunpretty=mir \
   -Zdump-mir= \
-  "$INPUTPATH"
+  "$INPUTPATH" \
+  -- \
+  --why3-config-file "$WHY3CONFIG" \
+  --output-file /dev/null \
+  --span-mode=absolute \
+  --creusot-extern creusot_contracts=./target/debug/libcreusot_contracts.rlib
+
 popd > /dev/null

--- a/mlcfg
+++ b/mlcfg
@@ -8,13 +8,15 @@ SCRIPTPATH=$(dirname "$BASH_SOURCE")
 pushd "$SCRIPTPATH" > /dev/null
 eval $(cargo run --bin dev-env)
 cargo run --bin creusot-rustc --  \
-  --why3-config-file "$WHY3CONFIG" \
-  --output-file="${INPUTPATH%.*}.coma" \
-  --span-mode=absolute \
-  -- -Zno-codegen \
+  -Zno-codegen \
   -Zmacro-backtrace \
   --extern creusot_contracts=./target/debug/libcreusot_contracts.rlib \
   -Ldependency=./target/debug/deps/ \
   --crate-type=lib \
-  "$INPUTPATH"
+  "$INPUTPATH" \
+  -- \
+  --why3-config-file "$WHY3CONFIG" \
+  --output-file="${INPUTPATH%.*}.coma" \
+  --span-mode=absolute
+
 popd > /dev/null


### PR DESCRIPTION
Instead of guessing when `creusot-rustc` is being called by `cargo` to decide whether rust options or creusot options come first, we make rust options always come first to simplify the parsing logic.

New usage:

```
creusot-rustc [RUST_OPTIONS] -- [CREUSOT_OPTIONS]
creusot-rustc [RUST_OPTIONS] --creusot=JSON_CREUSOT_OPTIONS
```

There was some funny thing going on with `rust_flags` because it was used also by `cargo-creusot` to forward arguments to `cargo` all while being uselessly sent to `creusot-rustc`. The original purpose of that field (forwarding arguments from `creusot-rustc`  to `rustc`) is made obsolete by this PR, so I renamed it to `cargo_flags` and moved it accordingly.