### PR TITLE
Reorganize installation scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install Creusot
       run: |
-        cargo install --path cargo-creusot
-        cargo creusot setup install --only-creusot-rustc
+        ./INSTALL --skip-extra-tools
     - name: Dummy creusot setup
       run: |
         mkdir -p ~/.config/creusot

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,9 +32,8 @@ jobs:
         sudo apt update
         opam install creusot-deps-nightly
         echo $(opam var bin) >> $GITHUB_PATH
-    - name: run cargo creusot setup install
+    - name: Install Creusot
       if: steps.cache-creusot-setup.outputs.cache-hit != 'true'
       # Use only 2 parallel provers, because more provers (4) makes replaying proofs unstable
-      run: |
-        cargo run --bin cargo-creusot creusot setup install --provers-parallelism 2 --no-check-version why3 --no-check-version why3find
+      run: ./INSTALL --provers-parallelism 2 --no-check-version why3 --no-check-version why3find
     - run: cargo test --test why3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,11 +130,11 @@ jobs:
       run: |
         tar -xzf _opam.tar.gz
         echo /home/runner/work/creusot/creusot/_opam/bin >> $GITHUB_PATH
-    - name: run cargo creusot setup install
+    - name: Install solvers
       if: steps.cache-creusot-setup.outputs.cache-hit != 'true'
       # Use only 2 parallel provers, because more provers (4) makes replaying proofs unstable
       run: |
-        cargo run --bin cargo-creusot creusot setup install --provers-parallelism 2
+        ./INSTALL --skip-cargo-creusot --skip-creusot-rustc --provers-parallelism 2
         echo -e "\n>> ~/.config/creusot/Config.toml:\n"
         cat ~/.config/creusot/Config.toml
         echo -e "\n>> ~/.config/creusot/why3.conf:\n"
@@ -152,18 +152,6 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-install-${{ hashFiles('**/Cargo.lock') }}
-    - uses: actions/cache@v4
-      id: cache-creusot-setup
-      with:
-        path: |
-          ~/.config/creusot
-          ~/.local/share/creusot
-          _opam/lib/why3find/packages
-        key: ${{ runner.os }}-cargo-creusot-setup-${{ hashFiles('creusot-deps.opam', 'creusot-setup/src/tools_versions_urls.rs', 'creusot-setup/src/config.rs') }}
-    - name: Install
-      run: |
-        cargo install --path cargo-creusot
-        cargo creusot setup install --only-creusot-rustc
     - name: download why3 and why3find
       uses: actions/download-artifact@v4
       with:
@@ -171,11 +159,10 @@ jobs:
     - name: unpack why3 and why3find
       run: tar -xzf _opam.tar.gz
     - name: Setup
+      # Add /home/runner/work/creusot/creusot/_opam/bin to PATH just for this step
       run: |
-        # Add /home/runner/work/creusot/creusot/_opam/bin to PATH just for this step
         export PATH=/home/runner/work/creusot/creusot/_opam/bin:$PATH
-        cargo creusot setup install --skip-creusot-rustc
-      if: steps.cache-creusot-setup.outputs.cache-hit != 'true'
+        ./INSTALL
     - name: test cargo creusot new
       run: |
         set -x

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _opam
 
 # Creusot local config for development
 /.creusot-config
