### PR TITLE
Use interior mutability in translaion contexts instead of passing mutable borrows everywhere.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +465,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "once_map",
  "pathdiff",
  "petgraph",
  "regex",
@@ -1376,6 +1390,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "lockfree-object-pool"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1565,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "once_map"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd2cae3bec3936bbed1ccc5a3343b3738858182419f9c0522c7260c80c430b0"
+dependencies = [
+ "ahash",
+ "hashbrown",
+ "parking_lot",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1625,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "pathdiff"
@@ -1844,6 +1903,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2136,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"

--- a/creusot/Cargo.toml
+++ b/creusot/Cargo.toml
@@ -22,6 +22,7 @@ tempdir = "0.3"
 serde_json = "1.0"
 lazy_static = "1.5"
 pathdiff = "0.2"
+once_map = "0.4"
 
 [dev-dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -12,6 +12,7 @@ use crate::{
     util::path_of_span,
 };
 use std::{
+    cell::RefCell,
     ops::{Deref, DerefMut},
     path::PathBuf,
 };
@@ -33,9 +34,9 @@ pub(crate) mod ty_inv;
 pub(crate) mod wto;
 
 pub struct Why3Generator<'tcx> {
-    ctx: TranslationCtx<'tcx>,
+    pub ctx: TranslationCtx<'tcx>,
     functions: Vec<TranslatedItem>,
-    pub(crate) span_map: SpanMap,
+    pub(crate) span_map: RefCell<SpanMap>,
 }
 
 impl<'tcx> Deref for Why3Generator<'tcx> {
@@ -96,10 +97,10 @@ impl<'tcx> Why3Generator<'tcx> {
         matches!(self.item_type(item), ItemType::Logic { .. } | ItemType::Predicate { .. })
     }
 
-    pub(crate) fn span_attr(&mut self, span: Span) -> Option<why3::declaration::Attribute> {
+    pub(crate) fn span_attr(&self, span: Span) -> Option<why3::declaration::Attribute> {
         let path = path_of_span(self.tcx, span, &self.opts.span_mode)?;
 
-        if let Some(span) = self.span_map.encode_span(&self.ctx.opts, span) {
+        if let Some(span) = self.span_map.borrow_mut().encode_span(&self.ctx.opts, span) {
             return Some(span);
         };
 

--- a/creusot/src/backend/logic.rs
+++ b/creusot/src/backend/logic.rs
@@ -43,7 +43,7 @@ pub(crate) fn binders_to_args(binders: Vec<Binder>) -> (Vec<Ident>, Vec<Binder>)
 }
 
 pub(crate) fn translate_logic_or_predicate(
-    ctx: &mut Why3Generator,
+    ctx: &Why3Generator,
     def_id: DefId,
 ) -> Result<Option<FileModule>, CannotFetchThir> {
     let mut names = Dependencies::new(ctx, def_id);
@@ -60,7 +60,7 @@ pub(crate) fn translate_logic_or_predicate(
         );
     }
 
-    let name = names.value(names.self_id, names.self_subst).as_ident();
+    let name = names.item(names.self_id, names.self_subst).as_ident();
     let mut sig = signature_of(ctx, &mut names, name, def_id);
 
     if sig.contract.is_empty()
@@ -132,8 +132,8 @@ pub(crate) fn translate_logic_or_predicate(
 }
 
 pub(crate) fn lower_logical_defn<'tcx, N: Namer<'tcx>>(
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
     mut sig: Signature,
     kind: Option<DeclKind>,
     body: Term<'tcx>,

--- a/creusot/src/backend/optimization/invariants.rs
+++ b/creusot/src/backend/optimization/invariants.rs
@@ -27,7 +27,7 @@ use crate::translation::fmir::{Block, FmirVisitor, Place, RValue, Statement, Ter
 /// (1) types with invariants being mutated inside of a loop
 /// (2) mutable borrows being mutated inside of a loop.
 
-pub fn infer_proph_invariants<'tcx>(ctx: &mut TranslationCtx<'tcx>, body: &mut fmir::Body<'tcx>) {
+pub fn infer_proph_invariants<'tcx>(ctx: &TranslationCtx<'tcx>, body: &mut fmir::Body<'tcx>) {
     let graph = node_graph(body);
 
     let wto = weak_topological_order(&graph, START_BLOCK);

--- a/creusot/src/backend/signature.rs
+++ b/creusot/src/backend/signature.rs
@@ -16,8 +16,8 @@ use crate::{
 use super::{logic::function_call, term::lower_pure, Namer, Why3Generator};
 
 pub(crate) fn signature_of<'tcx, N: Namer<'tcx>>(
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
     name: Ident,
     def_id: DefId,
 ) -> Signature {
@@ -27,8 +27,8 @@ pub(crate) fn signature_of<'tcx, N: Namer<'tcx>>(
 }
 
 pub(crate) fn sig_to_why3<'tcx, N: Namer<'tcx>>(
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
     name: Ident,
     pre_sig: PreSignature<'tcx>,
     // FIXME: Get rid of this def id
@@ -74,8 +74,8 @@ pub(crate) fn sig_to_why3<'tcx, N: Namer<'tcx>>(
 }
 
 fn lower_condition<'tcx, N: Namer<'tcx>>(
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
     cond: Condition<'tcx>,
 ) -> why3::declaration::Condition {
     why3::declaration::Condition { exp: lower_pure(ctx, names, &cond.term), expl: cond.expl }
@@ -83,8 +83,8 @@ fn lower_condition<'tcx, N: Namer<'tcx>>(
 
 fn contract_to_why3<'tcx, N: Namer<'tcx>>(
     pre: PreContract<'tcx>,
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
 ) -> Contract {
     let mut out = Contract::new();
     for cond in pre.requires.into_iter() {

--- a/creusot/src/backend/traits.rs
+++ b/creusot/src/backend/traits.rs
@@ -6,7 +6,7 @@ use crate::{
 use rustc_hir::def_id::DefId;
 use why3::declaration::{Decl, Goal, Module};
 
-pub(crate) fn lower_impl<'tcx>(ctx: &mut Why3Generator<'tcx>, def_id: DefId) -> Vec<FileModule> {
+pub(crate) fn lower_impl<'tcx>(ctx: &Why3Generator<'tcx>, def_id: DefId) -> Vec<FileModule> {
     let data = ctx.trait_impl(def_id).clone();
     let mut res = vec![];
 

--- a/creusot/src/backend/ty.rs
+++ b/creusot/src/backend/ty.rs
@@ -19,8 +19,8 @@ use why3::{
 };
 
 pub(crate) fn translate_ty<'tcx, N: Namer<'tcx>>(
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
     span: Span,
     ty: Ty<'tcx>,
 ) -> MlT {
@@ -127,8 +127,8 @@ pub(crate) fn translate_ty<'tcx, N: Namer<'tcx>>(
 }
 
 fn translate_projection_ty<'tcx, N: Namer<'tcx>>(
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
     pty: &AliasTy<'tcx>,
 ) -> MlT {
     let ty = Ty::new_alias(ctx.tcx, AliasTyKind::Projection, *pty);
@@ -140,8 +140,8 @@ fn translate_projection_ty<'tcx, N: Namer<'tcx>>(
 }
 
 pub(crate) fn translate_closure_ty<'tcx, N: Namer<'tcx>>(
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
     did: DefId,
     subst: GenericArgsRef<'tcx>,
 ) -> Option<TyDecl> {
@@ -172,8 +172,8 @@ pub(crate) fn translate_closure_ty<'tcx, N: Namer<'tcx>>(
 //
 // Mutually recursive types are translated separately, are later merged by the elaborator
 pub(crate) fn translate_tydecl<'tcx, N: Namer<'tcx>>(
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
     (did, subst): (DefId, GenericArgsRef<'tcx>),
     typing_env: TypingEnv<'tcx>,
 ) -> Vec<Decl> {
@@ -228,8 +228,8 @@ pub(crate) fn translate_tydecl<'tcx, N: Namer<'tcx>>(
 }
 
 pub(crate) fn eliminator<'tcx, N: Namer<'tcx>>(
-    ctx: &mut Why3Generator<'tcx>,
-    names: &mut N,
+    ctx: &Why3Generator<'tcx>,
+    names: &N,
     variant_id: DefId,
     subst: GenericArgsRef<'tcx>,
 ) -> Decl {
@@ -317,7 +317,7 @@ pub(crate) fn eliminator<'tcx, N: Namer<'tcx>>(
 }
 
 pub(crate) fn constructor<'tcx, N: Namer<'tcx>>(
-    names: &mut N,
+    names: &N,
     fields: Vec<Exp>,
     did: DefId,
     subst: GenericArgsRef<'tcx>,
@@ -343,7 +343,7 @@ pub(crate) fn constructor<'tcx, N: Namer<'tcx>>(
     }
 }
 
-pub(crate) fn intty_to_ty<'tcx, N: Namer<'tcx>>(names: &mut N, ity: IntTy) -> MlT {
+pub(crate) fn intty_to_ty<'tcx, N: Namer<'tcx>>(names: &N, ity: IntTy) -> MlT {
     names.import_prelude_module(int_to_prelude(ity));
     match ity {
         IntTy::Isize => MlT::TConstructor("isize".into()),
@@ -355,7 +355,7 @@ pub(crate) fn intty_to_ty<'tcx, N: Namer<'tcx>>(names: &mut N, ity: IntTy) -> Ml
     }
 }
 
-pub(crate) fn uintty_to_ty<'tcx, N: Namer<'tcx>>(names: &mut N, uty: UintTy) -> MlT {
+pub(crate) fn uintty_to_ty<'tcx, N: Namer<'tcx>>(names: &N, uty: UintTy) -> MlT {
     names.import_prelude_module(uint_to_prelude(uty));
     match uty {
         UintTy::Usize => MlT::TConstructor("usize".into()),
@@ -367,7 +367,7 @@ pub(crate) fn uintty_to_ty<'tcx, N: Namer<'tcx>>(names: &mut N, uty: UintTy) -> 
     }
 }
 
-pub(crate) fn floatty_to_ty<'tcx, N: Namer<'tcx>>(names: &mut N, fty: FloatTy) -> MlT {
+pub(crate) fn floatty_to_ty<'tcx, N: Namer<'tcx>>(names: &N, fty: FloatTy) -> MlT {
     names.import_prelude_module(floatty_to_prelude(fty));
     match fty {
         FloatTy::F32 => MlT::TConstructor("Float32.t".into()),
@@ -384,7 +384,7 @@ pub fn is_int(tcx: TyCtxt, ty: Ty) -> bool {
     }
 }
 
-pub fn int_ty<'tcx, N: Namer<'tcx>>(ctx: &mut Why3Generator<'tcx>, names: &mut N) -> MlT {
+pub fn int_ty<'tcx, N: Namer<'tcx>>(ctx: &Why3Generator<'tcx>, names: &N) -> MlT {
     let int_id = get_int_ty(ctx.tcx);
     let ty = ctx.type_of(int_id).skip_binder();
     translate_ty(ctx, names, DUMMY_SP, ty)

--- a/creusot/src/backend/ty_inv.rs
+++ b/creusot/src/backend/ty_inv.rs
@@ -74,12 +74,12 @@ pub(crate) fn is_tyinv_trivial<'tcx>(
 
 pub struct InvariantElaborator<'a, 'tcx> {
     typing_env: TypingEnv<'tcx>,
-    ctx: &'a mut Why3Generator<'tcx>,
+    ctx: &'a Why3Generator<'tcx>,
     pub rewrite: bool,
 }
 
 impl<'a, 'tcx> InvariantElaborator<'a, 'tcx> {
-    pub(crate) fn new(typing_env: TypingEnv<'tcx>, ctx: &'a mut Why3Generator<'tcx>) -> Self {
+    pub(crate) fn new(typing_env: TypingEnv<'tcx>, ctx: &'a Why3Generator<'tcx>) -> Self {
         InvariantElaborator { typing_env, ctx, rewrite: false }
     }
 

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     util::{erased_identity_for_item, parent_module},
 };
-use indexmap::IndexMap;
+use once_map::unsync::OnceMap;
 use rustc_ast::{
     visit::{walk_fn, FnKind, Visitor},
     Fn, FnSig, NodeId,
@@ -44,29 +44,19 @@ use rustc_middle::{
 };
 use rustc_span::{Span, Symbol};
 use rustc_trait_selection::traits::normalize_param_env_or_error;
-use std::{collections::HashMap, ops::Deref, rc::Rc};
+use std::{collections::HashMap, ops::Deref};
 
 pub(crate) use crate::{backend::clone_map::*, translated_item::*};
 
 macro_rules! queryish {
-    ($name:ident, $res:ty, $builder:ident) => {
-        pub(crate) fn $name(&mut self, item: DefId) -> $res {
-            if self.$name.get(&item).is_none() {
-                let res = self.$builder(item);
-                self.$name.insert(item, res);
-            };
-
-            &self.$name[&item]
+    ($name:ident, $key:ty, $res:ty, $builder:ident) => {
+        pub(crate) fn $name(&self, item: $key) -> &$res {
+            self.$name.insert(item, |&item| Box::new(self.$builder(item)))
         }
     };
-    ($name:ident, $res:ty, $builder:expr) => {
-        pub(crate) fn $name(&mut self, item: DefId) -> $res {
-            if self.$name.get(&item).is_none() {
-                let res = ($builder)(self, item);
-                self.$name.insert(item, res);
-            };
-
-            &self.$name[&item]
+    ($name:ident, $key:ty, $res:ty, $builder:expr) => {
+        pub(crate) fn $name(&self, item: $key) -> &$res {
+            self.$name.insert(item, |&item| Box::new(($builder)(self, item)))
         }
     };
 }
@@ -149,20 +139,21 @@ impl ItemType {
 // TODO: The state in here should be as opaque as possible...
 pub struct TranslationCtx<'tcx> {
     pub tcx: TyCtxt<'tcx>,
-    laws: IndexMap<DefId, Vec<DefId>>,
-    fmir_body: IndexMap<BodyId, fmir::Body<'tcx>>,
-    terms: IndexMap<DefId, Term<'tcx>>,
+
     pub externs: Metadata<'tcx>,
     pub(crate) opts: Options,
     creusot_items: CreusotItems,
     extern_specs: HashMap<DefId, ExternSpec<'tcx>>,
     extern_spec_items: HashMap<LocalDefId, DefId>,
-    trait_impl: HashMap<DefId, TraitImpl<'tcx>>,
-    sig: HashMap<DefId, PreSignature<'tcx>>,
-    bodies: HashMap<LocalDefId, Rc<BodyWithBorrowckFacts<'tcx>>>,
-    opacity: HashMap<DefId, Opacity>,
-    closure_contract: HashMap<DefId, ClosureContract<'tcx>>,
     params_open_inv: HashMap<DefId, Vec<usize>>,
+    laws: OnceMap<DefId, Box<Vec<DefId>>>,
+    fmir_body: OnceMap<BodyId, Box<fmir::Body<'tcx>>>,
+    terms: OnceMap<DefId, Box<Option<Term<'tcx>>>>,
+    trait_impl: OnceMap<DefId, Box<TraitImpl<'tcx>>>,
+    sig: OnceMap<DefId, Box<PreSignature<'tcx>>>,
+    bodies: OnceMap<LocalDefId, Box<BodyWithBorrowckFacts<'tcx>>>,
+    opacity: OnceMap<DefId, Box<Opacity>>,
+    closure_contract: OnceMap<DefId, Box<ClosureContract<'tcx>>>,
 }
 
 impl<'tcx> Deref for TranslationCtx<'tcx> {
@@ -245,17 +236,11 @@ impl<'tcx> TranslationCtx<'tcx> {
         }
     }
 
-    queryish!(trait_impl, &TraitImpl<'tcx>, translate_impl);
+    queryish!(trait_impl, DefId, TraitImpl<'tcx>, translate_impl);
 
-    queryish!(closure_contract, &ClosureContract<'tcx>, build_closure_contract);
+    queryish!(closure_contract, DefId, ClosureContract<'tcx>, build_closure_contract);
 
-    pub(crate) fn fmir_body(&mut self, body_id: BodyId) -> &fmir::Body<'tcx> {
-        if !self.fmir_body.contains_key(&body_id) {
-            let fmir = translation::function::fmir(self, body_id);
-            self.fmir_body.insert(body_id, fmir);
-        }
-        self.fmir_body.get(&body_id).unwrap()
-    }
+    queryish!(fmir_body, BodyId, fmir::Body<'tcx>, translation::function::fmir);
 
     /// Compute the pearlite term associated with `def_id`.
     ///
@@ -263,31 +248,35 @@ impl<'tcx> TranslationCtx<'tcx> {
     /// - `Ok(None)` if `def_id` does not have a body
     /// - `Ok(Some(term))` if `def_id` has a body, in this crate or in a dependency.
     /// - `Err(CannotFetchThir)` if typechecking the body of `def_id` failed.
-    pub(crate) fn term(&mut self, def_id: DefId) -> Result<Option<&Term<'tcx>>, CannotFetchThir> {
-        let Some(local_id) = def_id.as_local() else { return Ok(self.externs.term(def_id)) };
+    pub(crate) fn term<'a>(
+        &'a self,
+        def_id: DefId,
+    ) -> Result<Option<&'a Term<'tcx>>, CannotFetchThir> {
+        let Some(local_id) = def_id.as_local() else {
+            return Ok(self.externs.term(def_id));
+        };
 
-        if self.tcx.hir().maybe_body_owned_by(local_id).is_some() {
-            if !self.terms.contains_key(&def_id) {
-                let mut term = match pearlite::pearlite(self, local_id) {
-                    Ok(t) => t,
-                    Err(Error::MustPrint(msg)) => msg.emit(self.tcx),
-                    Err(Error::TypeCheck(thir)) => return Err(thir),
-                };
-                term = pearlite::normalize(self.tcx, self.typing_env(def_id), term);
-
-                self.terms.insert(def_id, term);
-            };
-            Ok(self.terms.get(&def_id))
-        } else {
-            Ok(None)
-        }
+        self.terms
+            .try_insert(def_id, |_| {
+                if self.tcx.hir().maybe_body_owned_by(local_id).is_some() {
+                    let term = match pearlite::pearlite(self, local_id) {
+                        Ok(t) => t,
+                        Err(Error::MustPrint(msg)) => msg.emit(self.tcx),
+                        Err(Error::TypeCheck(thir)) => return Err(thir),
+                    };
+                    Ok(Box::new(Some(pearlite::normalize(self.tcx, self.typing_env(def_id), term))))
+                } else {
+                    Ok(Box::new(None))
+                }
+            })
+            .map(|x| x.as_ref())
     }
 
     /// Same as [`Self::term`], but aborts if an error was found.
     ///
     /// This should only be used in [`after_analysis`](crate::translation::after_analysis),
     /// where we are confident that typechecking errors have already been reported.
-    pub(crate) fn term_fail_fast(&mut self, def_id: DefId) -> Option<&Term<'tcx>> {
+    pub(crate) fn term_fail_fast(&self, def_id: DefId) -> Option<&Term<'tcx>> {
         let tcx = self.tcx;
         self.term(def_id).unwrap_or_else(|_| {
             tcx.dcx().abort_if_errors();
@@ -302,14 +291,10 @@ impl<'tcx> TranslationCtx<'tcx> {
         self.params_open_inv.get(&def_id)
     }
 
-    queryish!(sig, &PreSignature<'tcx>, |ctx: &mut Self, key| { pre_sig_of(&mut *ctx, key) });
+    queryish!(sig, DefId, PreSignature<'tcx>, (pre_sig_of));
 
-    pub(crate) fn body_with_facts(
-        &mut self,
-        def_id: LocalDefId,
-    ) -> &Rc<BodyWithBorrowckFacts<'tcx>> {
-        let entry = self.bodies.entry(def_id);
-        entry.or_insert_with(|| {
+    pub(crate) fn body_with_facts(&self, def_id: LocalDefId) -> &BodyWithBorrowckFacts<'tcx> {
+        self.bodies.insert(def_id, |_| {
             let mut body = callbacks::get_body(self.tcx, def_id)
                 .unwrap_or_else(|| panic!("did not find body for {def_id:?}"));
 
@@ -325,7 +310,7 @@ impl<'tcx> TranslationCtx<'tcx> {
                 }
             }
 
-            Rc::new(body)
+            Box::new(body)
         })
     }
 
@@ -362,7 +347,7 @@ impl<'tcx> TranslationCtx<'tcx> {
         self.tcx.dcx().span_warn(span, msg.into())
     }
 
-    queryish!(laws, &[DefId], laws_inner);
+    queryish!(laws, DefId, [DefId], laws_inner);
 
     // TODO Make private
     pub(crate) fn extern_spec(&self, def_id: DefId) -> Option<&ExternSpec<'tcx>> {
@@ -377,16 +362,10 @@ impl<'tcx> TranslationCtx<'tcx> {
         self.opts.should_output
     }
 
+    queryish!(opacity, DefId, Opacity, mk_opacity);
+
     /// We encodes the opacity of functions using 'witnesses', funcitons that have the target opacity
     /// set as their *visibility*.
-    pub(crate) fn opacity(&mut self, item: DefId) -> &Opacity {
-        if !self.opacity.contains_key(&item) {
-            self.opacity.insert(item, self.mk_opacity(item));
-        }
-
-        &self.opacity[&item]
-    }
-
     fn mk_opacity(&self, item: DefId) -> Opacity {
         if !matches!(self.item_type(item), ItemType::Predicate { .. } | ItemType::Logic { .. }) {
             return Opacity(Visibility::Public);
@@ -401,13 +380,13 @@ impl<'tcx> TranslationCtx<'tcx> {
 
     /// Checks if `item` is transparent in the scope of `modl`.
     /// This will determine whether the solvers are allowed to unfold the body's definition.
-    pub(crate) fn is_transparent_from(&mut self, item: DefId, modl: DefId) -> bool {
+    pub(crate) fn is_transparent_from(&self, item: DefId, modl: DefId) -> bool {
         self.opacity(item).0.is_accessible_from(modl, self.tcx)
     }
 
-    pub(crate) fn metadata(&self) -> BinaryMetadata<'tcx> {
+    pub(crate) fn metadata(&mut self) -> BinaryMetadata<'tcx> {
         BinaryMetadata::from_parts(
-            &self.terms,
+            &mut self.terms,
             &self.creusot_items,
             &self.extern_specs,
             &self.params_open_inv,
@@ -447,7 +426,7 @@ impl<'tcx> TranslationCtx<'tcx> {
         TypingEnv { typing_mode: TypingMode::non_body_analysis(), param_env }
     }
 
-    pub(crate) fn has_body(&mut self, def_id: DefId) -> bool {
+    pub(crate) fn has_body(&self, def_id: DefId) -> bool {
         if let Some(local_id) = def_id.as_local() {
             self.tcx.hir().maybe_body_owned_by(local_id).is_some()
         } else {

--- a/creusot/src/gather_spec_closures.rs
+++ b/creusot/src/gather_spec_closures.rs
@@ -27,7 +27,7 @@ pub(crate) struct SpecClosures<'tcx> {
 }
 
 impl<'tcx> SpecClosures<'tcx> {
-    pub(crate) fn collect(ctx: &mut TranslationCtx<'tcx>, body: &Body<'tcx>) -> Self {
+    pub(crate) fn collect(ctx: &TranslationCtx<'tcx>, body: &Body<'tcx>) -> Self {
         let mut visitor = Closures::new(ctx.tcx);
         visitor.visit_body(body);
 
@@ -91,7 +91,7 @@ pub(crate) struct Invariants<'tcx> {
 }
 
 struct InvariantsVisitor<'a, 'tcx> {
-    ctx: &'a mut TranslationCtx<'tcx>,
+    ctx: &'a TranslationCtx<'tcx>,
     body: &'a Body<'tcx>,
     before_loop: IndexSet<BasicBlock>,
     invariants: Invariants<'tcx>,
@@ -166,7 +166,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InvariantsVisitor<'a, 'tcx> {
 
 // Calculate the *actual* location of invariants in MIR
 pub(crate) fn corrected_invariant_names_and_locations<'tcx>(
-    ctx: &mut TranslationCtx<'tcx>,
+    ctx: &TranslationCtx<'tcx>,
     body: &Body<'tcx>,
 ) -> Invariants<'tcx> {
     let mut invs_gather = InvariantsVisitor {

--- a/creusot/src/run_why3.rs
+++ b/creusot/src/run_why3.rs
@@ -69,7 +69,7 @@ pub(super) fn run_why3<'tcx>(ctx: &Why3Generator<'tcx>, file: Option<PathBuf>) {
 
     if matches!(why3_cmd.sub, Why3Sub::Prove) {
         command.arg("--json");
-        let span_map = &ctx.span_map;
+        let span_map = &ctx.span_map.borrow();
         let mut child = command.stdout(Stdio::piped()).spawn().expect("could not run why3");
         let mut stdout = BufReader::new(child.stdout.take().unwrap());
         let de = Deserializer::from_reader(&mut stdout);

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -138,7 +138,7 @@ pub(crate) fn after_analysis(ctx: TranslationCtx) -> Result<(), Box<dyn std::err
     }
 
     if why3.should_export() {
-        metadata::dump_exports(&why3, &why3.opts.metadata_path);
+        metadata::dump_exports(&mut why3);
     }
 
     if why3.should_compile() {

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -36,7 +36,7 @@ impl<'tcx> ExternSpec<'tcx> {
 
 // Must be run before MIR generation.
 pub(crate) fn extract_extern_specs_from_item<'tcx>(
-    ctx: &mut TranslationCtx<'tcx>,
+    ctx: &TranslationCtx<'tcx>,
     def_id: LocalDefId,
 ) -> CreusotResult<(DefId, ExternSpec<'tcx>)> {
     // Handle error gracefully

--- a/creusot/src/translation/function/promoted.rs
+++ b/creusot/src/translation/function/promoted.rs
@@ -22,7 +22,7 @@ pub(crate) fn promoted_signature<'tcx>(body: &Body<'tcx>) -> PreSignature<'tcx> 
 }
 
 pub(crate) fn translate_promoted<'tcx>(
-    ctx: &mut TranslationCtx<'tcx>,
+    ctx: &TranslationCtx<'tcx>,
     body_id: BodyId,
 ) -> CreusotResult<(PreSignature<'tcx>, fmir::Body<'tcx>)> {
     let body = ctx.body(body_id).clone();

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -400,7 +400,7 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
 ///
 /// - `report_location`: used to emit an eventual warning.
 fn resolve_function<'tcx>(
-    ctx: &mut TranslationCtx<'tcx>,
+    ctx: &TranslationCtx<'tcx>,
     typing_env: TypingEnv<'tcx>,
     def_id: DefId,
     subst: GenericArgsRef<'tcx>,

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -131,7 +131,7 @@ impl ContractClauses {
 
     fn get_pre<'tcx>(
         self,
-        ctx: &mut TranslationCtx<'tcx>,
+        ctx: &TranslationCtx<'tcx>,
         fn_name: &str,
     ) -> EarlyBinder<'tcx, PreContract<'tcx>> {
         let mut out = PreContract::default();
@@ -374,10 +374,7 @@ pub(crate) fn inherited_extern_spec<'tcx>(
     }
 }
 
-pub(crate) fn contract_of<'tcx>(
-    ctx: &mut TranslationCtx<'tcx>,
-    def_id: DefId,
-) -> PreContract<'tcx> {
+pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> PreContract<'tcx> {
     let fn_name = ctx.opt_item_name(def_id);
     let fn_name = match &fn_name {
         Some(fn_name) => fn_name.as_str(),
@@ -438,10 +435,7 @@ impl<'tcx> PreSignature<'tcx> {
     }
 }
 
-pub(crate) fn pre_sig_of<'tcx>(
-    ctx: &mut TranslationCtx<'tcx>,
-    def_id: DefId,
-) -> PreSignature<'tcx> {
+pub(crate) fn pre_sig_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> PreSignature<'tcx> {
     let (inputs, output) = inputs_and_output(ctx.tcx, def_id);
 
     let mut contract = crate::specification::contract_of(ctx, def_id);

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -54,7 +54,7 @@ impl<'tcx> TranslationCtx<'tcx> {
         laws
     }
 
-    pub(crate) fn translate_impl(&mut self, impl_id: DefId) -> TraitImpl<'tcx> {
+    pub(crate) fn translate_impl(&self, impl_id: DefId) -> TraitImpl<'tcx> {
         assert!(self.trait_id_of_impl(impl_id).is_some(), "{impl_id:?} is not a trait impl");
         let trait_ref = self.tcx.impl_trait_ref(impl_id).unwrap();
 
@@ -122,7 +122,7 @@ impl<'tcx> TranslationCtx<'tcx> {
 }
 
 fn logic_refinement_term<'tcx>(
-    ctx: &mut TranslationCtx<'tcx>,
+    ctx: &TranslationCtx<'tcx>,
     impl_item_id: DefId,
     trait_item_id: DefId,
     refn_subst: GenericArgsRef<'tcx>,

--- a/creusot/src/validate_terminates.rs
+++ b/creusot/src/validate_terminates.rs
@@ -63,7 +63,7 @@ use rustc_trait_selection::traits::normalize_param_env_or_error;
 ///
 /// Note that for logical functions, these are relaxed: we don't check loops, nor simple
 /// recursion, because why3 will handle it for us.
-pub(crate) fn validate_terminates(ctx: &mut TranslationCtx) -> Result<(), CannotFetchThir> {
+pub(crate) fn validate_terminates(ctx: &TranslationCtx) -> Result<(), CannotFetchThir> {
     ctx.tcx.dcx().abort_if_errors(); // There may have been errors before, if a `#[terminates]` calls a non-`#[terminates]`.
 
     let CallGraph { graph: mut call_graph, additional_data } = CallGraph::build(ctx)?;
@@ -312,7 +312,7 @@ impl<'tcx> BuildFunctionsGraph<'tcx> {
     /// Process the call from `node` to `called_id`.
     fn function_call(
         &mut self,
-        ctx: &mut TranslationCtx<'tcx>,
+        ctx: &TranslationCtx<'tcx>,
         node: graph::NodeIndex,
         typing_env: TypingEnv<'tcx>,
         called_id: DefId,
@@ -436,7 +436,7 @@ impl<'tcx> BuildFunctionsGraph<'tcx> {
     /// We use this function, so that only those specialization that are actually called are visited.
     fn visit_specialized_default_function(
         &mut self,
-        ctx: &mut TranslationCtx<'tcx>,
+        ctx: &TranslationCtx<'tcx>,
         graph_node: ImplDefaultTransparent,
     ) -> Result<Option<graph::NodeIndex>, CannotFetchThir> {
         let Some(&node) =
@@ -501,7 +501,7 @@ impl CallGraph {
     /// exclusively for the purpose of termination checking.
     ///
     /// In particular, this means it only contains `#[terminates]` functions.
-    fn build(ctx: &mut TranslationCtx) -> Result<Self, CannotFetchThir> {
+    fn build(ctx: &TranslationCtx) -> Result<Self, CannotFetchThir> {
         let tcx = ctx.tcx;
         let mut build_call_graph = BuildFunctionsGraph::default();
 

--- a/why3/src/coma.rs
+++ b/why3/src/coma.rs
@@ -160,7 +160,7 @@ impl Expr {
         // If we have `x [ x = z ]` replace this by `z`
         if defs.len() == 1
             && !defs[0].body.occurs_cont(&defs[0].name)
-            && self.as_symbol().and_then(QName::ident) == Some(&defs[0].name)
+            && self.as_symbol().is_some_and(|qn| qn.is_ident(&defs[0].name))
         {
             defs.remove(0).body
         } else {
@@ -191,7 +191,7 @@ impl Expr {
     /// Checks whether a symbol of name `cont` occurs in `self`
     pub fn occurs_cont(&self, cont: &Ident) -> bool {
         match self {
-            Expr::Symbol(v) => v.ident() == Some(&cont),
+            Expr::Symbol(v) => v.is_ident(cont),
             Expr::App(e, arg) => {
                 let arg = if let Arg::Cont(e) = &**arg { e.occurs_cont(cont) } else { false };
                 arg || e.occurs_cont(cont)

--- a/why3/src/name.rs
+++ b/why3/src/name.rs
@@ -100,14 +100,6 @@ impl QName {
         self.name.clone()
     }
 
-    pub fn ident(&self) -> Option<&Ident> {
-        if self.module.is_empty() {
-            Some(&self.name)
-        } else {
-            None
-        }
-    }
-
     pub fn without_search_path(mut self) -> QName {
         let mut i = 0;
         while i < self.module.len() {


### PR DESCRIPTION
The crucial point is the use of `OnceMap`, which provides a hash map where we can add new elements using a shared borrow and where we can get interior shared borrows.