### PR TITLE
Avoid unnecessarily resolving dependencies

### DIFF
--- a/creusot/src/analysis/not_final_places.rs
+++ b/creusot/src/analysis/not_final_places.rs
@@ -13,7 +13,7 @@ use std::{
     iter::once,
 };
 
-use crate::{extended_location::ExtendedLocation, fmir::BorrowKind};
+use crate::{extended_location::ExtendedLocation, translation::fmir::BorrowKind};
 
 type PlaceId = usize;
 

--- a/creusot/src/backend/clone_map.rs
+++ b/creusot/src/backend/clone_map.rs
@@ -6,7 +6,7 @@ use crate::{
     contracts_items::{get_builtin, get_inv_function, is_bitwise},
     ctx::*,
     options::SpanMode,
-    traits::TraitResolved,
+    translation::traits::TraitResolved,
     util::{erased_identity_for_item, path_of_span},
 };
 use elaborator::Strength;
@@ -192,11 +192,10 @@ pub(crate) trait Namer<'tcx> {
 
     fn resolve_dependency(&self, dep: Dependency<'tcx>) -> Dependency<'tcx> {
         let ctx = self.tcx();
-        if let Dependency::Item(def, args) = dep
-            && ctx.trait_of_item(def).is_some()
-            && let TraitResolved::Instance(def, args) =
-                TraitResolved::resolve_item(ctx, self.typing_env(), def, args)
-        {
+        if let Dependency::Item(def, args) = dep {
+            let (def, args) = TraitResolved::resolve_item(ctx, self.typing_env(), def, args)
+                .to_opt(def, args)
+                .unwrap();
             Dependency::Item(def, args)
         } else {
             dep

--- a/creusot/src/backend/clone_map.rs
+++ b/creusot/src/backend/clone_map.rs
@@ -6,6 +6,7 @@ use crate::{
     contracts_items::{get_builtin, get_inv_function, is_bitwise},
     ctx::*,
     options::SpanMode,
+    traits::TraitResolved,
     util::{erased_identity_for_item, path_of_span},
 };
 use elaborator::Strength;
@@ -181,9 +182,30 @@ pub(crate) trait Namer<'tcx> {
             .without_search_path()
     }
 
-    fn dependency(&self, dep: Dependency<'tcx>) -> &Kind;
+    // TODO: get rid of this. `erase_regions` should be the responsibility of the callers.
+    // NOTE: should `Namer::ty()` be asserting with `has_erasable_regions` instead?
+    fn raw_dependency(&self, dep: Dependency<'tcx>) -> &Kind;
+
+    fn dependency(&self, dep: Dependency<'tcx>) -> &Kind {
+        self.raw_dependency(dep.erase_regions(self.tcx()))
+    }
+
+    fn resolve_dependency(&self, dep: Dependency<'tcx>) -> Dependency<'tcx> {
+        let ctx = self.tcx();
+        if let Dependency::Item(def, args) = dep
+            && ctx.trait_of_item(def).is_some()
+            && let TraitResolved::Instance(def, args) =
+                TraitResolved::resolve_item(ctx, self.typing_env(), def, args)
+        {
+            Dependency::Item(def, args)
+        } else {
+            dep
+        }
+    }
 
     fn tcx(&self) -> TyCtxt<'tcx>;
+
+    fn typing_env(&self) -> TypingEnv<'tcx>;
 
     fn span(&self, span: Span) -> Option<Attribute>;
 
@@ -196,13 +218,28 @@ impl<'tcx> Namer<'tcx> for CloneNames<'tcx> {
         self.tcx().normalize_erasing_regions(self.typing_env, ty)
     }
 
-    fn dependency(&self, key: Dependency<'tcx>) -> &Kind {
-        let key = key.erase_regions(self.tcx);
-        self.insert(self.tcx, key)
+    fn raw_dependency(&self, key: Dependency<'tcx>) -> &Kind {
+        self.names.insert(key, |_| {
+            if let Some((did, _)) = key.did()
+                && let Some(why3_modl) = get_builtin(self.tcx, did)
+            {
+                let why3_modl =
+                    why3_modl.as_str().replace("$BW$", if self.bitwise_mode { "BW" } else { "" });
+                let qname = QName::parse(&why3_modl);
+                return Box::new(Kind::UsedBuiltin(qname));
+            }
+            Box::new(key.base_ident(self.tcx).map_or(Kind::Unnamed, |base| {
+                Kind::Named(Ident::fresh(crate_name(self.tcx), base.as_str()))
+            }))
+        })
     }
 
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
+    }
+
+    fn typing_env(&self) -> TypingEnv<'tcx> {
+        self.typing_env
     }
 
     fn span(&self, span: Span) -> Option<Attribute> {
@@ -222,22 +259,6 @@ impl<'tcx> Namer<'tcx> for CloneNames<'tcx> {
 }
 
 impl<'tcx> CloneNames<'tcx> {
-    fn insert(&self, tcx: TyCtxt<'tcx>, key: Dependency<'tcx>) -> &Kind {
-        self.names.insert(key, |_| {
-            if let Some((did, _)) = key.did()
-                && let Some(why3_modl) = get_builtin(tcx, did)
-            {
-                let why3_modl =
-                    why3_modl.as_str().replace("$BW$", if self.bitwise_mode { "BW" } else { "" });
-                let qname = QName::parse(&why3_modl);
-                return Box::new(Kind::UsedBuiltin(qname));
-            }
-            Box::new(key.base_ident(tcx).map_or(Kind::Unnamed, |base| {
-                Kind::Named(Ident::fresh(crate_name(tcx), base.as_str()))
-            }))
-        })
-    }
-
     fn bitwise_mode(&self) -> bool {
         self.bitwise_mode
     }
@@ -252,10 +273,13 @@ impl<'tcx> Namer<'tcx> for Dependencies<'tcx> {
         self.tcx
     }
 
-    fn dependency(&self, key: Dependency<'tcx>) -> &Kind {
-        let key = key.erase_regions(self.tcx);
+    fn typing_env(&self) -> TypingEnv<'tcx> {
+        self.names.typing_env()
+    }
+
+    fn raw_dependency(&self, key: Dependency<'tcx>) -> &Kind {
         self.dep_set.borrow_mut().insert(key);
-        self.names.dependency(key)
+        self.names.raw_dependency(key)
     }
 
     fn span(&self, span: Span) -> Option<Attribute> {

--- a/creusot/src/backend/clone_map/elaborator.rs
+++ b/creusot/src/backend/clone_map/elaborator.rs
@@ -20,7 +20,6 @@ use crate::{
         },
         ty_inv::InvariantElaborator,
     },
-    constant::from_ty_const,
     contracts_items::{
         get_builtin, get_fn_impl_postcond, get_fn_mut_impl_hist_inv, get_fn_mut_impl_postcond,
         get_fn_once_impl_postcond, get_fn_once_impl_precond, get_resolve_method,
@@ -30,16 +29,19 @@ use crate::{
     },
     ctx::{BodyId, ItemType},
     naming::name,
-    pearlite::{Pattern, QuantKind, SmallRenaming, Term, TermKind, Trigger, normalize},
-    specification::Condition,
-    traits::{self, TraitResolved},
+    translation::{
+        constant::from_ty_const,
+        pearlite::{Pattern, QuantKind, SmallRenaming, Term, TermKind, Trigger, normalize},
+        specification::Condition,
+        traits::TraitResolved,
+    },
 };
 use petgraph::graphmap::DiGraphMap;
 use rustc_ast::Mutability;
 use rustc_hir::{def::DefKind, def_id::DefId};
 use rustc_middle::ty::{
-    AssocItem, AssocItemContainer, Const, GenericArg, GenericArgsRef, TraitRef, Ty, TyCtxt, TyKind,
-    TypeFoldable, TypingEnv, UnevaluatedConst,
+    Const, GenericArg, GenericArgsRef, TraitRef, Ty, TyCtxt, TyKind, TypeFoldable, TypingEnv,
+    UnevaluatedConst,
 };
 use rustc_span::{DUMMY_SP, Span};
 use rustc_type_ir::{ClosureKind, ConstKind, EarlyBinder};
@@ -131,9 +133,7 @@ impl DepElab for ProgramElab {
                 .instantiate(ctx.tcx, subst)
                 .normalize(ctx.tcx, typing_env);
 
-            if let Some(AssocItem { container: AssocItemContainer::Trait, .. }) =
-                ctx.opt_associated_item(def_id)
-                && let TraitResolved::UnknownFound = TraitResolved::resolve_item(ctx.tcx, typing_env, def_id, subst)
+            if let TraitResolved::UnknownFound = TraitResolved::resolve_item(ctx.tcx, typing_env, def_id, subst)
                 // These conditions are important to make sure the Fn trait familly is implemented
                 && ctx.fn_sig(def_id).skip_binder().is_fn_trait_compatible()
                 && ctx.codegen_fn_attrs(def_id).target_features.is_empty()
@@ -233,21 +233,23 @@ impl DepElab for LogicElab {
             .normalize(ctx.tcx, typing_env);
         let bound: Box<[Ident]> = pre_sig.inputs.iter().map(|(ident, _, _)| ident.0).collect();
 
-        let trait_resol = ctx
-            .tcx
-            .trait_of_item(def_id)
-            .map(|_| traits::TraitResolved::resolve_item(ctx.tcx, typing_env, def_id, subst));
-
-        let is_opaque = matches!(
+        let trait_resol = TraitResolved::resolve_item(ctx.tcx, typing_env, def_id, subst);
+        assert_matches!(
             trait_resol,
-            Some(traits::TraitResolved::UnknownFound | traits::TraitResolved::UnknownNotFound)
-        ) || !ctx.is_transparent_from(def_id, elab.self_key.did().unwrap().0)
+            TraitResolved::NotATraitItem
+            | TraitResolved::Instance(..) // The default impl is known to be the final instance
+            | TraitResolved::UnknownFound // Unresolved trait method
+        );
+        // The other case are impossible, because that would mean we are  not guaranteed to have an instance
+
+        let opaque = matches!(trait_resol, TraitResolved::UnknownFound)
+            || !ctx.is_transparent_from(def_id, elab.self_key.did().unwrap().0)
             || is_trusted_item(ctx.tcx, def_id);
 
         let names = elab.namer(dep);
         let name = names.dependency(dep).ident();
         let sig = lower_logic_sig(ctx, &names, name, pre_sig, def_id);
-        if !is_opaque && let Some(term) = term(ctx, typing_env, &bound, dep) {
+        if !opaque && let Some(term) = term(ctx, typing_env, &bound, dep) {
             lower_logical_defn(ctx, &names, sig, kind, term)
         } else {
             let mut decls = val(sig, kind);
@@ -546,16 +548,17 @@ fn resolve_term<'tcx>(
     if let &TyKind::Closure(def_id, subst) = subst[0].as_type().unwrap().kind() {
         Some(closure_resolve(ctx, def_id, subst, bound))
     } else {
-        match traits::TraitResolved::resolve_item(ctx.tcx, typing_env, trait_meth_id, subst) {
-            traits::TraitResolved::Instance(meth_did, meth_substs) => {
+        match TraitResolved::resolve_item(ctx.tcx, typing_env, trait_meth_id, subst) {
+            TraitResolved::NotATraitItem => unreachable!(),
+            TraitResolved::Instance(meth_did, meth_substs) => {
                 // We know the instance => body points to it
                 Some(Term::call(ctx.tcx, typing_env, meth_did, meth_substs, [arg]))
             }
-            traits::TraitResolved::UnknownFound | traits::TraitResolved::UnknownNotFound => {
+            TraitResolved::UnknownFound | TraitResolved::UnknownNotFound => {
                 // We don't know the instance => body is opaque
                 None
             }
-            traits::TraitResolved::NoInstance => {
+            TraitResolved::NoInstance => {
                 // We know there is no instance => body is true
                 Some(Term::true_(ctx.tcx))
             }
@@ -641,17 +644,12 @@ fn fn_once_postcond_term<'tcx>(
             ))
         }
         &TyKind::FnDef(mut did, mut subst) => {
-            if let Some(AssocItem { container: AssocItemContainer::Trait, .. }) =
-                ctx.opt_associated_item(did)
-            {
-                let TraitResolved::Instance(did_i, subst_i) =
-                    TraitResolved::resolve_item(ctx.tcx, typing_env, did, subst)
-                else {
-                    return None;
-                };
-                did = did_i;
-                subst = subst_i;
-            };
+            match TraitResolved::resolve_item(ctx.tcx, typing_env, did, subst) {
+                TraitResolved::NotATraitItem => (),
+                TraitResolved::Instance(did_i, subst_i) => (did, subst) = (did_i, subst_i),
+                TraitResolved::UnknownFound => return None,
+                TraitResolved::UnknownNotFound | TraitResolved::NoInstance => unreachable!(),
+            }
             post_fndef(ctx, typing_env, did, subst, args, res)
         }
         _ => None,
@@ -753,17 +751,12 @@ fn fn_mut_postcond_term<'tcx>(
             ]))
         }
         &TyKind::FnDef(mut did, mut subst) => {
-            if let Some(AssocItem { container: AssocItemContainer::Trait, .. }) =
-                ctx.opt_associated_item(did)
-            {
-                let TraitResolved::Instance(did_i, subst_i) =
-                    TraitResolved::resolve_item(ctx.tcx, typing_env, did, subst)
-                else {
-                    return None;
-                };
-                did = did_i;
-                subst = subst_i;
-            };
+            match TraitResolved::resolve_item(ctx.tcx, typing_env, did, subst) {
+                TraitResolved::NotATraitItem => (),
+                TraitResolved::Instance(did_i, subst_i) => (did, subst) = (did_i, subst_i),
+                TraitResolved::UnknownFound => return None,
+                TraitResolved::UnknownNotFound | TraitResolved::NoInstance => unreachable!(),
+            }
             post_fndef(ctx, typing_env, did, subst, args, res)
         }
         _ => None,
@@ -834,17 +827,12 @@ fn fn_postcond_term<'tcx>(
             ]))
         }
         &TyKind::FnDef(mut did, mut subst) => {
-            if let Some(AssocItem { container: AssocItemContainer::Trait, .. }) =
-                ctx.opt_associated_item(did)
-            {
-                let TraitResolved::Instance(did_i, subst_i) =
-                    TraitResolved::resolve_item(ctx.tcx, typing_env, did, subst)
-                else {
-                    return None;
-                };
-                did = did_i;
-                subst = subst_i;
-            };
+            match TraitResolved::resolve_item(ctx.tcx, typing_env, did, subst) {
+                TraitResolved::NotATraitItem => (),
+                TraitResolved::Instance(did_i, subst_i) => (did, subst) = (did_i, subst_i),
+                TraitResolved::UnknownFound => return None,
+                TraitResolved::UnknownNotFound | TraitResolved::NoInstance => unreachable!(),
+            }
             post_fndef(ctx, typing_env, did, subst, args, res)
         }
         _ => None,
@@ -915,17 +903,12 @@ fn fn_once_precond_term<'tcx>(
             ]))
         }
         &TyKind::FnDef(mut did, mut subst) => {
-            if let Some(AssocItem { container: AssocItemContainer::Trait, .. }) =
-                ctx.opt_associated_item(did)
-            {
-                let TraitResolved::Instance(did_i, subst_i) =
-                    TraitResolved::resolve_item(ctx.tcx, typing_env, did, subst)
-                else {
-                    return None;
-                };
-                did = did_i;
-                subst = subst_i;
-            };
+            match TraitResolved::resolve_item(ctx.tcx, typing_env, did, subst) {
+                TraitResolved::NotATraitItem => (),
+                TraitResolved::Instance(did_i, subst_i) => (did, subst) = (did_i, subst_i),
+                TraitResolved::UnknownFound => return None,
+                TraitResolved::UnknownNotFound | TraitResolved::NoInstance => unreachable!(),
+            }
             pre_fndef(ctx, typing_env, did, subst, args)
         }
         // Handle `FnPureWrapper`

