### PR TITLE
Update Why3/Why3find versions

### DIFF
--- a/creusot-deps.opam
+++ b/creusot-deps.opam
@@ -4,9 +4,9 @@ opam-version: "2.0"
 maintainer: "Armaël Guéneau <armael.gueneau@inria.fr>"
 authors: "the creusot authors"
 depends: [
-  "why3" {= "git-187f"}
-  "why3-ide" {= "git-187f" & !?in-creusot-ci}
-  "why3find" {= "git-f572"}
+  "why3" {= "git-9c6f"}
+  "why3-ide" {= "git-9c6f" & !?in-creusot-ci}
+  "why3find" {= "git-d227"}
 # optional dependencies of why3
   "ocamlgraph"
   "camlzip"
@@ -15,7 +15,7 @@ depends: [
 # When updating the hash and git-XXX below, don't forget to update them in the
 # depends: field above!
 pin-depends: [
-  [ "why3.git-187f" "git+https://gitlab.inria.fr/why3/why3.git#187fd5210" ]
-  [ "why3-ide.git-187f" "git+https://gitlab.inria.fr/why3/why3.git#187fd5210" ]
-  [ "why3find.git-f572" "git+https://git.frama-c.com/pub/why3find.git#f57220c" ]
+  [ "why3.git-9c6f" "git+https://gitlab.inria.fr/why3/why3.git#9c6f54fbb" ]
+  [ "why3-ide.git-9c6f" "git+https://gitlab.inria.fr/why3/why3.git#9c6f54fbb" ]
+  [ "why3find.git-d227" "git+https://git.frama-c.com/pub/why3find.git#d227fc5" ]
 ]

--- a/creusot-install/src/main.rs
+++ b/creusot-install/src/main.rs
@@ -132,7 +132,7 @@ fn install_why3(cfg: &CfgPaths) -> anyhow::Result<()> {
         // Upgrade existing switch
         fs::copy(PathBuf::from("creusot-deps.opam"), switch_dir.join("creusot-deps.opam"))?;
         let mut cmd = Command::new("opam");
-        cmd.args(["install", "creusot-deps", "-y", "--switch"]).arg(switch_dir);
+        cmd.args(["install", "-y", "--switch"]).arg(&switch_dir).arg(switch_dir);
         if !cmd.status()?.success() {
             bail!("Failed to upgrade why3 and why3find")
         }


### PR DESCRIPTION
- in Why3, a memory leak was fixed (affects Creusot IDE)