### PR TITLE
Generate false invariant for empty enums

### DIFF
--- a/creusot/src/backend/ty.rs
+++ b/creusot/src/backend/ty.rs
@@ -48,6 +48,7 @@ pub(crate) fn translate_ty<'tcx, N: Namer<'tcx>>(
         Adt(def, _) if def.is_struct() && def.variant(VariantIdx::ZERO).fields.is_empty() => {
             MlT::unit()
         }
+        Adt(def, _) if def.is_enum() && def.variants().is_empty() => MlT::unit(),
         Ref(_, ty, borkind) => {
             use rustc_ast::Mutability::*;
             match borkind {


### PR DESCRIPTION
Part of fixing #761 (which is why there isn't a test case yet).

This handles the `std::convert::Infaillible` type used by `?`, but there are missing extern specs to fully handle `?`.