### PR TITLE
Handle version mismatch of creusot-contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-creusot"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "creusot"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "creusot-metadata",
  "include_dir",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-args"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "clap",
  "serde",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-contracts"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "creusot-contracts-proc",
  "num-rational",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-contracts-proc"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "pearlite-syn",
  "proc-macro2",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-dev-config"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "creusot-setup",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-install"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -535,14 +535,14 @@ dependencies = [
 
 [[package]]
 name = "creusot-metadata"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "creusot-rustc"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "creusot",
  "creusot-args",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-setup"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "anyhow",
  "creusot-args",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "pearlite-syn"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "why3"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "why3tests"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "serde_json",
  "tempdir",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2560,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.23"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",

--- a/cargo-creusot/Cargo.toml
+++ b/cargo-creusot/Cargo.toml
@@ -20,3 +20,4 @@ include_dir = "0.7"
 tempdir = "0.3"
 glob = "0.3"
 const-str = { version = "0.6.2", features = ["proc"] }
+toml_edit = "0.22.24"

--- a/cargo-creusot/Cargo.toml
+++ b/cargo-creusot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-creusot"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 publish = false
 

--- a/cargo-creusot/src/helpers.rs
+++ b/cargo-creusot/src/helpers.rs
@@ -66,3 +66,19 @@ pub(crate) fn get_coma(options: &CommonOptions) -> (PathBuf, Option<String>) {
     }
     (coma_src, coma_glob)
 }
+
+/// Only remember the version string at compile-time
+pub const CREUSOT_CONTRACTS_VERSION: &str = {
+    use const_str::split;
+    split!(split!(include_str!("../../creusot-contracts/Cargo.toml"), "version = \"")[1], "\"")[0]
+};
+
+pub fn creusot_contracts_path() -> PathBuf {
+    // This must be the dev version of `cargo-creusot`.
+    // It should have been installed from source and `creusot-contracts`
+    // should be available next to its source.
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.push("creusot-contracts");
+    path
+}

--- a/creusot-args/Cargo.toml
+++ b/creusot-args/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-args"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 publish = false
 

