### PR TITLE
Fix handling of Pearlite closures in `validate_purity` and `validate_terminates`

### DIFF
--- a/creusot-contracts-proc/src/creusot/pretyping.rs
+++ b/creusot-contracts-proc/src/creusot/pretyping.rs
@@ -294,6 +294,7 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
             ts = quote_spanned! {sp=>
                 ::creusot_contracts::__stubs::#quant_token(
                     #[creusot::no_translate]
+                    #[creusot::logic_closure]
                     |#args| { #ts }
                 )
             };
@@ -305,9 +306,8 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
             let inputs = &clos.inputs;
             let retty = &clos.output;
             let clos = encode_term(&clos.body)?;
-
             Ok(
-                quote_spanned! {sp=> ::creusot_contracts::__stubs::mapping_from_fn(#[creusot::no_translate] |#inputs| #retty #clos)},
+                quote_spanned! {sp=> ::creusot_contracts::__stubs::mapping_from_fn(#[creusot::no_translate] #[creusot::logic_closure] |#inputs| #retty #clos)},
             )
         }
         RT::__Nonexhaustive => todo!(),

--- a/creusot/src/contracts_items/attributes.rs
+++ b/creusot/src/contracts_items/attributes.rs
@@ -46,6 +46,7 @@ attribute_functions! {
     [creusot::before_loop]                   => is_before_loop
     [creusot::spec::assert]                  => is_assertion
     [creusot::spec::snapshot]                => is_snapshot_closure
+    [creusot::logic_closure]                 => is_logic_closure // marks `forall`, `exists`, and mappings
     [creusot::decl::logic]                   => is_logic
     [creusot::decl::logic::prophetic]        => is_prophetic
     [creusot::decl::predicate]               => is_predicate
@@ -70,6 +71,7 @@ pub fn get_invariant_expl(tcx: TyCtxt, def_id: DefId) -> Option<String> {
 pub(crate) fn is_pearlite(tcx: TyCtxt, def_id: DefId) -> bool {
     is_predicate(tcx, def_id)
         || is_spec(tcx, def_id)
+        || is_logic_closure(tcx, def_id)
         || is_logic(tcx, def_id)
         || is_assertion(tcx, def_id)
         || is_snapshot_closure(tcx, def_id)

--- a/creusot/src/validate/purity.rs
+++ b/creusot/src/validate/purity.rs
@@ -2,8 +2,8 @@ use crate::{
     backend::is_trusted_item,
     contracts_items::{
         get_builtin, get_fn_pure_trait, is_ghost_deref, is_ghost_deref_mut, is_ghost_into_inner,
-        is_ghost_new, is_logic, is_no_translate, is_predicate, is_prophetic, is_snapshot_closure,
-        is_snapshot_deref, is_spec,
+        is_ghost_new, is_logic, is_no_translate, is_predicate, is_prophetic, is_snap_from_fn,
+        is_snapshot_closure, is_snapshot_deref, is_spec,
     },
     ctx::TranslationCtx,
     translation::{
@@ -94,6 +94,11 @@ pub(crate) fn validate_purity<'tcx>(
     &(ref thir, expr): &(thir::Thir<'tcx>, thir::ExprId),
 ) {
     let def_id = def_id.to_def_id();
+    // Only start traversing from top-level definitions. Closures will be visited during the traversal of their parents
+    // so that they can inherit the context from their parent.
+    if ctx.tcx.is_closure_like(def_id) {
+        return;
+    }
     let purity = Purity::of_def_id(ctx, def_id);
     if matches!(purity, Purity::Program { .. })
         && (is_no_translate(ctx.tcx, def_id) || is_trusted_item(ctx.tcx, def_id))
@@ -101,7 +106,6 @@ pub(crate) fn validate_purity<'tcx>(
         return;
     }
     let typing_env = ctx.typing_env(def_id);
-
     let mut visitor = PurityVisitor { ctx, thir, context: purity, typing_env };
     thir::visit::walk_expr(&mut visitor, &thir[expr])
 }
@@ -159,6 +163,62 @@ impl PurityVisitor<'_, '_> {
         let (infcx, param_env) = tcx.infer_ctxt().build_with_typing_env(self.typing_env);
         let res = infcx.type_implements_trait(get_fn_pure_trait(tcx), [ty], param_env);
         res.must_apply_considering_regions()
+    }
+
+    /// If the statement is a spec statement, visit it and return `true`, otherwise return `false`.
+    fn try_visit_spec_statement(&mut self, stmt: &thir::Stmt) -> bool {
+        let thir::StmtKind::Let { ref pattern, initializer: Some(init), else_block, span, .. } =
+            stmt.kind
+        else {
+            return false;
+        };
+        let Some(closure_id) = self.get_spec_closure(init) else { return false };
+        let thir::PatKind::Wild = pattern.kind else {
+            self.ctx.dcx().span_fatal(pattern.span, "expected a wildcard pattern in spec statement")
+        };
+        let None = else_block else {
+            self.ctx.dcx().span_fatal(span, "expected no else block in spec statement")
+        };
+        self.validate_spec_purity(closure_id, true);
+        true
+    }
+
+    /// If the expression is a closure with attribute `creusot::spec`, return `Some` of its `LocalDefId`, otherwise `None`.
+    fn get_spec_closure(&self, mut expr: thir::ExprId) -> Option<LocalDefId> {
+        loop {
+            match self.thir[expr].kind {
+                ExprKind::Scope { value, .. } => expr = value,
+                ExprKind::Block { block } => {
+                    let block = &self.thir[block];
+                    if !block.stmts.is_empty() {
+                        return None;
+                    }
+                    let Some(expr_) = block.expr else { return None };
+                    expr = expr_;
+                }
+                ExprKind::Closure(box ClosureExpr { closure_id, .. }) => {
+                    if is_spec(self.ctx.tcx, closure_id.to_def_id()) {
+                        return Some(closure_id);
+                    } else {
+                        return None;
+                    }
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    /// Validate the body of a spec closure.
+    fn validate_spec_purity(&mut self, closure_id: LocalDefId, prophetic: bool) {
+        // If this is None there must be a type error that will be reported later so we can skip this silently.
+        let Some((thir, expr)) = self.ctx.get_thir(closure_id) else { return };
+        let mut visitor = PurityVisitor {
+            ctx: self.ctx,
+            thir,
+            context: Purity::Logic { prophetic },
+            typing_env: self.typing_env,
+        };
+        thir::visit::walk_expr(&mut visitor, &thir[expr]);
     }
 }
 
@@ -239,6 +299,17 @@ impl<'a, 'tcx> thir::visit::Visitor<'a, 'tcx> for PurityVisitor<'a, 'tcx> {
                             self.ctx.dcx().span_err(self.thir[fun].span, msg);
                         }
                     }
+                    if is_snap_from_fn(self.ctx.tcx, func_did) {
+                        assert!(args.len() == 1);
+                        let Some(closure_id) = self.get_spec_closure(args[0]) else {
+                            self.ctx.dcx().span_fatal(
+                                expr.span,
+                                "expected a spec closure as argument to `snapshot_from_fn`",
+                            );
+                        };
+                        self.validate_spec_purity(closure_id, false);
+                        return;
+                    }
                 } else if matches!(self.context, Purity::Logic { .. }) {
                     // TODO Add a "code" back in
                     self.ctx.dcx().span_fatal(expr.span, "non function call in logical context")
@@ -246,7 +317,10 @@ impl<'a, 'tcx> thir::visit::Visitor<'a, 'tcx> for PurityVisitor<'a, 'tcx> {
             }
             ExprKind::Closure(box ClosureExpr { closure_id, .. }) => {
                 if is_spec(self.ctx.tcx, closure_id.into()) {
-                    return;
+                    self.ctx.dcx().span_fatal(
+                        expr.span,
+                        format!("unexpected spec closure {}", self.ctx.def_path_str(closure_id)),
+                    );
                 }
                 // If this is None there must be a type error that will be reported later so we can skip this silently.
                 let Some((thir, expr)) = self.ctx.get_thir(closure_id) else { return };
@@ -273,5 +347,11 @@ impl<'a, 'tcx> thir::visit::Visitor<'a, 'tcx> for PurityVisitor<'a, 'tcx> {
             _ => {}
         }
         thir::visit::walk_expr(self, expr)
+    }
+
+    fn visit_stmt(&mut self, stmt: &'a thir::Stmt<'tcx>) {
+        if !self.try_visit_spec_statement(stmt) {
+            thir::visit::walk_stmt(self, stmt);
+        }
     }
 }


### PR DESCRIPTION
Closures for Pearlite quantifiers and mappings were mistaken for program closures, because they are only marked with `no_translate`. That attribute helped mitigate the mistake, but not completely because I am running into crashes in `validate_purity` and `validate_terminates` when they call `sig` believing such closures to be program closures.

- The first fix is to have `validate_purity` skip closures altogether. Closures will be visited while traversing their parents. This also ensures that each expression is only traversed once, which was previously not the case.
- The second fix is to mark Pearlite closures (= quantifiers and mappings) with another attribute `#[creusot::logic_closure]` to be included in the `is_pearlite` check. This avoids the crash in `validate_terminates`.
- I couldn't isolate a regression test case; when I tried to copy the culprit from my project into a standalone test case the crash went away. The crash is that in `creusot/src/backend/closures.rs`, in the function `ClosSubst::pre`, the `assert!(cap.place.projections.is_empty())` failed. This might be a symptom of yet another bug.