### PR TITLE
Add methods to clear ghost containers

### DIFF
--- a/creusot-contracts/src/logic/fmap.rs
+++ b/creusot-contracts/src/logic/fmap.rs
@@ -467,6 +467,26 @@ impl<K, V: ?Sized> FMap<K, V> {
         let _ = key;
         panic!()
     }
+
+    /// Clears the map, removing all values.
+    ///
+    /// # Example
+    /// ```rust,creusot
+    /// use creusot_contracts::{ghost, proof_assert, logic::FMap};
+    ///
+    /// let mut s = FMap::new();
+    /// ghost! {
+    ///     s.insert_ghost(1, 2);
+    ///     s.insert_ghost(2, 3);
+    ///     s.insert_ghost(3, 42);
+    ///     s.clear_ghost();
+    ///     proof_assert!(s == FMap::empty());
+    /// };
+    /// ```
+    #[trusted]
+    #[pure]
+    #[ensures(^self == Self::empty())]
+    pub fn clear_ghost(&mut self) {}
 }
 
 impl<K: Clone + Copy, V: Clone + Copy> Clone for FMap<K, V> {

--- a/creusot-contracts/src/logic/fset.rs
+++ b/creusot-contracts/src/logic/fset.rs
@@ -446,6 +446,26 @@ impl<T: ?Sized> FSet<T> {
         let _ = value;
         panic!()
     }
+
+    /// Clears the set, removing all values.
+    ///
+    /// # Example
+    /// ```rust,creusot
+    /// use creusot_contracts::{ghost, proof_assert, logic::FSet};
+    ///
+    /// let mut s = FSet::new();
+    /// ghost! {
+    ///     s.insert_ghost(1);
+    ///     s.insert_ghost(2);
+    ///     s.insert_ghost(3);
+    ///     s.clear_ghost();
+    ///     proof_assert!(s == FSet::EMPTY);
+    /// };
+    /// ```
+    #[trusted]
+    #[pure]
+    #[ensures(^self == Self::EMPTY)]
+    pub fn clear_ghost(&mut self) {}
 }
 
 impl<T: Clone + Copy> Clone for FSet<T> {

--- a/creusot-contracts/src/logic/seq.rs
+++ b/creusot-contracts/src/logic/seq.rs
@@ -630,6 +630,26 @@ impl<T> Seq<T> {
     pub fn pop_front_ghost(&mut self) -> Option<T> {
         panic!()
     }
+
+    /// Clears the sequence, removing all values.
+    ///
+    /// # Example
+    /// ```rust,creusot
+    /// use creusot_contracts::{ghost, proof_assert, Seq};
+    ///
+    /// let mut s = Seq::new();
+    /// ghost! {
+    ///     s.push_back_ghost(1);
+    ///     s.push_back_ghost(2);
+    ///     s.push_back_ghost(3);
+    ///     s.clear_ghost();
+    ///     proof_assert!(s == Seq::EMPTY);
+    /// };
+    /// ```
+    #[trusted]
+    #[pure]
+    #[ensures(^self == Self::EMPTY)]
+    pub fn clear_ghost(&mut self) {}
 }
 
 // Having `Copy` guarantees that the operation is pure, even if we decide to change the definition of `Clone`.

--- a/tests/creusot-contracts/creusot-contracts.coma
+++ b/tests/creusot-contracts/creusot-contracts.coma
@@ -9895,7 +9895,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
 
 end
 module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T_as_slice_body [#"../../creusot-contracts/src/std/option.rs" 103 16 103 42]
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span smodel = "../../creusot-contracts/src/model.rs" 54 8 54 22
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span sslice = "../../creusot-contracts/src/std/slice.rs" 374 27 374 28
@@ -9942,7 +9942,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
   
   axiom inv_axiom'0 [@rewrite] : forall x : t_T [inv'1 x] . inv'1 x = invariant''0 x
   
-  predicate invariant''1 [#"../../creusot-contracts/src/logic/seq.rs" 651 4 651 30] (self : Seq.seq t_T) =
+  predicate invariant''1 [#"../../creusot-contracts/src/logic/seq.rs" 671 4 671 30] (self : Seq.seq t_T) =
     [%#sseq] forall i : int . 0 <= i /\ i < Seq.length self  -> inv'1 (Seq.get self i)
   
   predicate inv'2 [#"../../creusot-contracts/src/invariant.rs" 111 0 111 35] (_0 : Seq.seq t_T)
@@ -10050,7 +10050,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
 end
 module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T_as_mut_slice_body [#"../../creusot-contracts/src/std/option.rs" 118 16 118 54]
   let%span sarray = "../../creusot-contracts/src/std/array.rs" 14 20 14 30
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span smodel = "../../creusot-contracts/src/model.rs" 72 8 72 22
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sslice = "../../creusot-contracts/src/std/slice.rs" 381 27 381 28
@@ -10101,7 +10101,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
   
   axiom inv_axiom'0 [@rewrite] : forall x : t_T [inv'1 x] . inv'1 x = invariant''0 x
   
-  predicate invariant''1 [#"../../creusot-contracts/src/logic/seq.rs" 651 4 651 30] (self : Seq.seq t_T) =
+  predicate invariant''1 [#"../../creusot-contracts/src/logic/seq.rs" 671 4 671 30] (self : Seq.seq t_T) =
     [%#sseq] forall i : int . 0 <= i /\ i < Seq.length self  -> inv'1 (Seq.get self i)
   
   predicate inv'2 [#"../../creusot-contracts/src/invariant.rs" 111 0 111 35] (_0 : Seq.seq t_T)
@@ -16243,7 +16243,7 @@ module M_creusot_contracts__logic__fmap__qyi17941324210461407630__contains_ghost
   let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
   let%span sfmap'8 = "../../creusot-contracts/src/logic/fmap.rs" 104 8 104 26
   let%span sfmap'9 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
-  let%span sfmap'10 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'10 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span soption = "../../creusot-contracts/src/std/option.rs" 40 16 40 17
   let%span soption'0 = "../../creusot-contracts/src/std/option.rs" 41 26 41 51
@@ -16302,7 +16302,7 @@ module M_creusot_contracts__logic__fmap__qyi17941324210461407630__contains_ghost
    =
     [%#sfmap'7] unwrap (get_unsized self k)
   
-  predicate invariant''0 [#"../../creusot-contracts/src/logic/fmap.rs" 488 4 488 30] (self : t_FMap) =
+  predicate invariant''0 [#"../../creusot-contracts/src/logic/fmap.rs" 508 4 508 30] (self : t_FMap) =
     [%#sfmap'10] forall k : t_K . contains self k  -> inv k /\ inv'1 (lookup_unsized self k)
   
   predicate inv'2 [#"../../creusot-contracts/src/invariant.rs" 111 0 111 35] (_0 : t_FMap)
@@ -16658,10 +16658,10 @@ module M_creusot_contracts__logic__fset__qyi15838233236912513155__replicate_up_t
     = (Seq.length xs <= n /\ (forall x : t_T . contains'0 xs x  -> contains'1 self x)))))
   )
 end
-module M_creusot_contracts__logic__fset__unions_union [#"../../creusot-contracts/src/logic/fset.rs" 480 0 480 27]
-  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 477 10 477 125
-  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 478 10 479 76
-  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 480 28 480 30
+module M_creusot_contracts__logic__fset__unions_union [#"../../creusot-contracts/src/logic/fset.rs" 500 0 500 27]
+  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 497 10 497 125
+  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 498 10 499 76
+  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 500 28 500 30
   let%span sfset'2 = "../../creusot-contracts/src/logic/fset.rs" 220 14 220 102
   let%span sfset'3 = "../../creusot-contracts/src/logic/fset.rs" 221 14 221 24
   let%span sfset'4 = "../../creusot-contracts/src/logic/fset.rs" 223 8 228 9
@@ -16703,16 +16703,16 @@ module M_creusot_contracts__logic__fset__unions_union [#"../../creusot-contracts
   axiom unions_spec : forall self : Fset.fset t_T, f : Map.map t_T (Fset.fset t_U) . [%#sfset'2] forall y : t_U . contains (unions self f) y
   = (exists x : t_T . contains'0 self x /\ contains (Map.get f x) y)
   
-  function unions_union [#"../../creusot-contracts/src/logic/fset.rs" 480 0 480 27]  : ()
+  function unions_union [#"../../creusot-contracts/src/logic/fset.rs" 500 0 500 27]  : ()
   
   goal vc_unions_union : ([%#sfset] forall s1 : Fset.fset t_T, s2 : Fset.fset t_T, f : Map.map t_T (Fset.fset t_U) . unions (Fset.union s1 s2) f
   = Fset.union (unions s1 f) (unions s2 f))
   && ([%#sfset'0] forall s : Fset.fset t_T, f : Map.map t_T (Fset.fset t_U), g : Map.map t_T (Fset.fset t_U) . unions s (fun (x : t_T) -> Fset.union (Map.get f x) (Map.get g x))
   = Fset.union (unions s f) (unions s g))
 end
-module M_creusot_contracts__logic__fset__map_union [#"../../creusot-contracts/src/logic/fset.rs" 486 0 486 24]
-  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 485 10 485 104
-  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 486 25 486 27
+module M_creusot_contracts__logic__fset__map_union [#"../../creusot-contracts/src/logic/fset.rs" 506 0 506 24]
+  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 505 10 505 104
+  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 506 25 506 27
   let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 243 8 243 27
   
   use set.Fset
@@ -16727,15 +16727,15 @@ module M_creusot_contracts__logic__fset__map_union [#"../../creusot-contracts/sr
    =
     [%#sfset'1] Fset.map f self
   
-  function map_union [#"../../creusot-contracts/src/logic/fset.rs" 486 0 486 24]  : ()
+  function map_union [#"../../creusot-contracts/src/logic/fset.rs" 506 0 506 24]  : ()
   
   goal vc_map_union : [%#sfset] forall s : Fset.fset t_T, t : Fset.fset t_T, f : Map.map t_T t_U . map (Fset.union s t) f
   = Fset.union (map s f) (map t f)
 end
-module M_creusot_contracts__logic__fset__concat_union [#"../../creusot-contracts/src/logic/fset.rs" 495 0 495 24]
-  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 491 10 492 83
-  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 493 10 494 83
-  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 495 25 495 27
+module M_creusot_contracts__logic__fset__concat_union [#"../../creusot-contracts/src/logic/fset.rs" 515 0 515 24]
+  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 511 10 512 83
+  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 513 10 514 83
+  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 515 25 515 27
   let%span sfset'2 = "../../creusot-contracts/src/logic/fset.rs" 268 14 268 144
   let%span sfset'3 = "../../creusot-contracts/src/logic/fset.rs" 47 8 47 26
   
@@ -16755,21 +16755,21 @@ module M_creusot_contracts__logic__fset__concat_union [#"../../creusot-contracts
   axiom concat_spec : forall s : Fset.fset (Seq.seq t_T), t : Fset.fset (Seq.seq t_T) . [%#sfset'2] forall xs : Seq.seq t_T . contains (concat s t) xs
   = (exists ys : Seq.seq t_T, zs : Seq.seq t_T . contains s ys /\ contains t zs /\ xs = Seq.(++) ys zs)
   
-  function concat_union [#"../../creusot-contracts/src/logic/fset.rs" 495 0 495 24]  : ()
+  function concat_union [#"../../creusot-contracts/src/logic/fset.rs" 515 0 515 24]  : ()
   
   goal vc_concat_union : ([%#sfset] forall s1 : Fset.fset (Seq.seq t_T), s2 : Fset.fset (Seq.seq t_T), t : Fset.fset (Seq.seq t_T) . concat (Fset.union s1 s2) t
   = Fset.union (concat s1 t) (concat s2 t))
   && ([%#sfset'0] forall s : Fset.fset (Seq.seq t_T), t1 : Fset.fset (Seq.seq t_T), t2 : Fset.fset (Seq.seq t_T) . concat s (Fset.union t1 t2)
   = Fset.union (concat s t1) (concat s t2))
 end
-module M_creusot_contracts__logic__fset__cons_concat [#"../../creusot-contracts/src/logic/fset.rs" 501 0 501 23]
+module M_creusot_contracts__logic__fset__cons_concat [#"../../creusot-contracts/src/logic/fset.rs" 521 0 521 23]
   let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 247 8 247 27
   let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 169 8 169 39
-  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 500 10 500 133
-  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 502 20 502 115
-  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 503 20 503 74
-  let%span sfset'2 = "../../creusot-contracts/src/logic/fset.rs" 504 20 504 89
-  let%span sfset'3 = "../../creusot-contracts/src/logic/fset.rs" 502 4 502 117
+  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 520 10 520 133
+  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 522 20 522 115
+  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 523 20 523 74
+  let%span sfset'2 = "../../creusot-contracts/src/logic/fset.rs" 524 20 524 89
+  let%span sfset'3 = "../../creusot-contracts/src/logic/fset.rs" 522 4 522 117
   let%span sfset'4 = "../../creusot-contracts/src/logic/fset.rs" 268 14 268 144
   let%span sfset'5 = "../../creusot-contracts/src/logic/fset.rs" 259 14 259 117
   let%span sfset'6 = "../../creusot-contracts/src/logic/fset.rs" 47 8 47 26
@@ -16810,7 +16810,7 @@ module M_creusot_contracts__logic__fset__cons_concat [#"../../creusot-contracts/
    =
     [%#sseq] Seq.cons x self
   
-  function cons_concat [#"../../creusot-contracts/src/logic/fset.rs" 501 0 501 23]  : ()
+  function cons_concat [#"../../creusot-contracts/src/logic/fset.rs" 521 0 521 23]  : ()
   
   goal vc_cons_concat : ([%#sfset'0] forall x : t_T, xs : Seq.seq t_T, ys : Seq.seq t_T . Seq.(++) (push_front xs x) ys
   = push_front (Seq.(++) xs ys) x)
@@ -16820,26 +16820,26 @@ module M_creusot_contracts__logic__fset__cons_concat [#"../../creusot-contracts/
   && (let _ = () in let _ = () in [%#sfset] forall s : Fset.fset t_T, t : Fset.fset (Seq.seq t_T), u : Fset.fset (Seq.seq t_T) . concat (cons s t) u
   = cons s (concat t u))))
 end
-module M_creusot_contracts__logic__fset__concat_replicate [#"../../creusot-contracts/src/logic/fset.rs" 513 0 513 54]
+module M_creusot_contracts__logic__fset__concat_replicate [#"../../creusot-contracts/src/logic/fset.rs" 533 0 533 54]
   let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 362 20 362 77
   let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 169 8 169 39
-  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 510 11 510 27
-  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 511 10 511 76
-  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 512 10 512 11
+  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 530 11 530 27
+  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 531 10 531 76
+  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 532 10 532 11
   let%span sfset'2 = "../../creusot-contracts/src/logic/fset.rs" 276 15 276 21
   let%span sfset'3 = "../../creusot-contracts/src/logic/fset.rs" 277 14 277 123
   let%span sfset'4 = "../../creusot-contracts/src/logic/fset.rs" 278 14 278 15
-  let%span sfset'5 = "../../creusot-contracts/src/logic/fset.rs" 527 10 527 59
-  let%span sfset'6 = "../../creusot-contracts/src/logic/fset.rs" 528 10 528 59
-  let%span sfset'7 = "../../creusot-contracts/src/logic/fset.rs" 500 10 500 133
-  let%span sfset'8 = "../../creusot-contracts/src/logic/fset.rs" 515 8 520 9
+  let%span sfset'5 = "../../creusot-contracts/src/logic/fset.rs" 547 10 547 59
+  let%span sfset'6 = "../../creusot-contracts/src/logic/fset.rs" 548 10 548 59
+  let%span sfset'7 = "../../creusot-contracts/src/logic/fset.rs" 520 10 520 133
+  let%span sfset'8 = "../../creusot-contracts/src/logic/fset.rs" 535 8 540 9
   let%span sfset'9 = "../../creusot-contracts/src/logic/fset.rs" 281 12 287 13
   let%span sfset'10 = "../../creusot-contracts/src/logic/fset.rs" 268 14 268 144
   let%span sfset'11 = "../../creusot-contracts/src/logic/fset.rs" 47 8 47 26
-  let%span sfset'12 = "../../creusot-contracts/src/logic/fset.rs" 530 4 530 68
+  let%span sfset'12 = "../../creusot-contracts/src/logic/fset.rs" 550 4 550 68
   let%span sfset'13 = "../../creusot-contracts/src/logic/fset.rs" 212 14 212 57
   let%span sfset'14 = "../../creusot-contracts/src/logic/fset.rs" 214 8 214 29
-  let%span sfset'15 = "../../creusot-contracts/src/logic/fset.rs" 502 4 502 117
+  let%span sfset'15 = "../../creusot-contracts/src/logic/fset.rs" 522 4 522 117
   let%span sfset'16 = "../../creusot-contracts/src/logic/fset.rs" 259 14 259 117
   let%span sfset'17 = "../../creusot-contracts/src/logic/fset.rs" 66 8 66 26
   
@@ -16905,14 +16905,14 @@ module M_creusot_contracts__logic__fset__concat_replicate [#"../../creusot-contr
   axiom concat_spec : forall s : Fset.fset (Seq.seq t_T), t : Fset.fset (Seq.seq t_T) . [%#sfset'10] forall xs : Seq.seq t_T . contains (concat s t) xs
   = (exists ys : Seq.seq t_T, zs : Seq.seq t_T . contains s ys /\ contains t zs /\ xs = Seq.(++) ys zs)
   
-  function concat_empty [#"../../creusot-contracts/src/logic/fset.rs" 529 0 529 39] (s : Fset.fset (Seq.seq t_T)) : () =
+  function concat_empty [#"../../creusot-contracts/src/logic/fset.rs" 549 0 549 39] (s : Fset.fset (Seq.seq t_T)) : () =
     [%#sfset'12] let _ = let _ = () in () in let _ = let _ = () in () in ()
   
   axiom concat_empty_spec : forall s : Fset.fset (Seq.seq t_T) . ([%#sfset'5] concat (singleton (Seq.empty : Seq.seq t_T)) s
   = s)
   && ([%#sfset'6] concat s (singleton (Seq.empty : Seq.seq t_T)) = s)
   
-  function cons_concat [#"../../creusot-contracts/src/logic/fset.rs" 501 0 501 23]  : () =
+  function cons_concat [#"../../creusot-contracts/src/logic/fset.rs" 521 0 521 23]  : () =
     [%#sfset'15] let _ = let _ = () in () in let _ = let _ = () in () in let _ = let _ = () in () in ()
   
   axiom cons_concat_spec : [%#sfset'7] forall s : Fset.fset t_T, t : Fset.fset (Seq.seq t_T), u : Fset.fset (Seq.seq t_T) . concat (cons s t) u
@@ -16924,7 +16924,7 @@ module M_creusot_contracts__logic__fset__concat_replicate [#"../../creusot-contr
   
   constant s  : Fset.fset t_T
   
-  function concat_replicate [#"../../creusot-contracts/src/logic/fset.rs" 513 0 513 54] (n'0 : int) (m'0 : int) (s'0 : Fset.fset t_T) : ()
+  function concat_replicate [#"../../creusot-contracts/src/logic/fset.rs" 533 0 533 54] (n'0 : int) (m'0 : int) (s'0 : Fset.fset t_T) : ()
   
   
   goal vc_concat_replicate : ([%#sfset] 0 <= n /\ 0 <= m)
@@ -16946,12 +16946,12 @@ module M_creusot_contracts__logic__fset__concat_replicate [#"../../creusot-contr
     = concat (replicate s n) (replicate s m))))
   )
 end
-module M_creusot_contracts__logic__fset__concat_empty [#"../../creusot-contracts/src/logic/fset.rs" 529 0 529 39]
-  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 527 10 527 59
-  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 528 10 528 59
-  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 530 20 530 66
-  let%span sfset'2 = "../../creusot-contracts/src/logic/fset.rs" 531 20 531 66
-  let%span sfset'3 = "../../creusot-contracts/src/logic/fset.rs" 530 4 530 68
+module M_creusot_contracts__logic__fset__concat_empty [#"../../creusot-contracts/src/logic/fset.rs" 549 0 549 39]
+  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 547 10 547 59
+  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 548 10 548 59
+  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 550 20 550 66
+  let%span sfset'2 = "../../creusot-contracts/src/logic/fset.rs" 551 20 551 66
+  let%span sfset'3 = "../../creusot-contracts/src/logic/fset.rs" 550 4 550 68
   let%span sfset'4 = "../../creusot-contracts/src/logic/fset.rs" 268 14 268 144
   let%span sfset'5 = "../../creusot-contracts/src/logic/fset.rs" 212 14 212 57
   let%span sfset'6 = "../../creusot-contracts/src/logic/fset.rs" 214 8 214 29
@@ -16989,30 +16989,30 @@ module M_creusot_contracts__logic__fset__concat_empty [#"../../creusot-contracts
   
   constant s  : Fset.fset (Seq.seq t_T)
   
-  function concat_empty [#"../../creusot-contracts/src/logic/fset.rs" 529 0 529 39] (s'0 : Fset.fset (Seq.seq t_T)) : ()
+  function concat_empty [#"../../creusot-contracts/src/logic/fset.rs" 549 0 549 39] (s'0 : Fset.fset (Seq.seq t_T)) : ()
   
   goal vc_concat_empty : ([%#sfset'1] forall xs : Seq.seq t_T . Seq.(++) xs (Seq.empty : Seq.seq t_T) = xs)
   && (let _ = () in let _ = () in ([%#sfset'2] forall xs : Seq.seq t_T . Seq.(++) (Seq.empty : Seq.seq t_T) xs = xs)
   && (let _ = () in let _ = () in ([%#sfset] concat (singleton (Seq.empty : Seq.seq t_T)) s = s)
   && ([%#sfset'0] concat s (singleton (Seq.empty : Seq.seq t_T)) = s)))
 end
-module M_creusot_contracts__logic__fset__concat_replicate_up_to [#"../../creusot-contracts/src/logic/fset.rs" 541 0 541 60]
+module M_creusot_contracts__logic__fset__concat_replicate_up_to [#"../../creusot-contracts/src/logic/fset.rs" 561 0 561 60]
   let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 362 20 362 77
   let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 169 8 169 39
-  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 537 11 537 26
-  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 538 10 539 67
-  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 540 10 540 11
+  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 557 11 557 26
+  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 558 10 559 67
+  let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 560 10 560 11
   let%span sfset'2 = "../../creusot-contracts/src/logic/fset.rs" 276 15 276 21
   let%span sfset'3 = "../../creusot-contracts/src/logic/fset.rs" 277 14 277 123
   let%span sfset'4 = "../../creusot-contracts/src/logic/fset.rs" 278 14 278 15
-  let%span sfset'5 = "../../creusot-contracts/src/logic/fset.rs" 527 10 527 59
-  let%span sfset'6 = "../../creusot-contracts/src/logic/fset.rs" 528 10 528 59
-  let%span sfset'7 = "../../creusot-contracts/src/logic/fset.rs" 491 10 492 83
-  let%span sfset'8 = "../../creusot-contracts/src/logic/fset.rs" 493 10 494 83
-  let%span sfset'9 = "../../creusot-contracts/src/logic/fset.rs" 510 11 510 27
-  let%span sfset'10 = "../../creusot-contracts/src/logic/fset.rs" 511 10 511 76
-  let%span sfset'11 = "../../creusot-contracts/src/logic/fset.rs" 512 10 512 11
-  let%span sfset'12 = "../../creusot-contracts/src/logic/fset.rs" 543 8 549 9
+  let%span sfset'5 = "../../creusot-contracts/src/logic/fset.rs" 547 10 547 59
+  let%span sfset'6 = "../../creusot-contracts/src/logic/fset.rs" 548 10 548 59
+  let%span sfset'7 = "../../creusot-contracts/src/logic/fset.rs" 511 10 512 83
+  let%span sfset'8 = "../../creusot-contracts/src/logic/fset.rs" 513 10 514 83
+  let%span sfset'9 = "../../creusot-contracts/src/logic/fset.rs" 530 11 530 27
+  let%span sfset'10 = "../../creusot-contracts/src/logic/fset.rs" 531 10 531 76
+  let%span sfset'11 = "../../creusot-contracts/src/logic/fset.rs" 532 10 532 11
+  let%span sfset'12 = "../../creusot-contracts/src/logic/fset.rs" 563 8 569 9
   let%span sfset'13 = "../../creusot-contracts/src/logic/fset.rs" 294 15 294 21
   let%span sfset'14 = "../../creusot-contracts/src/logic/fset.rs" 295 14 295 123
   let%span sfset'15 = "../../creusot-contracts/src/logic/fset.rs" 296 14 296 15
@@ -17020,15 +17020,15 @@ module M_creusot_contracts__logic__fset__concat_replicate_up_to [#"../../creusot
   let%span sfset'17 = "../../creusot-contracts/src/logic/fset.rs" 268 14 268 144
   let%span sfset'18 = "../../creusot-contracts/src/logic/fset.rs" 281 12 287 13
   let%span sfset'19 = "../../creusot-contracts/src/logic/fset.rs" 47 8 47 26
-  let%span sfset'20 = "../../creusot-contracts/src/logic/fset.rs" 530 4 530 68
+  let%span sfset'20 = "../../creusot-contracts/src/logic/fset.rs" 550 4 550 68
   let%span sfset'21 = "../../creusot-contracts/src/logic/fset.rs" 212 14 212 57
   let%span sfset'22 = "../../creusot-contracts/src/logic/fset.rs" 214 8 214 29
-  let%span sfset'23 = "../../creusot-contracts/src/logic/fset.rs" 495 25 495 27
-  let%span sfset'24 = "../../creusot-contracts/src/logic/fset.rs" 515 8 520 9
+  let%span sfset'23 = "../../creusot-contracts/src/logic/fset.rs" 515 25 515 27
+  let%span sfset'24 = "../../creusot-contracts/src/logic/fset.rs" 535 8 540 9
   let%span sfset'25 = "../../creusot-contracts/src/logic/fset.rs" 259 14 259 117
   let%span sfset'26 = "../../creusot-contracts/src/logic/fset.rs" 66 8 66 26
-  let%span sfset'27 = "../../creusot-contracts/src/logic/fset.rs" 500 10 500 133
-  let%span sfset'28 = "../../creusot-contracts/src/logic/fset.rs" 502 4 502 117
+  let%span sfset'27 = "../../creusot-contracts/src/logic/fset.rs" 520 10 520 133
+  let%span sfset'28 = "../../creusot-contracts/src/logic/fset.rs" 522 4 522 117
   
   use set.Fset
   use mach.int.Int
@@ -17107,14 +17107,14 @@ module M_creusot_contracts__logic__fset__concat_replicate_up_to [#"../../creusot
   axiom concat_spec : forall s : Fset.fset (Seq.seq t_T), t : Fset.fset (Seq.seq t_T) . [%#sfset'17] forall xs : Seq.seq t_T . contains (concat s t) xs
   = (exists ys : Seq.seq t_T, zs : Seq.seq t_T . contains s ys /\ contains t zs /\ xs = Seq.(++) ys zs)
   
-  function concat_empty [#"../../creusot-contracts/src/logic/fset.rs" 529 0 529 39] (s : Fset.fset (Seq.seq t_T)) : () =
+  function concat_empty [#"../../creusot-contracts/src/logic/fset.rs" 549 0 549 39] (s : Fset.fset (Seq.seq t_T)) : () =
     [%#sfset'20] let _ = let _ = () in () in let _ = let _ = () in () in ()
   
   axiom concat_empty_spec : forall s : Fset.fset (Seq.seq t_T) . ([%#sfset'5] concat (singleton (Seq.empty : Seq.seq t_T)) s
   = s)
   && ([%#sfset'6] concat s (singleton (Seq.empty : Seq.seq t_T)) = s)
   
-  function concat_union [#"../../creusot-contracts/src/logic/fset.rs" 495 0 495 24]  : () =
+  function concat_union [#"../../creusot-contracts/src/logic/fset.rs" 515 0 515 24]  : () =
     [%#sfset'23] ()
   
   axiom concat_union_spec : ([%#sfset'7] forall s1 : Fset.fset (Seq.seq t_T), s2 : Fset.fset (Seq.seq t_T), t : Fset.fset (Seq.seq t_T) . concat (Fset.union s1 s2) t
@@ -17122,13 +17122,13 @@ module M_creusot_contracts__logic__fset__concat_replicate_up_to [#"../../creusot
   && ([%#sfset'8] forall s : Fset.fset (Seq.seq t_T), t1 : Fset.fset (Seq.seq t_T), t2 : Fset.fset (Seq.seq t_T) . concat s (Fset.union t1 t2)
   = Fset.union (concat s t1) (concat s t2))
   
-  function cons_concat [#"../../creusot-contracts/src/logic/fset.rs" 501 0 501 23]  : () =
+  function cons_concat [#"../../creusot-contracts/src/logic/fset.rs" 521 0 521 23]  : () =
     [%#sfset'28] let _ = let _ = () in () in let _ = let _ = () in () in let _ = let _ = () in () in ()
   
   axiom cons_concat_spec : [%#sfset'27] forall s : Fset.fset t_T, t : Fset.fset (Seq.seq t_T), u : Fset.fset (Seq.seq t_T) . concat (cons s t) u
   = cons s (concat t u)
   
-  function concat_replicate [#"../../creusot-contracts/src/logic/fset.rs" 513 0 513 54] (n : int) (m : int) (s : Fset.fset t_T) : ()
+  function concat_replicate [#"../../creusot-contracts/src/logic/fset.rs" 533 0 533 54] (n : int) (m : int) (s : Fset.fset t_T) : ()
   
   
   axiom concat_replicate_def : forall n : int, m : int, s : Fset.fset t_T . ([%#sfset'9] 0 <= n /\ 0 <= m)
@@ -17148,7 +17148,7 @@ module M_creusot_contracts__logic__fset__concat_replicate_up_to [#"../../creusot
   
   constant s  : Fset.fset t_T
   
-  function concat_replicate_up_to [#"../../creusot-contracts/src/logic/fset.rs" 541 0 541 60] (n'0 : int) (m'0 : int) (s'0 : Fset.fset t_T) : ()
+  function concat_replicate_up_to [#"../../creusot-contracts/src/logic/fset.rs" 561 0 561 60] (n'0 : int) (m'0 : int) (s'0 : Fset.fset t_T) : ()
   
   
   goal vc_concat_replicate_up_to : ([%#sfset] 0 <= n /\ n < m)
@@ -21981,9 +21981,9 @@ module M_creusot_contracts__logic__seq__qyi16115490154402163220__flatten [#"../.
     0 <= ([%#sseq] Seq.length self) /\ ([%#sseq] Seq.length (tail self)) < ([%#sseq] Seq.length self)
 
 end
-module M_creusot_contracts__logic__seq__flat_map_singleton [#"../../creusot-contracts/src/logic/seq.rs" 659 0 659 33]
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 658 10 658 87
-  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 659 34 659 36
+module M_creusot_contracts__logic__seq__flat_map_singleton [#"../../creusot-contracts/src/logic/seq.rs" 679 0 679 33]
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 678 10 678 87
+  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 679 34 679 36
   let%span sseq'1 = "../../creusot-contracts/src/logic/seq.rs" 291 14 291 24
   let%span sseq'2 = "../../creusot-contracts/src/logic/seq.rs" 293 8 297 9
   let%span sseq'3 = "../../creusot-contracts/src/logic/seq.rs" 169 8 169 39
@@ -22008,16 +22008,16 @@ module M_creusot_contracts__logic__seq__flat_map_singleton [#"../../creusot-cont
     Seq.(++) (Map.get other (Seq.get self 0)) (flat_map (tail self) other)
   )
   
-  function flat_map_singleton [#"../../creusot-contracts/src/logic/seq.rs" 659 0 659 33]  : ()
+  function flat_map_singleton [#"../../creusot-contracts/src/logic/seq.rs" 679 0 679 33]  : ()
   
   goal vc_flat_map_singleton : [%#sseq] forall x : t_A, f : Map.map t_A (Seq.seq t_B) . flat_map (Seq.singleton x) f
   = Map.get f x
 end
-module M_creusot_contracts__logic__seq__flat_map_push_back [#"../../creusot-contracts/src/logic/seq.rs" 665 0 665 43]
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 663 10 663 108
-  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 664 10 664 18
-  let%span sseq'1 = "../../creusot-contracts/src/logic/seq.rs" 668 24 668 85
-  let%span sseq'2 = "../../creusot-contracts/src/logic/seq.rs" 666 4 669 5
+module M_creusot_contracts__logic__seq__flat_map_push_back [#"../../creusot-contracts/src/logic/seq.rs" 685 0 685 43]
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 683 10 683 108
+  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 684 10 684 18
+  let%span sseq'1 = "../../creusot-contracts/src/logic/seq.rs" 688 24 688 85
+  let%span sseq'2 = "../../creusot-contracts/src/logic/seq.rs" 686 4 689 5
   let%span sseq'3 = "../../creusot-contracts/src/logic/seq.rs" 291 14 291 24
   let%span sseq'4 = "../../creusot-contracts/src/logic/seq.rs" 293 8 297 9
   let%span sseq'5 = "../../creusot-contracts/src/logic/seq.rs" 169 8 169 39
@@ -22045,7 +22045,7 @@ module M_creusot_contracts__logic__seq__flat_map_push_back [#"../../creusot-cont
   
   constant xs  : Seq.seq t_A
   
-  function flat_map_push_back [#"../../creusot-contracts/src/logic/seq.rs" 665 0 665 43] (xs'0 : Seq.seq t_A) : ()
+  function flat_map_push_back [#"../../creusot-contracts/src/logic/seq.rs" 685 0 685 43] (xs'0 : Seq.seq t_A) : ()
   
   goal vc_flat_map_push_back : if Seq.length xs > 0 then
     (0 <= ([%#sseq'0] Seq.length xs) /\ ([%#sseq'0] Seq.length (tail xs)) < ([%#sseq'0] Seq.length xs))
@@ -33884,7 +33884,7 @@ module M_creusot_contracts__stdqy35z1__slice__qyi6798028551487775744__resolve_co
    -> structural_resolve self /\ (forall result : () . resolve'2 self  -> resolve'2 self)
 end
 module M_creusot_contracts__stdqy35z1__vec__qyi16169840827095121464__resolve_coherence__refines [#"../../creusot-contracts/src/std/vec.rs" 61 4 61 31] (* <std::vec::Vec<T, A> as resolve::Resolve> *)
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
@@ -33940,7 +33940,7 @@ module M_creusot_contracts__stdqy35z1__vec__qyi16169840827095121464__resolve_coh
   
   axiom inv_axiom [@rewrite] : forall x : t_T [inv'0 x] . inv'0 x = invariant' x
   
-  predicate invariant''0 [#"../../creusot-contracts/src/logic/seq.rs" 651 4 651 30] (self : Seq.seq t_T) =
+  predicate invariant''0 [#"../../creusot-contracts/src/logic/seq.rs" 671 4 671 30] (self : Seq.seq t_T) =
     [%#sseq] forall i : int . 0 <= i /\ i < Seq.length self  -> inv'0 (Seq.get self i)
   
   predicate inv'1 [#"../../creusot-contracts/src/invariant.rs" 111 0 111 35] (_0 : Seq.seq t_T)
@@ -34915,9 +34915,9 @@ module M_creusot_contracts__ghost__qyi11517682701084838082__clone__refines [#"..
   goal refines : [%#sghost] forall self_ : t_Ghost . inv'1 self_
    -> inv'1 self_ /\ (forall result : t_Ghost . result = self_ /\ inv'0 result  -> result = self_ /\ inv'0 result)
 end
-module M_creusot_contracts__logic__fmap__qyi1775402764303793352__clone__refines [#"../../creusot-contracts/src/logic/fmap.rs" 476 4 476 27] (* <logic::fmap::FMap<K, V> as std::clone::Clone> *)
-  let%span sfmap = "../../creusot-contracts/src/logic/fmap.rs" 476 4 476 27
-  let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+module M_creusot_contracts__logic__fmap__qyi1775402764303793352__clone__refines [#"../../creusot-contracts/src/logic/fmap.rs" 496 4 496 27] (* <logic::fmap::FMap<K, V> as std::clone::Clone> *)
+  let%span sfmap = "../../creusot-contracts/src/logic/fmap.rs" 496 4 496 27
+  let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sfmap'1 = "../../creusot-contracts/src/logic/fmap.rs" 133 8 133 35
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 104 8 104 26
@@ -34973,7 +34973,7 @@ module M_creusot_contracts__logic__fmap__qyi1775402764303793352__clone__refines 
    =
     [%#sfmap'2] unwrap (get_unsized self k)
   
-  predicate invariant''0 [#"../../creusot-contracts/src/logic/fmap.rs" 488 4 488 30] (self : t_FMap) =
+  predicate invariant''0 [#"../../creusot-contracts/src/logic/fmap.rs" 508 4 508 30] (self : t_FMap) =
     [%#sfmap'0] forall k : t_K . contains self k  -> inv k /\ inv'1 (lookup_unsized self k)
   
   predicate inv'2 [#"../../creusot-contracts/src/invariant.rs" 111 0 111 35] (_0 : t_FMap)
@@ -34990,9 +34990,9 @@ module M_creusot_contracts__logic__fmap__qyi1775402764303793352__clone__refines 
   goal refines : [%#sfmap] forall self_ : t_FMap . inv'3 self_
    -> inv'3 self_ /\ (forall result : t_FMap . result = self_ /\ inv'2 result  -> result = self_ /\ inv'2 result)
 end
-module M_creusot_contracts__logic__fset__qyi13324666171263681189__clone__refines [#"../../creusot-contracts/src/logic/fset.rs" 455 4 455 27] (* <logic::fset::FSet<T> as std::clone::Clone> *)
-  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 455 4 455 27
-  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 468 20 468 63
+module M_creusot_contracts__logic__fset__qyi13324666171263681189__clone__refines [#"../../creusot-contracts/src/logic/fset.rs" 475 4 475 27] (* <logic::fset::FSet<T> as std::clone::Clone> *)
+  let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 475 4 475 27
+  let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 488 20 488 63
   let%span sfset'1 = "../../creusot-contracts/src/logic/fset.rs" 47 8 47 26
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
   
@@ -35007,7 +35007,7 @@ module M_creusot_contracts__logic__fset__qyi13324666171263681189__clone__refines
   
   predicate inv [#"../../creusot-contracts/src/invariant.rs" 111 0 111 35] (_0 : t_T)
   
-  predicate invariant' [#"../../creusot-contracts/src/logic/fset.rs" 467 4 467 30] (self : Fset.fset t_T) =
+  predicate invariant' [#"../../creusot-contracts/src/logic/fset.rs" 487 4 487 30] (self : Fset.fset t_T) =
     [%#sfset'0] forall x : t_T . contains self x  -> inv x
   
   predicate inv'0 [#"../../creusot-contracts/src/invariant.rs" 111 0 111 35] (_0 : Fset.fset t_T)
@@ -35029,9 +35029,9 @@ module M_creusot_contracts__logic__int__qyi3540547019284611154__clone__refines [
   
   goal refines : [%#sint] forall self_ : int . forall result : int . result = self_  -> result = self_
 end
-module M_creusot_contracts__logic__seq__qyi7164078029063507335__clone__refines [#"../../creusot-contracts/src/logic/seq.rs" 640 4 640 27] (* <logic::seq::Seq<T> as std::clone::Clone> *)
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 640 4 640 27
-  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+module M_creusot_contracts__logic__seq__qyi7164078029063507335__clone__refines [#"../../creusot-contracts/src/logic/seq.rs" 660 4 660 27] (* <logic::seq::Seq<T> as std::clone::Clone> *)
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 660 4 660 27
+  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
@@ -35049,7 +35049,7 @@ module M_creusot_contracts__logic__seq__qyi7164078029063507335__clone__refines [
   
   axiom inv_axiom [@rewrite] : forall x : t_T [inv'0 x] . inv'0 x = invariant' x
   
-  predicate invariant''0 [#"../../creusot-contracts/src/logic/seq.rs" 651 4 651 30] (self : Seq.seq t_T) =
+  predicate invariant''0 [#"../../creusot-contracts/src/logic/seq.rs" 671 4 671 30] (self : Seq.seq t_T) =
     [%#sseq'0] forall i : int . 0 <= i /\ i < Seq.length self  -> inv'0 (Seq.get self i)
   
   predicate inv'1 [#"../../creusot-contracts/src/invariant.rs" 111 0 111 35] (_0 : Seq.seq t_T)

--- a/tests/should_fail/bug/878.coma
+++ b/tests/should_fail/bug/878.coma
@@ -89,7 +89,7 @@ module M_878__test2 [#"878.rs" 20 0 20 14]
   let%span svec'0 = "../../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 22 8 22 22
   let%span sboxed'0 = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   
   use creusot.int.UInt32
   use creusot.slice.Slice64
@@ -222,7 +222,7 @@ module M_878__test3 [#"878.rs" 26 0 26 14]
   let%span svec'0 = "../../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 22 8 22 22
   let%span sboxed'0 = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   
   use creusot.int.UInt32
   use creusot.slice.Slice64

--- a/tests/should_fail/bug/specialize.coma
+++ b/tests/should_fail/bug/specialize.coma
@@ -44,7 +44,7 @@ module M_specialize__g [#"specialize.rs" 28 0 28 18]
   let%span sspecialize'1 = "specialize.rs" 7 9 7 13
   let%span svec = "../../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span svec'0 = "../../../creusot-contracts/src/std/vec.rs" 21 14 21 41
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.Opaque
@@ -160,7 +160,7 @@ module M_specialize__qyi7590077194068412461__x__refines [#"specialize.rs" 13 4 1
   let%span sspecialize = "specialize.rs" 13 4 13 22
   let%span svec = "../../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span svec'0 = "../../../creusot-contracts/src/std/vec.rs" 21 14 21 41
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.Opaque

--- a/tests/should_succeed/bug/final_borrows.coma
+++ b/tests/should_succeed/bug/final_borrows.coma
@@ -1927,7 +1927,7 @@ module M_final_borrows__index_mut_slice [#"final_borrows.rs" 204 0 204 48]
   let%span sslice = "../../../creusot-contracts/src/std/slice.rs" 27 14 27 41
   let%span sslice'0 = "../../../creusot-contracts/src/std/slice.rs" 28 14 28 42
   let%span sslice'1 = "../../../creusot-contracts/src/std/slice.rs" 17 20 17 30
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   
   use creusot.int.UInt64
   use creusot.prelude.Opaque
@@ -2076,7 +2076,7 @@ module M_final_borrows__index_mut_array [#"final_borrows.rs" 210 0 210 52]
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span smodel = "../../../creusot-contracts/src/model.rs" 72 8 72 22
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 85 8 85 32
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sarray = "../../../creusot-contracts/src/std/array.rs" 14 20 14 30
   
   use creusot.int.UInt64

--- a/tests/should_succeed/cc/string.coma
+++ b/tests/should_succeed/cc/string.coma
@@ -160,8 +160,8 @@ module M_string__test_split_at [#"string.rs" 21 0 21 45]
   let%span sstring'8 = "../../../creusot-contracts/src/std/string.rs" 49 20 49 56
   let%span schar = "../../../creusot-contracts/src/std/char.rs" 40 14 40 52
   let%span smodel = "../../../creusot-contracts/src/model.rs" 54 8 54 22
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 658 10 658 87
-  let%span sseq'0 = "../../../creusot-contracts/src/logic/seq.rs" 659 34 659 36
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 678 10 678 87
+  let%span sseq'0 = "../../../creusot-contracts/src/logic/seq.rs" 679 34 679 36
   let%span sseq'1 = "../../../creusot-contracts/src/logic/seq.rs" 53 8 53 19
   let%span sseq'2 = "../../../creusot-contracts/src/logic/seq.rs" 291 14 291 24
   let%span sseq'3 = "../../../creusot-contracts/src/logic/seq.rs" 293 8 297 9

--- a/tests/should_succeed/hashmap.coma
+++ b/tests/should_succeed/hashmap.coma
@@ -127,7 +127,7 @@ module M_hashmap__qyi1307405214416629806__resolve_coherence [#"hashmap.rs" 115 4
   let%span svec'0 = "../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'1 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.Opaque
@@ -326,7 +326,7 @@ module M_hashmap__qyi9690720112976707081__new [#"hashmap.rs" 151 4 151 46] (* My
   let%span svec'2 = "../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'3 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.Opaque
@@ -538,7 +538,7 @@ module M_hashmap__qyi9690720112976707081__add [#"hashmap.rs" 157 4 157 41] (* My
   let%span svec'7 = "../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'8 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span scmp = "../../creusot-contracts/src/std/cmp.rs" 11 16 11 17
   let%span scmp'0 = "../../creusot-contracts/src/std/cmp.rs" 12 29 12 32
@@ -1087,7 +1087,7 @@ module M_hashmap__qyi9690720112976707081__get [#"hashmap.rs" 189 4 189 43] (* My
   let%span svec'4 = "../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'5 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span scmp = "../../creusot-contracts/src/std/cmp.rs" 11 16 11 17
   let%span scmp'0 = "../../creusot-contracts/src/std/cmp.rs" 12 29 12 32
@@ -1447,7 +1447,7 @@ module M_hashmap__qyi9690720112976707081__resize [#"hashmap.rs" 208 4 208 24] (*
   let%span svec'7 = "../../creusot-contracts/src/std/vec.rs" 162 26 162 55
   let%span svec'8 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span sslice = "../../creusot-contracts/src/std/slice.rs" 123 20 123 37
   let%span sslice'0 = "../../creusot-contracts/src/std/slice.rs" 130 20 130 37
@@ -2360,7 +2360,7 @@ module M_hashmap__qyi1307405214416629806__resolve_coherence__refines [#"hashmap.
   let%span svec'0 = "../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'1 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.Opaque

--- a/tests/should_succeed/heapsort_generic.coma
+++ b/tests/should_succeed/heapsort_generic.coma
@@ -152,7 +152,7 @@ module M_heapsort_generic__sift_down [#"heapsort_generic.rs" 41 0 43 29]
   let%span smodel'2 = "../../creusot-contracts/src/model.rs" 45 8 45 28
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
   let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 323 8 323 41
-  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span ssnapshot = "../../creusot-contracts/src/snapshot.rs" 50 20 50 39
   let%span svec = "../../creusot-contracts/src/std/vec.rs" 167 16 167 17
   let%span svec'0 = "../../creusot-contracts/src/std/vec.rs" 168 27 168 46
@@ -640,7 +640,7 @@ module M_heapsort_generic__heap_sort [#"heapsort_generic.rs" 93 0 95 29]
   let%span smodel'1 = "../../creusot-contracts/src/model.rs" 54 8 54 22
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
   let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 323 8 323 41
-  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span ssnapshot = "../../creusot-contracts/src/snapshot.rs" 50 20 50 39
   let%span svec = "../../creusot-contracts/src/std/vec.rs" 88 16 88 17
   let%span svec'0 = "../../creusot-contracts/src/std/vec.rs" 89 26 89 48

--- a/tests/should_succeed/hillel.coma
+++ b/tests/should_succeed/hillel.coma
@@ -27,7 +27,7 @@ module M_hillel__right_pad [#"hillel.rs" 17 0 17 59]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sinvariant'0 = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use seq.Seq
@@ -231,7 +231,7 @@ module M_hillel__left_pad [#"hillel.rs" 34 0 34 58]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sinvariant'0 = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use mach.int.Int
@@ -480,7 +480,7 @@ module M_hillel__insert_unique [#"hillel.rs" 80 0 80 62]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sinvariant'0 = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span sslice = "../../creusot-contracts/src/std/slice.rs" 302 8 302 9
   let%span sslice'0 = "../../creusot-contracts/src/std/slice.rs" 303 18 303 33
@@ -941,7 +941,7 @@ module M_hillel__unique [#"hillel.rs" 102 0 102 56]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sinvariant'0 = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span sslice = "../../creusot-contracts/src/std/slice.rs" 253 8 253 9
   let%span sslice'0 = "../../creusot-contracts/src/std/slice.rs" 254 18 254 40

--- a/tests/should_succeed/iterators/02_iter_mut.coma
+++ b/tests/should_succeed/iterators/02_iter_mut.coma
@@ -183,7 +183,7 @@ module M_02_iter_mut__qyi17529651713103399036__next [#"02_iter_mut.rs" 64 4 64 4
   let%span sslice'5 = "../../../creusot-contracts/src/std/slice.rs" 17 20 17 30
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 52 8 52 31
   let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 169 8 169 39
-  let%span sseq'0 = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'0 = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
@@ -382,7 +382,7 @@ module M_02_iter_mut__qyi13152079231411878505__into_iter [#"02_iter_mut.rs" 71 4
   let%span sslice = "../../../creusot-contracts/src/std/slice.rs" 27 14 27 41
   let%span sslice'0 = "../../../creusot-contracts/src/std/slice.rs" 28 14 28 42
   let%span sslice'1 = "../../../creusot-contracts/src/std/slice.rs" 17 20 17 30
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
@@ -474,7 +474,7 @@ module M_02_iter_mut__iter_mut [#"02_iter_mut.rs" 79 0 79 55]
   let%span sslice'2 = "../../../creusot-contracts/src/std/slice.rs" 216 20 216 31
   let%span sslice'3 = "../../../creusot-contracts/src/std/slice.rs" 222 20 222 24
   let%span sslice'4 = "../../../creusot-contracts/src/std/slice.rs" 17 20 17 30
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span svec = "../../../creusot-contracts/src/std/vec.rs" 157 16 157 17
@@ -965,7 +965,7 @@ module M_02_iter_mut__qyi6848152694368153063__resolve_coherence__refines [#"02_i
   let%span sslice = "../../../creusot-contracts/src/std/slice.rs" 27 14 27 41
   let%span sslice'0 = "../../../creusot-contracts/src/std/slice.rs" 28 14 28 42
   let%span sslice'1 = "../../../creusot-contracts/src/std/slice.rs" 17 20 17 30
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span sinvariant'0 = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
@@ -1127,7 +1127,7 @@ module M_02_iter_mut__qyi17529651713103399036__next__refines [#"02_iter_mut.rs" 
   let%span sslice'2 = "../../../creusot-contracts/src/std/slice.rs" 28 14 28 42
   let%span sslice'3 = "../../../creusot-contracts/src/std/slice.rs" 17 20 17 30
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 52 8 52 31
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   

--- a/tests/should_succeed/iterators/03_std_iterators.coma
+++ b/tests/should_succeed/iterators/03_std_iterators.coma
@@ -33,7 +33,7 @@ module M_03_std_iterators__slice_iter [#"03_std_iterators.rs" 7 0 7 42]
   let%span smodel'0 = "../../../creusot-contracts/src/model.rs" 72 8 72 22
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 52 8 52 31
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
@@ -291,7 +291,7 @@ module M_03_std_iterators__vec_iter [#"03_std_iterators.rs" 18 0 18 41]
   let%span smodel'0 = "../../../creusot-contracts/src/model.rs" 72 8 72 22
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 52 8 52 31
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span svec = "../../../creusot-contracts/src/std/vec.rs" 213 20 213 24
@@ -1971,7 +1971,7 @@ module M_03_std_iterators__my_reverse [#"03_std_iterators.rs" 92 0 92 37]
   let%span smodel'0 = "../../../creusot-contracts/src/model.rs" 54 8 54 22
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 96 8 96 33
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sinvariant'0 = "../../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18

--- a/tests/should_succeed/iterators/08_collect_extend.coma
+++ b/tests/should_succeed/iterators/08_collect_extend.coma
@@ -30,7 +30,7 @@ module M_08_collect_extend__extend [#"08_collect_extend.rs" 26 0 26 66]
   let%span svec'3 = "../../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use seq.Seq
@@ -312,7 +312,7 @@ module M_08_collect_extend__collect [#"08_collect_extend.rs" 44 0 44 52]
   let%span svec'4 = "../../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.Opaque

--- a/tests/should_succeed/knapsack.coma
+++ b/tests/should_succeed/knapsack.coma
@@ -136,7 +136,7 @@ module M_knapsack__knapsack01_dyn [#"knapsack.rs" 45 0 45 91]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span sinvariant'0 = "../../creusot-contracts/src/invariant.rs" 100 20 100 44
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.int.UInt64

--- a/tests/should_succeed/knapsack_full.coma
+++ b/tests/should_succeed/knapsack_full.coma
@@ -361,7 +361,7 @@ module M_knapsack_full__knapsack01_dyn [#"knapsack_full.rs" 81 0 81 91]
   let%span sslice'1 = "../../creusot-contracts/src/std/slice.rs" 137 20 137 94
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 90 8 90 18
   let%span sinvariant'0 = "../../creusot-contracts/src/invariant.rs" 100 20 100 44
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.int.UInt64

--- a/tests/should_succeed/linked_list.coma
+++ b/tests/should_succeed/linked_list.coma
@@ -9,7 +9,7 @@ module M_linked_list__qyi10858349784728989480__new [#"linked_list.rs" 61 4 61 27
   let%span sptr'1 = "../../creusot-contracts/src/std/ptr.rs" 64 8 64 35
   let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 451 4 451 31
   let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 449 14 449 36
-  let%span sseq'1 = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'1 = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sghost = "../../creusot-contracts/src/ghost.rs" 109 8 109 31
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span sptr_own = "../../creusot-contracts/src/ptr_own.rs" 51 8 51 35
@@ -180,7 +180,7 @@ module M_linked_list__qyi10858349784728989480__push_back [#"linked_list.rs" 66 4
   let%span sseq'7 = "../../creusot-contracts/src/logic/seq.rs" 518 38 518 39
   let%span sseq'8 = "../../creusot-contracts/src/logic/seq.rs" 517 14 517 40
   let%span sseq'9 = "../../creusot-contracts/src/logic/seq.rs" 86 8 86 82
-  let%span sseq'10 = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'10 = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sghost = "../../creusot-contracts/src/ghost.rs" 67 14 67 18
   let%span sghost'0 = "../../creusot-contracts/src/ghost.rs" 67 4 67 36
   let%span sghost'1 = "../../creusot-contracts/src/ghost.rs" 66 14 66 46
@@ -787,7 +787,7 @@ module M_linked_list__qyi10858349784728989480__push_front [#"linked_list.rs" 86 
   let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 496 39 496 40
   let%span sseq'1 = "../../creusot-contracts/src/logic/seq.rs" 495 14 495 41
   let%span sseq'2 = "../../creusot-contracts/src/logic/seq.rs" 247 8 247 27
-  let%span sseq'3 = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'3 = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sghost = "../../creusot-contracts/src/ghost.rs" 84 22 84 26
   let%span sghost'0 = "../../creusot-contracts/src/ghost.rs" 84 4 84 48
   let%span sghost'1 = "../../creusot-contracts/src/ghost.rs" 82 14 82 46

--- a/tests/should_succeed/selection_sort_generic.coma
+++ b/tests/should_succeed/selection_sort_generic.coma
@@ -44,7 +44,7 @@ module M_selection_sort_generic__selection_sort [#"selection_sort_generic.rs" 29
   let%span smodel'1 = "../../creusot-contracts/src/model.rs" 54 8 54 22
   let%span smodel'2 = "../../creusot-contracts/src/model.rs" 45 8 45 28
   let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 323 8 323 41
-  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span ssnapshot = "../../creusot-contracts/src/snapshot.rs" 50 20 50 39
   let%span srange = "../../creusot-contracts/src/std/iter/range.rs" 25 12 29 70
   let%span srange'0 = "../../creusot-contracts/src/std/iter/range.rs" 35 14 35 45

--- a/tests/should_succeed/slices/01.coma
+++ b/tests/should_succeed/slices/01.coma
@@ -135,7 +135,7 @@ module M_01__slice_first [#"01.rs" 20 0 20 44]
   let%span sslice'3 = "../../../creusot-contracts/src/std/slice.rs" 17 20 17 30
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 52 8 52 31
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 90 8 90 18
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.int.UInt64

--- a/tests/should_succeed/sparse_array.coma
+++ b/tests/should_succeed/sparse_array.coma
@@ -13,7 +13,7 @@ module M_sparse_array__qyi1509881402265219485__resolve_coherence [#"sparse_array
   let%span svec'1 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 82 8 85 9
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.int.UInt64
@@ -192,7 +192,7 @@ module M_sparse_array__qyi16402981711463100202__get [#"sparse_array.rs" 101 4 10
   let%span svec'2 = "../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'3 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span smodel = "../../creusot-contracts/src/model.rs" 54 8 54 22
   let%span sslice = "../../creusot-contracts/src/std/slice.rs" 123 20 123 37
@@ -443,7 +443,7 @@ module M_sparse_array__qyi16402981711463100202__lemma_permutation [#"sparse_arra
   let%span svec = "../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'0 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 47 8 47 26
   let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 66 8 66 26
@@ -643,7 +643,7 @@ module M_sparse_array__qyi16402981711463100202__lemma_permutation_aux [#"sparse_
   let%span svec = "../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'0 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span sfset = "../../creusot-contracts/src/logic/fset.rs" 47 8 47 26
   let%span sfset'0 = "../../creusot-contracts/src/logic/fset.rs" 66 8 66 26
@@ -902,7 +902,7 @@ module M_sparse_array__qyi16402981711463100202__set [#"sparse_array.rs" 157 4 15
   let%span svec'8 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span smodel = "../../creusot-contracts/src/model.rs" 72 8 72 22
   let%span smodel'0 = "../../creusot-contracts/src/model.rs" 54 8 54 22
@@ -1322,7 +1322,7 @@ module M_sparse_array__create [#"sparse_array.rs" 179 0 179 56]
   let%span svec'2 = "../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'3 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.Opaque
@@ -1809,7 +1809,7 @@ module M_sparse_array__qyi1509881402265219485__resolve_coherence__refines [#"spa
   let%span svec'1 = "../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 82 8 85 9
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
-  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.int.UInt64

--- a/tests/should_succeed/take_first_mut.coma
+++ b/tests/should_succeed/take_first_mut.coma
@@ -13,7 +13,7 @@ module M_take_first_mut__take_first_mut [#"take_first_mut.rs" 14 0 14 74]
   let%span sslice'4 = "../../creusot-contracts/src/std/slice.rs" 17 20 17 30
   let%span sindex = "../../creusot-contracts/src/logic/ops/index.rs" 52 8 52 31
   let%span sseq = "../../creusot-contracts/src/logic/seq.rs" 169 8 169 39
-  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'0 = "../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span smodel = "../../creusot-contracts/src/model.rs" 72 8 72 22
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 100 20 100 44

--- a/tests/should_succeed/traits/16_impl_cloning.coma
+++ b/tests/should_succeed/traits/16_impl_cloning.coma
@@ -6,7 +6,7 @@ module M_16_impl_cloning__test [#"16_impl_cloning.rs" 16 0 16 30]
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span svec = "../../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span svec'0 = "../../../creusot-contracts/src/std/vec.rs" 21 14 21 41
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.MutBorrow

--- a/tests/should_succeed/type_invariants/vec_inv.coma
+++ b/tests/should_succeed/type_invariants/vec_inv.coma
@@ -8,7 +8,7 @@ module M_vec_inv__vec [#"vec_inv.rs" 18 0 18 32]
   let%span svec'0 = "../../../creusot-contracts/src/std/vec.rs" 54 20 54 83
   let%span svec'1 = "../../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 54 20 54 34
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
   

--- a/tests/should_succeed/union_find.coma
+++ b/tests/should_succeed/union_find.coma
@@ -104,7 +104,7 @@ module M_union_find__implementation__qyi1944850640244667852__new [#"union_find.r
   let%span sfmap'9 = "../../creusot-contracts/src/logic/fmap.rs" 49 14 49 25
   let%span sfmap'10 = "../../creusot-contracts/src/logic/fmap.rs" 133 8 133 35
   let%span sfmap'11 = "../../creusot-contracts/src/logic/fmap.rs" 229 8 229 24
-  let%span sfmap'12 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'12 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sfmap'13 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
   let%span sfmap'14 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
   let%span sutil = "../../creusot-contracts/src/util.rs" 33 11 33 28
@@ -412,7 +412,7 @@ module M_union_find__implementation__qyi1944850640244667852__domain [#"union_fin
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
-  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sutil = "../../creusot-contracts/src/util.rs" 55 11 55 21
   let%span sutil'0 = "../../creusot-contracts/src/util.rs" 56 10 56 28
   let%span smapping = "../../creusot-contracts/src/logic/mapping.rs" 60 8 60 19
@@ -634,7 +634,7 @@ module M_union_find__implementation__qyi1944850640244667852__root_of [#"union_fi
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
-  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sutil = "../../creusot-contracts/src/util.rs" 55 11 55 21
   let%span sutil'0 = "../../creusot-contracts/src/util.rs" 56 10 56 28
   let%span smapping = "../../creusot-contracts/src/logic/mapping.rs" 60 8 60 19
@@ -859,7 +859,7 @@ module M_union_find__implementation__qyi1944850640244667852__values [#"union_fin
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
-  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sutil = "../../creusot-contracts/src/util.rs" 55 11 55 21
   let%span sutil'0 = "../../creusot-contracts/src/util.rs" 56 10 56 28
   let%span smapping = "../../creusot-contracts/src/logic/mapping.rs" 60 8 60 19
@@ -1118,7 +1118,7 @@ module M_union_find__implementation__qyi1944850640244667852__make [#"union_find.
   let%span sfmap'14 = "../../creusot-contracts/src/logic/fmap.rs" 68 14 68 61
   let%span sfmap'15 = "../../creusot-contracts/src/logic/fmap.rs" 69 14 69 66
   let%span sfmap'16 = "../../creusot-contracts/src/logic/fmap.rs" 93 8 96 9
-  let%span sfmap'17 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'17 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sfmap'18 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'19 = "../../creusot-contracts/src/logic/fmap.rs" 229 8 229 24
   let%span sfmap'20 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
@@ -1804,7 +1804,7 @@ module M_union_find__implementation__qyi1944850640244667852__find_inner [#"union
   let%span sfmap'8 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
   let%span sfmap'9 = "../../creusot-contracts/src/logic/fmap.rs" 104 8 104 26
   let%span sfmap'10 = "../../creusot-contracts/src/logic/fmap.rs" 49 14 49 25
-  let%span sfmap'11 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'11 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sfmap'12 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'13 = "../../creusot-contracts/src/logic/fmap.rs" 229 8 229 24
   let%span sfmap'14 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
@@ -2481,7 +2481,7 @@ module M_union_find__implementation__qyi1944850640244667852__find [#"union_find.
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
-  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sutil = "../../creusot-contracts/src/util.rs" 55 11 55 21
   let%span sutil'0 = "../../creusot-contracts/src/util.rs" 56 10 56 28
   let%span smapping = "../../creusot-contracts/src/logic/mapping.rs" 60 8 60 19
@@ -2791,7 +2791,7 @@ module M_union_find__implementation__qyi1944850640244667852__get [#"union_find.r
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 104 8 104 26
   let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'6 = "../../creusot-contracts/src/logic/fmap.rs" 229 8 229 24
-  let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sfmap'8 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
   let%span sutil = "../../creusot-contracts/src/util.rs" 55 11 55 21
   let%span sutil'0 = "../../creusot-contracts/src/util.rs" 56 10 56 28
@@ -3225,7 +3225,7 @@ module M_union_find__implementation__qyi1944850640244667852__equiv [#"union_find
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
-  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sutil = "../../creusot-contracts/src/util.rs" 55 11 55 21
   let%span sutil'0 = "../../creusot-contracts/src/util.rs" 56 10 56 28
   let%span smapping = "../../creusot-contracts/src/logic/mapping.rs" 60 8 60 19
@@ -3579,7 +3579,7 @@ module M_union_find__implementation__qyi1944850640244667852__link [#"union_find.
   let%span sfmap'8 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
   let%span sfmap'9 = "../../creusot-contracts/src/logic/fmap.rs" 104 8 104 26
   let%span sfmap'10 = "../../creusot-contracts/src/logic/fmap.rs" 49 14 49 25
-  let%span sfmap'11 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'11 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sfmap'12 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'13 = "../../creusot-contracts/src/logic/fmap.rs" 229 8 229 24
   let%span sfmap'14 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
@@ -4647,7 +4647,7 @@ module M_union_find__implementation__qyi1944850640244667852__union_aux [#"union_
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
-  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sutil = "../../creusot-contracts/src/util.rs" 55 11 55 21
   let%span sutil'0 = "../../creusot-contracts/src/util.rs" 56 10 56 28
   let%span smapping = "../../creusot-contracts/src/logic/mapping.rs" 60 8 60 19
@@ -5032,7 +5032,7 @@ module M_union_find__implementation__qyi1944850640244667852__union [#"union_find
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 59 14 59 86
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 117 8 117 31
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
-  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sutil = "../../creusot-contracts/src/util.rs" 55 11 55 21
   let%span sutil'0 = "../../creusot-contracts/src/util.rs" 56 10 56 28
   let%span smapping = "../../creusot-contracts/src/logic/mapping.rs" 60 8 60 19
@@ -5380,7 +5380,7 @@ module M_union_find__example [#"union_find.rs" 372 0 372 16]
   let%span sunion_find'38 = "union_find.rs" 160 16 162 52
   let%span sptr = "../../creusot-contracts/src/std/ptr.rs" 62 14 62 53
   let%span sptr'0 = "../../creusot-contracts/src/std/ptr.rs" 64 8 64 35
-  let%span sfmap = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 133 8 133 35
   let%span sfmap'1 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 104 8 104 26
@@ -5729,7 +5729,7 @@ module M_union_find__example_addrs_eq [#"union_find.rs" 392 0 392 77]
   let%span sptr = "../../creusot-contracts/src/std/ptr.rs" 62 14 62 53
   let%span sptr'0 = "../../creusot-contracts/src/std/ptr.rs" 64 8 64 35
   let%span smodel = "../../creusot-contracts/src/model.rs" 45 8 45 28
-  let%span sfmap = "../../creusot-contracts/src/logic/fmap.rs" 489 20 489 91
+  let%span sfmap = "../../creusot-contracts/src/logic/fmap.rs" 509 20 509 91
   let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 133 8 133 35
   let%span sfmap'1 = "../../creusot-contracts/src/logic/fmap.rs" 125 8 125 35
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 104 8 104 26

--- a/tests/should_succeed/vector/02_gnome.coma
+++ b/tests/should_succeed/vector/02_gnome.coma
@@ -14,7 +14,7 @@ module M_02_gnome__gnome_sort [#"02_gnome.rs" 22 0 24 29]
   let%span s02_gnome'11 = "02_gnome.rs" 11 8 11 74
   let%span s02_gnome'12 = "02_gnome.rs" 17 4 17 31
   let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 323 8 323 41
-  let%span sseq'0 = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'0 = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span smodel = "../../../creusot-contracts/src/model.rs" 72 8 72 22
   let%span smodel'0 = "../../../creusot-contracts/src/model.rs" 63 8 63 28
   let%span smodel'1 = "../../../creusot-contracts/src/model.rs" 54 8 54 22

--- a/tests/should_succeed/vector/03_knuth_shuffle.coma
+++ b/tests/should_succeed/vector/03_knuth_shuffle.coma
@@ -25,7 +25,7 @@ module M_03_knuth_shuffle__knuth_shuffle [#"03_knuth_shuffle.rs" 13 0 13 39]
   let%span siter'2 = "../../../creusot-contracts/src/std/iter.rs" 86 20 86 24
   let%span siter'3 = "../../../creusot-contracts/src/std/iter.rs" 92 8 92 19
   let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 323 8 323 41
-  let%span sseq'0 = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq'0 = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span smodel = "../../../creusot-contracts/src/model.rs" 72 8 72 22
   let%span smodel'0 = "../../../creusot-contracts/src/model.rs" 54 8 54 22
   let%span ssnapshot = "../../../creusot-contracts/src/snapshot.rs" 50 20 50 39

--- a/tests/should_succeed/vector/05_binary_search_generic.coma
+++ b/tests/should_succeed/vector/05_binary_search_generic.coma
@@ -66,7 +66,7 @@ module M_05_binary_search_generic__binary_search [#"05_binary_search_generic.rs"
   let%span sslice'0 = "../../../creusot-contracts/src/std/slice.rs" 130 20 130 37
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 90 8 90 18
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.int.UInt64

--- a/tests/should_succeed/vector/07_read_write.coma
+++ b/tests/should_succeed/vector/07_read_write.coma
@@ -26,7 +26,7 @@ module M_07_read_write__read_write [#"07_read_write.rs" 6 0 6 75]
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
   let%span sinvariant'0 = "../../../creusot-contracts/src/invariant.rs" 90 8 90 18
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.MutBorrow

--- a/tests/should_succeed/vector/09_capacity.coma
+++ b/tests/should_succeed/vector/09_capacity.coma
@@ -19,7 +19,7 @@ module M_09_capacity__change_capacity [#"09_capacity.rs" 6 0 6 41]
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 29 8 29 31
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.MutBorrow
@@ -186,7 +186,7 @@ module M_09_capacity__clear_vec [#"09_capacity.rs" 14 0 14 35]
   let%span svec'2 = "../../../creusot-contracts/src/std/vec.rs" 71 20 71 41
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 54 20 54 34
   let%span sinvariant = "../../../creusot-contracts/src/invariant.rs" 100 20 100 44
-  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 652 20 652 95
+  let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 672 20 672 95
   let%span sboxed = "../../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   
   use creusot.prelude.MutBorrow


### PR DESCRIPTION
Note that we cannot do something like
```rust
fn clear_set(set: &mut FSet) {
    *set = FSet::new();
}
```
Because `FSet::new` returns a `Ghost`.