### PR TITLE
Lint for usage of `#[trusted]`

### DIFF
--- a/creusot/messages.ftl
+++ b/creusot/messages.ftl
@@ -1,5 +1,7 @@
 creusot_contractless_external_function =
     calling external function `{$name}` with no contract will yield an impossible precondition
     .label = function called here
+creusot_trusted_code =
+    used the `#[trusted]` attribute
 creusot_experimental =
     support for trait objects (dyn) is limited and experimental

--- a/creusot/messages.ftl
+++ b/creusot/messages.ftl
@@ -1,3 +1,5 @@
 creusot_contractless_external_function =
     calling external function `{$name}` with no contract will yield an impossible precondition
     .label = function called here
+creusot_experimental =
+    support for trait objects (dyn) is limited and experimental

--- a/creusot/src/lints.rs
+++ b/creusot/src/lints.rs
@@ -1,5 +1,6 @@
 mod contractless_external_function;
 mod experimental_types;
+mod trusted;
 
 use rustc_lint::LintStore;
 use rustc_macros::LintDiagnostic;
@@ -14,6 +15,8 @@ pub(crate) use contractless_external_function::CONTRACTLESS_EXTERNAL_FUNCTION;
 // are defined in `creusot/messages.ftl`
 #[derive(Debug, LintDiagnostic)]
 pub(crate) enum Diagnostics {
+    #[diag(creusot_trusted_code)]
+    TrustedAttribute,
     /// Usually lints are emitted by implementing lint passes with the `impl_lint_pass!` macro.
     ///
     /// Since the lint is emmited at a "weird" time (during translation to
@@ -35,7 +38,9 @@ pub fn register_lints(_sess: &Session, store: &mut LintStore) {
     store.register_lints(&[
         experimental_types::EXPERIMENTAL,
         contractless_external_function::CONTRACTLESS_EXTERNAL_FUNCTION,
+        trusted::TRUSTED_CODE,
     ]);
     store.register_late_pass(move |_| Box::new(crate::validate::GhostValidate {}));
     store.register_late_pass(move |_| Box::new(experimental_types::Experimental {}));
+    store.register_late_pass(move |_| Box::new(trusted::TrustedCode {}));
 }

--- a/creusot/src/lints.rs
+++ b/creusot/src/lints.rs
@@ -1,8 +1,35 @@
-pub(crate) mod contractless_external_function;
+mod contractless_external_function;
 mod experimental_types;
 
 use rustc_lint::LintStore;
+use rustc_macros::LintDiagnostic;
 use rustc_session::Session;
+use rustc_span::{Span, Symbol};
+
+pub(crate) use contractless_external_function::CONTRACTLESS_EXTERNAL_FUNCTION;
+
+// Diagnostics for creusot's lints.
+//
+// This only describes the structure of the diagnostics. The actual messages
+// are defined in `creusot/messages.ftl`
+#[derive(Debug, LintDiagnostic)]
+pub(crate) enum Diagnostics {
+    /// Usually lints are emitted by implementing lint passes with the `impl_lint_pass!` macro.
+    ///
+    /// Since the lint is emmited at a "weird" time (during translation to
+    /// fmir), we cannot do this, so this structure will be used with the
+    /// `TyCtxt::emit_node_span_lint` function.
+    #[diag(creusot_contractless_external_function)]
+    ContractlessExternalFunction {
+        /// Name of the function
+        name: Symbol,
+        /// Location of the call
+        #[label]
+        span: Span,
+    },
+    #[diag(creusot_experimental)]
+    Experimental,
+}
 
 pub fn register_lints(_sess: &Session, store: &mut LintStore) {
     store.register_lints(&[

--- a/creusot/src/lints/contractless_external_function.rs
+++ b/creusot/src/lints/contractless_external_function.rs
@@ -1,20 +1,4 @@
-use rustc_macros::LintDiagnostic;
 use rustc_session::declare_tool_lint;
-use rustc_span::{Span, Symbol};
-
-// Usually lints are emitted by implementing lint passes with the `impl_lint_pass!` macro.
-// Here, since the lint is emmited at a "weird" time (during translation to fmir), we
-// cannot do this, so this structure will be used with the `TyCtxt::emit_node_span_lint`
-// function.
-#[derive(Debug, LintDiagnostic)]
-#[diag(creusot_contractless_external_function)]
-pub(crate) struct ContractlessExternalFunction {
-    /// Name of the function
-    pub(crate) name: Symbol,
-    /// Location of the call
-    #[label]
-    pub(crate) span: Span,
-}
 
 declare_tool_lint! {
     /// The `contractless_external_function` lint warns when calling a function from

--- a/creusot/src/lints/trusted.rs
+++ b/creusot/src/lints/trusted.rs
@@ -1,0 +1,35 @@
+use super::Diagnostics;
+use rustc_lint::{LateLintPass, LintContext};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_tool_lint! {
+    /// The `trusted_code` lint catches usage of `#[trusted]`.
+    ///
+    /// This lint is useful to ensure that you are not using any additionnal axioms in
+    /// your code.
+    pub creusot::TRUSTED_CODE,
+    Allow,
+    "`#[trusted]` adds additionnal unproved axioms",
+    report_in_external_macro: true
+}
+
+declare_lint_pass!(TrustedCode => [TRUSTED_CODE]);
+impl<'tcx> LateLintPass<'tcx> for TrustedCode {
+    fn check_attribute(
+        &mut self,
+        cx: &rustc_lint::LateContext<'tcx>,
+        attr: &'tcx rustc_hir::Attribute,
+    ) {
+        let expected = ["creusot", "decl", "trusted"];
+        let is_trusted = match &attr.kind {
+            rustc_hir::AttrKind::Normal(item) => {
+                let s = &item.path.segments;
+                s.len() == expected.len() && s.iter().zip(expected).all(|(a, b)| a.as_str() == b)
+            }
+            rustc_hir::AttrKind::DocComment { .. } => false,
+        };
+        if is_trusted {
+            cx.emit_span_lint(TRUSTED_CODE, attr.span, Diagnostics::TrustedAttribute);
+        }
+    }
+}

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -4,9 +4,7 @@ use crate::{
     contracts_items::{is_box_new, is_snap_from_fn},
     ctx::TranslationCtx,
     extended_location::ExtendedLocation,
-    lints::contractless_external_function::{
-        CONTRACTLESS_EXTERNAL_FUNCTION, ContractlessExternalFunction,
-    },
+    lints::{CONTRACTLESS_EXTERNAL_FUNCTION, Diagnostics},
     resolve::HasMoveDataExt,
     translation::{
         fmir::{self, *},
@@ -303,7 +301,7 @@ fn resolve_function<'tcx>(
                 CONTRACTLESS_EXTERNAL_FUNCTION,
                 lint_root,
                 span,
-                ContractlessExternalFunction { name, span },
+                Diagnostics::ContractlessExternalFunction { name, span },
             );
         }
     }

--- a/tests/should_fail/lints/trusted_code.rs
+++ b/tests/should_fail/lints/trusted_code.rs
@@ -1,0 +1,27 @@
+#![deny(creusot::trusted_code)]
+
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[trusted]
+#[ensures(result == 1i32)]
+fn foo() -> i32 {
+    1i32
+}
+
+#[trusted]
+pub struct S;
+
+#[logic]
+#[ensures(result == (x == 2i32))]
+#[trusted]
+pub fn is_two(x: i32) -> bool {
+    x == 2i32
+}
+
+#[allow(creusot::trusted_code)]
+#[trusted] // Should not get flagged
+#[ensures(is_two(result))]
+pub fn bar() -> i32 {
+    foo() + 1
+}

--- a/tests/should_fail/lints/trusted_code.stderr
+++ b/tests/should_fail/lints/trusted_code.stderr
@@ -1,0 +1,31 @@
+error: used the `#[trusted]` attribute
+ --> trusted_code.rs:6:1
+  |
+6 | #[trusted]
+  | ^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> trusted_code.rs:1:9
+  |
+1 | #![deny(creusot::trusted_code)]
+  |         ^^^^^^^^^^^^^^^^^^^^^
+  = note: this error originates in the attribute macro `trusted` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: used the `#[trusted]` attribute
+  --> trusted_code.rs:12:1
+   |
+12 | #[trusted]
+   | ^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `trusted` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: used the `#[trusted]` attribute
+  --> trusted_code.rs:17:1
+   |
+17 | #[trusted]
+   | ^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `trusted` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Allow using `#![forbid(creusot::trusted_code)]` to disallow usage of `#[trusted]` in the current crate.