+INSTALL.opts
 
 # Creusot files
 *.creusot

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bzip2"
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.12+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
 dependencies = [
  "cc",
  "libc",
@@ -525,6 +525,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "creusot-install"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "creusot-setup",
+ "hex",
+ "indoc",
+ "reqwest",
+ "sha2",
+ "zip",
+]
+
+[[package]]
 name = "creusot-metadata"
 version = "0.3.0"
 dependencies = [
@@ -550,14 +564,9 @@ dependencies = [
  "anyhow",
  "creusot-args",
  "directories",
- "hex",
- "indoc",
- "reqwest",
  "serde",
- "sha2",
  "toml",
  "which",
- "zip",
 ]
 
 [[package]]
@@ -1579,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.69"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1611,9 +1620,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -2028,15 +2037,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2068,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2293,12 +2301,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "creusot-contracts-dummy",
   "creusot-metadata",
   "creusot-dev-config",
+  "creusot-install",
   "why3",
   "why3tests",
   "pearlite-syn",

--- a/HACKING.md
+++ b/HACKING.md
@@ -7,12 +7,12 @@ working on the Creusot codebase.
 
 The testsuite will use the global Creusot configuration managed by 
 `cargo creusot setup`. 
-You first need to have successfully run `cargo creusot setup install` as
+You first need to have successfully run `./INSTALL` as
 detailed in the README installation instructions.
 
 **To be able to use custom versions of Why3 or the solvers** (instead of the
 built-in ones expected by Creusot), one can pass extra flags to 
-`cargo creusot setup install` (see also `--help`):
+`./INSTALL` (see also `--help`):
 - `--external <TOOL>` to specify that a solver should be looked up from the path
 - `--no-check-version <TOOL>` to allow unexpected versions of a given tool
 
@@ -54,7 +54,7 @@ If the proof of a test is broken (e.g.
 ## Calling why3 (and why3_tools, etc): shell environment setup
 
 To invoke why3 (manually or in scripts) with the same binary/configuration as
-setup by `cargo creusot setup`, one needs to setup a shell environment with the
+setup by `./INSTALL`, one needs to setup a shell environment with the
 correct PATH and environment variables.
 
 To do so, we provide the following command:
@@ -63,7 +63,7 @@ eval $(cargo run --bin dev-env)
 ```
 
 After that, the `why3` binary in PATH will be the one configured by
-`cargo creusot setup`, using the adequate configuration file (through the
+`./INSTALL`, using the adequate configuration file (through the
 `WHY3CONFIG` environment variable).
 
 ## Upgrading Why3
@@ -79,7 +79,7 @@ of the file (URLs and `git-XXXX` versions), and the `git-XXXX` versions in the
 
 - Install why3-tools: `opam pin git+https://github.com/xldenis/why3-tools`
 - Install the newer prover, make it available in `$PATH`
-- Setup Creusot to use it: `cargo creusot setup install --no-check-version <PROVER> --external <PROVER>`
+- Setup Creusot to use it: `./INSTALL --no-check-version <PROVER> --external <PROVER>`
 - Run `eval $(cargo run --bin dev-env)`
 - Use the `./testsuite_upgrade_prover` script to update why3 sessions in the testsuite.
   Launch the script without arguments to have some usage instructions.

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Install Creusot
+# Additional arguments can be stored in a file `INSTALL.opts`. For example:
+#     $ cat "--external z3" > INSTALL.opts
+#     $ ./INSTALL
+# To see a list of possible options, `./INSTALL --help`.
+if [ -f INSTALL.opts ] ; then
+    ARGS=$(cat INSTALL.opts)
+else
+    ARGS=""
+fi
+set -xe
+cargo run --bin creusot-install -- $ARGS $@

--- a/README.md
+++ b/README.md
@@ -52,14 +52,25 @@ More examples are found in [creusot/tests/should_succeed](creusot/tests/should_s
    ```
    This will build `why3`, `why3find`, and their ocaml dependencies in a local `_opam` directory.
 5. Install **Creusot**:
-    ```
-    $ cargo install --path cargo-creusot
-    $ cargo creusot setup install
-    ```
-    The first command will build the `cargo-creusot` executable and place it in `~/.cargo/bin/`.
-    The second command will download solvers (Alt-Ergo, Z3, CVC4, CVC5), configure Why3 to use them,
-    then it will install the `creusot-rustc` executable; configuration files are stored in
-    `~/.config/creusot/` and executables are stored in `~/.local/share/creusot/`.
+   ```
+   $ ./INSTALL
+   ```
+   The installation consists of:
+   - the `cargo-creusot` executable in `~/.cargo/bin/`;
+   - the `creusot-rustc` executable in `~/.local/share/creusot/toolchains/$TOOLCHAIN/bin`;
+   - SMT solvers (Alt-Ergo, CVC4, CVC5, Z3) in `~/.local/share/creusot/bin`;
+   - configuration files in `~/.config/creusot/`.
+
+## Configuring the installation
+
+You can create a text file `INSTALL.opts` to remember command-line options to be passed
+to the installation script. Type `./INSTALL --help` for a list of possible options.
+For example:
+
+```
+echo "--external z3" > INSTALL.opts
+./INSTALL
+```
 
 # Upgrading Creusot
 
@@ -74,13 +85,9 @@ More examples are found in [creusot/tests/should_succeed](creusot/tests/should_s
    $ opam update
    $ opam pin . -y
    ```
-3. Rebuild and reinstall Creusot:
+3. Reinstall Creusot:
    ```
-   $ cargo install --path cargo-creusot
-   ```
-4. Re-run Creusot's setup:
-   ```
-   $ cargo creusot setup install
+   $ ./INSTALL
    ```
 
 # Verifying with Creusot and Why3

--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -27,35 +27,6 @@ fn main() -> Result<()> {
             creusot(Some(subcmd), cargs.options, cargs.creusot_rustc, cargs.cargo_flags)
         }
         Some(Setup { command: SetupSubCommand::Status }) => setup::status(),
-        Some(Setup {
-            command:
-                SetupSubCommand::Install {
-                    provers_parallelism,
-                    external,
-                    no_check_version,
-                    only_creusot_rustc,
-                    skip_creusot_rustc,
-                },
-        }) => {
-            let extflag =
-                |name| setup::ExternalFlag { check_version: !no_check_version.contains(&name) };
-            let managedflag = |name, mname| setup::ManagedFlag {
-                check_version: !no_check_version.contains(&name),
-                external: external.contains(&mname),
-            };
-            let flags = setup::InstallFlags {
-                provers_parallelism,
-                why3: extflag(SetupTool::Why3),
-                why3find: extflag(SetupTool::Why3find),
-                altergo: managedflag(SetupTool::AltErgo, SetupManagedTool::AltErgo),
-                z3: managedflag(SetupTool::Z3, SetupManagedTool::Z3),
-                cvc4: managedflag(SetupTool::CVC4, SetupManagedTool::CVC4),
-                cvc5: managedflag(SetupTool::CVC5, SetupManagedTool::CVC5),
-                only_creusot_rustc,
-                skip_creusot_rustc,
-            };
-            setup::install(flags)
-        }
         Some(Config(args)) => why3find_config(args),
         Some(Prove(args)) => {
             creusot(None, cargs.options, cargs.creusot_rustc, cargs.cargo_flags)?;
@@ -153,8 +124,7 @@ fn invoke_cargo(args: &CreusotArgs, creusot_rustc: Option<PathBuf>, cargo_flags:
     };
     // creusot_rustc binary exists
     if !creusot_rustc_path.exists() {
-        eprintln!("creusot-rustc not found (expected at {creusot_rustc_path:?})");
-        eprintln!("Run 'cargo creusot setup install' in the source directory of Creusot to install creusot-rustc");
+        eprintln!("creusot-rustc not found (expected at {creusot_rustc_path:?}). You should reinstall Creusot.");
         exit(1);
     }
     let mut cmd = Command::new(cargo_path);
@@ -243,31 +213,6 @@ use CargoCreusotSubCommand::*;
 pub enum SetupSubCommand {
     /// Show the current status of the Creusot installation
     Status,
-    /// Setup Creusot or update an existing installation
-    Install {
-        /// Maximum number of provers to run in parallel
-        #[arg(long, default_value_t = default_provers_parallelism())]
-        provers_parallelism: usize,
-        /// Look-up <TOOL> from PATH instead of using the built-in version
-        #[arg(long, value_name = "TOOL")]
-        external: Vec<SetupManagedTool>,
-        /// Do not error if <TOOL>'s version does not match the one expected by creusot
-        #[arg(long, value_name = "TOOL")]
-        no_check_version: Vec<SetupTool>,
-        /// Only install creusot-rustc
-        #[arg(long)]
-        only_creusot_rustc: bool,
-        /// Skip installing creusot-rustc
-        #[arg(long, conflicts_with = "only_creusot_rustc")]
-        skip_creusot_rustc: bool,
-    },
-}
-
-fn default_provers_parallelism() -> usize {
-    match std::thread::available_parallelism() {
-        Ok(n) => n.get(),
-        Err(_) => 1,
-    }
 }
 
 /// Arguments for `cargo creusot clean`.

--- a/cargo-creusot/src/why3find_wrapper.rs
+++ b/cargo-creusot/src/why3find_wrapper.rs
@@ -37,7 +37,7 @@ fn raw_config(args: &Vec<String>, paths: &Paths) -> Result<()> {
         .arg("--package")
         .arg("prelude");
     for prover in PROVERS {
-        why3find.arg("--prover").arg(format!("+{}", prover.bin.binary_name));
+        why3find.arg("--prover").arg(format!("+{}", prover.binary_name));
     }
     for arg in args {
         why3find.arg(arg);

--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -81,24 +81,6 @@ pub enum Why3SubCommand {
     Replay,
 }
 
-#[derive(Debug, ValueEnum, Serialize, Deserialize, Clone, PartialEq)]
-pub enum SetupManagedTool {
-    AltErgo,
-    Z3,
-    CVC4,
-    CVC5,
-}
-
-#[derive(Debug, ValueEnum, Serialize, Deserialize, Clone, PartialEq)]
-pub enum SetupTool {
-    Why3,
-    Why3find,
-    AltErgo,
-    Z3,
-    CVC4,
-    CVC5,
-}
-
 /// Parse a single key-value pair
 fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
 where

--- a/creusot-install/Cargo.toml
+++ b/creusot-install/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "creusot-install"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive", "env"] }
+creusot-setup = {path = "../creusot-setup"}
+anyhow = "1.0"
+indoc = "2.0.5"
+reqwest = { version = "0.12", features = ["blocking"] }
+sha2 = "0.10"
+hex = "0.4"
+zip = "2.2"

--- a/creusot-install/src/main.rs
+++ b/creusot-install/src/main.rs
@@ -1,0 +1,450 @@
+use anyhow::{anyhow, bail, Context as _};
+use clap::*;
+use creusot_setup::{
+    self as setup,
+    config::{Config, ExternalTool, ManagedTool},
+    tools_versions_urls::*,
+    Binary,
+};
+use indoc::writedoc;
+use reqwest::blocking::Client;
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[derive(Clone, Copy)]
+pub struct ManagedBinary {
+    pub bin: setup::Binary,
+    url: &'static Url,
+    download_with: fn(&Client, &Url, &Path, &Path) -> anyhow::Result<()>,
+}
+
+const ALTERGO: ManagedBinary = ManagedBinary {
+    bin: setup::ALTERGO,
+    url: &URLS.altergo,
+    download_with: download_from_url_with_cache,
+};
+
+const Z3: ManagedBinary =
+    ManagedBinary { bin: setup::Z3, url: &URLS.z3, download_with: download_z3_from_url };
+
+const CVC4: ManagedBinary = ManagedBinary {
+    bin: setup::CVC4,
+    url: &URLS.cvc4,
+    download_with: download_from_url_with_cache,
+};
+
+const CVC5: ManagedBinary = ManagedBinary {
+    bin: setup::CVC5,
+    url: &URLS.cvc5,
+    download_with: download_from_url_with_cache,
+};
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    install(args)
+}
+
+/// Install Creusot
+#[derive(Debug, Parser)]
+struct Args {
+    /// Maximum number of provers to run in parallel
+    #[arg(long, default_value_t = default_provers_parallelism())]
+    provers_parallelism: usize,
+    /// Look-up <TOOL> from PATH instead of using the built-in version
+    #[arg(long, value_name = "TOOL")]
+    external: Vec<SetupManagedTool>,
+    /// Do not error if <TOOL>'s version does not match the one expected by creusot
+    #[arg(long, value_name = "TOOL")]
+    no_check_version: Vec<SetupTool>,
+    /// Use existing cargo-creusot
+    #[arg(long)]
+    skip_cargo_creusot: bool,
+    /// Use existing creusot-rustc
+    #[arg(long)]
+    skip_creusot_rustc: bool,
+    /// Skip installing Why3, Why3find, and provers
+    #[arg(long)]
+    skip_extra_tools: bool,
+}
+
+fn default_provers_parallelism() -> usize {
+    match std::thread::available_parallelism() {
+        Ok(n) => n.get(),
+        Err(_) => 1,
+    }
+}
+
+#[derive(Debug, ValueEnum, Clone, PartialEq)]
+enum SetupManagedTool {
+    AltErgo,
+    Z3,
+    CVC4,
+    CVC5,
+}
+
+#[derive(Debug, ValueEnum, Clone, PartialEq)]
+enum SetupTool {
+    Why3,
+    Why3find,
+    AltErgo,
+    Z3,
+    CVC4,
+    CVC5,
+}
+
+fn install(args: Args) -> anyhow::Result<()> {
+    let paths = setup::get_config_paths()?;
+    if !args.skip_cargo_creusot {
+        install_cargo_creusot()?;
+    }
+    if !args.skip_creusot_rustc {
+        install_creusot_rustc(&paths)?;
+    }
+    if !args.skip_extra_tools {
+        install_tools(&paths, args)?;
+    }
+    Ok(())
+}
+
+fn install_cargo_creusot() -> anyhow::Result<()> {
+    println! {"Installing cargo-creusot..."};
+    let mut cmd = Command::new("cargo");
+    cmd.args(["install", "--path", "cargo-creusot", "--quiet"]);
+    if !cmd.status()?.success() {
+        bail!("Failed to install cargo-creusot")
+    }
+    Ok(())
+}
+
+fn install_creusot_rustc(cfg: &setup::CfgPaths) -> anyhow::Result<()> {
+    println! {"Installing creusot-rustc..."};
+    let toolchain = setup::toolchain_channel();
+    let _ = fs::remove_dir_all(&cfg.data_dir.join("toolchains"));
+    // Usually ~/.local/share/creusot/toolchains/nightly-YYYY-MM-DD/
+    let toolchain_dir =
+        &setup::toolchain_dir(&cfg.data_dir, &toolchain).into_os_string().into_string().unwrap();
+    let mut cmd = Command::new("cargo");
+    cmd.args(["install", "--path", "creusot-rustc", "--root", toolchain_dir, "--quiet"]);
+    if !cmd.status()?.success() {
+        bail!("Failed to install creusot-rustc")
+    }
+    Ok(())
+}
+
+fn install_tools(paths: &setup::CfgPaths, args: Args) -> anyhow::Result<()> {
+    if args.provers_parallelism < 1 {
+        bail! {"--provers-parallelism should be at least 1"}
+    }
+
+    // helpers to generate the ExternalTool/ManagedTool config sections
+
+    let getpath = |bin: Binary| -> anyhow::Result<PathBuf> {
+        let path = bin.detect_path().ok_or(anyhow!(
+            "{} not found. Please install {} version {}",
+            &bin.display_name,
+            &bin.display_name,
+            &bin.version
+        ))?;
+        println!("Found {} at path: {}", &bin.display_name, &path.display());
+        Ok(path)
+    };
+
+    let external_tool = |bin: Binary, name: SetupTool| -> anyhow::Result<ExternalTool> {
+        Ok(ExternalTool {
+            path: getpath(bin)?,
+            check_version: !args.no_check_version.contains(&name),
+        })
+    };
+    let managed_tool =
+        |bin: Binary, name: SetupTool, mname: SetupManagedTool| -> anyhow::Result<ManagedTool> {
+            if args.external.contains(&mname) {
+                Ok(ManagedTool::External(ExternalTool {
+                    path: getpath(bin)?,
+                    check_version: !args.no_check_version.contains(&name),
+                }))
+            } else {
+                Ok(ManagedTool::Builtin { check_version: !args.no_check_version.contains(&name) })
+            }
+        };
+
+    // build the corresponding configuration
+
+    let config = Config {
+        provers_parallelism: std::cmp::max(1, args.provers_parallelism),
+        why3: external_tool(setup::WHY3, SetupTool::Why3)?,
+        why3find: external_tool(setup::WHY3FIND, SetupTool::Why3find)?,
+        altergo: managed_tool(ALTERGO.bin, SetupTool::AltErgo, SetupManagedTool::AltErgo)?,
+        z3: managed_tool(Z3.bin, SetupTool::Z3, SetupManagedTool::Z3)?,
+        cvc4: managed_tool(CVC4.bin, SetupTool::CVC4, SetupManagedTool::CVC4)?,
+        cvc5: managed_tool(CVC5.bin, SetupTool::CVC5, SetupManagedTool::CVC5)?,
+    };
+
+    // check for issues (incorrect versions of external binaries).
+    // do not attempt checking version of builtin solvers (we haven't installed
+    // them yet, and we know they will be of the expected version).
+
+    let issues = setup::diagnostic_config(&paths, &config, false);
+    for issue in &issues {
+        eprintln!("{issue}")
+    }
+    if issues.iter().any(|issue| issue.error) {
+        bail!("Aborting")
+    }
+
+    // apply the configuration to disk
+    apply_config(&paths, &config)
+}
+
+fn apply_config(paths: &setup::CfgPaths, cfg: &Config) -> anyhow::Result<()> {
+    // erase any previous existing config (but not the cache)
+    let _ = fs::remove_dir_all(&paths.config_dir);
+    let _ = fs::remove_dir_all(&paths.data_dir.join("bin"));
+
+    // create directories
+    fs::create_dir_all(&paths.config_dir)?;
+    fs::create_dir_all(&paths.data_dir)?;
+    fs::create_dir_all(&paths.bin_subdir)?;
+    fs::create_dir_all(&paths.cache_dir)?;
+
+    // separate managed tools into "builtin" (we need to download the binary)
+    // and "external" (we have a path to the binary)
+    let mut builtin: Vec<ManagedBinary> = Vec::new();
+    let mut external: Vec<(ManagedBinary, PathBuf)> = Vec::new();
+
+    for (bin, mode) in
+        [(ALTERGO, &cfg.altergo), (Z3, &cfg.z3), (CVC4, &cfg.cvc4), (CVC5, &cfg.cvc5)]
+    {
+        match mode {
+            ManagedTool::Builtin { check_version: _ } => builtin.push(bin),
+            ManagedTool::External(tool) => external.push((bin, tool.path.clone())),
+        }
+    }
+
+    // download binaries for builtins
+    download_all(&builtin, &paths.cache_dir, &paths.bin_subdir)?;
+
+    // create symbolic links for external tools so that why3 picks them up
+    for (bin, path) in external {
+        symlink_file(path, &paths.bin_subdir.join(bin.bin.binary_name))?;
+    }
+
+    // generate the corresponding .why3.conf
+    generate_why3_conf(
+        cfg.provers_parallelism,
+        &cfg.why3.path,
+        &paths.bin_subdir,
+        &paths.why3_config_file,
+    )?;
+
+    // write the config file to disk
+    cfg.write_to_file(&paths.config_file)?;
+
+    // install the why3find package `prelude`
+    install_prelude(&cfg.why3find.path)?;
+    Ok(())
+}
+
+fn install_prelude(why3find: &PathBuf) -> anyhow::Result<()> {
+    Command::new(why3find)
+        .current_dir("target")
+        .args(["install", "--global", "prelude"])
+        .status()?;
+    Ok(())
+}
+
+// download helper
+
+pub fn sha256sum(file: &Path) -> anyhow::Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    let mut f = fs::File::open(file).context("opening file to hash")?;
+    std::io::copy(&mut f, &mut hasher)?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn download_from_url(client: &Client, url: &Url, dest: &Path) -> anyhow::Result<()> {
+    const DOWNLOAD_RETRIES: u32 = 1;
+    let do_download = || -> anyhow::Result<()> {
+        let mut resp = client.get(url.url).send()?;
+        let mut file = fs::File::create(dest)?;
+        resp.copy_to(&mut file)?;
+        Ok(())
+    };
+    let mut success = false;
+    let mut tries: u32 = 0;
+    while !success && tries <= DOWNLOAD_RETRIES {
+        if tries > 0 {
+            eprintln!("Retrying...")
+        };
+        do_download().with_context(|| format!("downloading {} to {}", url.url, dest.display()))?;
+        let file_hash = sha256sum(dest)?;
+        if file_hash == url.sha256 {
+            success = true
+        } else {
+            eprintln!("Download failed (wrong hash)");
+            let _ = fs::remove_file(dest);
+        }
+        tries = tries + 1;
+    }
+    if !success {
+        bail!("Download failed after {DOWNLOAD_RETRIES} retries (wrong hash?)")
+    };
+    Ok(())
+}
+
+// looks up [cache_dir] to try to find a cached download; if not, stores the
+// result of the download in [cache_dir] (using the hash as the filename).
+fn download_from_url_with_cache(
+    client: &Client,
+    url: &Url,
+    cache_dir: &Path,
+    dest: &Path,
+) -> anyhow::Result<()> {
+    let cached_path = cache_dir.join(url.sha256);
+    if !(cached_path.is_file() && sha256sum(&cached_path)? == url.sha256) {
+        download_from_url(client, url, &cached_path)?;
+    }
+    if cached_path != dest {
+        fs::copy(cached_path, dest)?;
+    }
+    Ok(())
+}
+
+fn generate_why3_conf(
+    provers_parallelism: usize,
+    why3_path: &Path,
+    bin_dir: &Path,
+    dest_file: &Path,
+) -> anyhow::Result<()> {
+    println!("Generating a fresh why3 configuration...");
+    {
+        use std::io::Write;
+        let mut f = fs::File::create(&dest_file)?;
+        writeln!(&mut f, "[main]")?;
+        writeln!(&mut f, "magic = {WHY3_CONFIG_MAGIC_NUMBER}")?;
+        writeln!(&mut f, "running_provers_max = {}", provers_parallelism)?;
+    }
+    let status = Command::new(why3_path)
+        .arg("-C")
+        .arg(&dest_file)
+        .args(["config", "detect"])
+        .envs([("PATH", bin_dir)])
+        .status()
+        .context("launching 'why3 config detect' on downloaded solvers")?;
+    if !status.success() {
+        bail!("failed to generate why3's configuration")
+    };
+    {
+        let mut f = fs::OpenOptions::new().append(true).open(&dest_file)?;
+        generate_strategy(&mut f)?;
+    }
+
+    Ok(())
+}
+
+fn generate_strategy(f: &mut dyn Write) -> anyhow::Result<()> {
+    let altergo = format!("Alt-Ergo,{ALTERGO_VERSION}");
+    let z3 = format!("Z3,{Z3_VERSION}");
+    let cvc5 = format!("CVC5,{CVC5_VERSION}");
+    let cvc4 = format!("CVC4,{CVC4_VERSION}");
+    writedoc!(
+        f,
+        r#"
+
+        [strategy]
+        code = "start:
+        c {z3} .5 1000
+        t split_vc start
+        c {altergo} 3. 2000 | {z3} 3. 2000
+        c {cvc5} 3. 2000 | {cvc4} 3. 2000
+        t introduce_premises afterintro
+        afterintro:
+        t inline_goal afterinline
+        g trylongertime
+        afterinline:
+        t split_all_full start
+        trylongertime:
+        c {altergo} 6. 4000 | {cvc5} 6. 4000 | {z3} 6. 4000 | {cvc4} 6. 4000
+        "
+        desc = "Automatic@ run@ of@ provers@ and@ most@ useful@ transformations"
+        name = "Creusot_Auto"
+        shortcut = "4"
+    "#,
+    )?;
+
+    Ok(())
+}
+
+// download a list [ManagedBinary]s
+
+fn download_all(bins: &[ManagedBinary], cache_dir: &Path, dest_dir: &Path) -> anyhow::Result<()> {
+    let client = Client::new();
+    for bin in bins {
+        println!("Downloading {} {}...", bin.bin.display_name, bin.bin.version);
+        let path = dest_dir.join(bin.bin.binary_name);
+        let dl = bin.download_with;
+        dl(&client, bin.url, cache_dir, &path)?;
+        set_executable(&path)?;
+    }
+    Ok(())
+}
+
+// Z3 releases come as a .zip archive that includes many things. We are only
+// interested in the z3 binary, so we extract it from the archive and throw away
+// the rest.
+
+fn download_z3_from_url(
+    client: &Client,
+    url: &Url,
+    cache_dir: &Path,
+    dest: &Path,
+) -> anyhow::Result<()> {
+    use zip::read::ZipArchive;
+    // just use the zip file stored in the cache
+    let zip_path = cache_dir.join(url.sha256);
+    download_from_url_with_cache(client, url, cache_dir, &zip_path)?;
+    {
+        // extract the z3 binary from the .zip archive
+        let zipfile = std::fs::File::open(&zip_path)?;
+        let mut archive = ZipArchive::new(zipfile)?;
+        // find out the full path of the z3 binary in the archive
+        let z3_archive_path = archive
+            .file_names()
+            .find(|s| s.ends_with("/bin/z3"))
+            .map(String::from)
+            .ok_or(anyhow!("did not find a bin/z3 binary in the z3 release archive"))?;
+        let mut z3zipfile = archive.by_name(&z3_archive_path)?;
+        let mut z3file = fs::File::create(&dest)?;
+        std::io::copy(&mut z3zipfile, &mut z3file)?;
+    }
+    Ok(())
+}
+
+// cross-platform wrappers
+
+fn set_executable(dest: &Path) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&dest)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&dest, perms)?;
+    }
+    Ok(())
+}
+
+fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> std::io::Result<()> {
+    let _ = fs::remove_file(&link);
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(original, link)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_file(original, link)
+    }
+}

