### PR TITLE
creusot-contracts-dummy: Replace #[path] attribute with symbolic link

### DIFF
--- a/creusot-contracts-dummy/src/ghost.rs
+++ b/creusot-contracts-dummy/src/ghost.rs
@@ -1,0 +1,1 @@
+../../creusot-contracts-proc/src/ghost.rs

--- a/creusot-contracts-dummy/src/lib.rs
+++ b/creusot-contracts-dummy/src/lib.rs
@@ -1,6 +1,5 @@
 extern crate proc_macro;
 
-#[path = "../../creusot-contracts-proc/src/ghost.rs"]
 mod ghost;
 
 use proc_macro::TokenStream as TS1;


### PR DESCRIPTION
Makes the package self-contained so it can be published.