### PR TITLE
Rename true and false in Coma patterns to True and False

### DIFF
--- a/tests/should_succeed/bug/1504.coma
+++ b/tests/should_succeed/bug/1504.coma
@@ -1,0 +1,22 @@
+module M_1504__h [#"1504.rs" 8 0 8 26]
+  let%span s1504 = "1504.rs" 9 9 9 13
+  let%span s1504'0 = "1504.rs" 4 10 7 1
+  
+  use creusot.prelude.Any
+  
+  type t_Option  =
+    | C_None
+    | C_Some bool
+  
+  meta "compute_max_steps" 1000000
+  
+  let rec h[#"1504.rs" 8 0 8 26] (return'  (x:t_Option))= (! bb0
+    [ bb0 = s0 [ s0 =  [ &_0 <- C_Some ([%#s1504] true) ] s1 | s1 = return''0 {_0} ]  ]
+    ) [ & _0 : t_Option = Any.any_l () ] 
+    [ return''0 (result:t_Option)-> {[@expl:h ensures] [%#s1504'0] match result with
+        | C_Some (True) -> true
+        | _ -> false
+        end}
+      (! return' {result}) ]
+
+end

--- a/tests/should_succeed/bug/1504.rs
+++ b/tests/should_succeed/bug/1504.rs
@@ -1,0 +1,10 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[ensures(match result {
+    Some(true) => true,
+    _ => false,
+})]
+pub fn h() -> Option<bool> {
+    Some(true)
+}

--- a/tests/should_succeed/bug/1504/proof.json
+++ b/tests/should_succeed/bug/1504/proof.json
@@ -1,0 +1,11 @@
+{
+  "profile": [
+    { "prover": "z3@4.12.4", "size": 33, "time": 0.623 },
+    { "prover": "cvc5@1.0.5", "size": 46, "time": 0.533 },
+    { "prover": "alt-ergo@2.6.0", "size": 17, "time": 0.61 },
+    { "prover": "cvc4@1.8", "size": 45, "time": 0.426 }
+  ],
+  "proofs": {
+    "M_1504__h": { "vc_h": { "prover": "cvc5@1.0.5", "time": 0.01 } }
+  }
+}

--- a/why3/src/name.rs
+++ b/why3/src/name.rs
@@ -300,8 +300,8 @@ impl Name {
 }
 
 // Global names to intern only once.
-pub(crate) static TRUE: LazyLock<Symbol> = LazyLock::new(|| Symbol::intern("true"));
-pub(crate) static FALSE: LazyLock<Symbol> = LazyLock::new(|| Symbol::intern("false"));
+pub(crate) static TRUE: LazyLock<Symbol> = LazyLock::new(|| Symbol::intern("True"));
+pub(crate) static FALSE: LazyLock<Symbol> = LazyLock::new(|| Symbol::intern("False"));
 
 /// A mapping from Why3 keywords to valid identifiers.
 /// We use this to rename identifiers that come from Rust.
@@ -324,6 +324,8 @@ const RESERVED_STR: &[&str] = &[
     "string",  // builtin type
     "real",    // builtin type
     "unit",    // builtin type
+    "True",    // builtin constructor
+    "False",   // builtin constructor
     "current", // creusot prelude
     "final",   // creusot prelude
     "abstract",


### PR DESCRIPTION
Fix #1504 

This only affects patterns; `true` and `false` in expressions are unaffected, which is why existing tests are unchanged.