### PR TITLE
Update Rust edition in all crates

### DIFF
--- a/creusot-contracts-dummy/Cargo.toml
+++ b/creusot-contracts-dummy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "creusot-contracts-dummy"
 version = "0.4.0"
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/creusot-rs/creusot"
 license = "LGPL-2.1-or-later"
 description = "Dummy proc macros for creusot-contracts"

--- a/creusot-install/Cargo.toml
+++ b/creusot-install/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "creusot-install"
 version = "0.4.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "creusot-tests"
 authors = ["Xavier Denis <xldenis@gmail.com>"]
-edition = "2021"
+edition = "2024"
 license = "LGPL-2.1-or-later"
 publish = false
 


### PR DESCRIPTION
I was wondering why `cargo fmt` was not behaving the same as `rustfmt`. `rustfmt` defaults to the latest edition and "style edition".