### PR TITLE
Fix syntax of triggers.

### DIFF
--- a/creusot-contracts-proc/src/creusot/pretyping.rs
+++ b/creusot-contracts-proc/src/creusot/pretyping.rs
@@ -327,12 +327,8 @@ fn encode_trigger(
 ) -> Result<TokenStream, EncodeError> {
     while let [rest @ .., last] = trigger {
         trigger = rest;
-        let mut last_trigger = TokenStream::new();
-        for pair in last.terms.pairs() {
-            last_trigger.extend(encode_term(pair.value())?);
-            pair.punct().to_tokens(&mut last_trigger)
-        }
-        ts = quote!(::creusot_contracts::__stubs::trigger((#last_trigger), #ts))
+        let trigs = last.terms.iter().map(encode_term).collect::<Result<Vec<_>, _>>()?;
+        ts = quote!(::creusot_contracts::__stubs::trigger((#(#trigs,)*), #ts))
     }
     Ok(ts)
 }

--- a/creusot-contracts/src/std/iter/enumerate.rs
+++ b/creusot-contracts/src/std/iter/enumerate.rs
@@ -44,7 +44,7 @@ impl<I: Iterator> Invariant for Enumerate<I> {
     fn invariant(self) -> bool {
         pearlite! {
             (forall<s: Seq<I::Item>, i: I>
-                #![trigger self.iter().produces(s, i)]
+                #[trigger(self.iter().produces(s, i))]
                 self.iter().produces(s, i) ==>
                 self.n() + s.len() < std::usize::MAX@)
             && (forall<i: &mut I> (*i).completed() ==> (*i).produces(Seq::EMPTY, ^i))

--- a/creusot-contracts/src/std/iter/map.rs
+++ b/creusot-contracts/src/std/iter/map.rs
@@ -59,7 +59,7 @@ impl<I: Iterator, B, F: FnMut(I::Item) -> B> Iterator for Map<I, F> {
             self.func().hist_inv(succ.func())
             && exists<fs: Seq<&mut F>> fs.len() == visited.len()
             && exists<s: Seq<I::Item>>
-                #![trigger self.iter().produces(s, succ.iter())]
+                #[trigger(self.iter().produces(s, succ.iter()))]
                 s.len() == visited.len() && self.iter().produces(s, succ.iter())
             && (forall<i> 1 <= i && i < fs.len() ==>  ^fs[i - 1] == *fs[i])
             && if visited.len() == 0 { self.func() == succ.func() }
@@ -91,7 +91,7 @@ where
 {
     pearlite! {
         forall<e: I::Item, i: I>
-            #![trigger iter.produces(Seq::singleton(e), i)]
+            #[trigger(iter.produces(Seq::singleton(e), i))]
             iter.produces(Seq::singleton(e), i) ==>
             func.precondition((e,))
     }
@@ -106,7 +106,7 @@ where
 {
     pearlite! {
         forall<s: Seq<I::Item>, e1: I::Item, e2: I::Item, f: &mut F, b: B, i: I>
-            #![trigger iter.produces(s.push_back(e1).push_back(e2), i), (*f).postcondition_mut((e1,), ^f, b)]
+            #[trigger(iter.produces(s.push_back(e1).push_back(e2), i), (*f).postcondition_mut((e1,), ^f, b))]
             func.hist_inv(*f) ==>
             iter.produces(s.push_back(e1).push_back(e2), i) ==>
             (*f).precondition((e1,)) ==>

--- a/pearlite-syn/tests/test_term.rs
+++ b/pearlite-syn/tests/test_term.rs
@@ -163,7 +163,7 @@ fn test_exists() {
 
 #[test]
 fn test_trigger() {
-    snapshot!(quote!(forall<x: u32, y: u32> #![trigger f(x, y)] #![trigger g(x), g(y)] true) as Term, @r###"
+    snapshot!(quote!(forall<x: u32, y: u32> #[trigger(f(x, y))] #[trigger(g(x), g(y))] true) as Term, @r###"
     TermQuant {
         quant_token: Keyword [forall],
         lt_token: Lt,
@@ -222,9 +222,9 @@ fn test_trigger() {
         trigger: [
             Trigger {
                 pound_token: Pound,
-                bang_token: Not,
                 bracket_token: Bracket,
                 trigger_token: Keyword [trigger],
+                paren_token: Paren,
                 terms: [
                     TermCall {
                         func: TermPath {
@@ -287,9 +287,9 @@ fn test_trigger() {
             },
             Trigger {
                 pound_token: Pound,
-                bang_token: Not,
                 bracket_token: Bracket,
                 trigger_token: Keyword [trigger],
+                paren_token: Paren,
                 terms: [
                     TermCall {
                         func: TermPath {

--- a/tests/should_succeed/iterators/05_map.rs
+++ b/tests/should_succeed/iterators/05_map.rs
@@ -44,7 +44,7 @@ impl<I: Iterator, B, F: FnMut(I::Item) -> B> Iterator for Map<I, F> {
             self.func.hist_inv(succ.func)
             && exists<fs: Seq<&mut F>> fs.len() == visited.len()
             && exists<s: Seq<I::Item>>
-                #![trigger self.iter.produces(s, succ.iter)]
+                #[trigger(self.iter.produces(s, succ.iter))]
                 s.len() == visited.len() && self.iter.produces(s, succ.iter)
             && (forall<i> 1 <= i && i < fs.len() ==>  ^fs[i - 1] == *fs[i])
             && if visited.len() == 0 { self.func == succ.func }
@@ -77,7 +77,7 @@ impl<I: Iterator, B, F: FnMut(I::Item) -> B> Map<I, F> {
     fn next_precondition(iter: I, func: F) -> bool {
         pearlite! {
             forall<e: I::Item, i: I>
-                #![trigger iter.produces(Seq::singleton(e), i)]
+                #[trigger(iter.produces(Seq::singleton(e), i))]
                 iter.produces(Seq::singleton(e), i) ==>
                 func.precondition((e,))
         }
@@ -87,7 +87,7 @@ impl<I: Iterator, B, F: FnMut(I::Item) -> B> Map<I, F> {
     fn preservation(iter: I, func: F) -> bool {
         pearlite! {
             forall<s: Seq<I::Item>, e1: I::Item, e2: I::Item, f: &mut F, b: B, i: I>
-                #![trigger iter.produces(s.push_back(e1).push_back(e2), i), (*f).postcondition_mut((e1,), ^f, b)]
+                #[trigger(iter.produces(s.push_back(e1).push_back(e2), i), (*f).postcondition_mut((e1,), ^f, b))]
                 func.hist_inv(*f) ==>
                 iter.produces(s.push_back(e1).push_back(e2), i) ==>
                 (*f).precondition((e1,)) ==>
@@ -125,7 +125,7 @@ impl<I: Iterator, B, F: FnMut(I::Item) -> B> Map<I, F> {
     fn produces_one(self, visited: B, succ: Self) -> bool {
         pearlite! {
             exists<f: &mut F, e: I::Item>
-                #![trigger (*f).postcondition_mut((e,), ^f, visited)]
+                #[trigger((*f).postcondition_mut((e,), ^f, visited))]
                 *f == self.func && ^f == succ.func
                 && self.iter.produces(Seq::singleton(e), succ.iter)
                 && (*f).precondition((e,))

--- a/tests/should_succeed/iterators/06_map_precond.rs
+++ b/tests/should_succeed/iterators/06_map_precond.rs
@@ -46,7 +46,7 @@ impl<I: Iterator, B, F: FnMut(I::Item, Snapshot<Seq<I::Item>>) -> B> Iterator fo
             self.func.hist_inv(succ.func)
             && exists<fs: Seq<&mut F>> fs.len() == visited.len()
             && exists<s: Seq<I::Item>>
-                #![trigger self.iter.produces(s, succ.iter)]
+                #[trigger(self.iter.produces(s, succ.iter))]
                 s.len() == visited.len() && self.iter.produces(s, succ.iter)
             && succ.produced.inner() == self.produced.concat(s)
             && (forall<i> 1 <= i && i < fs.len() ==>  ^fs[i - 1] == * fs[i])
@@ -86,7 +86,7 @@ impl<I: Iterator, B, F: FnMut(I::Item, Snapshot<Seq<I::Item>>) -> B> Map<I, F> {
     fn next_precondition(iter: I, func: F, produced: Seq<I::Item>) -> bool {
         pearlite! {
             forall<e: I::Item, i: I>
-                #![trigger(iter.produces(Seq::singleton(e), i))]
+                #[trigger(iter.produces(Seq::singleton(e), i))]
                 iter.produces(Seq::singleton(e), i) ==>
                 func.precondition((e, Snapshot::new(produced)))
         }
@@ -97,7 +97,7 @@ impl<I: Iterator, B, F: FnMut(I::Item, Snapshot<Seq<I::Item>>) -> B> Map<I, F> {
     fn preservation_inv(iter: I, func: F, produced: Seq<I::Item>) -> bool {
         pearlite! {
             forall<s: Seq<I::Item>, e1: I::Item, e2: I::Item, f: &mut F, b: B, i: I>
-                #![trigger iter.produces(s.push_back(e1).push_back(e2), i),(*f).postcondition_mut((e1, Snapshot::new(produced.concat(s))), ^f, b)]
+                #[trigger(iter.produces(s.push_back(e1).push_back(e2), i),(*f).postcondition_mut((e1, Snapshot::new(produced.concat(s))), ^f, b))]
                 func.hist_inv(*f) ==>
                 iter.produces(s.push_back(e1).push_back(e2), i) ==>
                 (*f).precondition((e1, Snapshot::new(produced.concat(s)))) ==>
@@ -148,7 +148,7 @@ impl<I: Iterator, B, F: FnMut(I::Item, Snapshot<Seq<I::Item>>) -> B> Map<I, F> {
     fn produces_one(self, visited: B, succ: Self) -> bool {
         pearlite! {
             exists<f: &mut F, e: I::Item>
-                #![trigger (*f).postcondition_mut((e, self.produced), ^f, visited)]
+                #[trigger((*f).postcondition_mut((e, self.produced), ^f, visited))]
                 *f == self.func && ^f == succ.func
                 && self.iter.produces(Seq::singleton(e), succ.iter)
                 && succ.produced.inner() == self.produced.push_back(e)

--- a/tests/should_succeed/iterators/15_enumerate.rs
+++ b/tests/should_succeed/iterators/15_enumerate.rs
@@ -73,7 +73,7 @@ where
     fn invariant(self) -> bool {
         pearlite! {
             (forall<s: Seq<I::Item>, i: I>
-                #![trigger self.iter.produces(s, i)]
+                #[trigger(self.iter.produces(s, i))]
                 self.iter.produces(s, i) ==>
                 self.count@ + s.len() < std::usize::MAX@)
             && (forall<i: &mut I> i.completed() ==> i.produces(Seq::EMPTY, ^i))

--- a/tests/should_succeed/trigger.rs
+++ b/tests/should_succeed/trigger.rs
@@ -13,7 +13,7 @@ mod inner {
 
     #[law]
     #[open(self)]
-    #[ensures(forall<i, j> #![trigger id(i), id(j)] i <= j ==> id(i) <= id(j))]
+    #[ensures(forall<i, j> #[trigger(id(i), id(j))] i <= j ==> id(i) <= id(j))]
     pub fn id_mono() {}
 }
 use inner::*;

--- a/tests/should_succeed/trigger2.rs
+++ b/tests/should_succeed/trigger2.rs
@@ -5,7 +5,7 @@ use creusot_contracts::*;
 #[ensures(resolve(&seq) ==> result)]
 fn resolve_seq<T>(seq: Vec<&mut T>) -> bool {
     pearlite! {
-        forall<i> #![trigger seq@[i]] 0 <= i && i < seq@.len() ==>
+        forall<i> #[trigger(seq@[i])] 0 <= i && i < seq@.len() ==>
             *seq@[i] == ^seq@[i]
     }
 }


### PR DESCRIPTION
1- In some situations, triggers were not allowed if the trailing coma was missing. 2- The syntax of triggers is now #[trigger(..)], closer to the usual syntax of attributes.