--- a/creusot/src/backend/closures.rs
+++ b/creusot/src/backend/closures.rs
@@ -2,9 +2,12 @@ use crate::{
     contracts_items::get_fn_mut_impl_hist_inv,
     ctx::*,
     naming::name,
-    pearlite::{Ident, Pattern, Term, TermKind, TermVisitorMut, normalize, super_visit_mut_term},
-    specification::PreSignature,
-    translation::specification::contract_of,
+    translation::{
+        pearlite::{
+            Ident, Pattern, Term, TermKind, TermVisitorMut, normalize, super_visit_mut_term,
+        },
+        specification::{PreSignature, contract_of},
+    },
 };
 use indexmap::IndexMap;
 use itertools::Itertools;

--- a/creusot/src/backend/optimization/invariants.rs
+++ b/creusot/src/backend/optimization/invariants.rs
@@ -13,8 +13,10 @@ use crate::{
     },
     contracts_items::get_snap_ty,
     ctx::TranslationCtx,
-    pearlite::{Ident, Term},
-    translation::fmir,
+    translation::{
+        fmir,
+        pearlite::{Ident, Term},
+    },
 };
 use petgraph::Direction;
 

--- a/creusot/src/backend/place.rs
+++ b/creusot/src/backend/place.rs
@@ -1,8 +1,8 @@
 use crate::{
     backend::clone_map::Namer,
     ctx::PreMod,
-    fmir::{Place, ProjectionElem},
     naming::name,
+    translation::fmir::{Place, ProjectionElem},
 };
 use rustc_middle::{
     mir::tcx::PlaceTy,

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -25,11 +25,15 @@ use crate::{
         wto::{Component, weak_topological_order},
     },
     ctx::{BodyId, Dependencies},
-    fmir::{Body, BorrowKind, Operand, TrivialInv},
     naming::name,
-    pearlite::Pattern,
     translated_item::FileModule,
-    translation::fmir::{Block, Branches, LocalDecls, Place, RValue, Statement, Terminator},
+    translation::{
+        fmir::{
+            Block, Body, BorrowKind, Branches, LocalDecls, Operand, Place, RValue, Statement,
+            Terminator, TrivialInv,
+        },
+        pearlite::Pattern,
+    },
 };
 use indexmap::IndexMap;
 use petgraph::graphmap::DiGraphMap;

