### PR TITLE
Use edition 2018 for scripts

### DIFF
--- a/coma
+++ b/coma
@@ -8,6 +8,7 @@ SCRIPTPATH=$(dirname "$BASH_SOURCE")
 pushd "$SCRIPTPATH" > /dev/null
 eval $(cargo run --bin dev-env)
 cargo run --bin creusot-rustc --  \
+  --edition=2018 \
   -Zno-codegen \
   -Zmacro-backtrace \
   --extern creusot_contracts=./target/creusot/debug/libcreusot_contracts.rlib \

--- a/expand
+++ b/expand
@@ -7,6 +7,7 @@ SCRIPTPATH=$(dirname "$BASH_SOURCE")
 pushd $SCRIPTPATH > /dev/null
 eval $(cargo run --bin dev-env)
 cargo run --bin creusot-rustc --  \
+  --edition=2018 \
   -Zno-codegen \
   -Zmacro-backtrace \
   --extern creusot_contracts=./target/creusot/debug/libcreusot_contracts.rlib \

--- a/mir
+++ b/mir
@@ -7,6 +7,7 @@ SCRIPTPATH=$(dirname "$BASH_SOURCE")
 pushd $SCRIPTPATH > /dev/null
 eval $(cargo run --bin dev-env)
 cargo run --bin creusot-rustc --  \
+  --edition=2018 \
   -Zno-codegen \
   -Zmacro-backtrace \
   --extern creusot_contracts=./target/creusot/debug/libcreusot_contracts.rlib \


### PR DESCRIPTION
This makes for much better errors in macros (no more `missing crate core`) when using these scripts.