### PR TITLE
Add `new` command to create projects

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,29 +50,10 @@ jobs:
         cp ci/creusot-config-dummy.toml ~/.config/creusot/Config.toml
     - name: Run tests
       run: cargo test
-  why3:
-    runs-on: ubuntu-22.04
+  why3-deps:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: ${{ github.event.pull_request.commits }}
-    - name: Fetch target branch
-      if: github.base_ref
-      run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-creusot-${{ hashFiles('**/Cargo.lock') }}
-    - uses: actions/cache@v2
-      id: cache-creusot-setup
-      with:
-        path: |
-          ~/.config/creusot
-          ~/.local/share/creusot
-        key: ${{ runner.os }}-cargo-creusot-setup-${{ hashFiles('creusot-deps.opam', 'creusot-setup/src/tools_versions_urls.rs', 'creusot-setup/src/config.rs') }}
     - uses: actions/cache@v2
       id: cache-opam
       with:
@@ -93,8 +74,47 @@ jobs:
         opam info --list-files why3 why3find > keep
         sed -i 's/^.*\/_opam\///' keep
         rsync -a -r --remove-source-files --exclude-from=keep _opam/ /tmp/to-delete
+    - name: archive why3 and why3find
+      run: tar -czf _opam.tar.gz _opam
+      # use tar because upload-artifact does not preserve file permissions
+      # https://github.com/actions/upload-artifact/tree/v4/?tab=readme-ov-file#permission-loss
+    - name: upload why3 and why3find
+      uses: actions/upload-artifact@v4
+      with:
+        name: why3-deps
+        path: _opam.tar.gz
+  why3:
+    needs: why3-deps
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: ${{ github.event.pull_request.commits }}
+    - name: Fetch target branch
+      if: github.base_ref
+      run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-creusot-${{ hashFiles('**/Cargo.lock') }}
+    - uses: actions/cache@v2
+      id: cache-creusot-setup
+      with:
+        path: |
+          ~/.config/creusot
+          ~/.local/share/creusot
+          _opam/lib/why3find/packages
+        key: ${{ runner.os }}-cargo-creusot-setup-${{ hashFiles('creusot-deps.opam', 'creusot-setup/src/tools_versions_urls.rs', 'creusot-setup/src/config.rs') }}
+    - name: download why3 and why3find
+      uses: actions/download-artifact@v4
+      with:
+        name: why3-deps
     - name: setup opam PATH
       run: |
+        tar -xzf _opam.tar.gz
         echo /home/runner/work/creusot/creusot/_opam/bin >> $GITHUB_PATH
     - name: run cargo creusot setup install
       if: steps.cache-creusot-setup.outputs.cache-hit != 'true'
@@ -106,3 +126,46 @@ jobs:
         cat ~/.config/creusot/why3.conf
     - run: cargo test --test why3 "" -- --replay=none --diff-from=origin/master
     - run: cargo test --test why3 "" -- --skip-unstable
+  install:
+    needs: why3-deps
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-install-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install
+      run: |
+        cargo install --path cargo-creusot
+        cargo install --path creusot-rustc
+    - uses: actions/cache@v2
+      id: cache-creusot-setup
+      with:
+        path: |
+          ~/.config/creusot
+          ~/.local/share/creusot
+          _opam/lib/why3find/packages
+        key: ${{ runner.os }}-cargo-creusot-setup-${{ hashFiles('creusot-deps.opam', 'creusot-setup/src/tools_versions_urls.rs', 'creusot-setup/src/config.rs') }}
+    - run: cargo creusot setup install
+      if: steps.cache-creusot-setup.outputs.cache-hit != 'true'
+    - name: download why3 and why3find
+      uses: actions/download-artifact@v4
+      with:
+        name: why3-deps
+    - name: setup opam PATH
+      run: |
+        tar -xzf _opam.tar.gz
+        echo /home/runner/work/creusot/creusot/_opam/bin >> $GITHUB_PATH
+    - name: test cargo creusot new
+      run: |
+        cd ..
+        cargo creusot new test-project --main --creusot-contracts ../creusot/creusot-contracts
+        cd test-project
+        cargo fmt --check
+        cargo build
+        cargo creusot
+        cargo creusot prove

--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -13,6 +13,8 @@ mod why3_launcher;
 use why3_launcher::*;
 mod why3find_wrapper;
 use why3find_wrapper::*;
+mod new;
+use new::*;
 
 fn main() -> Result<()> {
     let cargs = CargoCreusotArgs::parse_from(std::env::args().skip(1));
@@ -43,6 +45,8 @@ fn main() -> Result<()> {
         }
         Some(Config(args)) => why3find_config(args),
         Some(Prove(args)) => why3find_prove(args),
+        Some(New(args)) => new(args),
+        Some(Init(args)) => init(args),
     }
 }
 
@@ -190,8 +194,14 @@ pub enum CargoCreusotSubCommand {
     },
     #[command(flatten)]
     Creusot(CreusotSubCommand),
+    /// Generate prover configuration
     Config(ConfigArgs),
+    /// Run prover on translated files
     Prove(ProveArgs),
+    /// Create new project in a sub-directory
+    New(NewArgs),
+    /// Create new project in current directory
+    Init(InitArgs),
 }
 use CargoCreusotSubCommand::*;
 

