### PR TITLE
Logical functions aliases

### DIFF
--- a/creusot-contracts-proc/src/creusot.rs
+++ b/creusot-contracts-proc/src/creusot.rs
@@ -14,7 +14,7 @@ pub(crate) use self::{
     extern_spec::extern_spec,
     logic::{logic, pearlite},
     proof::{ghost, ghost_let, invariant, proof_assert, snapshot},
-    specs::{bitwise_proof, check, ensures, maintains, requires, variant},
+    specs::{bitwise_proof, check, ensures, has_logical_alias, maintains, requires, variant},
 };
 
 use crate::common::{ContractSubject, FnOrMethod};

--- a/creusot-contracts-proc/src/creusot/specs.rs
+++ b/creusot-contracts-proc/src/creusot/specs.rs
@@ -10,7 +10,7 @@ use crate::{
 use pearlite_syn::{Term, TermPath};
 use proc_macro::TokenStream as TS1;
 use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use quote::{quote, quote_spanned};
 use syn::{
     Attribute, Ident, Item, Path, ReturnType, Signature, Stmt, Token, Type, parenthesized,
     parse::{self, Parse},
@@ -85,7 +85,7 @@ fn ensures_inner(attr: TS1, tokens: TS1, logical_alias_path: bool) -> TS1 {
     let ens_name = crate::creusot::generate_unique_ident(&item.name(), Span::call_site());
     let name_tag = ens_name.to_string();
     let logical_alias = if logical_alias_path {
-        quote!(#[creusot::decl::logical_alias_path = #name_tag])
+        quote_spanned! {term.span()=> #[creusot::decl::logical_alias_path = #name_tag]}
     } else {
         quote!()
     };
@@ -256,7 +256,7 @@ pub fn has_logical_alias(attr: TS1, tokens: TS1) -> TS1 {
             quote!(#pat)
         }
     });
-    let ensures_contract = quote!(result == #logic_path(#(#args),*));
+    let ensures_contract = quote_spanned! {logic_path.span()=> result == #logic_path(#(#args),*)};
     ensures_inner(ensures_contract.into(), tokens, true)
 }
 

--- a/creusot-contracts-proc/src/dummy.rs
+++ b/creusot-contracts-proc/src/dummy.rs
@@ -112,6 +112,10 @@ pub fn bitwise_proof(_: TS1, tokens: TS1) -> TS1 {
     tokens
 }
 
+pub fn has_logical_alias(_: TS1, tokens: TS1) -> TS1 {
+    tokens
+}
+
 pub fn derive_deep_model(_: TS1) -> TS1 {
     TS1::new()
 }

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -66,6 +66,7 @@ proc_macro_attributes! {
     bitwise_proof
     maintains
     erasure
+    has_logical_alias
 }
 
 macro_rules! proc_macros {

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -487,6 +487,38 @@ pub mod macros {
     pub use base_macros::erasure;
 
     pub(crate) use base_macros::intrinsic;
+
+    /// Defines a _logical alias_ for a program function.
+    ///
+    /// Logical aliases allow you to use the same name for a program and a [`logic`] function.
+    /// Creusot will generate a proof obligation to show that the two functions return
+    /// the same results.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use creusot_contracts::*;
+    /// pub struct S<T> {
+    ///     t: T,
+    /// }
+    /// impl<T> S<T> {
+    ///     #[has_logical_alias(Self::read_t_logic)]
+    ///     pub fn read_t(&self) -> &T {
+    ///         &self.t
+    ///     }
+    ///
+    ///     #[logic]
+    ///     pub fn read_t_logic(&self) -> &T {
+    ///         &self.t
+    ///     }
+    /// }
+    ///
+    /// // ...
+    ///
+    /// #[requires(s.read_t().view() == 1)]
+    /// pub fn foo(s: S<i32>) { /* ... */ }
+    /// ```
+    pub use base_macros::has_logical_alias;
 }
 
 #[doc(hidden)]

--- a/creusot/src/contracts_items/attributes.rs
+++ b/creusot/src/contracts_items/attributes.rs
@@ -258,7 +258,10 @@ pub(crate) fn is_open_inv_param(tcx: TyCtxt, p: &Param) -> bool {
 }
 
 /// If a function is annotated with `#[has_logical_alias(f)]`, return the [`DefId`] of `f`.
-pub(crate) fn function_has_logical_alias(ctx: &mut TranslationCtx, def_id: DefId) -> Option<DefId> {
+pub(crate) fn function_has_logical_alias(
+    ctx: &mut TranslationCtx,
+    def_id: DefId,
+) -> Option<(Span, DefId)> {
     let attrs = get_attrs(ctx.get_all_attrs(def_id), &["creusot", "decl", "logical_alias_path"]);
     let attr = match attrs.as_slice() {
         [] => return None,
@@ -281,7 +284,7 @@ pub(crate) fn function_has_logical_alias(ctx: &mut TranslationCtx, def_id: DefId
         ctx.term(ensures_def_id).expect("no ensures clause associated with this alias");
     match &ensures_body.1.kind {
         crate::translation::pearlite::TermKind::Binary { rhs, .. } => match &rhs.kind {
-            crate::translation::pearlite::TermKind::Call { id, .. } => Some(*id),
+            crate::translation::pearlite::TermKind::Call { id, .. } => Some((attr.span(), *id)),
             _ => unreachable!("this should be a function call"),
         },
         _ => unreachable!("this should be an equality"),

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -74,6 +74,7 @@ pub(crate) fn after_analysis<'tcx>(
     let start = Instant::now();
     let mut ctx = TranslationCtx::new(tcx, opts.clone(), thir, params_open_inv);
     ctx.load_extern_specs();
+    ctx.load_logical_aliases();
     ctx.load_erasures();
     validate(&ctx);
     ctx.dcx().abort_if_errors();

--- a/creusot/src/translation/pearlite.rs
+++ b/creusot/src/translation/pearlite.rs
@@ -801,7 +801,7 @@ impl<'tcx> ThirTerm<'_, 'tcx> {
                                 .collect::<Result<_, _>>()?;
                             let id = match self.ctx.logical_alias(id) {
                                 None => id,
-                                Some(alias_id) => alias_id,
+                                Some((_, alias_id)) => alias_id,
                             };
                             Ok(Term::call_no_normalize(self.ctx.tcx, id, subst, args).span(span))
                         }

--- a/creusot/src/translation/pearlite.rs
+++ b/creusot/src/translation/pearlite.rs
@@ -182,6 +182,9 @@ pub enum TermKind<'tcx> {
         trigger: Box<[Trigger<'tcx>]>,
         body: Box<Term<'tcx>>,
     },
+    /// A function call.
+    ///
+    /// Be careful when building this case, that it respects [logical aliases](TranslationCtx::logical_alias).
     // TODO: Get rid of (id, subst).
     Call {
         id: DefId,
@@ -796,6 +799,10 @@ impl<'tcx> ThirTerm<'_, 'tcx> {
                                 .iter()
                                 .map(|arg| self.expr_term(*arg))
                                 .collect::<Result<_, _>>()?;
+                            let id = match self.ctx.logical_alias(id) {
+                                None => id,
+                                Some(alias_id) => alias_id,
+                            };
                             Ok(Term::call_no_normalize(self.ctx.tcx, id, subst, args).span(span))
                         }
                     }
@@ -1444,6 +1451,7 @@ impl<'tcx> Term<'tcx> {
         Term { ty, kind: TermKind::Tuple { fields }, span }
     }
 
+    /// Same as [`Self::call`], but does not normalize the type of the result.
     pub(crate) fn call_no_normalize(
         tcx: TyCtxt<'tcx>,
         def_id: DefId,
@@ -1456,6 +1464,11 @@ impl<'tcx> Term<'tcx> {
         Term { ty: result, span: DUMMY_SP, kind: TermKind::Call { id: def_id, subst, args } }
     }
 
+    /// Generate a [`TermKind::Call`] for a special function described by `(def_id, subst)`
+    /// (e.g. `resolve`, `inv`, etc)
+    ///
+    /// Note that this should not be used for regular function calls, in particular because
+    /// it does not consider [logical aliases](TranslationCtx::logical_alias).
     pub(crate) fn call(
         tcx: TyCtxt<'tcx>,
         typing_env: TypingEnv<'tcx>,

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -1,5 +1,4 @@
-use std::{hash::Hash as _, path::Path};
-
+use creusot_args::options::SpanMode;
 use rustc_hir::{
     def::DefKind,
     def_id::{DefId, DefPathHash, LOCAL_CRATE},
@@ -14,8 +13,7 @@ use rustc_middle::{
 };
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_span::{Span, Symbol};
-
-use creusot_args::options::SpanMode;
+use std::{hash::Hash as _, path::Path};
 
 pub(crate) fn erased_identity_for_item(tcx: TyCtxt, did: DefId) -> GenericArgsRef {
     tcx.erase_and_anonymize_regions(GenericArgs::identity_for_item(tcx, did))

--- a/creusot/src/validate/purity.rs
+++ b/creusot/src/validate/purity.rs
@@ -215,6 +215,12 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for PurityVisitor<'a, 'tcx> {
                             .unwrap();
 
                     let fn_purity = self.purity(func_did, args);
+                    let fn_purity = match self.ctx.logical_alias(func_did) {
+                        Some(alias_did) if !self.context.can_call(fn_purity) => {
+                            self.purity(alias_did, args)
+                        }
+                        _ => fn_purity,
+                    };
                     if matches!(self.context, Purity::Logic { .. })
                         && (
                             // These methods are allowed to cheat the purity restrictions

--- a/tests/should_succeed/logical_aliases.rs
+++ b/tests/should_succeed/logical_aliases.rs
@@ -1,0 +1,46 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[has_logical_alias(add_logic)]
+#[check(ghost)]
+fn add(x: Int, y: Int) -> Int {
+    x + y
+}
+#[logic]
+fn add_logic(x: Int, y: Int) -> Int {
+    x + y
+}
+
+pub fn test_add() {
+    ghost! {
+       let x = 3int;
+       let y = add(x, 5int);
+       proof_assert!(y == add(x, 5));
+    };
+}
+
+struct Seq2<T>(Seq<T>);
+
+impl<T> Seq2<T> {
+    #[has_logical_alias(Self::len_logic)]
+    #[check(ghost)]
+    fn len(&self) -> Int {
+        self.0.len_ghost()
+    }
+    #[logic]
+    fn len_logic(&self) -> Int {
+        self.0.len()
+    }
+}
+
+pub fn test_seq() {
+    ghost! {
+        let mut s = Seq2(Seq::new().into_inner());
+        s.0.push_back_ghost(2int);
+        let l1 = s.len();
+        proof_assert!(l1 == s.len());
+        s.0.push_back_ghost(4int);
+        let l2 = s.len();
+        proof_assert!(l2 == s.len());
+    };
+}


### PR DESCRIPTION
# Example

```rust
// In `creusot_contracts`

impl<K, V> FMap<K, V> {
    #[trusted]
    #[logic]
    #[ensures(result >= 0)]
    pub fn len_logic(self) -> Int {
        dead
    }

    #[trusted]
    #[pure]
    #[has_logical_alias(Self::len_logic)]
    pub fn len(self) -> Int {
        panic!()
    }
}

// User code

pub fn foo() {
    let mut m = FMap::new();
    proof_assert!(m.len() == 0); // logic call
    ghost! {
        m.insert_ghost(1int, 1int);
        let l = m.len(); // program (ghost) call
        proof_assert!(l == 1);
        m.insert_ghost(2int, 2int);
        proof_assert!(m.len() == 2);
    };
}
```