--- a/creusot/src/backend/signature.rs
+++ b/creusot/src/backend/signature.rs
@@ -7,7 +7,7 @@ use crate::{
         ty::translate_ty,
     },
     contracts_items::{should_replace_trigger, why3_attrs},
-    specification::{PreContract, PreSignature},
+    translation::specification::{PreContract, PreSignature},
 };
 use rustc_hir::def_id::DefId;
 use why3::{

--- a/creusot/src/backend/structural_resolve.rs
+++ b/creusot/src/backend/structural_resolve.rs
@@ -5,7 +5,7 @@ use rustc_type_ir::TyKind;
 
 use crate::{
     contracts_items::{get_builtin, is_snap_ty, is_trusted},
-    pearlite::{Ident, Pattern, Term, TermKind},
+    translation::pearlite::{Ident, Pattern, Term, TermKind},
 };
 
 use super::Why3Generator;

--- a/creusot/src/backend/term.rs
+++ b/creusot/src/backend/term.rs
@@ -6,8 +6,12 @@ use crate::{
     },
     ctx::*,
     naming::name,
-    pearlite::{BinOp, Literal, Pattern, PatternKind, QuantKind, Term, TermKind, Trigger, UnOp},
-    specification::Condition,
+    translation::{
+        pearlite::{
+            BinOp, Literal, Pattern, PatternKind, QuantKind, Term, TermKind, Trigger, UnOp,
+        },
+        specification::Condition,
+    },
 };
 use rustc_ast::Mutability;
 use rustc_hir::def::DefKind;

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -10,15 +10,13 @@ use crate::{
     metadata::{BinaryMetadata, Metadata},
     naming::variable_name,
     options::Options,
-    pearlite::ScopedTerm,
-    specification::{PreSignature, inherited_extern_spec, pre_sig_of},
-    traits::TraitResolved,
     translation::{
         self,
         external::{ExternSpec, extract_extern_specs_from_item},
         fmir, pearlite,
-        specification::ContractClauses,
-        traits::TraitImpl,
+        pearlite::ScopedTerm,
+        specification::{ContractClauses, PreSignature, inherited_extern_spec, pre_sig_of},
+        traits::{TraitImpl, TraitResolved},
     },
     util::{erased_identity_for_item, parent_module},
 };

