### PR TITLE
Refactor of argument handling in cargo-creusot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "clap",
  "creusot-args",
  "creusot-setup",
  "env_logger",

--- a/cargo-creusot/Cargo.toml
+++ b/cargo-creusot/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.2.5", features = ["derive", "env"] }
 serde_json = { version = "1.0" }
 toml = { version = "0.5.8" }
 env_logger = "0.10"

--- a/cargo-creusot/src/helpers.rs
+++ b/cargo-creusot/src/helpers.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Error;
 use cargo_metadata;
-use creusot_args::options::CargoCreusotArgs;
+use creusot_args::options::CommonOptions;
 pub type Result<T> = anyhow::Result<T>;
 
 pub(crate) fn make_cargo_metadata() -> Result<cargo_metadata::Metadata> {
@@ -38,25 +38,25 @@ fn get_crate_() -> Result<String> {
 
 const OUTPUT_PREFIX: &str = "verif";
 
-pub(crate) fn get_coma(cargs: &CargoCreusotArgs) -> (PathBuf, Option<String>) {
+pub(crate) fn get_coma(options: &CommonOptions) -> (PathBuf, Option<String>) {
     let coma_src: PathBuf; // coma output file name or directory
     let coma_glob: Option<String>; // glob pattern for all coma files under coma_src
-    if let Some(f) = &cargs.options.output_file {
+    if let Some(f) = &options.output_file {
         coma_src = f.into();
         coma_glob = None;
-    } else if cargs.options.stdout {
+    } else if options.stdout {
         coma_src = PathBuf::new(); // don't care, dummy value
         coma_glob = None;
     } else {
         // default to --output-dir=target/creusot
-        let mut dir = match &cargs.options.output_dir {
+        let mut dir = match &options.output_dir {
             Some(dir) => dir.clone(),
             None => PathBuf::from("."),
         };
         dir.push(OUTPUT_PREFIX);
 
         let Ok(krate) = get_crate_() else { return (PathBuf::new(), None) };
-        if cargs.options.monolithic {
+        if options.monolithic {
             coma_glob = dir.to_str().map(|s| s.to_string() + "/" + &krate + ".coma");
         } else {
             dir.push(krate);

--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -1,3 +1,4 @@
+use clap::*;
 use creusot_args::{options::*, CREUSOT_RUSTC_ARGS};
 use creusot_setup as setup;
 use std::{
@@ -11,90 +12,18 @@ use helpers::*;
 mod why3_launcher;
 use why3_launcher::*;
 mod why3find_wrapper;
-use why3find_wrapper::{why3find_config, why3find_prove};
-
-enum Subcommand {
-    // subcommand to pass on to creusot-rustc
-    Creusot(Option<CreusotSubCommand>),
-    // subcommands to handle in cargo-creusot
-    Setup(SetupSubCommand),
-    Config(ConfigArgs),
-    Prove(ProveArgs),
-}
-use Subcommand::*;
+use why3find_wrapper::*;
 
 fn main() -> Result<()> {
     let cargs = CargoCreusotArgs::parse_from(std::env::args().skip(1));
-    let (coma_src, coma_glob) = get_coma(&cargs);
 
-    let subcommand = match cargs.subcommand {
-        None => Creusot(None),
-        Some(CargoCreusotSubCommand::Creusot(cmd)) => Creusot(Some(cmd)),
-        Some(CargoCreusotSubCommand::Setup { command }) => Setup(command),
-        Some(CargoCreusotSubCommand::Config(args)) => Config(args),
-        Some(CargoCreusotSubCommand::Prove(args)) => Prove(args),
-    };
-
-    match subcommand {
-        Creusot(subcmd) => {
-            // subcommand analysis:
-            //   we want to launch Why3 Ide and replay in cargo-creusot not by creusot-rustc.
-            //   however we want to keep the current behavior for other commands: prove
-            // why3session will be put in or next to `coma_src`
-            let (creusot_rustc_subcmd, launch_why3) = match subcmd {
-                Some(CreusotSubCommand::Why3 { command: Why3SubCommand::Ide, args, .. }) => {
-                    (None, Some((Why3Mode::Ide, coma_src, args)))
-                }
-                Some(CreusotSubCommand::Why3 { command: Why3SubCommand::Replay, args, .. }) => {
-                    let mut basename = coma_src.clone();
-                    basename.set_extension(""); // for single-file mode
-                    (None, Some((Why3Mode::Replay, basename, args)))
-                }
-                _ => (subcmd, None),
-            };
-
-            // Default output_dir to "." if not specified
-            let include_dir = Some(cargs.options.output_dir.clone().unwrap_or(".".into()));
-            let config_args = setup::status_for_creusot()?;
-            let creusot_args = CreusotArgs {
-                options: cargs.options,
-                why3_path: config_args.why3_path.clone(),
-                why3_config_file: config_args.why3_config.clone(),
-                subcommand: creusot_rustc_subcmd.clone(),
-            };
-
-            invoke_cargo(&creusot_args, cargs.cargo_flags);
-
-            if let Some((mode, coma_src, args)) = launch_why3 {
-                let mut coma_files = vec![coma_src];
-                // Glob coma files after creusot-rustc has generated them
-                if let Why3Mode::Ide = mode {
-                    if let Some(glob) = coma_glob {
-                        if let Ok(paths) = glob::glob(&glob) {
-                            coma_files.extend(paths.filter_map(|p| p.ok()));
-                        }
-                    }
-                }
-
-                // why3 configuration
-                let why3 = Why3Launcher {
-                    why3_path: config_args.why3_path,
-                    config_file: config_args.why3_config,
-                    mode,
-                    include_dir,
-                    coma_files,
-                    args,
-                };
-                let prelude_dir =
-                    TempDir::new("creusot_why3_prelude").expect("could not create temp dir");
-                let mut command = why3.make(prelude_dir.path())?;
-                command.status().expect("could not run why3");
-            }
-
-            Ok(())
-        }
-        Setup(SetupSubCommand::Status) => setup::status(),
-        Setup(SetupSubCommand::Install { provers_parallelism, external, no_check_version }) => {
+    match cargs.subcommand {
+        None => creusot(None, cargs.options, cargs.cargo_flags),
+        Some(Creusot(subcmd)) => creusot(Some(subcmd), cargs.options, cargs.cargo_flags),
+        Some(Setup { command: SetupSubCommand::Status }) => setup::status(),
+        Some(Setup {
+            command: SetupSubCommand::Install { provers_parallelism, external, no_check_version },
+        }) => {
             let extflag =
                 |name| setup::ExternalFlag { check_version: !no_check_version.contains(&name) };
             let managedflag = |name, mname| setup::ManagedFlag {
@@ -112,9 +41,72 @@ fn main() -> Result<()> {
             };
             setup::install(flags)
         }
-        Config(args) => why3find_config(args),
-        Prove(args) => why3find_prove(args),
+        Some(Config(args)) => why3find_config(args),
+        Some(Prove(args)) => why3find_prove(args),
     }
+}
+
+fn creusot(
+    subcmd: Option<CreusotSubCommand>,
+    options: CommonOptions,
+    cargo_flags: Vec<String>,
+) -> Result<()> {
+    let (coma_src, coma_glob) = get_coma(&options);
+
+    // subcommand analysis:
+    //   we want to launch Why3 Ide and replay in cargo-creusot not by creusot-rustc.
+    //   however we want to keep the current behavior for other commands: prove
+    // why3session will be put in or next to `coma_src`
+    let (creusot_rustc_subcmd, launch_why3) = match subcmd {
+        Some(CreusotSubCommand::Why3 { command: Why3SubCommand::Ide, args, .. }) => {
+            (None, Some((Why3Mode::Ide, coma_src, args)))
+        }
+        Some(CreusotSubCommand::Why3 { command: Why3SubCommand::Replay, args, .. }) => {
+            let mut basename = coma_src.clone();
+            basename.set_extension(""); // for single-file mode
+            (None, Some((Why3Mode::Replay, basename, args)))
+        }
+        _ => (subcmd, None),
+    };
+
+    // Default output_dir to "." if not specified
+    let include_dir = Some(options.output_dir.clone().unwrap_or(".".into()));
+    let config_args = setup::status_for_creusot()?;
+    let creusot_args = CreusotArgs {
+        options,
+        why3_path: config_args.why3_path.clone(),
+        why3_config_file: config_args.why3_config.clone(),
+        subcommand: creusot_rustc_subcmd.clone(),
+    };
+
+    invoke_cargo(&creusot_args, cargo_flags);
+
+    if let Some((mode, coma_src, args)) = launch_why3 {
+        let mut coma_files = vec![coma_src];
+        // Glob coma files after creusot-rustc has generated them
+        if let Why3Mode::Ide = mode {
+            if let Some(glob) = coma_glob {
+                if let Ok(paths) = glob::glob(&glob) {
+                    coma_files.extend(paths.filter_map(|p| p.ok()));
+                }
+            }
+        }
+
+        // why3 configuration
+        let why3 = Why3Launcher {
+            why3_path: config_args.why3_path,
+            config_file: config_args.why3_config,
+            mode,
+            include_dir,
+            coma_files,
+            args,
+        };
+        let prelude_dir = TempDir::new("creusot_why3_prelude").expect("could not create temp dir");
+        let mut command = why3.make(prelude_dir.path())?;
+        command.status().expect("could not run why3");
+    }
+
+    Ok(())
 }
 
 fn invoke_cargo(args: &CreusotArgs, cargo_flags: Vec<String>) {
@@ -173,4 +165,57 @@ fn toolchain_channel() -> Option<String> {
     let toolchain: toml::Value = toml::from_str(include_str!("../../rust-toolchain")).ok()?;
     let channel = toolchain["toolchain"]["channel"].as_str()?;
     Some(channel.into())
+}
+
+#[derive(Debug, Parser)]
+pub struct CargoCreusotArgs {
+    #[clap(flatten)]
+    pub options: CommonOptions,
+    /// Subcommand: why3, setup
+    #[command(subcommand)]
+    pub subcommand: Option<CargoCreusotSubCommand>,
+    /// Additional flags to pass to the underlying cargo invocation.
+    #[clap(last = true)]
+    #[clap(global = true)]
+    pub cargo_flags: Vec<String>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CargoCreusotSubCommand {
+    /// Setup and manage Creusot's installation
+    #[command(arg_required_else_help(true))]
+    Setup {
+        #[command(subcommand)]
+        command: SetupSubCommand,
+    },
+    #[command(flatten)]
+    Creusot(CreusotSubCommand),
+    Config(ConfigArgs),
+    Prove(ProveArgs),
+}
+use CargoCreusotSubCommand::*;
+
+#[derive(Debug, Parser, Clone)]
+pub enum SetupSubCommand {
+    /// Show the current status of the Creusot installation
+    Status,
+    /// Setup Creusot or update an existing installation
+    Install {
+        /// Maximum number of provers to run in parallel
+        #[arg(long, default_value_t = default_provers_parallelism())]
+        provers_parallelism: usize,
+        /// Look-up <TOOL> from PATH instead of using the built-in version
+        #[arg(long, value_name = "TOOL")]
+        external: Vec<SetupManagedTool>,
+        /// Do not error if <TOOL>'s version does not match the one expected by creusot
+        #[arg(long, value_name = "TOOL")]
+        no_check_version: Vec<SetupTool>,
+    },
+}
+
+fn default_provers_parallelism() -> usize {
+    match std::thread::available_parallelism() {
+        Ok(n) => n.get(),
+        Err(_) => 1,
+    }
 }

--- a/cargo-creusot/src/why3find_wrapper.rs
+++ b/cargo-creusot/src/why3find_wrapper.rs
@@ -1,11 +1,27 @@
 use anyhow::Result;
-use creusot_args::options::*;
+use clap::*;
 use creusot_setup::{get_why3_config_file, PROVERS};
 use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
     str::FromStr,
 };
+
+#[derive(Debug, Parser)]
+pub struct ProveArgs {
+    /// Run Why3 IDE on next unproved goal.
+    #[clap(short = 'i', default_value_t = false, action = clap::ArgAction::SetTrue)]
+    pub ide: bool,
+    /// Files to prove; default to everything in `verif/`.
+    pub files: Vec<PathBuf>,
+}
+
+#[derive(Debug, Parser)]
+pub struct ConfigArgs {
+    /// All arguments are forwarded to `why3find config`; see `why3find config --help` for a list of options.
+    #[clap(allow_hyphen_values = true)]
+    pub args: Vec<String>,
+}
 
 fn why3find_json_exists() -> bool {
     Path::new("why3find.json").exists()

--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -74,33 +74,6 @@ pub enum CreusotSubCommand {
     Doc,
 }
 
-#[derive(Debug, Parser)]
-pub struct CargoCreusotArgs {
-    #[clap(flatten)]
-    pub options: CommonOptions,
-    /// Subcommand: why3, setup
-    #[command(subcommand)]
-    pub subcommand: Option<CargoCreusotSubCommand>,
-    /// Additional flags to pass to the underlying cargo invocation.
-    #[clap(last = true)]
-    #[clap(global = true)]
-    pub cargo_flags: Vec<String>,
-}
-
-#[derive(Debug, Subcommand)]
-pub enum CargoCreusotSubCommand {
-    /// Setup and manage Creusot's installation
-    #[command(arg_required_else_help(true))]
-    Setup {
-        #[command(subcommand)]
-        command: SetupSubCommand,
-    },
-    #[command(flatten)]
-    Creusot(CreusotSubCommand),
-    Config(ConfigArgs),
-    Prove(ProveArgs),
-}
-
 #[derive(Debug, ValueEnum, Serialize, Deserialize, Clone)]
 pub enum Why3SubCommand {
     Prove,
@@ -126,31 +99,6 @@ pub enum SetupTool {
     CVC5,
 }
 
-fn default_provers_parallelism() -> usize {
-    match std::thread::available_parallelism() {
-        Ok(n) => n.get(),
-        Err(_) => 1,
-    }
-}
-
-#[derive(Debug, Parser, Clone)]
-pub enum SetupSubCommand {
-    /// Show the current status of the Creusot installation
-    Status,
-    /// Setup Creusot or update an existing installation
-    Install {
-        /// Maximum number of provers to run in parallel
-        #[arg(long, default_value_t = default_provers_parallelism())]
-        provers_parallelism: usize,
-        /// Look-up <TOOL> from PATH instead of using the built-in version
-        #[arg(long, value_name = "TOOL")]
-        external: Vec<SetupManagedTool>,
-        /// Do not error if <TOOL>'s version does not match the one expected by creusot
-        #[arg(long, value_name = "TOOL")]
-        no_check_version: Vec<SetupTool>,
-    },
-}
-
 /// Parse a single key-value pair
 fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
 where
@@ -169,31 +117,9 @@ impl CreusotArgs {
     }
 }
 
-impl CargoCreusotArgs {
-    pub fn parse_from<I: Into<OsString> + Clone>(it: impl IntoIterator<Item = I>) -> Self {
-        Parser::parse_from(it)
-    }
-}
-
 #[derive(Debug, clap::ValueEnum, Clone, Deserialize, Serialize)]
 pub enum SpanMode {
     Relative,
     Absolute,
     Off,
-}
-
-#[derive(Debug, Parser)]
-pub struct ProveArgs {
-    /// Run Why3 IDE on next unproved goal.
-    #[clap(short = 'i', default_value_t = false, action = clap::ArgAction::SetTrue)]
-    pub ide: bool,
-    /// Files to prove; default to everything in `verif/`.
-    pub files: Vec<PathBuf>,
-}
-
-#[derive(Debug, Parser)]
-pub struct ConfigArgs {
-    /// All arguments are forwarded to `why3find config`; see `why3find config --help` for a list of options.
-    #[clap(allow_hyphen_values = true)]
-    pub args: Vec<String>,
 }


### PR DESCRIPTION
1. Remove the intermediate `Subcommand` type in `cargo-creusot/src/main.rs` (annoying to update for every new subcommand)
2. Move `CargoCreusotArgs` from `creusot-args` to `cargo-creusot` (the only place that should be using it)