### PR TITLE
Add assertion locations

### DIFF
--- a/creusot-contracts-proc/Cargo.toml
+++ b/creusot-contracts-proc/Cargo.toml
@@ -16,5 +16,5 @@ quote = "1.0.35"
 uuid = { version = "1.3", features = ["v4"] }
 pearlite-syn = { version = "0.3", path = "../pearlite-syn", features = ["full"] }
 syn = { version = "2.0.15"}
-proc-macro2 = "1.0.29"
+proc-macro2 = { version = "1.0.29", features = ["span-locations"] }
 

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -392,6 +392,7 @@ impl Parse for Assertion {
 pub fn proof_assert(assertion: TS1) -> TS1 {
     let assert = parse_macro_input!(assertion as Assertion);
     let assert_body = pretyping::encode_block(&assert.0).unwrap_or_else(|e| e.into_tokens());
+    let location = format!("proof_assert L{}", Span::call_site().start().line);
 
     TS1::from(quote! {
         {
@@ -399,7 +400,7 @@ pub fn proof_assert(assertion: TS1) -> TS1 {
             let _ = {
                 #[creusot::no_translate]
                 #[creusot::spec]
-                #[creusot::spec::assert]
+                #[creusot::spec::assert = #location]
                 || -> bool { #assert_body }
             };
         }

--- a/creusot/src/contracts_items/attributes.rs
+++ b/creusot/src/contracts_items/attributes.rs
@@ -67,6 +67,15 @@ pub fn get_invariant_expl(tcx: TyCtxt, def_id: DefId) -> Option<String> {
     })
 }
 
+pub fn get_assert_msg(tcx: TyCtxt, def_id: DefId) -> Option<String> {
+    get_attr(tcx.get_attrs_unchecked(def_id), &["creusot", "spec", "assert"]).map(|a| {
+        match a.args {
+            AttrArgs::Eq(_, AttrArgsEq::Hir(ref msg)) => msg.symbol.to_string(),
+            _ => "assert".to_string(),
+        }
+    })
+}
+
 pub(crate) fn no_mir(tcx: TyCtxt, def_id: DefId) -> bool {
     is_no_translate(tcx, def_id) || is_predicate(tcx, def_id) || is_logic(tcx, def_id)
 }

--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -148,7 +148,7 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                             || contracts_items::is_variant(self.tcx(), *def_id)
                         {
                             return;
-                        } else if contracts_items::is_assertion(self.tcx(), *def_id) {
+                        } else if let Some(msg) = contracts_items::get_assert_msg(self.tcx(), *def_id) {
                             let mut assertion = self
                                 .assertions
                                 .remove(def_id)
@@ -157,7 +157,7 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                             self.check_frozen_in_logic(&assertion, loc);
                             self.emit_statement(fmir::Statement::Assertion {
                                 cond: assertion,
-                                msg: "assertion".to_owned(),
+                                msg,
                             });
                             return;
                         } else if contracts_items::is_spec(self.tcx(), *def_id) {


### PR DESCRIPTION
This is half a PR and half an issue: I can't figure out how to use the `span-location` feature of `proc-macro2` (which is really the unstable feature `proc_macro_span` in rustc). This compiles but the line numbers are all `0`. Is there something wrong with how we wrap rustc?

Beyond this PR I was thinking of getting Creusot to output span information somewhere so that Creusot IDE can work without parsing rust code.