### PR TITLE
Added temporary documentation for versioning mismatch issue

### DIFF
--- a/guide/src/quickstart.md
+++ b/guide/src/quickstart.md
@@ -37,6 +37,20 @@ A successful run gives us the certainty that functions defined in this package s
 for all arguments satisfying the preconditions (`requires` clauses), the result of the function will
 satisfy the postconditions (`ensures` clauses).
 
+However, if you get this error 
+```
+error: The `creusot_contracts` crate is loaded, but the following items are missing: ghost_new, ghost_into_inner, ghost_inner_logic, ghost_deref, ghost_deref_mut, ghost_ty. Maybe your version of `creusot-contracts` is wrong?
+```
+
+Then you can fix it by going into your Cargo.toml file in your new project and changing
+```
+creusot-contracts = "0.4.0"
+```
+To 
+```
+creusot-contracts = { path = "/relative/or/absolute/path/to/creusot-contracts/in/creusot/directory" }
+```
+
 ## Prove with Why3
 
 Finally, launch the why3 ide:


### PR DESCRIPTION
When I was following the [quickstart](https://creusot-rs.github.io/creusot/guide/), I came across this error: 
`The creusot_contracts crate is loaded, but the following items are missing: ghost_new, ghost_into_inner, ghost_inner_logic, ghost_deref, ghost_deref_mut, ghost_ty. Maybe your version of creusot-contracts is wrong?`

Luckily for me, issue #1447 gave me the solution to this issue, that being to replace `creusot-contracts = "0.4.0"` with `creusot-contracts = { path = "/path/to/creusot-contracts"` in Cargo.toml of the new project. The issue also gives some useful details about the issue.

Until this issue is solved, I think that some special documentation should be added to quickstart.md so nobody will need to look for #1447  in order to get the solution.