--- a/creusot/src/gather_spec_closures.rs
+++ b/creusot/src/gather_spec_closures.rs
@@ -3,7 +3,7 @@ use crate::{
         get_invariant_expl, is_assertion, is_before_loop, is_loop_variant, is_snapshot_closure,
     },
     ctx::TranslationCtx,
-    pearlite::Term,
+    translation::pearlite::Term,
 };
 use indexmap::{IndexMap, IndexSet};
 use rustc_hir::def_id::DefId;

--- a/creusot/src/lib.rs
+++ b/creusot/src/lib.rs
@@ -57,7 +57,6 @@ mod resolve;
 mod run_why3;
 mod translated_item;
 mod translation;
-use translation::*;
 mod util;
 mod validate;
 mod very_stable_hash;

--- a/creusot/src/metadata.rs
+++ b/creusot/src/metadata.rs
@@ -1,4 +1,8 @@
-use crate::{creusot_items::CreusotItems, ctx::*, external::ExternSpec, pearlite::ScopedTerm};
+use crate::{
+    creusot_items::CreusotItems,
+    ctx::*,
+    translation::{external::ExternSpec, pearlite::ScopedTerm},
+};
 use creusot_metadata::{decode_metadata, encode_metadata};
 use indexmap::IndexMap;
 use once_map::unsync::OnceMap;

