### PR TITLE
Do not pass the `sysroot` flag to rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,6 @@ dependencies = [
  "env_logger",
  "serde",
  "serde_json",
- "toml",
 ]
 
 [[package]]

--- a/creusot-rustc/Cargo.toml
+++ b/creusot-rustc/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 serde_json = { version = "1.0" }
 creusot = { path = "../creusot", version = "0.4" }
-toml = "0.8"
 env_logger = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 creusot-args = { path = "../creusot-args" }

--- a/creusot-rustc/src/main.rs
+++ b/creusot-rustc/src/main.rs
@@ -16,7 +16,7 @@ use creusot_args::CREUSOT_RUSTC_ARGS;
 use options::CreusotArgs;
 use rustc_driver::run_compiler;
 use rustc_session::{EarlyDiagCtxt, config::ErrorOutputType};
-use std::{env, panic, process::Command};
+use std::{env, panic};
 
 const BUG_REPORT_URL: &str = "https://github.com/creusot-rs/creusot/issues/new";
 
@@ -62,9 +62,6 @@ fn setup_plugin() {
     let has_contracts =
         args.iter().any(|arg| arg == "creusot_contracts" || arg.contains("creusot_contracts="));
 
-    let sysroot = sysroot_path();
-    args.push(format!("--sysroot={}", sysroot));
-
     match creusot {
         Some(creusot) if has_contracts => {
             for &arg in CREUSOT_RUSTC_ARGS {
@@ -83,20 +80,4 @@ fn setup_plugin() {
             run_compiler(&args, &mut DefaultCallbacks)
         }
     }
-}
-
-fn sysroot_path() -> String {
-    let toolchain: toml::Value = toml::from_str(include_str!("../../rust-toolchain")).unwrap();
-    let channel = toolchain["toolchain"]["channel"].as_str().unwrap();
-
-    let output = Command::new("rustup")
-        .arg("run")
-        .arg(channel)
-        .arg("rustc")
-        .arg("--print")
-        .arg("sysroot")
-        .output()
-        .unwrap();
-
-    String::from_utf8(output.stdout).unwrap().trim().to_owned()
 }


### PR DESCRIPTION
This is no longer needed: simply linking against rustc_driver does the job. See rust-lang/rust#103660.

Fixes #1429.