### PR TITLE
Fix a ICE in the final places analysis

### DIFF
--- a/creusot/tests/should_fail/bug/ice-final-borrows.rs
+++ b/creusot/tests/should_fail/bug/ice-final-borrows.rs
@@ -1,0 +1,10 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+// At some point, mutating an immutable borrow caused the code testing for final borrows
+// to crash. This test ensures that it does not happen again.
+
+#[requires(true)]
+pub fn mutates_immutable(x: &i32) {
+    *x = 1;
+}

--- a/creusot/tests/should_fail/bug/ice-final-borrows.stderr
+++ b/creusot/tests/should_fail/bug/ice-final-borrows.stderr
@@ -1,0 +1,14 @@
+error[E0594]: cannot assign to `*x`, which is behind a `&` reference
+ --> ice-final-borrows.rs:9:5
+  |
+9 |     *x = 1;
+  |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
+  |
+help: consider changing this to be a mutable reference
+  |
+8 | pub fn mutates_immutable(x: &mut i32) {
+  |                              +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0594`.


### PR DESCRIPTION
When trying to write to a shared reference, creusot generated a ICE file, which was annoying: this fixes that.