--- a/cargo-creusot/src/new.rs
+++ b/cargo-creusot/src/new.rs
@@ -1,0 +1,172 @@
+use anyhow::Result;
+use clap::Parser;
+use std::{
+    fs,
+    io::Write,
+    process::{Command, Stdio},
+};
+
+#[derive(Debug, Parser)]
+pub struct NewArgs {
+    /// Package name
+    pub name: String,
+    #[clap(flatten)]
+    pub args: NewInitArgs,
+}
+
+#[derive(Debug, Parser)]
+pub struct InitArgs {
+    /// Package name (default: name of the current directory)
+    pub name: Option<String>,
+    #[clap(flatten)]
+    pub args: NewInitArgs,
+}
+
+/// Shared arguments for `new` and `init`
+#[derive(Debug, Parser)]
+pub struct NewInitArgs {
+    /// Create main.rs
+    #[clap(long)]
+    pub main: bool,
+    /// Create test directory
+    #[clap(long)]
+    pub tests: bool,
+    /// Path to local creusot-contracts relative to the generated Cargo.toml
+    #[clap(long)]
+    pub creusot_contracts: Option<String>,
+}
+
+fn cargo_template(name: &str, dep: &str) -> String {
+    format!(
+        r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+creusot-contracts = {dep}
+
+[lints.rust]
+unexpected_cfgs = {{ level = "warn", check-cfg = ['cfg(creusot)'] }}
+"#
+    )
+}
+
+fn bin_template(name: &str) -> String {
+    let name = name.replace("-", "_");
+    format!(
+        r#"#![cfg_attr(
+    not(creusot),
+    feature(stmt_expr_attributes, proc_macro_hygiene, register_tool)
+)]
+#![cfg_attr(not(creusot),register_tool(creusot))]
+
+#[allow(unused_imports)]
+use creusot_contracts::*;
+use {name}::*;
+
+#[allow(creusot::experimental)]
+fn main() {{
+    assert!(add(1, 2) == 3);
+    println!("Hello, world!");
+}}
+"#
+    )
+}
+
+const TEST_TEMPLATE: &str = r#"#![cfg_attr(not(creusot),feature(stmt_expr_attributes,proc_macro_hygiene))]
+use creusot_contracts::*;
+
+#[test]
+fn it_works() {
+    assert_eq!(2 + 2, 4);
+}
+"#;
+
+const LIB_TEMPLATE: &str = r#"#![cfg_attr(not(creusot),feature(stmt_expr_attributes,proc_macro_hygiene))]
+use creusot_contracts::*;
+
+#[requires(a@ + b@ <= usize::MAX@)]
+#[ensures(result@ == a@ + b@)]
+pub fn add(a: usize, b: usize) -> usize {
+    a + b
+}
+"#;
+
+const RUST_TOOLCHAIN: &str = r#"[toolchain]
+channel = "nightly-2024-07-25"
+components = [ "rustfmt" ]
+"#;
+
+pub fn new(args: NewArgs) -> Result<()> {
+    validate_name(&args.name)?;
+    fs::create_dir(&args.name).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::AlreadyExists {
+            anyhow::anyhow!("Directory '{}' already exists", args.name)
+        } else {
+            e.into()
+        }
+    })?;
+    std::env::set_current_dir(&args.name)?;
+    create_project(args.name, args.args)
+}
+
+pub fn init(args: InitArgs) -> Result<()> {
+    let name = match args.name {
+        None => {
+            // Use name of the current directory
+            let current_dir = std::env::current_dir()?;
+            current_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| anyhow::anyhow!("Could not determine project name"))?
+                .to_string()
+        }
+        Some(name) => name,
+    };
+    validate_name(&name)?;
+    create_project(name, args.args)
+}
+
+pub fn create_project(name: String, args: NewInitArgs) -> Result<()> {
+    let contract_dep = match args.creusot_contracts {
+        Some(path) => format!(r#"{{ path = "{}" }}"#, path),
+        None => r#""*""#.to_string(),
+    };
+    write("Cargo.toml", &cargo_template(&name, &contract_dep));
+    write("rust-toolchain", RUST_TOOLCHAIN);
+    if args.tests {
+        fs::create_dir_all("tests")?;
+        write("tests/test.rs", TEST_TEMPLATE);
+    }
+    fs::create_dir_all("src")?;
+    if args.main {
+        write("src/main.rs", &bin_template(&name));
+    }
+    write("src/lib.rs", LIB_TEMPLATE);
+    Command::new("cargo").args(["creusot", "config"]).stdout(Stdio::null()).status()?;
+    Ok(())
+}
+
+fn validate_name(name: &str) -> Result<()> {
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+        return Err(anyhow::anyhow!(
+            "Invalid name {name}, must contain only 'a-z', 'A-Z', '0-9', '-', or '_'",
+        ));
+    }
+    Ok(())
+}
+
+/// Do not overwrite existing file.
+/// Warn if writing fails, then keep going
+fn write(path: &str, contents: &str) {
+    fs::File::create_new(path)
+        .and_then(|mut file| file.write_all(contents.as_ref()))
+        .unwrap_or_else(|e| {
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                eprintln!("File '{}' already exists. (Skipped)", path);
+            } else {
+                eprintln!("Could not write to '{}': {} (Skipped)", path, e);
+            }
+        });
+}

--- a/creusot-setup/src/tools.rs
+++ b/creusot-setup/src/tools.rs
@@ -386,5 +386,5 @@ fn run(cmd: &mut Command) -> anyhow::Result<std::process::Output> {
 }
 
 pub fn why3find_install() {
-    Command::new("why3find").arg("install").arg("prelude").status().unwrap();
+    Command::new("why3find").args(["install", "--global", "prelude"]).status().unwrap();
 }


### PR DESCRIPTION
Set up a minimal project with some contracts.

- This uses the released `creusot-contracts`, which is out of date because it's missing the ghost primitives (I am manually testing this PR by replacing it with a `{ path = ... }` dependency).
- In the future I'd like to be able to check test suite with creusot (blocked by #1265 and also an anomaly in Why3 due to tuples generated by `assert_eq!`, reported at https://gitlab.inria.fr/why3/why3/-/issues/890)