### PR TITLE
Remove redundant parentheses in desugaring of predicate bodies

### DIFF
--- a/creusot-contracts-proc/src/creusot.rs
+++ b/creusot-contracts-proc/src/creusot.rs
@@ -667,9 +667,7 @@ fn predicate_item(
         #prophetic
         #(#attrs)*
         #documentation
-        #vis #def #sig {
-            #req_body
-        }
+        #vis #def #sig #req_body
     })
 }
 


### PR DESCRIPTION
Causes warning in the example from #1208

```
#[predicate]
fn invariant() -> bool { true }
```

desugared to

```
fn invariant() -> bool { { true } }
```