### PR TITLE
cargo-creusot: Refactor handling of existing Rust projects

### DIFF
--- a/cargo-creusot/src/why3find_wrapper.rs
+++ b/cargo-creusot/src/why3find_wrapper.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use clap::*;
-use creusot_setup::{PROVERS, Paths, creusot_paths};
+use creusot_setup::{Paths, creusot_paths};
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -25,32 +25,6 @@ pub struct ConfigArgs {
 
 fn why3find_json_exists() -> bool {
     Path::new("why3find.json").exists()
-}
-
-fn raw_config(args: &Vec<String>, paths: &Paths) -> Result<()> {
-    let mut why3find = Command::new(&paths.why3find);
-    why3find
-        .arg("config")
-        .arg("--quiet")
-        .arg("--why3-warn-off")
-        .arg("unused_variable,axiom_abstract")
-        .arg("--package")
-        .arg("creusot");
-    for prover in PROVERS {
-        why3find.arg("--prover").arg(format!("+{}", prover.binary_name));
-    }
-    for arg in args {
-        why3find.arg(arg);
-    }
-    why3find
-        .env("WHY3CONFIG", &paths.why3_config)
-        .status()
-        .map_err(|e| anyhow::Error::new(e).context("'why3find config' failed to launch"))
-        .and_then(
-            |status| {
-                if status.success() { Ok(()) } else { Err(anyhow!("'why3find config' failed")) }
-            },
-        )
 }
 
 fn raw_prove(args: ProveArgs, paths: &Paths) -> Result<()> {
@@ -82,16 +56,11 @@ fn raw_prove(args: ProveArgs, paths: &Paths) -> Result<()> {
         )
 }
 
-pub fn why3find_config(args: ConfigArgs) -> Result<()> {
-    let paths = creusot_paths()?;
-    raw_config(&args.args, &paths)
-}
-
 pub fn why3find_prove(args: ProveArgs) -> Result<()> {
     let paths = creusot_paths()?;
     if !why3find_json_exists() {
         return Err(anyhow::anyhow!(
-            "why3find.json not found. Perhaps you are in the wrong directory, or you need to run `cargo creusot config`."
+            "why3find.json not found. Perhaps you are in the wrong directory, or you need to run `cargo creusot init`."
         ));
     }
     raw_prove(args, &paths)

--- a/creusot-setup/src/lib.rs
+++ b/creusot-setup/src/lib.rs
@@ -186,6 +186,7 @@ pub fn status() -> anyhow::Result<()> {
 pub struct Paths {
     pub why3: PathBuf,
     pub why3find: PathBuf,
+    pub config_dir: PathBuf,
     pub why3_config: PathBuf,
 }
 
@@ -216,6 +217,7 @@ pub fn creusot_paths() -> anyhow::Result<Paths> {
             Ok(Paths {
                 why3: cfg.why3.path.to_path_buf(),
                 why3find: cfg.why3find.path.to_path_buf(),
+                config_dir: paths.config_dir,
                 why3_config: paths.why3_config_file,
             })
         }

--- a/guide/src/command_line_interface.md
+++ b/guide/src/command_line_interface.md
@@ -8,8 +8,6 @@
 - [`cargo creusot clean`](#clean)
 - [`cargo creusot new`](#new)
 - [`cargo creusot init`](#init)
-- [`cargo creusot config`](#config)
-- [`cargo creusot setup install`](#setup-install)
 - [`cargo creusot setup status`](#setup-status)
 
 ## Main commands
@@ -82,9 +80,9 @@ otherwise you can remove them with `cargo creusot clean`.
 cargo creusot new <NAME> [--main]
 ```
 
-Create package named `<NAME>`.
+Create or update package named `<NAME>`.
 
-Create a directory `<NAME>` and initialize it with starting configuration and source files.
+Create directory `<NAME>` if it doesn't already exist, and run `cargo creusot init` inside it.
 
 #### Options
 
@@ -96,42 +94,31 @@ Create a directory `<NAME>` and initialize it with starting configuration and so
 cargo creusot init [<NAME>] [--main]
 ```
 
-Create package in the current directory.
+Create or update package in the current directory.
+
+If `Cargo.toml` doesn't exist, create a new package with starting configuration and source files.
+
+If `Cargo.toml` exists, update an existing package for verification with Creusot:
+
+- add or update `creusot-contracts` in the list of dependencies with the version matching your Creusot installation;
+
+    For released versions of Creusot, this is equivalent to `cargo add creusot-contracts@<VERSION>` just with the right version.
+
+    For a development version of Creusot (prerelease version `-dev`), this also adds the following lines:
+
+    ```
+    [patch.crates-io]
+    creusot-contracts = { path = "/path/to/creusot-contracts" }
+    ```
+
+    This setting is documented in [The Cargo Book: Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html).
+
+- add `why3find.json` if it doesn't exist.
 
 #### Options
 
 - `<NAME>`: Name of the package. (By default, it is the name of the directory.)
 - `--main`: Create `main.rs` for an executable crate. (By default, only a library crate `lib.rs` is created.)
-
-### `config`
-
-```
-cargo creusot config
-```
-
-Generate `why3find` configuration.
-
-This is used to set up Creusot in an existing Rust package.
-You don't need to run this command if you used `cargo creusot new` or `cargo creusot init`.
-
-### `patch-deps`
-
-```
-cargo creusot patch-deps
-```
-
-Update `Cargo.toml` with a `creusot-contracts` version matching your Creusot installation.
-
-For released versions of Creusot, this is equivalent to `cargo add creusot-contracts@$VERSION` just with the right version.
-
-For a development version of Creusot (those that don't have a git tag), this also adds the following lines:
-
-```
-[patch.crates-io]
-creusot-contracts = { path = "/path/to/creusot-contracts" }
-```
-
-This setting is documented in [The Cargo Book: Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html).
 
 ## Show configuration
 

--- a/guide/src/quickstart.md
+++ b/guide/src/quickstart.md
@@ -71,23 +71,7 @@ If you'd like to help, a prototype VSCode plugin for Why3 is [in development](ht
 
 ## Prove with Why3find
 
-### Configure
-
-```sh
-$ cargo creusot config
-```
-
-The configuration is stored in `why3find.json`.
-
-### Prove
-
-1. Run the Creusot translation.
-
-    ```sh
-    $ cargo creusot
-    ```
-
-2. Run the Why3find prover.
+1. Run the Why3find prover:
 
     ```sh
     $ cargo creusot prove
@@ -99,7 +83,7 @@ The configuration is stored in `why3find.json`.
     $ cargo creusot prove verif/[COMA_FILES]
     ```
 
-3. Launch Why3 IDE on unproved goals (this will only open one file even if there are many listed with unproved goals).
+2. Launch Why3 IDE on unproved goals (this will only open one file even if there are many listed with unproved goals).
 
     ```sh
     $ cargo creusot prove -i

--- a/why3tests/tests/why3.rs
+++ b/why3tests/tests/why3.rs
@@ -56,7 +56,7 @@ fn main() {
     std::env::set_current_dir("..").unwrap();
 
     // Use the Creusot installation for Why3, Why3find, and solvers (because they're a pain to keep track of if we allow them to come from anywhere)
-    let creusot_setup::Paths { why3, why3find, why3_config } =
+    let creusot_setup::Paths { why3, why3find, why3_config, .. } =
         creusot_setup::creusot_paths().unwrap();
     // Use the local prelude, so that it's easy to test quick changes.
     let build_prelude_success = Command::new("cargo")


### PR DESCRIPTION
- Merge config and patch-deps commands into init
- Store why3find.json once for all at installation time and copy it, instead of re-running `why3find config` which takes a few seconds

Fixes #1409 (note that we don't need to create/update `rust-toolchain` since `creusot-contracts` now compiles with stable toolchains in non-Creusot mode).

