### PR TITLE
Pearlite parser fixes

### DIFF
--- a/creusot-contracts-proc/src/creusot/pretyping.rs
+++ b/creusot-contracts-proc/src/creusot/pretyping.rs
@@ -142,6 +142,13 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
             Ok(res)
         }
         RT::If(TermIf { cond, then_branch, else_branch, .. }) => {
+            let cond = if let RT::Paren(TermParen { expr, .. }) = &**cond
+                && matches!(&**expr, RT::Quant(_))
+            {
+                &**expr
+            } else {
+                cond
+            };
             let cond = encode_term(cond)?;
             let then_branch: Vec<_> =
                 then_branch.stmts.iter().map(encode_stmt).collect::<Result<_, _>>()?;

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -1,6 +1,13 @@
 #![cfg_attr(
     feature = "creusot",
-    feature(box_patterns, extract_if, extend_one, proc_macro_def_site, proc_macro_span)
+    feature(
+        box_patterns,
+        extract_if,
+        extend_one,
+        proc_macro_def_site,
+        proc_macro_span,
+        let_chains
+    )
 )]
 
 use proc_macro::TokenStream as TS1;

--- a/pearlite-syn/tests/test_term.rs
+++ b/pearlite-syn/tests/test_term.rs
@@ -86,21 +86,25 @@ fn test_forall() {
                 ident: Ident {
                     sym: x,
                 },
-                colon_token: Colon,
-                ty: Type::Path {
-                    qself: None,
-                    path: Path {
-                        leading_colon: None,
-                        segments: [
-                            PathSegment {
-                                ident: Ident {
-                                    sym: u32,
-                                },
-                                arguments: PathArguments::None,
+                ty: Some(
+                    (
+                        Colon,
+                        Type::Path {
+                            qself: None,
+                            path: Path {
+                                leading_colon: None,
+                                segments: [
+                                    PathSegment {
+                                        ident: Ident {
+                                            sym: u32,
+                                        },
+                                        arguments: PathArguments::None,
+                                    },
+                                ],
                             },
-                        ],
-                    },
-                },
+                        },
+                    ),
+                ),
             },
         ],
         gt_token: Gt,
@@ -125,21 +129,25 @@ fn test_exists() {
                 ident: Ident {
                     sym: x,
                 },
-                colon_token: Colon,
-                ty: Type::Path {
-                    qself: None,
-                    path: Path {
-                        leading_colon: None,
-                        segments: [
-                            PathSegment {
-                                ident: Ident {
-                                    sym: u32,
-                                },
-                                arguments: PathArguments::None,
+                ty: Some(
+                    (
+                        Colon,
+                        Type::Path {
+                            qself: None,
+                            path: Path {
+                                leading_colon: None,
+                                segments: [
+                                    PathSegment {
+                                        ident: Ident {
+                                            sym: u32,
+                                        },
+                                        arguments: PathArguments::None,
+                                    },
+                                ],
                             },
-                        ],
-                    },
-                },
+                        },
+                    ),
+                ),
             },
         ],
         gt_token: Gt,
@@ -164,42 +172,50 @@ fn test_trigger() {
                 ident: Ident {
                     sym: x,
                 },
-                colon_token: Colon,
-                ty: Type::Path {
-                    qself: None,
-                    path: Path {
-                        leading_colon: None,
-                        segments: [
-                            PathSegment {
-                                ident: Ident {
-                                    sym: u32,
-                                },
-                                arguments: PathArguments::None,
+                ty: Some(
+                    (
+                        Colon,
+                        Type::Path {
+                            qself: None,
+                            path: Path {
+                                leading_colon: None,
+                                segments: [
+                                    PathSegment {
+                                        ident: Ident {
+                                            sym: u32,
+                                        },
+                                        arguments: PathArguments::None,
+                                    },
+                                ],
                             },
-                        ],
-                    },
-                },
+                        },
+                    ),
+                ),
             },
             Comma,
             QuantArg {
                 ident: Ident {
                     sym: y,
                 },
-                colon_token: Colon,
-                ty: Type::Path {
-                    qself: None,
-                    path: Path {
-                        leading_colon: None,
-                        segments: [
-                            PathSegment {
-                                ident: Ident {
-                                    sym: u32,
-                                },
-                                arguments: PathArguments::None,
+                ty: Some(
+                    (
+                        Colon,
+                        Type::Path {
+                            qself: None,
+                            path: Path {
+                                leading_colon: None,
+                                segments: [
+                                    PathSegment {
+                                        ident: Ident {
+                                            sym: u32,
+                                        },
+                                        arguments: PathArguments::None,
+                                    },
+                                ],
                             },
-                        ],
-                    },
-                },
+                        },
+                    ),
+                ),
             },
         ],
         gt_token: Gt,


### PR DESCRIPTION
- Prevent warning when using a parenthized quantifier in a  condition
- Types of binders of quantifiers can now be omitted.