### PR TITLE
Move Creusot logic into after_analysis

### DIFF
--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -6,7 +6,6 @@ use why3::declaration::Attribute;
 use crate::{
     contracts_items::{is_resolve_function, is_spec, is_trusted},
     ctx::{ItemType, TranslatedItem, TranslationCtx},
-    error::CannotFetchThir,
     naming::ModulePath,
     options::SpanMode,
     run_why3::SpanMap,
@@ -58,7 +57,7 @@ impl<'tcx> Why3Generator<'tcx> {
         Why3Generator { ctx, functions: Default::default(), span_map: Default::default() }
     }
 
-    pub(crate) fn translate(&mut self, def_id: DefId) -> Result<(), CannotFetchThir> {
+    pub(crate) fn translate(&mut self, def_id: DefId) {
         debug!("translating {:?}", def_id);
 
         match self.item_type(def_id) {
@@ -70,7 +69,7 @@ impl<'tcx> Why3Generator<'tcx> {
                 self.functions.push(TranslatedItem::Logic { proof_modl: None });
             }
             ItemType::Logic { .. } | ItemType::Predicate { .. } => {
-                let proof_modl = logic::translate_logic_or_predicate(self, def_id)?;
+                let proof_modl = logic::translate_logic_or_predicate(self, def_id);
                 self.functions.push(TranslatedItem::Logic { proof_modl });
             }
             ItemType::Program => {
@@ -84,7 +83,6 @@ impl<'tcx> Why3Generator<'tcx> {
             ),
             _ => (),
         }
-        Ok(())
     }
 
     pub(crate) fn modules(&mut self) -> impl Iterator<Item = TranslatedItem> + '_ {

--- a/creusot/src/backend/clone_map/elaborator.rs
+++ b/creusot/src/backend/clone_map/elaborator.rs
@@ -1048,7 +1048,7 @@ fn term<'tcx>(
             } else if is_fn_mut_impl_hist_inv(ctx.tcx, def_id) {
                 fn_mut_hist_inv_term(ctx, typing_env, subst, bound)
             } else {
-                let term = ctx.term_fail_fast(def_id).unwrap().rename(bound);
+                let term = ctx.term(def_id).unwrap().rename(bound);
                 let term = normalize(
                     ctx.tcx,
                     typing_env,

--- a/creusot/src/backend/logic.rs
+++ b/creusot/src/backend/logic.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::{
-        CannotFetchThir, Why3Generator, is_trusted_item, logic::vcgen::wp,
-        signature::lower_logic_sig, term::lower_pure, ty::translate_ty,
+        Why3Generator, is_trusted_item, logic::vcgen::wp, signature::lower_logic_sig,
+        term::lower_pure, ty::translate_ty,
     },
     contracts_items::get_builtin,
     ctx::*,
@@ -21,12 +21,12 @@ mod vcgen;
 pub(crate) fn translate_logic_or_predicate(
     ctx: &Why3Generator,
     def_id: DefId,
-) -> Result<Option<FileModule>, CannotFetchThir> {
+) -> Option<FileModule> {
     let mut names = Dependencies::new(ctx, def_id);
     let pre_sig = ctx.sig(def_id).clone().normalize(ctx.tcx, ctx.typing_env(def_id));
 
     if pre_sig.contract.is_empty() {
-        return Ok(None);
+        return None;
     }
 
     // Check that we don't have both `builtins` and a contract at the same time (which are contradictory)
@@ -38,7 +38,7 @@ pub(crate) fn translate_logic_or_predicate(
     }
 
     if !def_id.is_local() || is_trusted_item(ctx.tcx, def_id) || !ctx.has_body(def_id) {
-        return Ok(None);
+        return None;
     }
 
     let mut body_decls = Vec::new();
@@ -86,7 +86,7 @@ pub(crate) fn translate_logic_or_predicate(
 
     let postcondition = sig.contract.ensures_conj();
 
-    let term = ctx.ctx.term(def_id)?.unwrap().rename(&bound);
+    let term = ctx.ctx.term(def_id).unwrap().rename(&bound);
     let wp = wp(
         ctx,
         &mut names,
@@ -113,7 +113,7 @@ pub(crate) fn translate_logic_or_predicate(
     let meta = ctx.display_impl_of(def_id);
     let path = ctx.module_path(def_id);
     let name = path.why3_ident();
-    Ok(Some(FileModule { path, modl: Module { name, decls: decls.into(), attrs, meta } }))
+    Some(FileModule { path, modl: Module { name, decls: decls.into(), attrs, meta } })
 }
 
 /// Translate a logical term to why3.

--- a/creusot/src/error.rs
+++ b/creusot/src/error.rs
@@ -1,11 +1,11 @@
 use rustc_middle::ty::TyCtxt;
-use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
+use rustc_span::{DUMMY_SP, Span};
 
 pub type CreusotResult<T> = Result<T, Error>;
 
 pub(crate) enum Error {
     MustPrint(Message),
-    TypeCheck(CannotFetchThir),
+    ErrorGuaranteed,
 }
 
 // TODO: make this a vector of spans and strings
@@ -30,62 +30,21 @@ impl Error {
     pub(crate) fn msg(span: Span, msg: impl Into<String>) -> Self {
         Self::MustPrint(Message { span, msg: msg.into() })
     }
+
+    pub(crate) fn abort(self, tcx: TyCtxt) -> ! {
+        match self {
+            Error::MustPrint(msg) => msg.emit(tcx),
+            Error::ErrorGuaranteed => {
+                tcx.dcx().abort_if_errors();
+                tcx.dcx().bug("unexpected ErrorGuaranteed")
+            }
+        }
+    }
 }
 
 impl From<Message> for Error {
     fn from(value: Message) -> Self {
         Self::MustPrint(value)
-    }
-}
-impl From<CannotFetchThir> for Error {
-    fn from(value: CannotFetchThir) -> Self {
-        Self::TypeCheck(value)
-    }
-}
-
-/// This error should be raised when fetching a function's THIR failed, because of a
-/// typechecking error.
-///
-/// In this case, you can call `.into()` on the raised [`ErrorGuaranteed`].
-///
-/// The error should usually be bubbled up to the caller, which should then proceed to
-/// call [`Self::abort`].
-///
-/// Not doing this will cause a crash when the error is dropped.
-#[derive(Debug)]
-pub(crate) struct CannotFetchThir(());
-
-impl From<ErrorGuaranteed> for CannotFetchThir {
-    fn from(_: ErrorGuaranteed) -> Self {
-        Self(())
-    }
-}
-
-impl CannotFetchThir {
-    /// Abort the program.
-    pub(crate) fn abort(self, tcx: TyCtxt) {
-        std::mem::forget(self);
-        // Some of those errors may not show up until after `before_analysis` terminates
-        tcx.dcx().abort_if_errors();
-        // TODO: ideally this point should be unreachable: investigate why it isn't.
-    }
-
-    /// Merge two errors together, so that more errors may be reported.
-    pub(crate) fn merge(&mut self, other: Self) {
-        std::mem::forget(other)
-    }
-
-    pub(crate) fn merge_opt(opt: &mut Option<Self>, other: Self) {
-        match opt {
-            None => *opt = Some(other),
-            Some(err) => err.merge(other),
-        }
-    }
-}
-
-impl Drop for CannotFetchThir {
-    fn drop(&mut self) {
-        panic!("internal error: all thir error should be handled");
     }
 }
 

--- a/creusot/src/gather_spec_closures.rs
+++ b/creusot/src/gather_spec_closures.rs
@@ -35,10 +35,10 @@ impl<'tcx> SpecClosures<'tcx> {
         let mut snapshots = IndexMap::new();
         for clos in visitor.closures.into_iter() {
             if is_assertion(ctx.tcx, clos) {
-                let term = ctx.term_fail_fast(clos).unwrap().1.clone();
+                let term = ctx.term(clos).unwrap().1.clone();
                 assertions.insert(clos, term);
             } else if is_snapshot_closure(ctx.tcx, clos) {
-                let term = ctx.term_fail_fast(clos).unwrap().1.clone();
+                let term = ctx.term(clos).unwrap().1.clone();
                 snapshots.insert(clos, term);
             }
         }
@@ -140,7 +140,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InvariantsVisitor<'a, 'tcx> {
                 }
                 return;
             };
-            let term = self.ctx.term_fail_fast(*id).unwrap().1.clone();
+            let term = self.ctx.term(*id).unwrap().1.clone();
             match self.find_loop_header(loc) {
                 None if let LoopSpecKind::Invariant(expl) = kind => {
                     self.ctx.warn(

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -128,7 +128,7 @@ impl ContractClauses {
         let mut requires = Vec::new();
         for req_id in self.requires {
             log::trace!("require clause {:?}", req_id);
-            let term = ctx.term_fail_fast(req_id).unwrap().rename(bound);
+            let term = ctx.term(req_id).unwrap().rename(bound);
             let expl = if n_requires == 1 {
                 format!("expl:{} requires", fn_name)
             } else {
@@ -141,7 +141,7 @@ impl ContractClauses {
         let mut ensures = Vec::new();
         for ens_id in self.ensures {
             log::trace!("ensures clause {:?}", ens_id);
-            let term = ctx.term_fail_fast(ens_id).unwrap().rename(bound_with_result);
+            let term = ctx.term(ens_id).unwrap().rename(bound_with_result);
             let expl = if n_ensures == 1 {
                 format!("expl:{} ensures", fn_name)
             } else {
@@ -153,7 +153,7 @@ impl ContractClauses {
         let mut variant = None;
         if let Some(var_id) = self.variant {
             log::trace!("variant clause {:?}", var_id);
-            let term = ctx.term_fail_fast(var_id).unwrap().rename(bound);
+            let term = ctx.term(var_id).unwrap().rename(bound);
             variant = Some(term);
         };
         log::trace!("no_panic: {}", self.no_panic);
@@ -167,10 +167,6 @@ impl ContractClauses {
             extern_no_spec: false,
             has_user_contract,
         })
-    }
-
-    pub(crate) fn iter_ids(&self) -> impl Iterator<Item = DefId> + '_ {
-        self.requires.iter().chain(self.ensures.iter()).chain(self.variant.iter()).cloned()
     }
 }
 

--- a/tests/should_fail/array.rs
+++ b/tests/should_fail/array.rs
@@ -2,7 +2,7 @@ extern crate creusot_contracts;
 use creusot_contracts::*;
 
 fn main() {
-    let x = [0; 8];
+    let _ = [0; 8];
 }
 
 // Checks that array expressions are not allowed in specificatiosn

--- a/tests/should_fail/bad_law.rs
+++ b/tests/should_fail/bad_law.rs
@@ -1,7 +1,7 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-trait BadLaw {
+pub trait BadLaw {
     #[law]
     fn my_law<T>(x: T);
 }

--- a/tests/should_fail/bug/1439.rs
+++ b/tests/should_fail/bug/1439.rs
@@ -1,5 +1,7 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-#[requires(match opt { })]
-fn foo(opt: Option<i32>) {}
+pub enum Empty {}
+
+#[requires(match empty { })]
+pub fn foo(empty: Empty) {}

--- a/tests/should_fail/bug/1439.stderr
+++ b/tests/should_fail/bug/1439.stderr
@@ -1,8 +1,8 @@
 error: Empty matches are forbidden in Pearlite, because Why3 types are always inhabited.
- --> 1439.rs:4:12
+ --> 1439.rs:6:12
   |
-4 | #[requires(match opt { })]
-  |            ^^^^^^^^^^^^^
+6 | #[requires(match empty { })]
+  |            ^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/should_fail/bug/1519.stderr
+++ b/tests/should_fail/bug/1519.stderr
@@ -1,17 +1,18 @@
-error: Could not generate a term for RA::le
-  --> 1519.rs:36:5
-   |
-36 |     fn le(self, other: Self) -> bool;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: The trait function is not implemented here
+error[E0046]: not all trait items implemented, missing: `le`, `idemp`
   --> 1519.rs:42:1
    |
+36 |       fn le(self, other: Self) -> bool;
+   |       --------------------------------- `le` from trait
+...
+39 |       fn idemp(self) -> bool;
+   |       ----------------------- `idemp` from trait
+...
 42 | / impl<T, U> RA for (T, U)
 43 | | where
 44 | |     T: RA,
 45 | |     U: RA,
-   | |__________^
+   | |__________^ missing `le`, `idemp` in implementation
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0046`.

--- a/tests/should_fail/bug/1544_2.stderr
+++ b/tests/should_fail/bug/1544_2.stderr
@@ -17,12 +17,6 @@ error[E0277]: the trait bound `Base: creusot_contracts::DeepModel` is not satisf
    = note: required for `&Base` to implement `creusot_contracts::DeepModel`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: no instance of creusot_contracts::PartialEq::eq found
-  --> 1544_2.rs:26:9
-   |
-26 |         *self == Self::one()
-   |         ^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/should_fail/bug/459.rs
+++ b/tests/should_fail/bug/459.rs
@@ -1,7 +1,7 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-enum A {
+pub enum A {
     Cons(Box<A>),
     Nil,
 }

--- a/tests/should_fail/duplicate_specs.rs
+++ b/tests/should_fail/duplicate_specs.rs
@@ -13,6 +13,6 @@ extern_spec! {
     }
 }
 
-fn main() {
+pub fn main() {
     let _: Vec<bool> = Vec::new();
 }

--- a/tests/should_fail/ghost_mapping.rs
+++ b/tests/should_fail/ghost_mapping.rs
@@ -2,21 +2,25 @@ extern crate creusot_contracts;
 use creusot_contracts::{logic::Mapping, *};
 
 #[logic(prophetic)]
-fn f(x: &mut i32) -> Mapping<(), i32> {
+#[open(self)]
+pub fn f(x: &mut i32) -> Mapping<(), i32> {
     pearlite! { |_| ^x }
 }
 
 #[logic]
-fn g(x: &mut i32) -> Mapping<(), i32> {
+#[open(self)]
+pub fn g(x: &mut i32) -> Mapping<(), i32> {
     pearlite! { |_| ^x }
 }
 
 #[logic(prophetic)]
-fn h(y: &mut i32) -> bool {
+#[open(self)]
+pub fn h(y: &mut i32) -> bool {
     pearlite! { forall<_x:Int> ^y == 1i32 }
 }
 
 #[logic]
-fn i(y: &mut i32) -> bool {
+#[open(self)]
+pub fn i(y: &mut i32) -> bool {
     pearlite! { forall<_x:Int> ^y == 1i32 }
 }

--- a/tests/should_fail/ghost_mapping.stderr
+++ b/tests/should_fail/ghost_mapping.stderr
@@ -1,13 +1,13 @@
 error: called prophetic logic function `creusot_contracts::__stubs::fin` in logic context
-  --> ghost_mapping.rs:11:21
+  --> ghost_mapping.rs:13:21
    |
-11 |     pearlite! { |_| ^x }
+13 |     pearlite! { |_| ^x }
    |                     ^^
 
 error: called prophetic logic function `creusot_contracts::__stubs::fin` in logic context
-  --> ghost_mapping.rs:21:32
+  --> ghost_mapping.rs:25:32
    |
-21 |     pearlite! { forall<_x:Int> ^y == 1i32 }
+25 |     pearlite! { forall<_x:Int> ^y == 1i32 }
    |                                ^^
 
 error: aborting due to 2 previous errors

--- a/tests/should_fail/impure_functions.rs
+++ b/tests/should_fail/impure_functions.rs
@@ -6,6 +6,6 @@ fn x<T>(v: &Vec<T>) -> Int {
     pearlite! { v.len()@ }
 }
 
-fn y() {
+pub fn y() {
     let _ = x(&Vec::<()>::new());
 }

--- a/tests/should_fail/logic_prophetic_impl.rs
+++ b/tests/should_fail/logic_prophetic_impl.rs
@@ -1,13 +1,14 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-trait T {
+pub trait T {
     #[logic]
     fn f();
 }
 
 impl T for () {
     #[logic(prophetic)]
+    #[open(self)]
     fn f() {
         ()
     }

--- a/tests/should_fail/logic_prophetic_impl.stderr
+++ b/tests/should_fail/logic_prophetic_impl.stderr
@@ -1,7 +1,7 @@
 error: Expected `f` to be a logic function as specified by the trait declaration
-  --> logic_prophetic_impl.rs:11:5
+  --> logic_prophetic_impl.rs:12:5
    |
-11 |     fn f() {
+12 |     fn f() {
    |     ^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/should_fail/result_param.rs
+++ b/tests/should_fail/result_param.rs
@@ -3,4 +3,4 @@ use creusot_contracts::*;
 
 // Should fail saying result is not a valid parameter name
 #[ensures(result == result)]
-fn result_arg(result: u32) {}
+pub fn result_arg(result: u32) {}

--- a/tests/should_fail/result_param.stderr
+++ b/tests/should_fail/result_param.stderr
@@ -1,8 +1,8 @@
 error: `result` is not allowed as a parameter name
  --> result_param.rs:6:1
   |
-6 | fn result_arg(result: u32) {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+6 | pub fn result_arg(result: u32) {}
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/should_fail/terminates/default_function_non_logic.rs
+++ b/tests/should_fail/terminates/default_function_non_logic.rs
@@ -1,7 +1,7 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-trait Foo {
+pub trait Foo {
     #[terminates]
     fn f() {}
     #[terminates]

--- a/tests/should_fail/terminates/default_function_non_open.rs
+++ b/tests/should_fail/terminates/default_function_non_open.rs
@@ -1,9 +1,9 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-mod inner {
+pub mod inner {
     use super::*;
-    pub(super) trait Foo {
+    pub trait Foo {
         #[open(self)]
         #[logic]
         fn f() {}

--- a/tests/should_fail/trait_item_types_mismatch.rs
+++ b/tests/should_fail/trait_item_types_mismatch.rs
@@ -2,12 +2,13 @@ extern crate creusot_contracts;
 use creusot_contracts::*;
 
 #[trusted]
-trait Trusted {}
+pub trait Trusted {}
 
 impl Trusted for () {}
 
-trait HasPredicate {
+pub trait HasPredicate {
     #[predicate]
+    #[open(self)]
     fn my_predicate() -> bool {
         true
     }

--- a/tests/should_fail/trait_item_types_mismatch.stderr
+++ b/tests/should_fail/trait_item_types_mismatch.stderr
@@ -5,9 +5,9 @@ error: Expected implementation of trait `Trusted` for `()` to be marked as `#[tr
   | ^^^^^^^^^^^^^^^^^^^
 
 error: Expected `my_predicate` to be a predicate as specified by the trait declaration
-  --> trait_item_types_mismatch.rs:17:5
+  --> trait_item_types_mismatch.rs:18:5
    |
-17 |     fn my_predicate() -> bool {
+18 |     fn my_predicate() -> bool {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
Fix #1547 

- The core change is to only clone the THIR in before_analysis so we are guaranteed to have access to it in all other passes afterwards.
- Simplify error handling: if we don't find a THIR body, there must be a pending type error, so we are free to abort now (in pearlite()) or skip work silently (in validation functions) with the guarantee that the pending error will be raised later.
- No more need to "pre-load" Pearlite terms (calls to `term()` that discard their result).
- Move all the validation into its own function.