### PR TITLE
Pearlite macros errors

### DIFF
--- a/creusot-contracts-proc/src/invariant.rs
+++ b/creusot-contracts-proc/src/invariant.rs
@@ -27,7 +27,7 @@ impl ToTokens for Invariant {
 
         // TODO: Move out of `ToTokens`
         let s = self.span;
-        let inv_body = pretyping::encode_term(term).unwrap();
+        let inv_body = pretyping::encode_term(term).unwrap_or_else(|e| e.into_tokens());
         let inv_body = quote_spanned! {s=> #inv_body};
 
         tokens.extend(quote_spanned! {s=>

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -391,7 +391,7 @@ impl Parse for Assertion {
 #[proc_macro]
 pub fn proof_assert(assertion: TS1) -> TS1 {
     let assert = parse_macro_input!(assertion as Assertion);
-    let assert_body = pretyping::encode_block(&assert.0).unwrap();
+    let assert_body = pretyping::encode_block(&assert.0).unwrap_or_else(|e| e.into_tokens());
 
     TS1::from(quote! {
         {
@@ -409,7 +409,7 @@ pub fn proof_assert(assertion: TS1) -> TS1 {
 #[proc_macro]
 pub fn snapshot(assertion: TS1) -> TS1 {
     let assert = parse_macro_input!(assertion as Assertion);
-    let assert_body = pretyping::encode_block(&assert.0).unwrap();
+    let assert_body = pretyping::encode_block(&assert.0).unwrap_or_else(|e| e.into_tokens());
 
     TS1::from(quote! {
         {
@@ -551,7 +551,7 @@ fn logic_item(log: LogicItem, prophetic: Option<TokenStream>, documentation: Tok
     let def = log.defaultness;
     let sig = log.sig;
     let attrs = log.attrs;
-    let req_body = pretyping::encode_block(&term.stmts).unwrap();
+    let req_body = pretyping::encode_block(&term.stmts).unwrap_or_else(|e| e.into_tokens());
 
     TS1::from(quote_spanned! {span =>
         #[::creusot_contracts::pure]
@@ -651,7 +651,7 @@ fn predicate_item(
     let sig = log.sig;
     let attrs = log.attrs;
 
-    let req_body = pretyping::encode_block(&term.stmts).unwrap();
+    let req_body = pretyping::encode_block(&term.stmts).unwrap_or_else(|e| e.into_tokens());
 
     TS1::from(quote_spanned! {span =>
         #[::creusot_contracts::pure]
@@ -692,7 +692,7 @@ pub fn pearlite(tokens: TS1) -> TS1 {
             .iter()
             .map(pretyping::encode_stmt)
             .collect::<std::result::Result<TokenStream, _>>()
-            .unwrap(),
+            .unwrap_or_else(|e| e.into_tokens()),
     )
 }
 

--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -20,7 +20,7 @@ impl EncodeError {
             }
             Self::Unsupported(sp, msg) => {
                 let msg = format!("Unsupported expression: {}", msg);
-                quote_spanned! {sp=> compile_error!(#msg) }
+                quote_spanned! { sp=> compile_error!(#msg) }
             }
         }
     }
@@ -40,7 +40,7 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
             } else {
                 Err(EncodeError::Unsupported(
                     term.span(),
-                    "Macros other than pearlite! or proof_assert! are unsupported".into(),
+                    "macros other than `pearlite!` or `proof_assert!` are unsupported in pearlite code".into(),
                 ))
             }
         }

--- a/creusot/tests/creusot-contracts/creusot-contracts.coma
+++ b/creusot/tests/creusot-contracts/creusot-contracts.coma
@@ -8071,7 +8071,7 @@ module M_creusot_contracts__stdqy35z1__iter__map_inv__qyi4413682431414748756__ne
   let%span smap_inv19 = "../../../creusot-contracts/src/std/iter/map_inv.rs" 184 15 184 57
   let%span smap_inv20 = "../../../creusot-contracts/src/std/iter/map_inv.rs" 185 14 185 69
   let%span smap_inv21 = "../../../creusot-contracts/src/std/iter/map_inv.rs" 186 14 186 70
-  let%span smap_inv22 = "../../../creusot-contracts/src/std/iter/map_inv.rs" 176 4 176 12
+  let%span smap_inv22 = "../../../creusot-contracts/src/std/iter/map_inv.rs" 188 8 193 9
   let%span smap_inv23 = "../../../creusot-contracts/src/std/iter/map_inv.rs" 200 14 200 68
   let%span smap_inv24 = "../../../creusot-contracts/src/std/iter/map_inv.rs" 202 8 209 9
   let%span smap_inv25 = "../../../creusot-contracts/src/std/iter/map_inv.rs" 15 8 18 9

--- a/creusot/tests/should_fail/unsupported_macros.rs
+++ b/creusot/tests/should_fail/unsupported_macros.rs
@@ -1,0 +1,8 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[logic]
+#[open]
+pub fn f() {
+    panic!()
+}

--- a/creusot/tests/should_fail/unsupported_macros.stderr
+++ b/creusot/tests/should_fail/unsupported_macros.stderr
@@ -1,0 +1,10 @@
+error: Unsupported expression: macros other than `pearlite!` or `proof_assert!` are unsupported in pearlite code
+ --> unsupported_macros.rs:7:5
+  |
+7 |     panic!()
+  |     ^^^^^^^^
+
+error: internal error: Cannot fetch THIR body
+
+error: aborting due to 2 previous errors
+

--- a/creusot/tests/should_succeed/iterators/05_map.coma
+++ b/creusot/tests/should_succeed/iterators/05_map.coma
@@ -790,7 +790,7 @@ module M_05_map__qyi14910388998417814812__next [#"05_map.rs" 69 4 69 44] (* <Map
   let%span s05_map15 = "05_map.rs" 124 15 124 43
   let%span s05_map16 = "05_map.rs" 125 14 125 42
   let%span s05_map17 = "05_map.rs" 126 14 126 47
-  let%span s05_map18 = "05_map.rs" 116 4 116 12
+  let%span s05_map18 = "05_map.rs" 128 8 133 9
   let%span sops19 = "../../../../creusot-contracts/src/std/ops.rs" 163 27 163 52
   let%span sops20 = "../../../../creusot-contracts/src/std/ops.rs" 151 0 175 1
   let%span s05_map21 = "05_map.rs" 26 8 26 75
@@ -1185,7 +1185,7 @@ module M_05_map__qyi9543869049664362474__produces_one_invariant [#"05_map.rs" 12
   let%span s05_map7 = "05_map.rs" 124 15 124 43
   let%span s05_map8 = "05_map.rs" 125 14 125 42
   let%span s05_map9 = "05_map.rs" 126 14 126 47
-  let%span s05_map10 = "05_map.rs" 116 4 116 12
+  let%span s05_map10 = "05_map.rs" 128 8 133 9
   let%span s05_map11 = "05_map.rs" 95 8 103 9
   let%span s05_map12 = "05_map.rs" 84 8 90 9
   let%span scommon13 = "common.rs" 14 15 14 24

--- a/creusot/tests/should_succeed/iterators/06_map_precond.coma
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.coma
@@ -1056,7 +1056,7 @@ module M_06_map_precond__qyi18374305379273630819__next [#"06_map_precond.rs" 72 
   let%span s06_map_precond19 = "06_map_precond.rs" 146 15 146 57
   let%span s06_map_precond20 = "06_map_precond.rs" 147 14 147 69
   let%span s06_map_precond21 = "06_map_precond.rs" 148 14 148 70
-  let%span s06_map_precond22 = "06_map_precond.rs" 138 4 138 12
+  let%span s06_map_precond22 = "06_map_precond.rs" 150 8 155 9
   let%span s06_map_precond23 = "06_map_precond.rs" 25 8 28 9
   let%span s06_map_precond24 = "06_map_precond.rs" 159 14 159 68
   let%span s06_map_precond25 = "06_map_precond.rs" 161 8 169 9
@@ -1514,7 +1514,7 @@ module M_06_map_precond__qyi16548623944279504987__produces_one_invariant [#"06_m
   let%span s06_map_precond7 = "06_map_precond.rs" 146 15 146 57
   let%span s06_map_precond8 = "06_map_precond.rs" 147 14 147 69
   let%span s06_map_precond9 = "06_map_precond.rs" 148 14 148 70
-  let%span s06_map_precond10 = "06_map_precond.rs" 138 4 138 12
+  let%span s06_map_precond10 = "06_map_precond.rs" 150 8 155 9
   let%span s06_map_precond11 = "06_map_precond.rs" 102 4 102 83
   let%span s06_map_precond12 = "06_map_precond.rs" 104 8 112 9
   let%span s06_map_precond13 = "06_map_precond.rs" 93 8 98 9


### PR DESCRIPTION
In this example:
```rust
#[logic]
#[open]
pub fn f() {
    panic!()
}
```
The error `macros other than pearlite and snapshot are unsupported` is now correctly reported on `panic!()`, and not `#[logic]`.