--- a/creusot-setup/Cargo.toml
+++ b/creusot-setup/Cargo.toml
@@ -11,9 +11,3 @@ toml = { version = "0.8", features = ["preserve_order"] }
 directories = "6.0"
 which = "7.0"
 anyhow = "1.0"
-reqwest = { version = "0.12", features = ["blocking"] }
-zip = "2.2"
-hex = "0.4"
-sha2 = "0.10"
-indoc = "2.0"
-

--- a/creusot-setup/src/tools.rs
+++ b/creusot-setup/src/tools.rs
@@ -1,10 +1,6 @@
 use crate::tools_versions_urls::*;
-use anyhow::{anyhow, bail, Context};
-use indoc::writedoc;
-use reqwest::blocking::Client;
+use anyhow::{anyhow, bail};
 use std::{
-    fs,
-    io::Write,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -27,60 +23,37 @@ pub const WHY3FIND: Binary = Binary {
     detect_version: detect_why3find_version,
 };
 
-pub const ALTERGO: ManagedBinary = ManagedBinary {
-    bin: Binary {
-        display_name: "Alt-Ergo",
-        binary_name: "alt-ergo",
-        version: ALTERGO_VERSION,
-        detect_version: detect_altergo_version,
-    },
-    url: &URLS.altergo,
-    download_with: download_from_url_with_cache,
+pub const ALTERGO: Binary = Binary {
+    display_name: "Alt-Ergo",
+    binary_name: "alt-ergo",
+    version: ALTERGO_VERSION,
+    detect_version: detect_altergo_version,
 };
 
-pub const Z3: ManagedBinary = ManagedBinary {
-    bin: Binary {
-        display_name: "Z3",
-        binary_name: "z3",
-        version: Z3_VERSION,
-        detect_version: detect_z3_version,
-    },
-    url: &URLS.z3,
-    download_with: download_z3_from_url,
+pub const Z3: Binary = Binary {
+    display_name: "Z3",
+    binary_name: "z3",
+    version: Z3_VERSION,
+    detect_version: detect_z3_version,
 };
 
-pub const CVC4: ManagedBinary = ManagedBinary {
-    bin: Binary {
-        display_name: "CVC4",
-        binary_name: "cvc4",
-        version: CVC4_VERSION,
-        detect_version: detect_cvc4_version,
-    },
-    url: &URLS.cvc4,
-    download_with: download_from_url_with_cache,
+pub const CVC4: Binary = Binary {
+    display_name: "CVC4",
+    binary_name: "cvc4",
+    version: CVC4_VERSION,
+    detect_version: detect_cvc4_version,
 };
 
-pub const CVC5: ManagedBinary = ManagedBinary {
-    bin: Binary {
-        display_name: "CVC5",
-        binary_name: "cvc5",
-        version: CVC5_VERSION,
-        detect_version: detect_cvc5_version,
-    },
-    url: &URLS.cvc5,
-    download_with: download_from_url_with_cache,
+pub const CVC5: Binary = Binary {
+    display_name: "CVC5",
+    binary_name: "cvc5",
+    version: CVC5_VERSION,
+    detect_version: detect_cvc5_version,
 };
 
-pub const PROVERS: &[ManagedBinary] = &[ALTERGO, Z3, CVC4, CVC5];
+pub const PROVERS: &[Binary] = &[ALTERGO, Z3, CVC4, CVC5];
 
 // ----
-
-#[derive(Clone, Copy)]
-pub struct ManagedBinary {
-    pub bin: Binary,
-    url: &'static Url,
-    download_with: fn(&Client, &Url, &Path, &Path) -> anyhow::Result<()>,
-}
 
 #[derive(Clone, Copy)]
 pub struct Binary {
@@ -88,82 +61,6 @@ pub struct Binary {
     pub binary_name: &'static str,
     pub version: &'static str,
     detect_version: fn(&Path) -> anyhow::Result<String>,
-}
-
-// download a list [ManagedBinary]s
-
-pub fn download_all(
-    bins: &[ManagedBinary],
-    cache_dir: &Path,
-    dest_dir: &Path,
-) -> anyhow::Result<()> {
-    let client = Client::new();
-    for bin in bins {
-        println!("Downloading {} {}...", bin.bin.display_name, bin.bin.version);
-        let path = dest_dir.join(bin.bin.binary_name);
-        let dl = bin.download_with;
-        dl(&client, bin.url, cache_dir, &path)?;
-        set_executable(&path)?;
-    }
-    Ok(())
-}
-
-// download helper
-
-fn sha256sum(file: &Path) -> anyhow::Result<String> {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    let mut f = fs::File::open(file).context("opening file to hash")?;
-    std::io::copy(&mut f, &mut hasher)?;
-    Ok(hex::encode(hasher.finalize()))
-}
-
-fn download_from_url(client: &Client, url: &Url, dest: &Path) -> anyhow::Result<()> {
-    const DOWNLOAD_RETRIES: u32 = 1;
-    let do_download = || -> anyhow::Result<()> {
-        let mut resp = client.get(url.url).send()?;
-        let mut file = fs::File::create(dest)?;
-        resp.copy_to(&mut file)?;
-        Ok(())
-    };
-    let mut success = false;
-    let mut tries: u32 = 0;
-    while !success && tries <= DOWNLOAD_RETRIES {
-        if tries > 0 {
-            eprintln!("Retrying...")
-        };
-        do_download().with_context(|| format!("downloading {} to {}", url.url, dest.display()))?;
-        let file_hash = sha256sum(dest)?;
-        if file_hash == url.sha256 {
-            success = true
-        } else {
-            eprintln!("Download failed (wrong hash)");
-            let _ = fs::remove_file(dest);
-        }
-        tries = tries + 1;
-    }
-    if !success {
-        bail!("Download failed after {DOWNLOAD_RETRIES} retries (wrong hash?)")
-    };
-    Ok(())
-}
-
-// looks up [cache_dir] to try to find a cached download; if not, stores the
-// result of the download in [cache_dir] (using the hash as the filename).
-fn download_from_url_with_cache(
-    client: &Client,
-    url: &Url,
-    cache_dir: &Path,
-    dest: &Path,
-) -> anyhow::Result<()> {
-    let cached_path = cache_dir.join(url.sha256);
-    if !(cached_path.is_file() && sha256sum(&cached_path)? == url.sha256) {
-        download_from_url(client, url, &cached_path)?;
-    }
-    if cached_path != dest {
-        fs::copy(cached_path, dest)?;
-    }
-    Ok(())
 }
 
 // helpers: external binaries
@@ -182,8 +79,7 @@ impl Binary {
 // helpers: why3
 
 fn detect_why3_version(why3: &Path) -> anyhow::Result<String> {
-    let output = run(Command::new(&why3).arg("--version"))?;
-    let version_full = String::from_utf8(output.stdout)?;
+    let version_full = run(Command::new(&why3).arg("--version"))?;
     match version_full.strip_prefix("Why3 platform, version ") {
         Some(version) => {
             let parts: Vec<_> = version.trim_end().split(|c| c == '.' || c == '+').collect();
@@ -195,75 +91,10 @@ fn detect_why3_version(why3: &Path) -> anyhow::Result<String> {
     }
 }
 
-pub fn generate_why3_conf(
-    provers_parallelism: usize,
-    why3_path: &Path,
-    bin_dir: &Path,
-    dest_file: &Path,
-) -> anyhow::Result<()> {
-    println!("Generating a fresh why3 configuration...");
-    {
-        use std::io::Write;
-        let mut f = fs::File::create(&dest_file)?;
-        writeln!(&mut f, "[main]")?;
-        writeln!(&mut f, "magic = {WHY3_CONFIG_MAGIC_NUMBER}")?;
-        writeln!(&mut f, "running_provers_max = {}", provers_parallelism)?;
-    }
-    let status = Command::new(why3_path)
-        .arg("-C")
-        .arg(&dest_file)
-        .args(["config", "detect"])
-        .envs([("PATH", bin_dir)])
-        .status()
-        .context("launching 'why3 config detect' on downloaded solvers")?;
-    if !status.success() {
-        bail!("failed to generate why3's configuration")
-    };
-    {
-        let mut f = fs::OpenOptions::new().append(true).open(&dest_file)?;
-        generate_strategy(&mut f)?;
-    }
-
-    Ok(())
-}
-
-fn generate_strategy(f: &mut dyn Write) -> anyhow::Result<()> {
-    let altergo = format!("Alt-Ergo,{ALTERGO_VERSION}");
-    let z3 = format!("Z3,{Z3_VERSION}");
-    let cvc5 = format!("CVC5,{CVC5_VERSION}");
-    let cvc4 = format!("CVC4,{CVC4_VERSION}");
-    writedoc!(
-        f,
-        r#"
-        [strategy]
-        code = "start:
-        c {z3} .5 1000
-        t split_vc start
-        c {altergo} 3. 2000 | {z3} 3. 2000
-        c {cvc5} 3. 2000 | {cvc4} 3. 2000
-        t introduce_premises afterintro
-        afterintro:
-        t inline_goal afterinline
-        g trylongertime
-        afterinline:
-        t split_all_full start
-        trylongertime:
-        c {altergo} 6. 4000 | {cvc5} 6. 4000 | {z3} 6. 4000 | {cvc4} 6. 4000
-        "
-        desc = "Automatic@ run@ of@ provers@ and@ most@ useful@ transformations"
-        name = "Creusot_Auto"
-        shortcut = "4"
-    "#,
-    )?;
-
-    Ok(())
-}
-
 // helpers: why3find
 
-pub fn detect_why3find_version(why3find: &Path) -> anyhow::Result<String> {
-    let output = run(Command::new(&why3find).arg("--version"))?;
-    let version_full = String::from_utf8(output.stdout)?;
+fn detect_why3find_version(why3find: &Path) -> anyhow::Result<String> {
+    let version_full = run(Command::new(&why3find).arg("--version"))?;
     match version_full.strip_prefix("why3find v") {
         Some(version) => {
             let parts: Vec<_> = version.trim_end().split(|c| c == '.' || c == '+').collect();
@@ -276,8 +107,7 @@ pub fn detect_why3find_version(why3find: &Path) -> anyhow::Result<String> {
 // helpers: alt-ergo
 
 fn detect_altergo_version(altergo: &Path) -> anyhow::Result<String> {
-    let output = run(Command::new(&altergo).arg("--version"))?;
-    let version_full = String::from_utf8(output.stdout)?;
+    let version_full = run(Command::new(&altergo).arg("--version"))?;
     let version = version_full.trim_end().strip_prefix("v").map(String::from);
     version.ok_or(anyhow!("bad Altergo version: {}", version_full))
 }
@@ -286,51 +116,18 @@ fn detect_altergo_version(altergo: &Path) -> anyhow::Result<String> {
 
 // assumes a version string of the form: "Z3 version 4.12.4 - 64 bit"
 fn detect_z3_version(z3: &Path) -> anyhow::Result<String> {
-    let output = run(Command::new(&z3).arg("--version"))?;
-    let version_full = String::from_utf8(output.stdout)?;
+    let version_full = run(Command::new(&z3).arg("--version"))?;
     let version = version_full
         .strip_prefix("Z3 version ")
         .and_then(|version| version.split_ascii_whitespace().next().map(String::from));
     version.ok_or(anyhow!("bad Z3 version: {}", version_full))
 }
 
-// Z3 releases come as a .zip archive that includes many things. We are only
-// interested in the z3 binary, so we extract it from the archive and throw away
-// the rest.
-
-fn download_z3_from_url(
-    client: &Client,
-    url: &Url,
-    cache_dir: &Path,
-    dest: &Path,
-) -> anyhow::Result<()> {
-    use zip::read::ZipArchive;
-    // just use the zip file stored in the cache
-    let zip_path = cache_dir.join(url.sha256);
-    download_from_url_with_cache(client, url, cache_dir, &zip_path)?;
-    {
-        // extract the z3 binary from the .zip archive
-        let zipfile = std::fs::File::open(&zip_path)?;
-        let mut archive = ZipArchive::new(zipfile)?;
-        // find out the full path of the z3 binary in the archive
-        let z3_archive_path = archive
-            .file_names()
-            .find(|s| s.ends_with("/bin/z3"))
-            .map(String::from)
-            .ok_or(anyhow!("did not find a bin/z3 binary in the z3 release archive"))?;
-        let mut z3zipfile = archive.by_name(&z3_archive_path)?;
-        let mut z3file = fs::File::create(&dest)?;
-        std::io::copy(&mut z3zipfile, &mut z3file)?;
-    }
-    Ok(())
-}
-
 // cvc4
 
 // assumes a version of the form: "This is CVC4 version 1.8 [git HEAD 52479010]\n....."
 fn detect_cvc4_version(cvc4: &Path) -> anyhow::Result<String> {
-    let output = run(Command::new(&cvc4).arg("--version"))?;
-    let version_full = String::from_utf8(output.stdout)?;
+    let version_full = run(Command::new(&cvc4).arg("--version"))?;
     let version = version_full
         .strip_prefix("This is CVC4 version ")
         .and_then(|version| version.split_ascii_whitespace().next().map(String::from));
@@ -341,54 +138,30 @@ fn detect_cvc4_version(cvc4: &Path) -> anyhow::Result<String> {
 
 // assumes a version of the form: "This is cvc5 version 1.0.5 [git ...]\n....."
 fn detect_cvc5_version(cvc5: &Path) -> anyhow::Result<String> {
-    let output = run(Command::new(&cvc5).arg("--version"))?;
-    let version_full = String::from_utf8(output.stdout)?;
+    let version_full = run(Command::new(&cvc5).arg("--version"))?;
     let version = version_full
         .strip_prefix("This is cvc5 version ")
         .and_then(|version| version.split_ascii_whitespace().next().map(String::from));
     version.ok_or(anyhow!("bad CVC5 version: {}", version_full))
 }
 
-// cross-platform wrappers
-
-fn set_executable(dest: &Path) -> anyhow::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&dest)?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&dest, perms)?;
-    }
-    Ok(())
-}
-
-pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> std::io::Result<()> {
-    let _ = fs::remove_file(&link);
-    #[cfg(unix)]
-    {
-        std::os::unix::fs::symlink(original, link)
-    }
-    #[cfg(windows)]
-    {
-        std::os::windows::fs::symlink_file(original, link)
-    }
-}
-
 // Wrapper for Command::output(), error is wrapped in anyhow::Error
-fn run(cmd: &mut Command) -> anyhow::Result<std::process::Output> {
-    cmd.output().map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            anyhow!("{:?} not found", cmd.get_program())
-        } else {
-            anyhow!("{:?}: {}", cmd, e)
-        }
-    })
-}
-
-pub fn why3find_install(why3find: &PathBuf) -> anyhow::Result<()> {
-    Command::new(why3find)
-        .current_dir("target")
-        .args(["install", "--global", "prelude"])
-        .status()?;
-    Ok(())
+fn run(cmd: &mut Command) -> anyhow::Result<String> {
+    cmd.output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                anyhow!("{:?} not found", cmd.get_program())
+            } else {
+                anyhow!("{:?}: {}", cmd, e)
+            }
+        })
+        .and_then(|output| {
+            if output.status.success() {
+                Ok(String::from_utf8(output.stdout)?)
+            } else {
+                let stderr =
+                    String::from_utf8(output.stderr).unwrap_or_else(|_| String::from("<stderr>"));
+                bail!("{:?} failed: {}\n{}", cmd, output.status, stderr)
+            }
+        })
 }

--- a/guide/src/command_line_interface.md
+++ b/guide/src/command_line_interface.md
@@ -114,15 +114,7 @@ Generate `why3find` configuration.
 This is used to set up Creusot in an existing Rust package.
 You don't need to run this command if you used `cargo creusot new` or `cargo creusot init`.
 
-## Install Creusot
-
-### `setup install`
-
-```
-cargo creusot setup install
-```
-
-See the [README](https://github.com/creusot-rs/creusot) for installation instructions.
+## Show configuration
 
 ### `setup status`
 


### PR DESCRIPTION
Closes #1358 

- Just run `./INSTALL.opts`
- Options can be stored in `CONFIG`
- The main logic lives in creusot-install