### PR TITLE
Exclude `target` when running the `fmt` script

### DIFF
--- a/fmt
+++ b/fmt
@@ -3,8 +3,9 @@
 # We don't instead run "shopt -s globstar", because shopt is not supported in Mac OS.
 
 set -e
+setopt extendedglob
 
 SCRIPTPATH=${0:a:h}
 pushd $SCRIPTPATH > /dev/null
-rustfmt $@ **/*.rs
+rustfmt $@ **/*.rs~target/**/*.rs
 popd > /dev/null


### PR DESCRIPTION
Useful when running the script locally.