### PR TITLE
Ensure translated variable names are valid Why3 identifiers

### DIFF
--- a/creusot/src/backend/ty.rs
+++ b/creusot/src/backend/ty.rs
@@ -4,7 +4,7 @@ use crate::{
     backend::Why3Generator,
     contracts_items::{get_builtin, get_int_ty, is_int_ty, is_logic, is_snap_ty, is_trusted},
     ctx::*,
-    naming::name,
+    naming::{name, variable_name},
 };
 use rustc_hir::{def::DefKind, def_id::DefId};
 use rustc_middle::ty::{AliasTyKind, GenericArgsRef, Ty, TyCtxt, TyKind, TypingEnv};
@@ -223,7 +223,7 @@ pub(crate) fn eliminator<'tcx, N: Namer<'tcx>>(
             };
             let ty =
                 translate_ty(ctx, names, DUMMY_SP, names.normalize(ctx, fld.ty(ctx.tcx, subst)));
-            (Ident::fresh_local(id), ty)
+            (Ident::fresh_local(variable_name(id)), ty)
         })
         .collect();
 

--- a/creusot/src/backend/ty_inv.rs
+++ b/creusot/src/backend/ty_inv.rs
@@ -4,6 +4,7 @@ use crate::{
         get_inv_function, get_invariant_method, is_ignore_structural_inv, is_trusted,
         is_tyinv_trivial_if_param_trivial,
     },
+    naming::variable_name,
     pearlite::{Ident, Trigger},
     traits::TraitResolved,
     translation::{
@@ -231,7 +232,9 @@ impl<'a, 'tcx> InvariantElaborator<'a, 'tcx> {
                     let field_name = if tuple_var {
                         Ident::fresh_local(&format!("a_{field_idx}"))
                     } else {
-                        Ident::fresh_local(field_def.ident(self.ctx.tcx).name.as_str())
+                        Ident::fresh_local(variable_name(
+                            field_def.ident(self.ctx.tcx).name.as_str(),
+                        ))
                     };
 
                     let field_ty = field_def.ty(self.ctx.tcx, substs);

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -8,6 +8,7 @@ use crate::{
     creusot_items::{self, CreusotItems},
     error::{CannotFetchThir, CreusotResult, Error},
     metadata::{BinaryMetadata, Metadata},
+    naming::variable_name,
     options::Options,
     pearlite::ScopedTerm,
     specification::{PreSignature, inherited_extern_spec, pre_sig_of},
@@ -549,7 +550,8 @@ impl<'tcx> TranslationCtx<'tcx> {
             .borrow_mut()
             .entry(ident)
             .or_insert_with(|| {
-                let r = Ident::fresh(self.crate_name(), self.hir().name(ident).as_str());
+                let r =
+                    Ident::fresh(self.crate_name(), variable_name(self.hir().name(ident).as_str()));
                 self.corenamer.borrow_mut().insert(r, ident);
                 r
             })

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     ctx::*,
     function::closure_capture_subst,
-    naming::name,
+    naming::{name, variable_name},
     pearlite::{Ident, PIdent, TermVisitorMut},
     translation::pearlite::{Literal, Term, TermKind, normalize, type_invariant_term},
     util::erased_identity_for_item,
@@ -501,7 +501,7 @@ pub fn inputs_and_output<'tcx>(
                     let ident = if name.is_empty() {
                         Ident::fresh_local(&format!("_{ix}"))
                     } else {
-                        Ident::fresh_local(name)
+                        Ident::fresh_local(variable_name(name))
                     };
                     (ident.into(), span, ty)
                 })
@@ -524,7 +524,7 @@ pub fn inputs_and_output<'tcx>(
                         let ident = if name.is_empty() {
                             Ident::fresh_local(&format!("_{ix}"))
                         } else {
-                            Ident::fresh_local(name)
+                            Ident::fresh_local(variable_name(name))
                         };
                         (ident.into(), span, ty)
                     },

--- a/tests/should_succeed/syntax/01_idents.coma
+++ b/tests/should_succeed/syntax/01_idents.coma
@@ -79,3 +79,37 @@ module M_01_idents__v_F [#"01_idents.rs" 22 0 22 12]
     [ & _0 : () = Any.any_l () ]
      [ return''0 (result:())-> (! return' {result}) ] 
 end
+module M_01_idents__qy95zqy974z [#"01_idents.rs" 34 0 34 11]
+  let%span s01_idents = "01_idents.rs" 35 12 35 13
+  let%span s01_idents'0 = "01_idents.rs" 37 13 37 14
+  let%span s01_idents'1 = "01_idents.rs" 38 13 38 14
+  
+  use creusot.int.Int32
+  use creusot.prelude.Any
+  
+  type t_qy931z  =
+    | C_qy937z
+  
+  type t_qy214z  =
+    { qy214z__qy216z: t_qy931z }
+  
+  meta "compute_max_steps" 1000000
+  
+  let rec qy95zqy974z[#"01_idents.rs" 34 0 34 11] (return'  (x:()))= (! bb0
+    [ bb0 = s0
+      [ s0 =  [ &v_A <- [%#s01_idents] (0 : Int32.t) ] s1
+      | s1 =  [ &_3 <- C_qy937z ] s2
+      | s2 =  [ &_937_ <- { qy214z__qy216z = _3 } ] s3
+      | s3 =  [ &_0'0 <- [%#s01_idents'0] (2 : Int32.t) ] s4
+      | s4 =  [ &_1 <- [%#s01_idents'1] (3 : Int32.t) ] s5
+      | s5 = return''0 {_0} ]
+     ]
+    )
+    [ & _0 : () = Any.any_l ()
+    | & v_A : Int32.t = Any.any_l ()
+    | & _937_ : t_qy214z = Any.any_l ()
+    | & _3 : t_qy931z = Any.any_l ()
+    | & _0'0 : Int32.t = Any.any_l ()
+    | & _1 : Int32.t = Any.any_l () ]
+     [ return''0 (result:())-> (! return' {result}) ] 
+end

--- a/tests/should_succeed/syntax/01_idents.rs
+++ b/tests/should_succeed/syntax/01_idents.rs
@@ -20,3 +20,20 @@ pub fn F() {}
 
 #[allow(non_snake_case)]
 pub fn v_F() {}
+
+pub enum Σ {
+    Ω,
+}
+
+#[allow(non_snake_case, dead_code)]
+pub struct Ö {
+    Ø: Σ,
+}
+
+#[allow(non_snake_case, unused_variables)]
+pub fn _ώ() {
+    let A = 0;
+    let Ω = Ö { Ø: Σ::Ω };
+    let _0 = 2;
+    let _1 = 3;
+}

--- a/tests/should_succeed/syntax/01_idents/proof.json
+++ b/tests/should_succeed/syntax/01_idents/proof.json
@@ -28,6 +28,9 @@
     "M_01_idents__qy95zaqy95z": {
       "vc_qy95zaqy95z": { "prover": "cvc5@1.0.5", "time": 0.014 }
     },
+    "M_01_idents__qy95zqy974z": {
+      "vc_qy95zqy974z": { "prover": "cvc5@1.0.5", "time": 0.019 }
+    },
     "M_01_idents__result": {
       "vc_result": { "prover": "cvc5@1.0.5", "time": 0.014 }
     },


### PR DESCRIPTION
Fix #1503