--- a/creusot/src/translation/constant.rs
+++ b/creusot/src/translation/constant.rs
@@ -1,12 +1,10 @@
 use crate::{
     contracts_items::get_builtin,
     ctx::TranslationCtx,
-    fmir::{self, Operand},
-    traits::TraitResolved,
-    translation::pearlite::Literal,
+    translation::{fmir::Operand, pearlite::Literal, traits::TraitResolved},
 };
 use rustc_middle::{
-    mir::{self, ConstValue, UnevaluatedConst, interpret::AllocRange},
+    mir::{self, ConstOperand, ConstValue, UnevaluatedConst, interpret::AllocRange},
     ty::{Const, ConstKind, Ty, TyCtxt, TypingEnv},
 };
 use rustc_span::{DUMMY_SP, Span};
@@ -17,8 +15,8 @@ use super::pearlite::{Term, TermKind};
 pub(crate) fn from_mir_constant<'tcx>(
     env: TypingEnv<'tcx>,
     ctx: &TranslationCtx<'tcx>,
-    c: &rustc_middle::mir::ConstOperand<'tcx>,
-) -> fmir::Operand<'tcx> {
+    c: &ConstOperand<'tcx>,
+) -> Operand<'tcx> {
     from_mir_constant_kind(ctx, c.const_, env, c.span)
 }
 
