### PR TITLE
Install why3 and why3find in local switch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install Creusot
       run: |
-        ./INSTALL --skip-extra-tools
+        ./INSTALL --external why3-and-why3find --skip-extra-tools
     - name: Dummy creusot setup
       run: |
         mkdir -p ~/.config/creusot

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,32 +8,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4
+    - name: Cache Cargo build
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - uses: actions/cache@v4
-      id: cache-creusot-setup
+    - name: Cache Opam switch
+      uses: actions/cache@v4
       with:
-        path: |
-          ~/.config/creusot
-          ~/.local/share/creusot
-        key: ${{ runner.os }}-cargo-creusot-setup-${{ hashFiles('creusot-deps.opam', 'creusot-setup/src/tools_versions_urls.rs', 'creusot-setup/src/config.rs') }}
-    - name: Install OCaml
+        path: ~/.local/share/creusot/_opam
+        key: ${{ runner.os }}-opam-${{ hashFiles('creusot-deps.opam') }}
+        restore-keys: ${{ runner.os }}-opam-
+    - name: Install Opam
       uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: 5.3.0
-        opam-local-packages: ci/creusot-deps-nightly.opam
-    - name: Build opam packages
+        opam-pin: false
+    - name: Setup environment
       run: |
         sudo apt update
-        opam install creusot-deps-nightly
-        echo $(opam var bin) >> $GITHUB_PATH
+        opam --cli=2.1 var --global in-creusot-ci=true
     - name: Install Creusot
-      if: steps.cache-creusot-setup.outputs.cache-hit != 'true'
       # Use only 2 parallel provers, because more provers (4) makes replaying proofs unstable
-      run: ./INSTALL --provers-parallelism 2 --no-check-version why3 --no-check-version why3find
+      run: ./INSTALL --provers-parallelism 2
     - run: cargo test --test why3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4
+    - name: Cache Cargo build
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -35,7 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4
+    - name: Cache Cargo build
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -48,13 +50,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4
+    - name: Cache Cargo build
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
     - name: Build
       run: cargo build
     - name: dummy creusot setup
@@ -63,42 +67,7 @@ jobs:
         cp ci/creusot-config-dummy.toml ~/.config/creusot/Config.toml
     - name: Run tests
       run: cargo test
-  why3-deps:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/cache@v4
-      id: cache-opam
-      with:
-        path: |
-          /home/runner/work/creusot/creusot/_opam
-        key: ${{ runner.os }}-opam-${{ hashFiles('creusot-deps.opam') }}
-    - uses: ocaml/setup-ocaml@v3
-      if: steps.cache-opam.outputs.cache-hit != 'true'
-      with:
-        ocaml-compiler: 5.3.0
-    - name: install opam dependencies
-      if: steps.cache-opam.outputs.cache-hit != 'true'
-      run: |
-        sudo apt update
-        opam switch
-        opam --cli=2.1 var --global in-creusot-ci=true
-        opam install .
-        mkdir /tmp/to-delete
-        opam info --list-files why3 why3find > keep
-        sed -i 's/^.*\/_opam\///' keep
-        rsync -a -r --remove-source-files --exclude-from=keep _opam/ /tmp/to-delete
-    - name: archive why3 and why3find
-      run: tar -czf _opam.tar.gz _opam
-      # use tar because upload-artifact does not preserve file permissions
-      # https://github.com/actions/upload-artifact/tree/v4/?tab=readme-ov-file#permission-loss
-    - name: upload why3 and why3find
-      uses: actions/upload-artifact@v4
-      with:
-        name: why3-deps
-        path: _opam.tar.gz
   why3:
-    needs: why3-deps
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -107,31 +76,31 @@ jobs:
     - name: Fetch target branch
       if: github.base_ref
       run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
-    - uses: actions/cache@v4
+    - name: Cache Cargo build
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-creusot-${{ hashFiles('prelude/**', '**/Cargo.lock') }}
-    - uses: actions/cache@v4
-      id: cache-creusot-setup
+        restore-keys: ${{ runner.os }}-cargo-creusot-
+    - name: Cache Opam switch
+      uses: actions/cache/restore@v4 # This cache is saved by the install job
       with:
