### PR TITLE
Install creusot-rustc in a toolchain-dependent location

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -138,10 +138,6 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-install-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install
-      run: |
-        cargo install --path cargo-creusot
-        cargo install --path creusot-rustc
     - uses: actions/cache@v4
       id: cache-creusot-setup
       with:
@@ -150,17 +146,21 @@ jobs:
           ~/.local/share/creusot
           _opam/lib/why3find/packages
         key: ${{ runner.os }}-cargo-creusot-setup-${{ hashFiles('creusot-deps.opam', 'creusot-setup/src/tools_versions_urls.rs', 'creusot-setup/src/config.rs') }}
+    - name: Install
+      run: |
+        cargo install --path cargo-creusot
+        cargo creusot setup install --only-creusot-rustc
     - name: download why3 and why3find
       uses: actions/download-artifact@v4
       with:
         name: why3-deps
     - name: unpack why3 and why3find
       run: tar -xzf _opam.tar.gz
-    - name: setup creusot
+    - name: Setup
       run: |
         # Add /home/runner/work/creusot/creusot/_opam/bin to PATH just for this step
         export PATH=/home/runner/work/creusot/creusot/_opam/bin:$PATH
-        cargo creusot setup install
+        cargo creusot setup install --skip-creusot-rustc
       if: steps.cache-creusot-setup.outputs.cache-hit != 'true'
     - name: test cargo creusot new
       run: |

--- a/README.md
+++ b/README.md
@@ -51,17 +51,15 @@ More examples are found in [creusot/tests/should_succeed](creusot/tests/should_s
    $ eval $(opam env)
    ```
    This will build `why3`, `why3find`, and their ocaml dependencies in a local `_opam` directory.
-5. Build **Creusot**:
+5. Install **Creusot**:
     ```
-    $ cargo install --path creusot-rustc
     $ cargo install --path cargo-creusot
+    $ cargo creusot setup install
     ```
-    this will build the `cargo-creusot` and `creusot-rustc` executables and place them in `~/.cargo/bin`.
-6. Set up **Creusot**:
-   ```
-   $ cargo creusot setup install
-   ```
-   this will download additional solvers (Alt-Ergo, Z3, CVC4, CVC5) and configure Why3 to use them.
+    The first command will build the `cargo-creusot` executable and place it in `~/.cargo/bin/`.
+    The second command will download solvers (Alt-Ergo, Z3, CVC4, CVC5), configure Why3 to use them,
+    then it will install the `creusot-rustc` executable; configuration files are stored in
+    `~/.config/creusot/` and executables are stored in `~/.local/share/creusot/`.
 
 # Upgrading Creusot 
 

--- a/creusot/tests/creusot-contracts.rs
+++ b/creusot/tests/creusot-contracts.rs
@@ -27,7 +27,7 @@ fn main() {
         args.force_color = true;
     }
     // Build creusot-rustc to make it available to cargo-creusot
-    let _ = escargot::CargoBuild::new()
+    let creusot_rustc = escargot::CargoBuild::new()
         .bin("creusot-rustc")
         .current_release()
         .manifest_path("../creusot-rustc/Cargo.toml")
@@ -52,6 +52,8 @@ fn main() {
         .unwrap();
     cargo_creusot.current_dir(&base_path).args([
         "creusot",
+        "--creusot-rustc",
+        creusot_rustc.path().to_str().unwrap(),
         "--stdout",
         "--export-metadata=false",
         "--span-mode=relative",

--- a/creusot/tests/ui.rs
+++ b/creusot/tests/ui.rs
@@ -74,6 +74,8 @@ fn main() {
     let mut metadata_file = cargo_creusot;
     metadata_file.current_dir(base_path);
     metadata_file.arg("creusot").args(&[
+        "--creusot-rustc".as_ref(),
+        creusot_rustc.path().as_os_str(),
         "--metadata-path".as_ref(),
         temp_file.as_os_str(),
         "--output-file=/dev/null".as_ref(),


### PR DESCRIPTION
Fixes #671. 

Problem: creusot-rustc is dynamically linked with rustc_driver, so it can't be run
directly from the command line because it can't find its dependencies alone.

Solution: Putting it in a special directory controlled by Creusot:
 1. removes it from $PATH, suppressing the temptation to run it from the command line
 2. allows cargo-creusot to detect incomplete upgrades (this prevents
       an obscure dynlink error if one updates the toolchain that creusot depends
       on and only reinstalls one of cargo-creusot or creusot-rustc).

The installation of creusot-rustc is now handled by `cargo creusot setup install`.