### PR TITLE
No more annoying 'strings are experimental' warning

### DIFF
--- a/creusot-contracts/src/std/string.rs
+++ b/creusot-contracts/src/std/string.rs
@@ -5,6 +5,7 @@ extern_spec! {
     mod std {
         mod string {
             impl Deref for String {
+                #[expect(creusot::experimental)] // Suppress the warning until string are no longer experimental
                 #[pure]
                 #[ensures(result@ == self@)]
                 fn deref(&self) -> &str;


### PR DESCRIPTION
Suppress this warning that always appear when building creusot-contracts.