### PR TITLE
Disable git2 default features in why3tests to reduce dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,8 +885,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -1307,9 +1305,7 @@ checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -1321,20 +1317,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags",
  "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]

--- a/why3tests/Cargo.toml
+++ b/why3tests/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 glob = "*"
 assert_cmd = "2.0"
 termcolor = "1.4"
-git2 = "0.20"
+git2 = { version = "0.20", default-features = false }
 clap = { version = "4.5", features = ["env", "derive"]}
 roxmltree = "0.20.0"
 creusot-setup = { path = "../creusot-setup" }


### PR DESCRIPTION
Avoids a useless dependency on openssl from why3tests (there is still one from creusot-install)