### PR TITLE
Add creusot-dev-config to workspace in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "creusot-dev-config"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "creusot-setup",
+ "which",
+]
+
+[[package]]
 name = "creusot-metadata"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "creusot-contracts-proc",
   "creusot-contracts-dummy",
   "creusot-metadata",
+  "creusot-dev-config",
   "why3",
   "why3tests",
   "pearlite-syn",


### PR DESCRIPTION
Follow up of #1277. Fixes scripts `./ide`, etc.. `cargo run --bin dev-env` used to work because the dependency was implicitly added by depending on the library next to it, which was removed in #1277.