### PR TITLE
hide generated files for tests from github diffs 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+creusot/tests/**/*.coma linguist-generated=true
+creusot/tests/**/why3session.xml linguist-generated=true
+creusot/tests/**/why3shapes.gz linguist-generated=true


### PR DESCRIPTION
This is an attempt to use https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github to hide generated .coma/session files from github diffs by default, to make it easier to review PRs.