@@ -27,7 +25,7 @@ fn from_mir_constant_kind<'tcx>(
     ck: mir::Const<'tcx>,
     env: TypingEnv<'tcx>,
     span: Span,
-) -> fmir::Operand<'tcx> {
+) -> Operand<'tcx> {
     if let mir::Const::Ty(ty, c) = ck {
         return Operand::Constant(from_ty_const(ctx, c, ty, env, span));
     }

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -59,7 +59,7 @@ pub(crate) fn extract_extern_specs_from_item<'tcx>(
 
     let (id, subst) = visit.items.pop().unwrap();
 
-    let (id, _) = if ctx.trait_of_item(id).is_some() {
+    let (id, _) =
         TraitResolved::resolve_item(ctx.tcx, ctx.typing_env(def_id_), id, subst).to_opt(id, subst).unwrap_or_else(|| {
             let mut err = ctx.fatal_error(
                 ctx.def_span(def_id_),
@@ -68,10 +68,7 @@ pub(crate) fn extract_extern_specs_from_item<'tcx>(
 
             err.span_warn(ctx.def_span(def_id_), "the bounds on an external specification must be at least as strong as the original impl bounds");
             err.emit()
-        })
-    } else {
-        (id, subst)
-    };
+        });
 
     // Generics of the actual item.
     let mut inner_subst = erased_identity_for_item(ctx.tcx, id).to_vec();

