### PR TITLE
Reintroduce Expr::boxed

### DIFF
--- a/why3/src/coma.rs
+++ b/why3/src/coma.rs
@@ -136,6 +136,10 @@ impl Defn {
 }
 
 impl Expr {
+    pub fn boxed(self) -> Box<Self> {
+        Box::new(self)
+    }
+
     pub fn app(self, args: impl IntoIterator<Item = Arg>) -> Self {
         args.into_iter().fold(self, |acc, a| Expr::App(Box::new(acc), Box::new(a)))
     }


### PR DESCRIPTION
Apparently we can use `.into()` on array to make boxed slices, and I quite liked the consistency with `.boxed()`.