### PR TITLE
Do not check that trusted impls are correct.

### DIFF
--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -172,7 +172,7 @@ fn display_impl_subject(i: &rustc_middle::ty::ImplSubject<'_>) -> String {
     }
 }
 
-pub fn is_trusted_function(tcx: TyCtxt, mut def_id: DefId) -> bool {
+pub fn is_trusted_item(tcx: TyCtxt, mut def_id: DefId) -> bool {
     if is_spec(tcx, def_id) {
         return false;
     }

--- a/creusot/src/backend/clone_map/elaborator.rs
+++ b/creusot/src/backend/clone_map/elaborator.rs
@@ -7,7 +7,7 @@ use crate::{
     backend::{
         Namer, TranslationCtx, Why3Generator,
         clone_map::{CloneNames, Dependency, Kind},
-        is_trusted_function,
+        is_trusted_item,
         logic::{lower_logical_defn, spec_axiom},
         program,
         signature::sig_to_why3,
@@ -189,7 +189,7 @@ impl DepElab for LogicElab {
             trait_resol,
             Some(traits::TraitResolved::UnknownFound | traits::TraitResolved::UnknownNotFound)
         ) || !ctx.is_transparent_from(def_id, elab.self_key.did().unwrap().0)
-            || is_trusted_function(ctx.tcx, def_id);
+            || is_trusted_item(ctx.tcx, def_id);
 
         let mut names = elab.namer(dep);
         let name = names.dependency(dep).ident();
@@ -401,7 +401,7 @@ fn expand_laws<'tcx>(
     // TODO: Push out of graph expansion
     // If the function we are cloning into is `#[trusted]` there is no need for laws.
     // Similarily, if it has no body, there will be no proofs.
-    if is_trusted_function(ctx.tcx, self_did) || !ctx.has_body(self_did) {
+    if is_trusted_item(ctx.tcx, self_did) || !ctx.has_body(self_did) {
         return;
     }
 

--- a/creusot/src/backend/logic.rs
+++ b/creusot/src/backend/logic.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::{
-        CannotFetchThir, Why3Generator, is_trusted_function, logic::vcgen::wp,
-        signature::sig_to_why3, term::lower_pure, ty::translate_ty,
+        CannotFetchThir, Why3Generator, is_trusted_item, logic::vcgen::wp, signature::sig_to_why3,
+        term::lower_pure, ty::translate_ty,
     },
     contracts_items::get_builtin,
     ctx::*,
@@ -37,7 +37,7 @@ pub(crate) fn translate_logic_or_predicate(
         );
     }
 
-    if !def_id.is_local() || is_trusted_function(ctx.tcx, def_id) || !ctx.has_body(def_id) {
+    if !def_id.is_local() || is_trusted_item(ctx.tcx, def_id) || !ctx.has_body(def_id) {
         return Ok(None);
     }
 

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -3,7 +3,7 @@ use crate::{
         NameSupply, Namer, Why3Generator,
         clone_map::PreludeModule,
         dependency::Dependency,
-        is_trusted_function,
+        is_trusted_item,
         optimization::{gather_usage, infer_proph_invariants, simplify_fmir},
         place::{Focus, create_assign_inner, projections_to_expr, rplace_to_expr},
         signature::sig_to_why3,
@@ -56,7 +56,7 @@ pub(crate) fn translate_function<'tcx, 'sess>(
 ) -> Option<FileModule> {
     let mut names = Dependencies::new(ctx, def_id);
 
-    if !def_id.is_local() || !ctx.has_body(def_id) || is_trusted_function(ctx.tcx, def_id) {
+    if !def_id.is_local() || !ctx.has_body(def_id) || is_trusted_item(ctx.tcx, def_id) {
         return None;
     }
 

--- a/creusot/src/backend/traits.rs
+++ b/creusot/src/backend/traits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::{Why3Generator, clone_map::Dependencies, term::lower_pure},
+    backend::{Why3Generator, clone_map::Dependencies, is_trusted_item, term::lower_pure},
     contracts_items::is_snapshot_deref,
     ctx::FileModule,
 };
@@ -7,6 +7,10 @@ use rustc_hir::def_id::DefId;
 use why3::declaration::{Decl, Goal, Module};
 
 pub(crate) fn lower_impl<'tcx>(ctx: &Why3Generator<'tcx>, def_id: DefId) -> Vec<FileModule> {
+    if is_trusted_item(ctx.tcx, def_id) {
+        return vec![];
+    }
+
     let data = ctx.trait_impl(def_id).clone();
     let mut res = vec![];
 

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -8,7 +8,7 @@ pub(crate) mod specification;
 pub(crate) mod traits;
 
 use crate::{
-    backend::{Why3Generator, is_trusted_function},
+    backend::{Why3Generator, is_trusted_item},
     contracts_items::{
         AreContractsLoaded, are_contracts_loaded, is_logic, is_no_translate, is_predicate, is_spec,
     },
@@ -65,7 +65,7 @@ pub(crate) fn before_analysis(ctx: &mut TranslationCtx) -> Result<(), Box<dyn st
 
         let def_id = def_id.to_def_id();
         if (is_spec(ctx.tcx, def_id) || is_predicate(ctx.tcx, def_id) || is_logic(ctx.tcx, def_id))
-            && !is_trusted_function(ctx.tcx, def_id)
+            && !is_trusted_item(ctx.tcx, def_id)
         {
             // OK to ignore this error, because we abort after the loop.
             let _ = ctx.term(def_id);

--- a/creusot/src/validate/purity.rs
+++ b/creusot/src/validate/purity.rs
@@ -5,7 +5,7 @@ use rustc_middle::{
 };
 
 use crate::{
-    backend::is_trusted_function,
+    backend::is_trusted_item,
     contracts_items::{
         get_builtin, is_ghost_deref, is_ghost_deref_mut, is_ghost_into_inner, is_ghost_new,
         is_logic, is_no_translate, is_predicate, is_prophetic, is_snapshot_closure, is_spec,
@@ -15,9 +15,8 @@ use crate::{
     pearlite::{Stub, pearlite_stub},
     specification::contract_of,
     traits::TraitResolved,
+    validate::is_overloaded_item,
 };
-
-use super::is_overloaded_item;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Purity {
@@ -101,7 +100,7 @@ pub(crate) fn validate_purity(
     let def_id = def_id.to_def_id();
     let purity = Purity::of_def_id(ctx, def_id);
     if matches!(purity, Purity::Program { .. })
-        && (is_no_translate(ctx.tcx, def_id) || is_trusted_function(ctx.tcx, def_id))
+        && (is_no_translate(ctx.tcx, def_id) || is_trusted_item(ctx.tcx, def_id))
     {
         return Ok(());
     }

--- a/creusot/src/validate/terminates.rs
+++ b/creusot/src/validate/terminates.rs
@@ -31,7 +31,7 @@
 //! [`ImplDefaultTransparent`] for more details.
 
 use crate::{
-    backend::is_trusted_function,
+    backend::is_trusted_item,
     contracts_items::{has_variant_clause, is_no_translate, is_pearlite},
     ctx::TranslationCtx,
     error::CannotFetchThir,
@@ -540,7 +540,7 @@ impl CallGraph {
 
         for local_id in ctx.hir().body_owners() {
             let def_id = local_id.to_def_id();
-            if is_trusted_function(ctx.tcx, def_id) || is_no_translate(ctx.tcx, def_id) {
+            if is_trusted_item(ctx.tcx, def_id) || is_no_translate(ctx.tcx, def_id) {
                 continue;
             }
             let (thir, expr) = ctx.thir_body(local_id).unwrap();
@@ -566,7 +566,7 @@ impl CallGraph {
             let def_id = local_id.to_def_id();
             let node = build_call_graph.insert_function(ctx.tcx, GraphNode::Function(def_id));
 
-            if is_trusted_function(ctx.tcx, def_id) || is_no_translate(ctx.tcx, def_id) {
+            if is_trusted_item(ctx.tcx, def_id) || is_no_translate(ctx.tcx, def_id) {
                 // Cut all arcs from this function.
                 continue;
             }


### PR DESCRIPTION
These impls may require additional predictates from extern specs, and these may not be implemented.