### PR TITLE
Update to the latest why3 version

### DIFF
--- a/creusot-deps.opam
+++ b/creusot-deps.opam
@@ -5,8 +5,8 @@ maintainer: "Armaël Guéneau <armael.gueneau@inria.fr>"
 authors: "the creusot authors"
 depends: [
   "ocaml" {= "5.3.0"}
-  "why3" {= "git-9c6f"}
-  "why3-ide" {= "git-9c6f" & !?in-creusot-ci}
+  "why3" {= "git-f0b5"}
+  "why3-ide" {= "git-f0b5" & !?in-creusot-ci}
   "why3find" {= "git-d227"}
 # optional dependencies of why3
   "ocamlgraph"
@@ -16,7 +16,7 @@ depends: [
 # When updating the hash and git-XXX below, don't forget to update them in the
 # depends: field above!
 pin-depends: [
-  [ "why3.git-9c6f" "git+https://gitlab.inria.fr/why3/why3.git#6db1a4816" ]
-  [ "why3-ide.git-9c6f" "git+https://gitlab.inria.fr/why3/why3.git#6db1a4816" ]
+  [ "why3.git-f0b5" "git+https://gitlab.inria.fr/why3/why3.git#f0b5206c" ]
+  [ "why3-ide.git-f0b5" "git+https://gitlab.inria.fr/why3/why3.git#f0b5206c" ]
   [ "why3find.git-d227" "git+https://git.frama-c.com/pub/why3find.git#d227fc5" ]
 ]

--- a/creusot-setup/src/tools_versions_urls.rs
+++ b/creusot-setup/src/tools_versions_urls.rs
@@ -6,7 +6,7 @@
 // - update the SHA256 hash for each binary accordingly (use e.g. sha256sum to compute it)
 
 // tools without binary releases
-pub const WHY3_VERSION: &'static str = "1.8.0";
+pub const WHY3_VERSION: &'static str = "1.8.1";
 pub const WHY3_CONFIG_MAGIC_NUMBER: &'static str = "14";
 pub const WHY3FIND_VERSION: &'static str = "1.1.1";
 // tools with binary releases


### PR DESCRIPTION
There was a recent change (https://gitlab.inria.fr/why3/why3/-/commit/a5898d4657275e25126b9a3ff830eebfd33377af) lifting a limitation of recursive coma handlers. This might be useful for defining variants.