### PR TITLE
fix: markdown links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Follow the instructions provided in the [README](./README.md). This will provide
 
 ## 2.1. UI Tests
 
-The UI tests are used to validate the translation of Creusot. They can be found in `creusot/tests/should_fail` and `creusot/tests/should_suceed`.
+The UI tests are used to validate the translation of Creusot. They can be found in `tests/should_fail` and `tests/should_suceed`.
 Ideally, each test includes a comment specifying the property or feature being checked.
 To validate the translation one can run `cargo test --test ui`, or to run only a subset of tests run `cargo test --test ui "pattern"`.
 
@@ -19,7 +19,7 @@ When contributing or updating tests, we ask that you minimize avoidable warnings
 The warnings and errors of each test are recorded in an accompanying `stderr` file if any were present.
 
 The `ui` test also runs the Creusot translation on `creusot-contracts`.
-The result is located at `creusot/tests/creusot-contracts/creusot-contracts.coma`.
+The result is located at `tests/creusot-contracts/creusot-contracts.coma`.
 To run the translation only on `creusot-contracts`, use a pattern that matches nothing, like `cargo test --test ui qq`
 
 # 3. Verifying proofs

--- a/HACKING.md
+++ b/HACKING.md
@@ -46,9 +46,9 @@ Additional useful parameters, to avoid replaying *every* proof in development:
 ## Inspecting/fixing the proof of a test
 
 If the proof of a test is broken (e.g.
-`creusot/tests/should_succeed/cell/01.rs`), launch the why3 ide with `./ide`:
+`tests/should_succeed/cell/01.rs`), launch the why3 ide with `./ide`:
 ```
-./ide creusot/tests/should_succeed/cell/01
+./ide tests/should_succeed/cell/01
 ```
 
 ## Calling why3 (and why3_tools, etc): shell environment setup

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ If you would like to cite Creusot in academic contexts, we encourage you to use 
 
 To get an idea of what verifying a program with Creusot looks like, we encourage you to take a look at some of our test suite:
 
-- [Zeroing out a vector](creusot/tests/should_succeed/vector/01.rs)
-- [Binary search on Vectors](creusot/tests/should_succeed/vector/04_binary_search.rs)
-- [Sorting a vector](creusot/tests/should_succeed/vector/02_gnome.rs)
-- [IterMut](creusot/tests/should_succeed/iterators/02_iter_mut.rs)
-- [Normalizing If-Then-Else Expressions](creusot/tests/should_succeed/ite_normalize.rs)
+- [Zeroing out a vector](tests/should_succeed/vector/01.rs)
+- [Binary search on Vectors](tests/should_succeed/vector/04_binary_search.rs)
+- [Sorting a vector](tests/should_succeed/vector/02_gnome.rs)
+- [IterMut](tests/should_succeed/iterators/02_iter_mut.rs)
+- [Normalizing If-Then-Else Expressions](tests/should_succeed/ite_normalize.rs)
 
-More examples are found in [creusot/tests/should_succeed](creusot/tests/should_succeed).
+More examples are found in [tests/should_succeed](tests/should_succeed).
 
 ## Projects built with Creusot
 


### PR DESCRIPTION
Hey, thanks for the great work on this project!

I'm exploring formal methods and came across this repo. I noticed some markdown links stopped working due to file moves, so this PR fixes them.

There are still some outdated links in:
* .gitattributes
* testsuite_regenerate
* testsuite_upgrade_prover
* session_stats.rs

Might be worth checking those as well.

Thanks!