### PR TITLE
Creusot conditional dependencies

### DIFF
--- a/creusot-contracts/Cargo.toml
+++ b/creusot-contracts/Cargo.toml
@@ -9,10 +9,12 @@ description = "Provides contracts and logic helpers for Creusot"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-creusot-contracts-proc = { path = "../creusot-contracts-proc", version = "0.3.0" }
-creusot-contracts-dummy = { path = "../creusot-contracts-dummy", version = "0.3.0" }
+[target.'cfg(creusot)'.dependencies]
 num-rational = "0.3.2"
+creusot-contracts-proc = { path = "../creusot-contracts-proc", version = "0.3.0" }
+
+[target.'cfg(not(creusot))'.dependencies]
+creusot-contracts-dummy = { path = "../creusot-contracts-dummy", version = "0.3.0" }
 
 [features]
 default = []

--- a/creusot-metadata/Cargo.toml
+++ b/creusot-metadata/Cargo.toml
@@ -9,3 +9,7 @@ publish = false
 [dependencies]
 indexmap = "1.7.0"
 
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)].
+# See https://github.com/rust-analyzer/rust-analyzer/pull/7891
+rustc_private = true

--- a/creusot-rustc/Cargo.toml
+++ b/creusot-rustc/Cargo.toml
@@ -12,5 +12,9 @@ creusot = { path = "../creusot", version = "0.3" }
 toml = "0.5.8"
 env_logger = "0.10"
 serde = { version = "1.0", features = ["derive"] }
-creusot-args = {path = "../creusot-args"}
+creusot-args = { path = "../creusot-args" }
 
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)].
+# See https://github.com/rust-analyzer/rust-analyzer/pull/7891
+rustc_private = true

--- a/creusot-rustc/src/main.rs
+++ b/creusot-rustc/src/main.rs
@@ -18,7 +18,7 @@ use rustc_driver::RunCompiler;
 use rustc_session::{config::ErrorOutputType, EarlyDiagCtxt};
 use std::{env, panic, process::Command};
 
-const BUG_REPORT_URL: &'static str = &"https://github.com/creusot-rs/creusot/issues/new";
+const BUG_REPORT_URL: &str = "https://github.com/creusot-rs/creusot/issues/new";
 
 struct DefaultCallbacks;
 impl rustc_driver::Callbacks for DefaultCallbacks {}
@@ -75,7 +75,10 @@ fn setup_plugin() {
             };
             RunCompiler::new(&args, &mut ToWhy::new(opts)).run().unwrap();
         }
-        _ => RunCompiler::new(&args, &mut DefaultCallbacks).run().unwrap(),
+        _ => {
+            args.push("--cfg=creusot".to_string());
+            RunCompiler::new(&args, &mut DefaultCallbacks).run().unwrap()
+        }
     }
 }
 


### PR DESCRIPTION
Allow conditionally pulling dependencies depending on `cfg(creusot)`.

In particular this means crates using `creusot-contracts` pull much less dependencies in normal compilation.