### PR TITLE
impl DeepModel for std::cmp::Ordering

### DIFF
--- a/creusot-contracts/src/model.rs
+++ b/creusot-contracts/src/model.rs
@@ -102,3 +102,13 @@ impl View for String {
         dead
     }
 }
+
+impl DeepModel for std::cmp::Ordering {
+    type DeepModelTy = std::cmp::Ordering;
+
+    #[logic]
+    #[open]
+    fn deep_model(self) -> Self::DeepModelTy {
+        self
+    }
+}


### PR DESCRIPTION
This is used in the implementation of slices