--- a/creusot-contracts-proc/Cargo.toml
+++ b/creusot-contracts-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-contracts-proc"
-version = "0.4.0"
+version = "0.5.0-dev"
 authors = ["Xavier Denis <xldenis@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/creusot-rs/creusot"
@@ -22,7 +22,7 @@ creusot = ["dep:uuid", "dep:pearlite-syn", "proc-macro2/span-locations"]
 [dependencies]
 quote = "1.0"
 uuid = { version = "1.12", features = ["v4"], optional = true }
-pearlite-syn = { version = "0.4", path = "../pearlite-syn", features = ["full"], optional = true }
+pearlite-syn = { version = "0.5.0-dev", path = "../pearlite-syn", features = ["full"], optional = true }
 syn = { version = "2.0", features = ["full", "visit-mut"] }
 proc-macro2 = { version = "1.0" }
 

--- a/creusot-contracts/Cargo.toml
+++ b/creusot-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-contracts"
-version = "0.4.0"
+version = "0.5.0-dev"
 authors = ["Xavier Denis <xldenis@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/creusot-rs/creusot"
@@ -13,7 +13,7 @@ description = "Provides contracts and logic helpers for Creusot"
 num-rational = "0.4"
 
 [dependencies]
-creusot-contracts-proc = { path = "../creusot-contracts-proc", version = "0.4.0" }
+creusot-contracts-proc = { path = "../creusot-contracts-proc", version = "0.5.0-dev" }
 
 [features]
 # Enabled by creusot.

--- a/creusot-dev-config/Cargo.toml
+++ b/creusot-dev-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-dev-config"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 publish = false
 

--- a/creusot-install/Cargo.toml
+++ b/creusot-install/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-install"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 publish = false
 

--- a/creusot-metadata/Cargo.toml
+++ b/creusot-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-metadata"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 publish = false
 

--- a/creusot-rustc/Cargo.toml
+++ b/creusot-rustc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-rustc"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 publish = false
 
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 serde_json = { version = "1.0" }
-creusot = { path = "../creusot", version = "0.4" }
+creusot = { path = "../creusot", version = "0.5.0-dev" }
 env_logger = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 creusot-args = { path = "../creusot-args" }

--- a/creusot-setup/Cargo.toml
+++ b/creusot-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-setup"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 publish = false
 

--- a/creusot/Cargo.toml
+++ b/creusot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot"
-version = "0.4.0"
+version = "0.5.0-dev"
 authors = ["Xavier Denis <xldenis@gmail.com>"]
 edition = "2024"
 license = "LGPL-2.1-or-later"

--- a/guide/src/command_line_interface.md
+++ b/guide/src/command_line_interface.md
@@ -74,7 +74,7 @@ otherwise you can remove them with `cargo creusot clean`.
 - `--force`: Don't ask for confirmation before removing dangling files.
 - `--dry-run`: Only print the list of files that would be removed by `cargo creusot clean`.
 
-## Create package
+## Create and maintain package
 
 ### `new`
 
@@ -113,6 +113,25 @@ Generate `why3find` configuration.
 
 This is used to set up Creusot in an existing Rust package.
 You don't need to run this command if you used `cargo creusot new` or `cargo creusot init`.
+
+### `patch-deps`
+
+```
+cargo creusot patch-deps
+```
+
+Update `Cargo.toml` with a `creusot-contracts` version matching your Creusot installation.
+
+For released versions of Creusot, this is equivalent to `cargo add creusot-contracts@$VERSION` just with the right version.
+
+For a development version of Creusot (those that don't have a git tag), this also adds the following lines:
+
+```
+[patch.crates-io]
+creusot-contracts = { path = "/path/to/creusot-contracts" }
+```
+
+This setting is documented in [The Cargo Book: Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html).
 
 ## Show configuration
 

--- a/guide/src/quickstart.md
+++ b/guide/src/quickstart.md
@@ -37,19 +37,22 @@ A successful run gives us the certainty that functions defined in this package s
 for all arguments satisfying the preconditions (`requires` clauses), the result of the function will
 satisfy the postconditions (`ensures` clauses).
 
-However, if you get this error 
+### Troubleshooting
+
+If you get an error like this
+
 ```
-error: The `creusot_contracts` crate is loaded, but the following items are missing: ghost_new, ghost_into_inner, ghost_inner_logic, ghost_deref, ghost_deref_mut, ghost_ty. Maybe your version of `creusot-contracts` is wrong?
+error: The `creusot_contracts` crate is loaded, but the following items are missing: <a list of identifiers> Maybe your version of `creusot-contracts` is wrong?
 ```
 
-Then you can fix it by going into your Cargo.toml file in your new project and changing
+Add the following to your `Cargo.toml` file:
+
 ```
-creusot-contracts = "0.4.0"
-```
-To 
-```
+[patch.crates-io]
 creusot-contracts = { path = "/relative/or/absolute/path/to/creusot-contracts/in/creusot/directory" }
 ```
+
+And please notify the Creusot developers that the version of Creusot should be bumped to `NEXT_VERSION-dev` to prevent this error.
 
 ## Prove with Why3
 

--- a/pearlite-syn/Cargo.toml
+++ b/pearlite-syn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pearlite-syn"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/creusot-rs/creusot"

--- a/why3/Cargo.toml
+++ b/why3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "why3"
-version = "0.4.0"
+version = "0.5.0-dev"
 authors = ["Xavier Denis <xldenis@gmail.com>"]
 edition = "2024"
 repository = "https://github.com/creusot-rs/creusot"

--- a/why3tests/Cargo.toml
+++ b/why3tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "why3tests"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
Fix #1447

- The `creusot-contracts` version is now checked by `cargo creusot`, which should prevent the error about missing definitions in `creusot-contracts`.
- Added a `patch-dep` command which is basically `cargo add creusot-contracts@VERSION`, but (1) `patch-dep` knows what `VERSION` to use, (2) `patch-dep` also handles unreleased versions of creusot-contracts by adding the local path to it in `Cargo.toml`.
- This works only if we make sure to bump the versions of `cargo-creusot` and `creusot-contracts` on `master` to `NEXT_VERSION-dev` as soon as there is a breaking change. The existing "install" test on CI will remind us of this (hopefully) at least in the most flagrant case where new primitives are added by `creusot-contracts` that are used in `creusot`.