-        path: |
-          ~/.config/creusot
-          ~/.local/share/creusot
-          _opam/lib/why3find/packages
-        key: ${{ runner.os }}-cargo-creusot-setup-${{ hashFiles('prelude/**', 'creusot-deps.opam', 'creusot-setup/src/tools_versions_urls.rs', 'creusot-setup/src/config.rs') }}
-    - name: download why3 and why3find
-      uses: actions/download-artifact@v4
+        path: ~/.local/share/creusot/_opam
+        key: ${{ runner.os }}-opam-${{ hashFiles('creusot-deps.opam') }}
+        restore-keys: ${{ runner.os }}-opam-
+    - name: Install Opam
+      uses: ocaml/setup-ocaml@v3
       with:
-        name: why3-deps
-    - name: setup opam PATH
+        ocaml-compiler: 5.3.0
+        opam-pin: false
+    - name: Setup environment
       run: |
-        tar -xzf _opam.tar.gz
-        echo /home/runner/work/creusot/creusot/_opam/bin >> $GITHUB_PATH
+        sudo apt update
+        opam --cli=2.1 var --global in-creusot-ci=true
     - name: Install solvers
-      if: steps.cache-creusot-setup.outputs.cache-hit != 'true'
       # Use only 2 parallel provers, because more provers (4) makes replaying proofs unstable
       run: |
         ./INSTALL --skip-cargo-creusot --skip-creusot-rustc --provers-parallelism 2
@@ -141,28 +110,33 @@ jobs:
         cat ~/.config/creusot/why3.conf
     - run: cargo test --test why3
   install:
-    needs: why3-deps
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4
+    - name: Cache Cargo build
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-install-${{ hashFiles('**/Cargo.lock') }}
-    - name: download why3 and why3find
-      uses: actions/download-artifact@v4
+    - name: Cache Opam switch
+      uses: actions/cache@v4
       with:
-        name: why3-deps
-    - name: unpack why3 and why3find
-      run: tar -xzf _opam.tar.gz
-    - name: Setup
-      # Add /home/runner/work/creusot/creusot/_opam/bin to PATH just for this step
+        path: ~/.local/share/creusot/_opam
+        key: ${{ runner.os }}-opam-${{ hashFiles('creusot-deps.opam') }}
+        restore-keys: ${{ runner.os }}-opam-
+    - name: Install Opam
+      uses: ocaml/setup-ocaml@v3
+      with:
+        ocaml-compiler: 5.3.0
+        opam-pin: false
+    - name: Setup environment
       run: |
-        export PATH=/home/runner/work/creusot/creusot/_opam/bin:$PATH
-        ./INSTALL
+        sudo apt update
+        opam --cli=2.1 var --global in-creusot-ci=true
+    - run: ./INSTALL
     - name: test cargo creusot new
       run: |
         set -x
@@ -173,3 +147,5 @@ jobs:
         cargo build
         cargo creusot
         cargo creusot prove
+    - name: Minimize Opam cache
+      run: rm -rf ~/.local/share/creusot/_opam/.opam-switch/{build,sources}

--- a/HACKING.md
+++ b/HACKING.md
@@ -22,7 +22,7 @@ To avoid first installing the `cargo-creusot` binary before running `cargo
 
 ## Running the testsuite
 
-- Test the output of creusot (coma files) against reference files:
+Test the output of creusot (coma files) against reference files:
 ```
 cargo test --test ui
 ```
@@ -32,16 +32,21 @@ Then, to update an out-of-date reference file:
 cargo test --test ui -- "optional-string" --bless
 ```
 
-(NB: to bless all the tests, you need to pass the empty string `""`)
-
-- Replay proofs:
+Replay proofs:
 ```
 cargo test --test why3
 ```
 
 Additional useful parameters, to avoid replaying *every* proof in development:
 - `--diff-from=GIT_REF`
-- `--replay=<none|obsolete|all>`
+
+Update `proof.json` of selected tests:
+```
+cargo test --test why3 -- "optional-string" --update
+```
+
+Note: the `why3` tests require Creusot to be installed so that the necessary tools can be found
+(Why3, Why3find, and provers).
 
 ## Inspecting/fixing the proof of a test
 

