### PR TITLE
Specialize extern implementation of extern traits

### DIFF
--- a/creusot/src/contracts_items/attributes.rs
+++ b/creusot/src/contracts_items/attributes.rs
@@ -57,6 +57,8 @@ attribute_functions! {
     [creusot::trusted_ignore_structural_inv] => is_ignore_structural_inv
     [creusot::trusted_is_tyinv_trivial_if_param_trivial] => is_tyinv_trivial_if_param_trivial
     [creusot::clause::variant]               => has_variant_clause
+    [creusot::clause::terminates]            => is_terminates
+    [creusot::clause::no_panic]              => is_no_panic
     [creusot::bitwise]                       => is_bitwise
 }
 
@@ -119,7 +121,7 @@ pub(crate) fn get_creusot_item(tcx: TyCtxt, def_id: DefId) -> Option<Symbol> {
     )
 }
 
-pub(crate) fn is_open_inv_param<'tcx>(tcx: TyCtxt<'tcx>, p: &Param) -> bool {
+pub(crate) fn is_open_inv_param(tcx: TyCtxt, p: &Param) -> bool {
     let mut found = false;
     for a in &p.attrs {
         if a.is_doc_comment() {
@@ -147,7 +149,7 @@ pub(crate) fn is_open_inv_param<'tcx>(tcx: TyCtxt<'tcx>, p: &Param) -> bool {
         }
     }
 
-    return found;
+    found
 }
 
 fn get_attrs<'a>(attrs: &'a [Attribute], path: &[&str]) -> Vec<&'a Attribute> {
@@ -173,15 +175,11 @@ fn get_attrs<'a>(attrs: &'a [Attribute], path: &[&str]) -> Vec<&'a Attribute> {
     matched
 }
 
-fn get_attr<'a, 'tcx>(
-    tcx: TyCtxt<'tcx>,
-    attrs: &'a [Attribute],
-    path: &[&str],
-) -> Option<&'a Attribute> {
+fn get_attr<'a>(tcx: TyCtxt, attrs: &'a [Attribute], path: &[&str]) -> Option<&'a Attribute> {
     let matched = get_attrs(attrs, path);
     match matched.len() {
-        0 => return None,
-        1 => return Some(matched[0]),
+        0 => None,
+        1 => Some(matched[0]),
         _ => tcx.dcx().span_fatal(matched[0].span, "Unexpected duplicate attribute.".to_string()),
     }
 }

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -3,7 +3,7 @@ use crate::{
     contracts_items::{
         creusot_clause_attrs, get_fn_mut_impl_hist_inv, is_fn_impl_postcond,
         is_fn_mut_impl_hist_inv, is_fn_mut_impl_postcond, is_fn_once_impl_postcond,
-        is_fn_once_impl_precond, is_open_inv_result,
+        is_fn_once_impl_precond, is_no_panic, is_open_inv_result, is_terminates,
     },
     ctx::*,
     naming::{name, variable_name},
@@ -207,8 +207,8 @@ pub(crate) fn contract_clauses_of(
             return Err(MultipleVariant { id: def_id });
         }
     }
-    let terminates = creusot_clause_attrs(ctx.tcx, def_id, "terminates").next().is_some();
-    let no_panic = creusot_clause_attrs(ctx.tcx, def_id, "no_panic").next().is_some();
+    let terminates = is_terminates(ctx.tcx, def_id);
+    let no_panic = is_no_panic(ctx.tcx, def_id);
 
     Ok(ContractClauses { requires, ensures, variant, terminates, no_panic })
 }

--- a/tests/should_succeed/purity.coma
+++ b/tests/should_succeed/purity.coma
@@ -37,3 +37,22 @@ module M_purity__result [#"purity.rs" 39 0 39 15]
     [ bb0 = s0 [ s0 = {[@expl:assertion] [%#spurity] calls_g = 1} s1 | s1 = return''0 {_0} ]  ]
     ) [ & _0 : () = Any.any_l () ]  [ return''0 (result'0:())-> (! return' {result'0}) ] 
 end
+module M_purity__clone_id [#"purity.rs" 45 0 45 22]
+  let%span spcell = "../../creusot-contracts/src/pcell.rs" 33 14 33 29
+  
+  use creusot.prelude.Any
+  
+  type t_Id
+  
+  let rec clone' (self:t_Id) (return'  (x:t_Id))= any
+    [ return''0 (result:t_Id)-> {[%#spcell] result = self} (! return' {result}) ]
+  
+  
+  meta "compute_max_steps" 1000000
+  
+  let rec clone_id[#"purity.rs" 45 0 45 22] (i:t_Id) (return'  (x:()))= (! bb0
+    [ bb0 = s0 [ s0 = clone' {i'0} (fun (_ret:t_Id) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
+    ) [ & _0 : () = Any.any_l () | & i'0 : t_Id = i | & _2 : t_Id = Any.any_l () ] 
+    [ return''0 (result:())-> (! return' {result}) ]
+
+end

--- a/tests/should_succeed/purity.rs
+++ b/tests/should_succeed/purity.rs
@@ -1,5 +1,5 @@
 extern crate creusot_contracts;
-use creusot_contracts::*;
+use creusot_contracts::{pcell::Id, *};
 
 // This tests showcases specialization of purity attribute when calling trait implementations.
 
@@ -38,4 +38,10 @@ pub fn calls_g() -> Int {
 
 pub fn result() {
     proof_assert!(calls_g() == 1);
+}
+
+// Shows that a trait impl in an external crate (creusot_contracts) is correctly specialized.
+#[pure]
+pub fn clone_id(i: Id) {
+    let _ = i.clone();
 }

--- a/tests/should_succeed/purity/proof.json
+++ b/tests/should_succeed/purity/proof.json
@@ -10,6 +10,10 @@
       "vc_calls_f": { "prover": "cvc5@1.0.5", "time": 0.014 },
       "vc_f": { "prover": "cvc5@1.0.5", "time": 0.014 }
     },
+    "M_purity__clone_id": {
+      "vc_clone'": { "prover": "cvc5@1.0.5", "time": 0.025 },
+      "vc_clone_id": { "prover": "cvc5@1.0.5", "time": 0.023 }
+    },
     "M_purity__qyi14899607085053415061__f": {
       "vc_f": { "prover": "cvc5@1.0.5", "time": 0.014 }
     },


### PR DESCRIPTION
A small thing that I found: if a trait is specified using `extern_spec!`, and an impl is declared in a dependency (eg `creusot_contracts`), the spec for the _trait_ (and not the impl) was used.