--- a/creusot/src/translation/fmir.rs
+++ b/creusot/src/translation/fmir.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{backend::place::projection_ty, ctx::TranslationCtx, pearlite::Term};
+use crate::{backend::place::projection_ty, ctx::TranslationCtx, translation::pearlite::Term};
 use indexmap::IndexMap;
 use rustc_hir::def_id::DefId;
 use rustc_middle::{

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -4,16 +4,18 @@ mod terminator;
 use crate::{
     analysis::NotFinalPlaces,
     backend::ty_inv::is_tyinv_trivial,
-    constant::from_mir_constant,
     contracts_items::{is_snapshot_closure, is_spec},
     ctx::*,
     extended_location::ExtendedLocation,
-    fmir::{self, LocalDecl, LocalDecls, RValue, TrivialInv, inline_pearlite_subst},
     gather_spec_closures::{LoopSpecKind, SpecClosures, corrected_invariant_names_and_locations},
     naming::variable_name,
-    pearlite::{Ident, Term},
     resolve::{HasMoveDataExt, Resolver, place_contains_borrow_deref},
-    translation::function::terminator::discriminator_for_switch,
+    translation::{
+        constant::from_mir_constant,
+        fmir::{self, LocalDecl, LocalDecls, RValue, TrivialInv, inline_pearlite_subst},
+        function::terminator::discriminator_for_switch,
+        pearlite::{Ident, Term},
+    },
 };
 use indexmap::IndexMap;
 use rustc_borrowck::consumers::BorrowSet;

--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -5,8 +5,10 @@ use crate::{
         is_assertion, is_before_loop, is_invariant, is_snapshot_closure, is_spec, is_variant,
     },
     extended_location::ExtendedLocation,
-    fmir::Operand,
-    translation::fmir::{self, RValue, inline_pearlite_subst},
+    translation::{
+        constant::from_ty_const,
+        fmir::{self, Operand, RValue, inline_pearlite_subst},
+    },
 };
 use rustc_borrowck::consumers::TwoPhaseActivation;
 use rustc_middle::{
@@ -197,7 +199,7 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
             }
             Rvalue::Repeat(op, len) => RValue::Repeat(
                 self.translate_operand(op)?,
-                Operand::Constant(crate::constant::from_ty_const(
+                Operand::Constant(from_ty_const(
                     self.ctx,
                     *len,
                     self.ctx.types.usize,

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -7,8 +7,9 @@ use crate::{
     },
     ctx::*,
     naming::{name, variable_name},
-    pearlite::{Ident, PIdent, TermVisitorMut},
-    translation::pearlite::{Literal, Term, TermKind, normalize, type_invariant_term},
+    translation::pearlite::{
+        Ident, Literal, PIdent, Term, TermKind, TermVisitorMut, normalize, type_invariant_term,
+    },
     util::erased_identity_for_item,
 };
 use rustc_hir::{AttrArgs, Safety, def_id::DefId};

--- a/creusot/src/validate/opacity.rs
+++ b/creusot/src/validate/opacity.rs
@@ -6,8 +6,7 @@ use crate::{
     contracts_items::{is_spec, opacity_witness_name},
     ctx::TranslationCtx,
     error::CannotFetchThir,
-    pearlite::ScopedTerm,
-    translation::pearlite::{TermKind, TermVisitor, super_visit_term},
+    translation::pearlite::{ScopedTerm, TermKind, TermVisitor, super_visit_term},
     util::parent_module,
 };
 


### PR DESCRIPTION
I was having problems with dependencies having wrong names because they are normalized at expansion time by `update_graph`. This moves them to dependency insertion time in `dependency`.

~~I'm probably still missing something because this change introduces duplicate declarations.~~ Trait laws were added to the expansion queue directly and needed an ad hoc call to normalization.