--- a/README.md
+++ b/README.md
@@ -40,31 +40,26 @@ More examples are found in [tests/should_succeed](tests/should_succeed).
 1. [Install `rustup`](https://www.rust-lang.org/tools/install), to get the suitable Rust toolchain
 2. [Get `opam`](https://opam.ocaml.org/doc/Install.html), the package manager for OCaml
 3. Clone the [creusot](https://github.com/creusot-rs/creusot/) repository,
-   then *move into the `creusot` directory* for the rest of the setup.
+   then move into the `creusot` directory.
     ```
     $ git clone https://github.com/creusot-rs/creusot
     $ cd creusot
     ```
-4. Set up **Why3** and **Why3find**. Create a local `opam` switch with why3:
-   ```
-   $ opam switch create -y . ocaml.5.3.0
-   $ eval $(opam env)
-   ```
-   This will build `why3`, `why3find`, and their ocaml dependencies in a local `_opam` directory.
-5. Install **Creusot**:
+4. Install **Creusot**:
    ```
    $ ./INSTALL
    ```
-   The installation consists of:
+   A regular installation consists of:
    - the `cargo-creusot` executable in `~/.cargo/bin/`;
    - the `creusot-rustc` executable in `~/.local/share/creusot/toolchains/$TOOLCHAIN/bin`;
+   - the `why3` and `why3find` executables in `~/.local/share/creusot/_opam/bin` (in a local opam switch);
+   - the Creusot prelude in `~/.local/share/creusot/_opam/lib/why3find/packages/creusot`;
    - SMT solvers (Alt-Ergo, CVC4, CVC5, Z3) in `~/.local/share/creusot/bin`;
    - configuration files in `~/.config/creusot/`.
 
-## Configuring the installation
-
-You can create a text file `INSTALL.opts` to remember command-line options to be passed
-to the installation script. Type `./INSTALL --help` for a list of possible options.
+Installation options can be set in a text file `INSTALL.opts`.
+They are just space-separated command-line arguments.
+Type `./INSTALL --help` for a list of available options.
 For example:
 
 ```

--- a/why3tests/tests/why3.rs
+++ b/why3tests/tests/why3.rs
@@ -55,6 +55,10 @@ fn main() {
 
     std::env::set_current_dir("..").unwrap();
 
+    // Use the Creusot installation for Why3, Why3find, and solvers (because they're a pain to keep track of if we allow them to come from anywhere)
+    let creusot_setup::Paths { why3, why3find, why3_config } =
+        creusot_setup::creusot_paths().unwrap();
+    // Use the local prelude, so that it's easy to test quick changes.
     let build_prelude_success = Command::new("cargo")
         .args(["run", "-p", "creusot-install", "--", "--only-build-prelude"])
         .status()
@@ -116,9 +120,8 @@ fn main() {
         sessiondir.set_file_name(file.file_stem().unwrap());
 
         let output;
-        let paths = creusot_setup::creusot_paths().unwrap();
-        let mut why3 = Command::new(paths.why3.clone());
-        why3.arg("-C").arg(&paths.why3_config);
+        let mut why3 = Command::new(&why3);
+        why3.arg("-C").arg(&why3_config);
         why3.arg("--warn-off=unused_variable");
         why3.arg("--warn-off=clone_not_abstract");
         why3.arg("--warn-off=axiom_abstract");
@@ -222,8 +225,8 @@ fn main() {
                 }
             }
         } else {
-            let mut why3find = Command::new(paths.why3find);
-            why3find.env("WHY3CONFIG", &paths.why3_config);
+            let mut why3find = Command::new(&why3find);
+            why3find.env("WHY3CONFIG", &why3_config);
             why3find.arg("prove").arg(file.canonicalize().unwrap());
             why3find.arg("--root");
             why3find.arg("target");


### PR DESCRIPTION
Close #1359

- This finally reduces the installation to "clone then install".
- `./INSTALL` now creates a local switch in `~/.local/share/creusot/_opam`, and reuses it if there already is one.
- an install option `--external why3-and-why3find` to use whatever is in the `$PATH`. That is the old behavior, "for experts". ~~CI also uses this option because the new behavior doesn't work well with caching (we do not want to cache the whole opam switch in CI (3Gb)).~~
- I noticed that `cargo test --test why3` does an odd thing where it uses the installed `why3`, `why3find`, and provers, but the local prelude. It's a bit ad hoc, but I also couldn't think of a better solution, so I added some comments to remember that oddity.