### PR TITLE
Wrap local variables under black box

### DIFF
--- a/tests/creusot-contracts/creusot-contracts.coma
+++ b/tests/creusot-contracts/creusot-contracts.coma
@@ -101,7 +101,7 @@ module M_creusot_contracts__stdqy35z1__clone__extern_spec_Clone_bool_clone_body 
   
   let rec extern_spec_Clone_bool_clone_body[#"../../creusot-contracts/src/std/clone.rs" 19 8 19 31] (self_:bool) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & self_'0: bool = self_ ] 
+     [ & _0: bool = Any.any_l () | & self_'0: bool = self_ ] )
     [ return''0 (result:bool)-> {[@expl:extern_spec_Clone_bool_clone_body ensures] [%#sclone] result = self_}
       (! return' {result}) ]
 
@@ -118,7 +118,7 @@ module M_creusot_contracts__stdqy35z1__clone__extern_spec_Clone_f32_clone_body [
   
   let rec extern_spec_Clone_f32_clone_body[#"../../creusot-contracts/src/std/clone.rs" 26 8 26 30] (self_:Float32.t) (return'  (x:Float32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Float32.t = Any.any_l () | & self_'0: Float32.t = self_ ] 
+     [ & _0: Float32.t = Any.any_l () | & self_'0: Float32.t = self_ ] )
     [ return''0 (result:Float32.t)-> {[@expl:extern_spec_Clone_f32_clone_body ensures] [%#sclone] result = self_}
       (! return' {result}) ]
 
@@ -135,7 +135,7 @@ module M_creusot_contracts__stdqy35z1__clone__extern_spec_Clone_f64_clone_body [
   
   let rec extern_spec_Clone_f64_clone_body[#"../../creusot-contracts/src/std/clone.rs" 33 8 33 30] (self_:Float64.t) (return'  (x:Float64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Float64.t = Any.any_l () | & self_'0: Float64.t = self_ ] 
+     [ & _0: Float64.t = Any.any_l () | & self_'0: Float64.t = self_ ] )
     [ return''0 (result:Float64.t)-> {[@expl:extern_spec_Clone_f64_clone_body ensures] [%#sclone] result = self_}
       (! return' {result}) ]
 
@@ -171,9 +171,9 @@ module M_creusot_contracts__stdqy35z1__clone__extern_spec_T_Cloneqy95z_ref_T_clo
   meta "select_lsinst" "all"
   
   let rec extern_spec_T_Cloneqy95z_ref_T_clone_body[#"../../creusot-contracts/src/std/clone.rs" 40 8 40 32] (self_:t_T) (return'  (x:t_T))= {[@expl:extern_spec_T_Clone__ref_T_clone_body 'self_' type invariant] [%#sclone] inv'1 self_}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ] 
     [ & _0: t_T = Any.any_l () | & self_'0: t_T = self_ ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_T_Clone__ref_T_clone_body result type invariant] [%#sclone'0] inv'0 result}
       {[@expl:extern_spec_T_Clone__ref_T_clone_body ensures] [%#sclone'1] result = self_}
       (! return' {result}) ]
@@ -2407,7 +2407,7 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_PartialEq_Rhs_ne
     (! bb0
     [ bb0 = s0 [ s0 = eq {self_'0} {rhs'0} (fun (_ret:bool) ->  [ &_4 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- not _4 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & self_'0: t_Self_ = self_ | & rhs'0: t_Rhs = rhs | & _4: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () | & self_'0: t_Self_ = self_ | & rhs'0: t_Rhs = rhs | & _4: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:extern_spec_std_cmp_PartialEq_Rhs_ne_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <> deep_model'3 rhs)}
       (! return' {result}) ]
@@ -2576,12 +2576,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_PartialOrd_Rhs_l
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: t_Self_ = self_
     | & other'0: t_Rhs = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_std_cmp_PartialOrd_Rhs_lt_body ensures] [%#scmp'3] result
       = lt_log (deep_model'1 self_) (deep_model'2 other)}
       (! return' {result}) ]
@@ -2750,12 +2750,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_PartialOrd_Rhs_l
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: t_Self_ = self_
     | & other'0: t_Rhs = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_std_cmp_PartialOrd_Rhs_le_body ensures] [%#scmp'3] result
       = le_log (deep_model'1 self_) (deep_model'2 other)}
       (! return' {result}) ]
@@ -2924,12 +2924,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_PartialOrd_Rhs_g
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: t_Self_ = self_
     | & other'0: t_Rhs = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_std_cmp_PartialOrd_Rhs_gt_body ensures] [%#scmp'3] result
       = gt_log (deep_model'1 self_) (deep_model'2 other)}
       (! return' {result}) ]
@@ -3098,12 +3098,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_PartialOrd_Rhs_g
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: t_Self_ = self_
     | & other'0: t_Rhs = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_std_cmp_PartialOrd_Rhs_ge_body ensures] [%#scmp'3] result
       = ge_log (deep_model'1 self_) (deep_model'2 other)}
       (! return' {result}) ]
@@ -3254,7 +3254,7 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_Ord_max_body [#"
       [ s0 = {[@expl:type invariant] inv o'0} s1 | s1 = -{resolve o'0}- s2 | s2 =  [ &_0 <- self_'0 ] s3 | s3 = bb6 ]
     
     | bb6 = return''0 {_0} ]
-    ) [ & _0: t_Self_ = Any.any_l () | & self_'0: t_Self_ = self_ | & o'0: t_Self_ = o | & _8: bool = Any.any_l () ] 
+     [ & _0: t_Self_ = Any.any_l () | & self_'0: t_Self_ = self_ | & o'0: t_Self_ = o | & _8: bool = Any.any_l () ] )
     [ return''0 (result:t_Self_)-> {[@expl:extern_spec_std_cmp_Ord_max_body result type invariant] [%#scmp'1] inv result}
       {[@expl:extern_spec_std_cmp_Ord_max_body ensures #0] [%#scmp'2] ge_log (deep_model result) (deep_model self_)}
       {[@expl:extern_spec_std_cmp_Ord_max_body ensures #1] [%#scmp'3] ge_log (deep_model result) (deep_model o)}
@@ -3411,7 +3411,7 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_Ord_min_body [#"
       | s3 = bb6 ]
     
     | bb6 = return''0 {_0} ]
-    ) [ & _0: t_Self_ = Any.any_l () | & self_'0: t_Self_ = self_ | & o'0: t_Self_ = o | & _8: bool = Any.any_l () ] 
+     [ & _0: t_Self_ = Any.any_l () | & self_'0: t_Self_ = self_ | & o'0: t_Self_ = o | & _8: bool = Any.any_l () ] )
     [ return''0 (result:t_Self_)-> {[@expl:extern_spec_std_cmp_Ord_min_body result type invariant] [%#scmp'1] inv result}
       {[@expl:extern_spec_std_cmp_Ord_min_body ensures #0] [%#scmp'2] le_log (deep_model result) (deep_model self_)}
       {[@expl:extern_spec_std_cmp_Ord_min_body ensures #1] [%#scmp'3] le_log (deep_model result) (deep_model o)}
@@ -3607,14 +3607,14 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_Ord_clamp_body [
       | s3 = bb11 ]
     
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Self_ = Any.any_l ()
     | & self_'0: t_Self_ = self_
     | & min'0: t_Self_ = min
     | & max'0: t_Self_ = max
     | & _9: bool = Any.any_l ()
     | & _12: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Self_)-> {[@expl:extern_spec_std_cmp_Ord_clamp_body result type invariant] [%#scmp'3] inv result}
       {[@expl:extern_spec_std_cmp_Ord_clamp_body ensures #0] [%#scmp'4] ge_log (deep_model result) (deep_model min)}
       {[@expl:extern_spec_std_cmp_Ord_clamp_body ensures #1] [%#scmp'5] le_log (deep_model result) (deep_model max)}
@@ -3749,7 +3749,7 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_max_body [#"../.
     {[@expl:extern_spec_std_cmp_max_body 'v2' type invariant] [%#scmp'0] inv v2}
     (! bb0
     [ bb0 = s0 [ s0 = max {v1'0} {v2'0} (fun (_ret:t_T) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ]  | bb3 = return''0 {_0} ]
-    ) [ & _0: t_T = Any.any_l () | & v1'0: t_T = v1 | & v2'0: t_T = v2 ] 
+     [ & _0: t_T = Any.any_l () | & v1'0: t_T = v1 | & v2'0: t_T = v2 ] )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_cmp_max_body result type invariant] [%#scmp'1] inv result}
       {[@expl:extern_spec_std_cmp_max_body ensures #0] [%#scmp'2] ge_log (deep_model result) (deep_model v1)}
       {[@expl:extern_spec_std_cmp_max_body ensures #1] [%#scmp'3] ge_log (deep_model result) (deep_model v2)}
@@ -3883,7 +3883,7 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_std_cmp_min_body [#"../.
     {[@expl:extern_spec_std_cmp_min_body 'v2' type invariant] [%#scmp'0] inv v2}
     (! bb0
     [ bb0 = s0 [ s0 = min {v1'0} {v2'0} (fun (_ret:t_T) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ]  | bb3 = return''0 {_0} ]
-    ) [ & _0: t_T = Any.any_l () | & v1'0: t_T = v1 | & v2'0: t_T = v2 ] 
+     [ & _0: t_T = Any.any_l () | & v1'0: t_T = v1 | & v2'0: t_T = v2 ] )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_cmp_min_body result type invariant] [%#scmp'1] inv result}
       {[@expl:extern_spec_std_cmp_min_body ensures #0] [%#scmp'2] le_log (deep_model result) (deep_model v1)}
       {[@expl:extern_spec_std_cmp_min_body ensures #1] [%#scmp'3] le_log (deep_model result) (deep_model v2)}
@@ -4001,12 +4001,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i8_i8_lt_body
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int8.t = self_
     | & other'0: Int8.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i8_i8_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -4118,12 +4118,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i8_i8_le_body
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int8.t = self_
     | & other'0: Int8.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i8_i8_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -4235,12 +4235,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i8_i8_gt_body
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int8.t = self_
     | & other'0: Int8.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i8_i8_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -4352,12 +4352,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i8_i8_ge_body
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int8.t = self_
     | & other'0: Int8.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i8_i8_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -4469,12 +4469,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i16_i16_lt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int16.t = self_
     | & other'0: Int16.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i16_i16_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -4586,12 +4586,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i16_i16_le_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int16.t = self_
     | & other'0: Int16.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i16_i16_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -4703,12 +4703,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i16_i16_gt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int16.t = self_
     | & other'0: Int16.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i16_i16_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -4820,12 +4820,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i16_i16_ge_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int16.t = self_
     | & other'0: Int16.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i16_i16_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -4937,12 +4937,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i32_i32_lt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int32.t = self_
     | & other'0: Int32.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i32_i32_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -5054,12 +5054,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i32_i32_le_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int32.t = self_
     | & other'0: Int32.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i32_i32_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -5171,12 +5171,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i32_i32_gt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int32.t = self_
     | & other'0: Int32.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i32_i32_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -5288,12 +5288,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i32_i32_ge_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int32.t = self_
     | & other'0: Int32.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i32_i32_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -5405,12 +5405,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i64_i64_lt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int64.t = self_
     | & other'0: Int64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i64_i64_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -5522,12 +5522,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i64_i64_le_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int64.t = self_
     | & other'0: Int64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i64_i64_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -5639,12 +5639,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i64_i64_gt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int64.t = self_
     | & other'0: Int64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i64_i64_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -5756,12 +5756,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i64_i64_ge_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int64.t = self_
     | & other'0: Int64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i64_i64_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -5873,12 +5873,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i128_i128_lt_
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int128.t = self_
     | & other'0: Int128.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i128_i128_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -5990,12 +5990,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i128_i128_le_
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int128.t = self_
     | & other'0: Int128.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i128_i128_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -6107,12 +6107,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i128_i128_gt_
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int128.t = self_
     | & other'0: Int128.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i128_i128_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -6224,12 +6224,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_i128_i128_ge_
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int128.t = self_
     | & other'0: Int128.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_i128_i128_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -6341,12 +6341,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_isize_isize_l
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int64.t = self_
     | & other'0: Int64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_isize_isize_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -6458,12 +6458,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_isize_isize_l
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int64.t = self_
     | & other'0: Int64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_isize_isize_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -6575,12 +6575,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_isize_isize_g
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int64.t = self_
     | & other'0: Int64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_isize_isize_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -6692,12 +6692,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_isize_isize_g
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: Int64.t = self_
     | & other'0: Int64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_isize_isize_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -6809,12 +6809,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u8_u8_lt_body
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt8.t = self_
     | & other'0: UInt8.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u8_u8_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -6926,12 +6926,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u8_u8_le_body
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt8.t = self_
     | & other'0: UInt8.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u8_u8_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -7043,12 +7043,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u8_u8_gt_body
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt8.t = self_
     | & other'0: UInt8.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u8_u8_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -7160,12 +7160,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u8_u8_ge_body
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt8.t = self_
     | & other'0: UInt8.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u8_u8_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -7277,12 +7277,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u16_u16_lt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt16.t = self_
     | & other'0: UInt16.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u16_u16_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -7394,12 +7394,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u16_u16_le_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt16.t = self_
     | & other'0: UInt16.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u16_u16_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -7511,12 +7511,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u16_u16_gt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt16.t = self_
     | & other'0: UInt16.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u16_u16_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -7628,12 +7628,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u16_u16_ge_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt16.t = self_
     | & other'0: UInt16.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u16_u16_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -7745,12 +7745,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u32_u32_lt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt32.t = self_
     | & other'0: UInt32.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u32_u32_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -7862,12 +7862,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u32_u32_le_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt32.t = self_
     | & other'0: UInt32.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u32_u32_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -7979,12 +7979,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u32_u32_gt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt32.t = self_
     | & other'0: UInt32.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u32_u32_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -8096,12 +8096,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u32_u32_ge_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt32.t = self_
     | & other'0: UInt32.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u32_u32_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -8213,12 +8213,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u64_u64_lt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt64.t = self_
     | & other'0: UInt64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u64_u64_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -8330,12 +8330,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u64_u64_le_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt64.t = self_
     | & other'0: UInt64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u64_u64_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -8447,12 +8447,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u64_u64_gt_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt64.t = self_
     | & other'0: UInt64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u64_u64_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -8564,12 +8564,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u64_u64_ge_bo
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt64.t = self_
     | & other'0: UInt64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u64_u64_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -8681,12 +8681,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u128_u128_lt_
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt128.t = self_
     | & other'0: UInt128.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u128_u128_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -8798,12 +8798,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u128_u128_le_
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt128.t = self_
     | & other'0: UInt128.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u128_u128_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -8915,12 +8915,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u128_u128_gt_
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt128.t = self_
     | & other'0: UInt128.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u128_u128_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -9032,12 +9032,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_u128_u128_ge_
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt128.t = self_
     | & other'0: UInt128.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_u128_u128_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -9149,12 +9149,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_usize_usize_l
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt64.t = self_
     | & other'0: UInt64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_usize_usize_lt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ < deep_model'0 other)}
       (! return' {result}) ]
@@ -9266,12 +9266,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_usize_usize_l
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt64.t = self_
     | & other'0: UInt64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_usize_usize_le_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ <= deep_model'0 other)}
       (! return' {result}) ]
@@ -9383,12 +9383,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_usize_usize_g
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt64.t = self_
     | & other'0: UInt64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_usize_usize_gt_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ > deep_model'0 other)}
       (! return' {result}) ]
@@ -9500,12 +9500,12 @@ module M_creusot_contracts__stdqy35z1__cmp__extern_spec_PartialOrd_usize_usize_g
     | bb2 = s0 [ s0 =  [ &_0 <- [%#scmp] false ] s1 | s1 = bb6 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- [%#scmp'0] true ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: UInt64.t = self_
     | & other'0: UInt64.t = other
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_PartialOrd_usize_usize_ge_body ensures] [%#scmp'1] result
       = (deep_model'0 self_ >= deep_model'0 other)}
       (! return' {result}) ]
@@ -10579,7 +10579,7 @@ module M_creusot_contracts__stdqy35z1__hint__extern_spec_std_hint_assert_uncheck
   meta "select_lsinst" "all"
   
   let rec extern_spec_std_hint_assert_unchecked_body[#"../../creusot-contracts/src/std/hint.rs" 3 0 35 1] (cond:bool) (return'  (x:()))= {[@expl:extern_spec_std_hint_assert_unchecked_body requires] [%#shint] cond}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_creusot_contracts__stdqy35z1__hint__extern_spec_std_hint_black_box_body [#"../../creusot-contracts/src/std/hint.rs" 12 12 12 42]
   let%span shint = "../../creusot-contracts/src/std/hint.rs" 12 28 12 33
@@ -10597,9 +10597,9 @@ module M_creusot_contracts__stdqy35z1__hint__extern_spec_std_hint_black_box_body
   meta "select_lsinst" "all"
   
   let rec extern_spec_std_hint_black_box_body[#"../../creusot-contracts/src/std/hint.rs" 12 12 12 42] (dummy:t_T) (return'  (x:t_T))= {[@expl:extern_spec_std_hint_black_box_body 'dummy' type invariant] [%#shint] inv dummy}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- dummy'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- dummy'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ] 
     [ & _0: t_T = Any.any_l () | & dummy'0: t_T = dummy ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_hint_black_box_body result type invariant] [%#shint'0] inv result}
       {[@expl:extern_spec_std_hint_black_box_body ensures] [%#shint'1] result = dummy}
       (! return' {result}) ]
@@ -10616,7 +10616,7 @@ module M_creusot_contracts__stdqy35z1__hint__extern_spec_std_hint_spin_loop_body
   meta "select_lsinst" "all"
   
   let rec extern_spec_std_hint_spin_loop_body[#"../../creusot-contracts/src/std/hint.rs" 3 0 35 1] (return'  (x:()))= {[@expl:extern_spec_std_hint_spin_loop_body requires] [%#shint] true}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:extern_spec_std_hint_spin_loop_body ensures] [%#shint'0] true}
       (! return' {result}) ]
 
@@ -10659,9 +10659,9 @@ module M_creusot_contracts__stdqy35z1__hint__extern_spec_std_hint_must_use_body 
   meta "select_lsinst" "all"
   
   let rec extern_spec_std_hint_must_use_body[#"../../creusot-contracts/src/std/hint.rs" 30 12 30 41] (value:t_T) (return'  (x:t_T))= {[@expl:extern_spec_std_hint_must_use_body 'value' type invariant] [%#shint] inv value}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- value'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- value'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ] 
     [ & _0: t_T = Any.any_l () | & value'0: t_T = value ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_hint_must_use_body result type invariant] [%#shint'0] inv result}
       {[@expl:extern_spec_std_hint_must_use_body ensures] [%#shint'1] result = value}
       (! return' {result}) ]
@@ -10721,7 +10721,7 @@ module M_creusot_contracts__stdqy35z1__io__extern_spec_std_ioqy95z_print_body [#
   
   let rec extern_spec_std_ioqy95z_print_body[#"../../creusot-contracts/src/std/io.rs" 4 0 18 1] (args:t_Arguments) (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:extern_spec_std_io__print_body ensures] [%#sio] true} (! return' {result}) ]
 
 end
@@ -10779,7 +10779,7 @@ module M_creusot_contracts__stdqy35z1__io__extern_spec_std_ioqy95z_eprint_body [
   
   let rec extern_spec_std_ioqy95z_eprint_body[#"../../creusot-contracts/src/std/io.rs" 4 0 18 1] (args:t_Arguments) (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:extern_spec_std_io__eprint_body ensures] [%#sio] true} (! return' {result}) ]
 
 end
@@ -13239,7 +13239,7 @@ module M_creusot_contracts__stdqy35z1__iter__map_inv__qyi8002351551305542163__ne
       | s4 = bb16 ]
     
     | bb16 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_MapInv = self
     | & old_self: t_MapInv = Any.any_l ()
@@ -13252,7 +13252,7 @@ module M_creusot_contracts__stdqy35z1__iter__map_inv__qyi8002351551305542163__ne
     | & _15: tuple = Any.any_l ()
     | & _19: () = Any.any_l ()
     | & _24: Seq.seq t_Item = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:next result type invariant] [%#smap_inv'6] inv'9 result}
       {[@expl:next ensures] [%#smap_inv'7] match result with
         | C_None'0 -> completed'0 self
@@ -15211,12 +15211,12 @@ module M_creusot_contracts__stdqy35z1__iter__Iterator__map_inv [#"../../creusot-
       [ s0 =  [ &_0 <- { t_MapInv__iter = self'0; t_MapInv__func = func'0; t_MapInv__produced = _9 } ] s1 | s1 = bb6 ]
     
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: t_MapInv = Any.any_l ()
     | & self'0: t_Self = self
     | & func'0: t_F = func
     | & _9: Seq.seq t_Item = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_MapInv)-> {[@expl:map_inv result type invariant] [%#siter'5] inv'1 result}
       {[@expl:map_inv ensures] [%#siter'6] result
       = { t_MapInv__iter = self; t_MapInv__func = func; t_MapInv__produced = Seq.empty: Seq.seq t_Item }}
@@ -15400,7 +15400,7 @@ module M_creusot_contracts__stdqy35z1__mem__extern_spec_std_mem_replace_body [#"
       | s5 = bb3 ]
     
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: t_T = Any.any_l ()
     | & dest'0: MutBorrow.t t_T = dest
     | & src'0: t_T = src
@@ -15409,7 +15409,7 @@ module M_creusot_contracts__stdqy35z1__mem__extern_spec_std_mem_replace_body [#"
     | & _7: MutBorrow.t t_T = Any.any_l ()
     | & _8: MutBorrow.t t_T = Any.any_l ()
     | & _9: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_mem_replace_body result type invariant] [%#smem'1] inv result}
       {[@expl:extern_spec_std_mem_replace_body ensures #0] [%#smem'2] dest.final = src}
       {[@expl:extern_spec_std_mem_replace_body ensures #1] [%#smem'3] result = dest.current}
@@ -15553,12 +15553,12 @@ module M_creusot_contracts__stdqy35z1__mem__extern_spec_std_mem_take_body [#"../
       | s2 = bb2 ]
     
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv'0 dest'0} s1 | s1 = -{resolve'0 dest'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_T = Any.any_l ()
     | & dest'0: MutBorrow.t t_T = dest
     | & _4: MutBorrow.t t_T = Any.any_l ()
     | & _5: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_mem_take_body result type invariant] [%#smem'0] inv result}
       {[@expl:extern_spec_std_mem_take_body ensures #0] [%#smem'1] result = dest.current}
       {[@expl:extern_spec_std_mem_take_body ensures #1] [%#smem'2] postcondition () () dest.final}
@@ -15585,7 +15585,7 @@ module M_creusot_contracts__stdqy35z1__mem__extern_spec_std_mem_drop_body [#"../
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv t'0} s1 | s1 = -{resolve t'0}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & t'0: t_T = t ] 
+     [ & _0: () = Any.any_l () | & t'0: t_T = t ] )
     [ return''0 (result:())-> {[@expl:extern_spec_std_mem_drop_body ensures] [%#smem'0] resolve t}
       (! return' {result}) ]
 
@@ -15610,7 +15610,7 @@ module M_creusot_contracts__stdqy35z1__mem__extern_spec_std_mem_forget_body [#".
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv t'0} s1 | s1 = -{resolve t'0}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & t'0: t_T = t ] 
+     [ & _0: () = Any.any_l () | & t'0: t_T = t ] )
     [ return''0 (result:())-> {[@expl:extern_spec_std_mem_forget_body ensures] [%#smem'0] resolve t}
       (! return' {result}) ]
 
@@ -15627,7 +15627,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_u8_clone_body [#".
   
   let rec extern_spec_Clone_u8_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:UInt8.t) (return'  (x:UInt8.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt8.t = Any.any_l () | & self_'0: UInt8.t = self_ ] 
+     [ & _0: UInt8.t = Any.any_l () | & self_'0: UInt8.t = self_ ] )
     [ return''0 (result:UInt8.t)-> {[@expl:extern_spec_Clone_u8_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15644,7 +15644,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_u16_clone_body [#"
   
   let rec extern_spec_Clone_u16_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:UInt16.t) (return'  (x:UInt16.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt16.t = Any.any_l () | & self_'0: UInt16.t = self_ ] 
+     [ & _0: UInt16.t = Any.any_l () | & self_'0: UInt16.t = self_ ] )
     [ return''0 (result:UInt16.t)-> {[@expl:extern_spec_Clone_u16_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15661,7 +15661,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_u32_clone_body [#"
   
   let rec extern_spec_Clone_u32_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:UInt32.t) (return'  (x:UInt32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32.t = Any.any_l () | & self_'0: UInt32.t = self_ ] 
+     [ & _0: UInt32.t = Any.any_l () | & self_'0: UInt32.t = self_ ] )
     [ return''0 (result:UInt32.t)-> {[@expl:extern_spec_Clone_u32_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15678,7 +15678,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_u64_clone_body [#"
   
   let rec extern_spec_Clone_u64_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:UInt64.t) (return'  (x:UInt64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & self_'0: UInt64.t = self_ ] 
+     [ & _0: UInt64.t = Any.any_l () | & self_'0: UInt64.t = self_ ] )
     [ return''0 (result:UInt64.t)-> {[@expl:extern_spec_Clone_u64_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15695,7 +15695,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_u128_clone_body [#
   
   let rec extern_spec_Clone_u128_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:UInt128.t) (return'  (x:UInt128.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt128.t = Any.any_l () | & self_'0: UInt128.t = self_ ] 
+     [ & _0: UInt128.t = Any.any_l () | & self_'0: UInt128.t = self_ ] )
     [ return''0 (result:UInt128.t)-> {[@expl:extern_spec_Clone_u128_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15712,7 +15712,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_usize_clone_body [
   
   let rec extern_spec_Clone_usize_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:UInt64.t) (return'  (x:UInt64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & self_'0: UInt64.t = self_ ] 
+     [ & _0: UInt64.t = Any.any_l () | & self_'0: UInt64.t = self_ ] )
     [ return''0 (result:UInt64.t)-> {[@expl:extern_spec_Clone_usize_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15729,7 +15729,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_i8_clone_body [#".
   
   let rec extern_spec_Clone_i8_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:Int8.t) (return'  (x:Int8.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int8.t = Any.any_l () | & self_'0: Int8.t = self_ ] 
+     [ & _0: Int8.t = Any.any_l () | & self_'0: Int8.t = self_ ] )
     [ return''0 (result:Int8.t)-> {[@expl:extern_spec_Clone_i8_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15746,7 +15746,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_i16_clone_body [#"
   
   let rec extern_spec_Clone_i16_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:Int16.t) (return'  (x:Int16.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int16.t = Any.any_l () | & self_'0: Int16.t = self_ ] 
+     [ & _0: Int16.t = Any.any_l () | & self_'0: Int16.t = self_ ] )
     [ return''0 (result:Int16.t)-> {[@expl:extern_spec_Clone_i16_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15763,7 +15763,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_i32_clone_body [#"
   
   let rec extern_spec_Clone_i32_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:Int32.t) (return'  (x:Int32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int32.t = Any.any_l () | & self_'0: Int32.t = self_ ] 
+     [ & _0: Int32.t = Any.any_l () | & self_'0: Int32.t = self_ ] )
     [ return''0 (result:Int32.t)-> {[@expl:extern_spec_Clone_i32_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15780,7 +15780,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_i64_clone_body [#"
   
   let rec extern_spec_Clone_i64_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:Int64.t) (return'  (x:Int64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64.t = Any.any_l () | & self_'0: Int64.t = self_ ] 
+     [ & _0: Int64.t = Any.any_l () | & self_'0: Int64.t = self_ ] )
     [ return''0 (result:Int64.t)-> {[@expl:extern_spec_Clone_i64_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15797,7 +15797,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_i128_clone_body [#
   
   let rec extern_spec_Clone_i128_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:Int128.t) (return'  (x:Int128.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int128.t = Any.any_l () | & self_'0: Int128.t = self_ ] 
+     [ & _0: Int128.t = Any.any_l () | & self_'0: Int128.t = self_ ] )
     [ return''0 (result:Int128.t)-> {[@expl:extern_spec_Clone_i128_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15814,7 +15814,7 @@ module M_creusot_contracts__stdqy35z1__num__extern_spec_Clone_isize_clone_body [
   
   let rec extern_spec_Clone_isize_clone_body[#"../../creusot-contracts/src/std/num.rs" 9 22 36 37] (self_:Int64.t) (return'  (x:Int64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64.t = Any.any_l () | & self_'0: Int64.t = self_ ] 
+     [ & _0: Int64.t = Any.any_l () | & self_'0: Int64.t = self_ ] )
     [ return''0 (result:Int64.t)-> {[@expl:extern_spec_Clone_isize_clone_body ensures] [%#snum] result = self_}
       (! return' {result}) ]
 
@@ -15847,9 +15847,9 @@ module M_creusot_contracts__stdqy35z1__ops__extern_spec_core_option_T_Try_Option
   meta "select_lsinst" "all"
   
   let rec extern_spec_core_option_T_Try_Option_T_from_output_body[#"../../creusot-contracts/src/std/ops.rs" 288 36 290 18] (output:t_T) (return'  (x:t_Option))= {[@expl:extern_spec_core_option_T_Try_Option_T_from_output_body 'output' type invariant] [%#sops] inv output}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- C_Some output'0 ] s1 | s1 = bb2 ]  | bb2 = return''0 {_0} ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- C_Some output'0 ] s1 | s1 = bb2 ]  | bb2 = return''0 {_0} ] 
     [ & _0: t_Option = Any.any_l () | & output'0: t_T = output ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_core_option_T_Try_Option_T_from_output_body result type invariant] [%#sops'0] inv'0 result}
       {[@expl:extern_spec_core_option_T_Try_Option_T_from_output_body ensures] [%#sops'1] result = C_Some output}
       (! return' {result}) ]
@@ -15923,12 +15923,12 @@ module M_creusot_contracts__stdqy35z1__ops__extern_spec_core_option_T_Try_Option
     
     | bb3 = s0 [ s0 =  [ &_6 <- C_None'0 ] s1 | s1 =  [ &_0 <- C_Break _6 ] s2 | s2 = bb8 ] 
     | bb8 = return''0 {_0} ]
-    )
+    
     [ & _0: t_ControlFlow = Any.any_l ()
     | & self_'0: t_Option = self_
     | & v: t_T = Any.any_l ()
     | & _6: t_Option'0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_ControlFlow)-> {[@expl:extern_spec_core_option_T_Try_Option_T_branch_body result type invariant] [%#sops'0] inv'3 result}
       {[@expl:extern_spec_core_option_T_Try_Option_T_branch_body ensures] [%#sops'1] match self_ with
         | C_Some v -> result = C_Continue v
@@ -15981,7 +15981,7 @@ module M_creusot_contracts__stdqy35z1__ops__extern_spec_core_option_T_FromResidu
   meta "select_lsinst" "all"
   
   let rec extern_spec_core_option_T_FromResidual_Option_Infallible_Option_T_from_residual_body[#"../../creusot-contracts/src/std/ops.rs" 306 65 308 18] (residual:t_Option'0) (return'  (x:t_Option))= {[@expl:extern_spec_core_option_T_FromResidual_Option_Infallible_Option_T_from_residual_body 'residual' type invariant] [%#sops] inv'0 residual}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- C_None ] s1 | s1 = return''0 {_0} ]  ] ) [ & _0: t_Option = Any.any_l () ] 
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- C_None ] s1 | s1 = return''0 {_0} ]  ]  [ & _0: t_Option = Any.any_l () ] )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_core_option_T_FromResidual_Option_Infallible_Option_T_from_residual_body result type invariant] [%#sops'0] inv'2 result}
       {[@expl:extern_spec_core_option_T_FromResidual_Option_Infallible_Option_T_from_residual_body ensures] [%#sops'1] result
       = C_None}
@@ -16020,9 +16020,9 @@ module M_creusot_contracts__stdqy35z1__ops__extern_spec_core_result_T_E_Try_Resu
   meta "select_lsinst" "all"
   
   let rec extern_spec_core_result_T_E_Try_Result_T_E_from_output_body[#"../../creusot-contracts/src/std/ops.rs" 318 42 320 18] (output:t_T) (return'  (x:t_Result))= {[@expl:extern_spec_core_result_T_E_Try_Result_T_E_from_output_body 'output' type invariant] [%#sops] inv output}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- C_Ok output'0 ] s1 | s1 = bb2 ]  | bb2 = return''0 {_0} ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- C_Ok output'0 ] s1 | s1 = bb2 ]  | bb2 = return''0 {_0} ] 
     [ & _0: t_Result = Any.any_l () | & output'0: t_T = output ]
-    
+    )
     [ return''0 (result:t_Result)-> {[@expl:extern_spec_core_result_T_E_Try_Result_T_E_from_output_body result type invariant] [%#sops'0] inv'1 result}
       {[@expl:extern_spec_core_result_T_E_Try_Result_T_E_from_output_body ensures] [%#sops'1] result = C_Ok output}
       (! return' {result}) ]
@@ -16106,13 +16106,13 @@ module M_creusot_contracts__stdqy35z1__ops__extern_spec_core_result_T_E_Try_Resu
       [ s0 = v_Ok {self_'0} (fun (r0:t_T) ->  [ &v <- r0 ] s1) | s1 =  [ &_0 <- C_Continue v ] s2 | s2 = bb11 ]
     
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: t_ControlFlow = Any.any_l ()
     | & self_'0: t_Result = self_
     | & v: t_T = Any.any_l ()
     | & e: t_E = Any.any_l ()
     | & _7: t_Result'0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_ControlFlow)-> {[@expl:extern_spec_core_result_T_E_Try_Result_T_E_branch_body result type invariant] [%#sops'0] inv'4 result}
       {[@expl:extern_spec_core_result_T_E_Try_Result_T_E_branch_body ensures] [%#sops'1] match self_ with
         | C_Ok v -> result = C_Continue v
@@ -16266,12 +16266,12 @@ module M_creusot_contracts__stdqy35z1__ops__extern_spec_core_result_T_E_F_FromRe
     
     | bb1 = s0 [ s0 =  [ &_0 <- C_Err'0 _4 ] s1 | s1 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Result'0 = Any.any_l ()
     | & residual'0: t_Result = residual
     | & e: t_E = Any.any_l ()
     | & _4: t_F = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Result'0)-> {[@expl:extern_spec_core_result_T_E_F_FromResidual_Result_Infallible_E_Result_T_F_from_residual_body result type invariant] [%#sops'0] inv'4 result}
       {[@expl:extern_spec_core_result_T_E_F_FromResidual_Result_Infallible_E_Result_T_F_from_residual_body ensures] [%#sops'1] match { _p0 = result;
                                                                                                                                        _p1 = residual } with
@@ -16392,14 +16392,14 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_PartialE
     | bb1 = s0 [ s0 =  [ &_0 <- [%#soption] false ] s1 | s1 = bb9 ] 
     | bb7 = s0 [ s0 =  [ &_0 <- [%#soption'0] true ] s1 | s1 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: t_Option = self_
     | & rhs'0: t_Option = rhs
     | & _4: tuple = Any.any_l ()
     | & x: t_T = Any.any_l ()
     | & y: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_std_option_T_PartialEq_Option_T_eq_body ensures] [%#soption'3] result
       = (deep_model'3 self_ = deep_model'3 rhs)}
       (! return' {result}) ]
@@ -16543,9 +16543,9 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_T_Clone_Option_T_clon
     | bb5 = s0 [ s0 =  [ &_0 <- C_Some _5 ] s1 | s1 = bb7 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_None ] s1 | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    )
-    [ & _0: t_Option = Any.any_l () | & self_'0: t_Option = self_ | & x: t_T = Any.any_l () | & _5: t_T = Any.any_l () ]
     
+    [ & _0: t_Option = Any.any_l () | & self_'0: t_Option = self_ | & x: t_T = Any.any_l () | & _5: t_T = Any.any_l () ]
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_T_Clone_Option_T_clone_body result type invariant] [%#soption'0] inv'1 result}
       {[@expl:extern_spec_T_Clone_Option_T_clone_body ensures] [%#soption'1] match { _p0 = self_; _p1 = result } with
         | {_p0 = C_None ; _p1 = C_None} -> true
@@ -16597,7 +16597,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb3 = s0 [ s0 =  [ &_0 <- [%#soption] true ] s1 | s1 = bb5 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- [%#soption'0] false ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & self_'0: t_Option = self_ ] 
+     [ & _0: bool = Any.any_l () | & self_'0: t_Option = self_ ] )
     [ return''0 (result:bool)-> {[@expl:extern_spec_std_option_T_Option_T_is_some_body ensures] [%#soption'2] result
       = (self_ <> C_None)}
       (! return' {result}) ]
@@ -16679,13 +16679,13 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb4 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- [%#soption] false ] s1 | s1 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self_'0: t_Option = self_
     | & f'0: impl_FnOnce_T_____bool = f
     | & t: t_T = Any.any_l ()
     | & _8: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:extern_spec_std_option_T_Option_T_is_some_and_body ensures] [%#soption'3] match self_ with
         | C_None -> result = false
         | C_Some t -> postcondition_once f t result
@@ -16735,7 +16735,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb3 = s0 [ s0 =  [ &_0 <- [%#soption] false ] s1 | s1 = bb5 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- [%#soption'0] true ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & self_'0: t_Option = self_ ] 
+     [ & _0: bool = Any.any_l () | & self_'0: t_Option = self_ ] )
     [ return''0 (result:bool)-> {[@expl:extern_spec_std_option_T_Option_T_is_none_body ensures] [%#soption'2] result
       = (self_ = C_None)}
       (! return' {result}) ]
@@ -16807,7 +16807,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb3 = s0 [ s0 = v_Some {self_'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- C_Some'0 t ] s2 | s2 = bb5 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: t_Option'0 = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] 
+     [ & _0: t_Option'0 = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] )
     [ return''0 (result:t_Option'0)-> {[@expl:extern_spec_std_option_T_Option_T_as_ref_body result type invariant] [%#soption'0] inv'3 result}
       {[@expl:extern_spec_std_option_T_Option_T_as_ref_body ensures #0] [%#soption'1] self_ = C_None
        -> result = C_None'0}
@@ -16920,12 +16920,12 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb5 = s0
       [ s0 = {[@expl:type invariant] inv'2 self_'0} s1 | s1 = -{resolve'2 self_'0}- s2 | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self_'0: MutBorrow.t t_Option = self_
     | & t: MutBorrow.t t_T = Any.any_l ()
     | & _6: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:extern_spec_std_option_T_Option_T_as_mut_body result type invariant] [%#soption'0] inv'3 result}
       {[@expl:extern_spec_std_option_T_Option_T_as_mut_body ensures #0] [%#soption'1] self_.current = C_None
        -> result = C_None'0 /\ self_.final = C_None}
@@ -17071,7 +17071,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
       | s3 = bb6 ]
     
     | bb6 = s0 [ s0 =  [ &_0 <- _3 ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Slice64.slice t_T = Any.any_l ()
     | & self_'0: t_Option = self_
     | & _3: Slice64.slice t_T = Any.any_l ()
@@ -17079,7 +17079,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & t: t_T = Any.any_l ()
     | & _9: Slice64.slice t_T = Any.any_l ()
     | & _11: Slice64.array t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:Slice64.slice t_T)-> {[@expl:extern_spec_std_option_T_Option_T_as_slice_body result type invariant] [%#soption'0] inv'4 result}
       {[@expl:extern_spec_std_option_T_Option_T_as_slice_body ensures] [%#soption'1] match self_ with
         | C_None -> Seq.length (view'0 result) = 0
@@ -17348,7 +17348,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
       | s7 = -{resolve'4 self_'0}- s8
       | s8 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t (Slice64.slice t_T) = Any.any_l ()
     | & self_'0: MutBorrow.t t_Option = self_
     | & _2: MutBorrow.t (Slice64.slice t_T) = Any.any_l ()
@@ -17359,7 +17359,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & _10: MutBorrow.t (Slice64.slice t_T) = Any.any_l ()
     | & _11: MutBorrow.t t_T = Any.any_l ()
     | & _12: MutBorrow.t (Slice64.array t_T) = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t (Slice64.slice t_T))-> {[@expl:extern_spec_std_option_T_Option_T_as_mut_slice_body result type invariant] [%#soption'0] inv'4 result}
       {[@expl:extern_spec_std_option_T_Option_T_as_mut_slice_body ensures] [%#soption'1] match self_.current with
         | C_None -> Seq.length (view'0 result) = 0
@@ -17412,7 +17412,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb3 = s0 [ s0 = v_Some {self_'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- t ] s2 | s2 = bb6 ] 
     | bb6 = return''0 {_0}
     | bb4 = {false} any ]
-    ) [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] 
+     [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_option_T_Option_T_expect_body result type invariant] [%#soption'1] inv result}
       {[@expl:extern_spec_std_option_T_Option_T_expect_body ensures] [%#soption'2] C_Some result = self_}
       (! return' {result}) ]
@@ -17458,7 +17458,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb3 = s0 [ s0 = v_Some {self_'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- t ] s2 | s2 = bb6 ] 
     | bb6 = return''0 {_0}
     | bb4 = {false} any ]
-    ) [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] 
+     [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_option_T_Option_T_unwrap_body result type invariant] [%#soption'1] inv result}
       {[@expl:extern_spec_std_option_T_Option_T_unwrap_body ensures] [%#soption'2] C_Some result = self_}
       (! return' {result}) ]
@@ -17513,7 +17513,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb4 = s0 [ s0 =  [ &_0 <- default'0 ] s1 | s1 = bb8 ] 
     | bb8 = return''0 {_0} ]
-    ) [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & default'0: t_T = default | & t: t_T = Any.any_l () ] 
+     [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & default'0: t_T = default | & t: t_T = Any.any_l () ] )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_option_T_Option_T_unwrap_or_body result type invariant] [%#soption'1] inv result}
       {[@expl:extern_spec_std_option_T_Option_T_unwrap_or_body ensures #0] [%#soption'2] self_ = C_None
        -> result = default}
@@ -17591,13 +17591,13 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb4 = s0 [ s0 = call_once {f'0} {_7} (fun (_ret:t_T) ->  [ &_0 <- _ret ] s1) | s1 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: t_T = Any.any_l ()
     | & self_'0: t_Option = self_
     | & f'0: t_F = f
     | & _7: () = Any.any_l ()
     | & t: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_option_T_Option_T_unwrap_or_else_body result type invariant] [%#soption'2] inv'0 result}
       {[@expl:extern_spec_std_option_T_Option_T_unwrap_or_else_body ensures] [%#soption'3] match self_ with
         | C_None -> postcondition_once f () result
@@ -17722,7 +17722,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb3 = s0 [ s0 = v_Some {self_'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- t ] s2 | s2 = bb7 ] 
     | bb4 = s0 [ s0 = default (fun (_ret:t_T) ->  [ &_0 <- _ret ] s1) | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    ) [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] 
+     [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_option_T_Option_T_unwrap_or_default_body result type invariant] [%#soption'0] inv result}
       {[@expl:extern_spec_std_option_T_Option_T_unwrap_or_default_body ensures #0] [%#soption'1] self_ = C_None
        -> postcondition () () result}
@@ -17771,7 +17771,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb3 = s0 [ s0 = v_Some {self_'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- t ] s2 | s2 = bb6 ] 
     | bb6 = return''0 {_0}
     | bb4 = {false} any ]
-    ) [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] 
+     [ & _0: t_T = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] )
     [ return''0 (result:t_T)-> {[@expl:extern_spec_std_option_T_Option_T_unwrap_unchecked_body result type invariant] [%#soption'1] inv result}
       {[@expl:extern_spec_std_option_T_Option_T_unwrap_unchecked_body ensures] [%#soption'2] C_Some result = self_}
       (! return' {result}) ]
@@ -17871,14 +17871,14 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb4 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb11 ] 
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self_'0: t_Option = self_
     | & f'0: t_F = f
     | & t: t_T = Any.any_l ()
     | & _7: t_U = Any.any_l ()
     | & _9: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:extern_spec_std_option_T_Option_T_map_body result type invariant] [%#soption'2] inv'4 result}
       {[@expl:extern_spec_std_option_T_Option_T_map_body ensures] [%#soption'3] match self_ with
         | C_None -> result = C_None'0
@@ -17973,7 +17973,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb4 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_None ] s1 | s1 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self_'0: t_Option = self_
     | & f'0: t_F = f
@@ -17981,7 +17981,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & _8: () = Any.any_l ()
     | & _10: t_T = Any.any_l ()
     | & _12: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_std_option_T_Option_T_inspect_body result type invariant] [%#soption'2] inv'3 result}
       {[@expl:extern_spec_std_option_T_Option_T_inspect_body ensures #0] [%#soption'3] result = self_}
       {[@expl:extern_spec_std_option_T_Option_T_inspect_body ensures #1] [%#soption'4] match self_ with
@@ -18076,14 +18076,14 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv'0 f'0} s1 | s1 = -{resolve'0 f'0}- s2 | s2 = bb4 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- default'0 ] s1 | s1 = bb11 ] 
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: t_U = Any.any_l ()
     | & self_'0: t_Option = self_
     | & default'0: t_U = default
     | & f'0: t_F = f
     | & t: t_T = Any.any_l ()
     | & _9: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_U)-> {[@expl:extern_spec_std_option_T_Option_T_map_or_body result type invariant] [%#soption'3] inv result}
       {[@expl:extern_spec_std_option_T_Option_T_map_or_body ensures] [%#soption'4] match self_ with
         | C_None -> result = default
@@ -18194,7 +18194,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv'0 f'0} s1 | s1 = -{resolve'0 f'0}- s2 | s2 = bb4 ] 
     | bb4 = s0 [ s0 = call_once'0 {default'0} {_8} (fun (_ret:t_U) ->  [ &_0 <- _ret ] s1) | s1 = bb12 ] 
     | bb12 = return''0 {_0} ]
-    )
+    
     [ & _0: t_U = Any.any_l ()
     | & self_'0: t_Option = self_
     | & default'0: t_D = default
@@ -18202,7 +18202,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & _8: () = Any.any_l ()
     | & t: t_T = Any.any_l ()
     | & _11: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_U)-> {[@expl:extern_spec_std_option_T_Option_T_map_or_else_body result type invariant] [%#soption'3] inv'3 result}
       {[@expl:extern_spec_std_option_T_Option_T_map_or_else_body ensures] [%#soption'4] match self_ with
         | C_None -> postcondition_once'0 default () result
@@ -18275,7 +18275,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb4 = s0 [ s0 =  [ &_0 <- C_Err err'0 ] s1 | s1 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    ) [ & _0: t_Result = Any.any_l () | & self_'0: t_Option = self_ | & err'0: t_E = err | & t: t_T = Any.any_l () ] 
+     [ & _0: t_Result = Any.any_l () | & self_'0: t_Option = self_ | & err'0: t_E = err | & t: t_T = Any.any_l () ] )
     [ return''0 (result:t_Result)-> {[@expl:extern_spec_std_option_T_Option_T_ok_or_body result type invariant] [%#soption'1] inv'2 result}
       {[@expl:extern_spec_std_option_T_Option_T_ok_or_body ensures] [%#soption'2] match self_ with
         | C_None -> result = C_Err err
@@ -18370,14 +18370,14 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb4 = s0 [ s0 = call_once {err'0} {_8} (fun (_ret:t_E) ->  [ &_6 <- _ret ] s1) | s1 = bb5 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- C_Err _6 ] s1 | s1 = bb11 ] 
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Result = Any.any_l ()
     | & self_'0: t_Option = self_
     | & err'0: t_F = err
     | & _6: t_E = Any.any_l ()
     | & _8: () = Any.any_l ()
     | & t: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Result)-> {[@expl:extern_spec_std_option_T_Option_T_ok_or_else_body result type invariant] [%#soption'2] inv'3 result}
       {[@expl:extern_spec_std_option_T_Option_T_ok_or_else_body ensures] [%#soption'3] match self_ with
         | C_None -> exists r: t_E. result = C_Err r /\ postcondition_once err () r
@@ -18473,7 +18473,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb4 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    ) [ & _0: t_Option'0 = Any.any_l () | & self_'0: t_Option = self_ | & optb'0: t_Option'0 = optb ] 
+     [ & _0: t_Option'0 = Any.any_l () | & self_'0: t_Option = self_ | & optb'0: t_Option'0 = optb ] )
     [ return''0 (result:t_Option'0)-> {[@expl:extern_spec_std_option_T_Option_T_and_body result type invariant] [%#soption'1] inv'2 result}
       {[@expl:extern_spec_std_option_T_Option_T_and_body ensures #0] [%#soption'2] self_ = C_None
        -> result = C_None'0 /\ resolve'3 optb}
@@ -18577,13 +18577,13 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb4 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self_'0: t_Option = self_
     | & f'0: t_F = f
     | & t: t_T = Any.any_l ()
     | & _8: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:extern_spec_std_option_T_Option_T_and_then_body result type invariant] [%#soption'2] inv'3 result}
       {[@expl:extern_spec_std_option_T_Option_T_and_then_body ensures] [%#soption'3] match self_ with
         | C_None -> result = C_None'0
@@ -18682,7 +18682,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv predicate''0} s1 | s1 = -{resolve'0 predicate''0}- s2 | s2 = bb4 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_None ] s1 | s1 = bb14 ] 
     | bb14 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self_'0: t_Option = self_
     | & predicate''0: t_P = predicate'
@@ -18690,7 +18690,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & _7: bool = Any.any_l ()
     | & _9: t_T = Any.any_l ()
     | & _11: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_std_option_T_Option_T_filter_body result type invariant] [%#soption'2] inv'3 result}
       {[@expl:extern_spec_std_option_T_Option_T_filter_body ensures] [%#soption'3] match self_ with
         | C_None -> result = C_None
@@ -18761,12 +18761,12 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb4 = s0 [ s0 =  [ &_0 <- optb'0 ] s1 | s1 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self_'0: t_Option = self_
     | & optb'0: t_Option = optb
     | & t: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_std_option_T_Option_T_or_body result type invariant] [%#soption'1] inv'0 result}
       {[@expl:extern_spec_std_option_T_Option_T_or_body ensures #0] [%#soption'2] self_ = C_None  -> result = optb}
       {[@expl:extern_spec_std_option_T_Option_T_or_body ensures #1] [%#soption'3] self_ = C_None
@@ -18844,13 +18844,13 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb4 = s0 [ s0 = call_once {f'0} {_7} (fun (_ret:t_Option) ->  [ &_0 <- _ret ] s1) | s1 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self_'0: t_Option = self_
     | & f'0: t_F = f
     | & _7: () = Any.any_l ()
     | & t: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_std_option_T_Option_T_or_else_body result type invariant] [%#soption'2] inv'1 result}
       {[@expl:extern_spec_std_option_T_Option_T_or_else_body ensures] [%#soption'3] match self_ with
         | C_None -> postcondition_once f () result
@@ -18957,13 +18957,13 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb8 = s0 [ s0 = v_Some {_4._p1} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 = bb10 ] 
     | bb10 = s0 [ s0 =  [ &_0 <- C_Some t ] s1 | s1 = bb16 ] 
     | bb16 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self_'0: t_Option = self_
     | & optb'0: t_Option = optb
     | & _4: tuple = Any.any_l ()
     | & t: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_std_option_T_Option_T_xor_body result type invariant] [%#soption'1] inv'0 result}
       {[@expl:extern_spec_std_option_T_Option_T_xor_body ensures] [%#soption'2] match { _p0 = self_; _p1 = optb } with
         | {_p0 = C_None ; _p1 = C_None} -> result = C_None
@@ -19110,7 +19110,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb9 = s0 [ s0 = {[@expl:type invariant] inv'2 self_'0} s1 | s1 = -{resolve'5 self_'0}- s2 | s2 = return''0 {_0} ] 
     | bb6 = s0 [ s0 = {[@expl:type invariant] inv'2 self_'0} s1 | s1 = -{resolve'5 self_'0}- s2 | s2 = bb8 ] 
     | bb8 = {false} any ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & self_'0: MutBorrow.t t_Option = self_
     | & value'0: t_T = value
@@ -19118,7 +19118,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & _6: t_Option = Any.any_l ()
     | & _8: MutBorrow.t t_T = Any.any_l ()
     | & v: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:extern_spec_std_option_T_Option_T_insert_body result type invariant] [%#soption'1] inv'1 result}
       {[@expl:extern_spec_std_option_T_Option_T_insert_body ensures #0] [%#soption'2] match self_.current with
         | C_Some t -> resolve t
@@ -19268,7 +19268,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb11 = s0 [ s0 = {[@expl:type invariant] inv'2 self_'0} s1 | s1 = -{resolve'5 self_'0}- s2 | s2 = bb13 ] 
     | bb13 = {false} any ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & self_'0: MutBorrow.t t_Option = self_
     | & value'0: t_T = value
@@ -19276,7 +19276,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & _7: t_Option = Any.any_l ()
     | & _9: MutBorrow.t t_T = Any.any_l ()
     | & v: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:extern_spec_std_option_T_Option_T_get_or_insert_body result type invariant] [%#soption'1] inv'1 result}
       {[@expl:extern_spec_std_option_T_Option_T_get_or_insert_body ensures] [%#soption'2] match self_.current with
         | C_None -> result.current = value /\ self_.final = C_Some (result.final)
@@ -19516,7 +19516,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb13 = s0
       [ s0 = {[@expl:type invariant] inv'3 self_'0} s1 | s1 = -{resolve'6 self_'0}- s2 | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & self_'0: MutBorrow.t t_Option = self_
     | & f'0: t_F = f
@@ -19530,7 +19530,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & _14: t_Option'0 = Any.any_l ()
     | & _15: MutBorrow.t t_Option = Any.any_l ()
     | & t: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:extern_spec_std_option_T_Option_T_get_or_insert_with_body result type invariant] [%#soption'2] inv'1 result}
       {[@expl:extern_spec_std_option_T_Option_T_get_or_insert_with_body ensures] [%#soption'3] match self_.current with
         | C_None -> postcondition_once f () result.current /\ self_.final = C_Some (result.final)
@@ -19612,12 +19612,12 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | bb1 = s0
       [ s0 = {[@expl:type invariant] inv'1 self_'0} s1 | s1 = -{resolve'0 self_'0}- s2 | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self_'0: MutBorrow.t t_Option = self_
     | & _3: MutBorrow.t t_Option = Any.any_l ()
     | & _4: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_std_option_T_Option_T_take_body result type invariant] [%#soption'0] inv'0 result}
       {[@expl:extern_spec_std_option_T_Option_T_take_body ensures] [%#soption'1] result = self_.current
       /\ self_.final = C_None}
@@ -19777,7 +19777,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb4 = s0 [ s0 =  [ &_0 <- C_None ] s1 | s1 = bb12 ] 
     | bb12 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self_'0: MutBorrow.t t_Option = self_
     | & predicate''0: t_P = predicate'
@@ -19786,7 +19786,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & _9: MutBorrow.t t_T = Any.any_l ()
     | & _10: MutBorrow.t t_T = Any.any_l ()
     | & _11: MutBorrow.t t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_std_option_T_Option_T_take_if_body result type invariant] [%#soption'2] inv'3 result}
       {[@expl:extern_spec_std_option_T_Option_T_take_if_body ensures] [%#soption'3] match self_.current with
         | C_None -> result = C_None /\ self_.final = C_None
@@ -19876,13 +19876,13 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv'1 self_'0} s1 | s1 = -{resolve'0 self_'0}- s2 | s2 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self_'0: MutBorrow.t t_Option = self_
     | & value'0: t_T = value
     | & _4: MutBorrow.t t_Option = Any.any_l ()
     | & _5: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_std_option_T_Option_T_replace_body result type invariant] [%#soption'1] inv'0 result}
       {[@expl:extern_spec_std_option_T_Option_T_replace_body ensures] [%#soption'2] result = self_.current
       /\ self_.final = C_Some value}
@@ -20047,7 +20047,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     
     | bb8 = s0 [ s0 =  [ &_0 <- C_Some'1 _11 ] s1 | s1 = bb15 ] 
     | bb15 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'1 = Any.any_l ()
     | & self_'0: t_Option = self_
     | & other'0: t_Option'0 = other
@@ -20055,7 +20055,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_T
     | & t: t_T = Any.any_l ()
     | & u: t_U = Any.any_l ()
     | & _11: tuple'0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'1)-> {[@expl:extern_spec_std_option_T_Option_T_zip_body result type invariant] [%#soption'1] inv'4 result}
       {[@expl:extern_spec_std_option_T_Option_T_zip_body ensures] [%#soption'2] match { _p0 = self_; _p1 = other } with
         | {_p0 = C_None} -> result = C_None'1 /\ resolve'0 other
@@ -20158,7 +20158,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_U_Option
       | s3 = bb14 ]
     
     | bb14 = return''0 {_0} ]
-    )
+    
     [ & _0: tuple'0 = Any.any_l ()
     | & self_'0: t_Option = self_
     | & t: t_T = Any.any_l ()
@@ -20167,7 +20167,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_U_Option
     | & _8: t_Option'1 = Any.any_l ()
     | & _10: t_Option'0 = Any.any_l ()
     | & _11: t_Option'1 = Any.any_l () ]
-    
+    )
     [ return''0 (result:tuple'0)-> {[@expl:extern_spec_std_option_T_U_Option__tuple2_T_U_unzip_body result type invariant] [%#soption'0] inv'5 result}
       {[@expl:extern_spec_std_option_T_U_Option__tuple2_T_U_unzip_body ensures] [%#soption'1] match self_ with
         | C_None -> result = { _p0'0 = C_None'0; _p1'0 = C_None'1 }
@@ -20234,7 +20234,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Optionqy
     | bb3 = s0 [ s0 = v_Some {self_'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- C_Some'0 t ] s2 | s2 = bb5 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: t_Option'0 = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] 
+     [ & _0: t_Option'0 = Any.any_l () | & self_'0: t_Option = self_ | & t: t_T = Any.any_l () ] )
     [ return''0 (result:t_Option'0)-> {[@expl:extern_spec_std_option_T_Option__ref_T_copied_body result type invariant] [%#soption'0] inv'2 result}
       {[@expl:extern_spec_std_option_T_Option__ref_T_copied_body ensures] [%#soption'1] match self_ with
         | C_None -> result = C_None'0
@@ -20386,12 +20386,12 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Optionqy
     | bb5 = s0 [ s0 =  [ &_0 <- C_Some'0 _5 ] s1 | s1 = bb7 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self_'0: t_Option = self_
     | & t: t_T = Any.any_l ()
     | & _5: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:extern_spec_std_option_T_Option__ref_T_cloned_body result type invariant] [%#soption'0] inv'2 result}
       {[@expl:extern_spec_std_option_T_Option__ref_T_cloned_body ensures] [%#soption'1] match { _p0 = self_;
                                                                                                 _p1 = result } with
@@ -20474,7 +20474,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Optionqy
     
     | bb4 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: t_Option'0 = Any.any_l () | & self_'0: t_Option = self_ | & t: MutBorrow.t t_T = Any.any_l () ] 
+     [ & _0: t_Option'0 = Any.any_l () | & self_'0: t_Option = self_ | & t: MutBorrow.t t_T = Any.any_l () ] )
     [ return''0 (result:t_Option'0)-> {[@expl:extern_spec_std_option_T_Option__refmut_T_copied_body result type invariant] [%#soption'0] inv'2 result}
       {[@expl:extern_spec_std_option_T_Option__refmut_T_copied_body ensures] [%#soption'1] match self_ with
         | C_None -> result = C_None'0
@@ -20647,12 +20647,12 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Optionqy
     
     | bb4 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self_'0: t_Option = self_
     | & t: MutBorrow.t t_T = Any.any_l ()
     | & _5: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:extern_spec_std_option_T_Option__refmut_T_cloned_body result type invariant] [%#soption'0] inv'3 result}
       {[@expl:extern_spec_std_option_T_Option__refmut_T_cloned_body ensures] [%#soption'1] match { _p0 = self_;
                                                                                                    _p1 = result } with
@@ -20763,14 +20763,14 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_E_Option
     | bb9 = s0 [ s0 =  [ &_0 <- C_Ok'0 _7 ] s1 | s1 = bb15 ] 
     | bb7 = s0 [ s0 =  [ &_5 <- C_None'0 ] s1 | s1 =  [ &_0 <- C_Ok'0 _5 ] s2 | s2 = bb15 ] 
     | bb15 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Result'0 = Any.any_l ()
     | & self_'0: t_Option = self_
     | & _5: t_Option'0 = Any.any_l ()
     | & ok: t_T = Any.any_l ()
     | & _7: t_Option'0 = Any.any_l ()
     | & err: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Result'0)-> {[@expl:extern_spec_std_option_T_E_Option_Result_T_E_transpose_body result type invariant] [%#soption'0] inv'4 result}
       {[@expl:extern_spec_std_option_T_E_Option_Result_T_E_transpose_body ensures] [%#soption'1] match self_ with
         | C_None -> result = C_Ok'0 (C_None'0)
@@ -20831,7 +20831,7 @@ module M_creusot_contracts__stdqy35z1__option__extern_spec_std_option_T_Option_O
     | bb3 = s0 [ s0 = v_Some {self_'0} (fun (r0:t_Option) ->  [ &opt <- r0 ] s1) | s1 =  [ &_0 <- opt ] s2 | s2 = bb7 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_None ] s1 | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    ) [ & _0: t_Option = Any.any_l () | & self_'0: t_Option'0 = self_ | & opt: t_Option = Any.any_l () ] 
+     [ & _0: t_Option = Any.any_l () | & self_'0: t_Option'0 = self_ | & opt: t_Option = Any.any_l () ] )
     [ return''0 (result:t_Option)-> {[@expl:extern_spec_std_option_T_Option_Option_T_flatten_body result type invariant] [%#soption'0] inv'0 result}
       {[@expl:extern_spec_std_option_T_Option_Option_T_flatten_body ensures #0] [%#soption'1] self_ = C_None'0
        -> result = C_None}
@@ -22152,7 +22152,7 @@ module M_creusot_contracts__stdqy35z1__ptr__extern_spec_T_Cloneqy95z_ptrmut_T_cl
   
   let rec extern_spec_T_Cloneqy95z_ptrmut_T_clone_body[#"../../creusot-contracts/src/std/ptr.rs" 118 8 118 33] (self_:Opaque.ptr) (return'  (x:Opaque.ptr))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Opaque.ptr = Any.any_l () | & self_'0: Opaque.ptr = self_ ] 
+     [ & _0: Opaque.ptr = Any.any_l () | & self_'0: Opaque.ptr = self_ ] )
     [ return''0 (result:Opaque.ptr)-> {[@expl:extern_spec_T_Clone__ptrmut_T_clone_body ensures] [%#sptr] result = self_}
       (! return' {result}) ]
 
@@ -22169,7 +22169,7 @@ module M_creusot_contracts__stdqy35z1__ptr__extern_spec_T_Cloneqy95z_ptrconst_T_
   
   let rec extern_spec_T_Cloneqy95z_ptrconst_T_clone_body[#"../../creusot-contracts/src/std/ptr.rs" 125 8 125 35] (self_:Opaque.ptr) (return'  (x:Opaque.ptr))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Opaque.ptr = Any.any_l () | & self_'0: Opaque.ptr = self_ ] 
+     [ & _0: Opaque.ptr = Any.any_l () | & self_'0: Opaque.ptr = self_ ] )
     [ return''0 (result:Opaque.ptr)-> {[@expl:extern_spec_T_Clone__ptrconst_T_clone_body ensures] [%#sptr] result
       = self_}
       (! return' {result}) ]
@@ -22984,7 +22984,7 @@ module M_creusot_contracts__fn_ghost__qyi4984999370661040133__clone [#"../../cre
     [ bb0 = s0 [ s0 = clone' {self'0.t_FnGhostWrapper__0} (fun (_ret:t_F) ->  [ &_3 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- { t_FnGhostWrapper__0 = _3 } ] s1 | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: t_FnGhostWrapper = Any.any_l () | & self'0: t_FnGhostWrapper = self | & _3: t_F = Any.any_l () ] 
+     [ & _0: t_FnGhostWrapper = Any.any_l () | & self'0: t_FnGhostWrapper = self | & _3: t_F = Any.any_l () ] )
     [ return''0 (result:t_FnGhostWrapper)-> {[@expl:clone result type invariant] [%#sfn_ghost'0] inv'1 result}
       {[@expl:clone ensures] [%#sfn_ghost'1] postcondition () (view'0 self) (view result)}
       (! return' {result}) ]
@@ -23020,9 +23020,9 @@ module M_creusot_contracts__fn_ghost__qyi6891646202668648470__qy95z_new [#"../..
   meta "select_lsinst" "all"
   
   let rec qy95z_new[#"../../creusot-contracts/src/fn_ghost.rs" 76 4 76 30] (f:t_F) (return'  (x:t_FnGhostWrapper))= {[@expl:__new 'f' type invariant] [%#sfn_ghost] inv f}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- { t_FnGhostWrapper__0 = f'0 } ] s1 | s1 = bb2 ]  | bb2 = return''0 {_0} ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- { t_FnGhostWrapper__0 = f'0 } ] s1 | s1 = bb2 ]  | bb2 = return''0 {_0} ] 
     [ & _0: t_FnGhostWrapper = Any.any_l () | & f'0: t_F = f ]
-    
+    )
     [ return''0 (result:t_FnGhostWrapper)-> {[@expl:__new result type invariant] [%#sfn_ghost'0] inv'0 result}
       {[@expl:__new ensures] [%#sfn_ghost'1] view result = f}
       (! return' {result}) ]
@@ -23174,13 +23174,13 @@ module M_creusot_contracts__invariant__qyi11000281680484769800__clone [#"../../c
     | bb2 = s0 [ s0 = clone' {_7} (fun (_ret:t_T) ->  [ &_5 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = s0 [ s0 = new {_5} (fun (_ret:t_Subset) ->  [ &_0 <- _ret ] s1) | s1 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Subset = Any.any_l ()
     | & self'0: t_Subset = self
     | & _3: () = Any.any_l ()
     | & _5: t_T = Any.any_l ()
     | & _7: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Subset)-> {[@expl:clone ensures] [%#sinvariant'0] postcondition () (view'0 self) (view result)}
       (! return' {result}) ]
 
@@ -23296,12 +23296,12 @@ module M_creusot_contracts__local_invariant__qyi17763416549578214088__open [#"..
     (! bb0
     [ bb0 = s0 [ s0 = open {self'0} {namespaces'1} {f'0} (fun (_ret:t_A) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: t_A = Any.any_l ()
     | & self'0:  t_LocalInvariant = self
     | & namespaces'1:  t_Namespaces = namespaces'0
     | & f'0: t_F = f ]
-    
+    )
     [ return''0 (result:t_A)-> {[@expl:open result type invariant] [%#slocal_invariant'2] inv'3 result}
       {[@expl:open ensures] [%#slocal_invariant'3] exists t:  (MutBorrow.t t_T). invariant_with_data t.current (public self)
       /\ postcondition_once f t result}
@@ -23573,7 +23573,7 @@ module M_creusot_contracts__local_invariant__qyi11806525195294501830__open [#"..
     | bb2 = s0 [ s0 = new {_9} (fun (_ret: t_Target) ->  [ &this <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = s0 [ s0 = open {this} {namespaces'0} {f'0} (fun (_ret:t_A) ->  [ &_0 <- _ret ] s1) | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    )
+    
     [ & _0: t_A = Any.any_l ()
     | & self'0:  t_T = self
     | & namespaces'0:  t_Namespaces = namespaces
@@ -23582,7 +23582,7 @@ module M_creusot_contracts__local_invariant__qyi11806525195294501830__open [#"..
     | & _9: t_Target = Any.any_l ()
     | & _11: t_T = Any.any_l ()
     | & _13:  t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_A)-> {[@expl:open result type invariant] [%#slocal_invariant'3] inv'7 result}
       {[@expl:open ensures] [%#slocal_invariant'4] exists this: t_Target. postcondition () self this
       /\ postcondition'0 () { _p0 = new_logic this; _p1 = namespaces; _p2 = f } result}
@@ -23755,13 +23755,13 @@ module M_creusot_contracts__local_invariant__qyi14562131538618297666__open [#"..
     [ bb0 = s0 [ s0 = borrow {self'0} (fun (_ret: t_L) ->  [ &_6 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = open {_6} {namespaces'0} {f'0} (fun (_ret:t_A) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: t_A = Any.any_l ()
     | & self'0:  t_L = self
     | & namespaces'0:  t_Namespaces = namespaces
     | & f'0: t_F = f
     | & _6:  t_L = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_A)-> {[@expl:open result type invariant] [%#slocal_invariant'2] inv'4 result}
       {[@expl:open ensures] [%#slocal_invariant'3] postcondition () { _p0 = new_logic self;
                                                                       _p1 = namespaces;
@@ -23976,7 +23976,7 @@ module M_creusot_contracts__logic__fmap__qyi17941324210461407630__contains_ghost
     [ bb0 = s0 [ s0 = get_ghost {self'0} {key'0} (fun (_ret:t_Option) ->  [ &_5 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = is_some {_5} (fun (_ret:bool) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & self'0: t_FMap = self | & key'0: t_K = key | & _5: t_Option = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () | & self'0: t_FMap = self | & key'0: t_K = key | & _5: t_Option = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:contains_ghost ensures] [%#sfmap'1] result = contains self key}
       (! return' {result}) ]
 
@@ -24909,7 +24909,7 @@ module M_creusot_contracts__logic__id__qyi676594641912026951__clone [#"../../cre
   
   let rec clone'[#"../../creusot-contracts/src/logic/id.rs" 20 4 20 27] (self:t_Id) (return'  (x:t_Id))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Id = Any.any_l () | & self'0: t_Id = self ] 
+     [ & _0: t_Id = Any.any_l () | & self'0: t_Id = self ] )
     [ return''0 (result:t_Id)-> {[@expl:clone ensures] [%#sid] result = self} (! return' {result}) ]
 
 end
@@ -24937,7 +24937,7 @@ module M_creusot_contracts__logic__id__qyi14416423697585690270__ne [#"../../creu
   let rec ne[#"../../creusot-contracts/src/logic/id.rs" 37 4 37 38] (self:t_Id) (other:t_Id) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 = eq {self'0} {other'0} (fun (_ret:bool) ->  [ &_4 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- not _4 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & self'0: t_Id = self | & other'0: t_Id = other | & _4: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () | & self'0: t_Id = self | & other'0: t_Id = other | & _4: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:ne ensures] [%#sid] result <> (self = other)} (! return' {result}) ]
 
 end
@@ -47289,12 +47289,12 @@ module M_creusot_contracts__pcell__qyi14846468513926953542__take [#"../../creuso
     [ bb0 = s0 [ s0 = default (fun (_ret:t_T) ->  [ &_9 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = replace {self'0} {perm'0} {_9} (fun (_ret:t_T) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: t_T = Any.any_l ()
     | & self'0: t_PCell = self
     | & perm'0:  (MutBorrow.t t_PCellOwn) = perm
     | & _9: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:take result type invariant] [%#spcell'2] inv result}
       {[@expl:take ensures #0] [%#spcell'3] id self = id'0 perm.final}
       {[@expl:take ensures #1] [%#spcell'4] result = view'1 perm}
@@ -47400,12 +47400,12 @@ module M_creusot_contracts__peano__qyi18263836234684628832__clone [#"../../creus
       | s2 = bb1 ]
     
     | bb1 = s0 [ s0 =  [ &_0 <- { t_PeanoInt__0 = _3 } ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_PeanoInt = Any.any_l ()
     | & self'0: t_PeanoInt = self
     | & _3: UInt64.t = Any.any_l ()
     | & _5: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_PeanoInt)-> {[@expl:clone ensures] [%#speano] postcondition () self.t_PeanoInt__0 result.t_PeanoInt__0}
       (! return' {result}) ]
 
@@ -47503,7 +47503,7 @@ module M_creusot_contracts__peano__qyi17635635094782400840__default [#"../../cre
   let rec default'0[#"../../creusot-contracts/src/peano.rs" 34 22 34 29] (return'  (x:t_PeanoInt))= (! bb0
     [ bb0 = s0 [ s0 = default (fun (_ret:UInt64.t) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- { t_PeanoInt__0 = _2 } ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_PeanoInt = Any.any_l () | & _2: UInt64.t = Any.any_l () ] 
+     [ & _0: t_PeanoInt = Any.any_l () | & _2: UInt64.t = Any.any_l () ] )
     [ return''0 (result:t_PeanoInt)-> {[@expl:default ensures] [%#speano] true
       /\ postcondition () () result.t_PeanoInt__0}
       (! return' {result}) ]
@@ -47527,7 +47527,7 @@ module M_creusot_contracts__peano__qyi13288218011503588188__assert_receiver_is_t
   
   let rec assert_receiver_is_total_eq[#"../../creusot-contracts/src/peano.rs" 34 31 34 33] (self:t_PeanoInt) (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_creusot_contracts__peano__qyi5347411415401763779__cmp_le_log [#"../../creusot-contracts/src/logic/ord.rs" 130 8 130 39] (* <peano::PeanoInt as logic::ord::OrdLogic> *)
   type namespace_other
@@ -48617,12 +48617,12 @@ module M_creusot_contracts__peano__qyi18300662544233371341__partial_cmp [#"../..
   let rec partial_cmp[#"../../creusot-contracts/src/peano.rs" 89 4 89 59] (self:t_PeanoInt) (other:t_PeanoInt) (return'  (x:t_Option))= (! bb0
     [ bb0 = s0 [ s0 = cmp {self'0} {other'0} (fun (_ret:t_Ordering) ->  [ &_4 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- C_Some _4 ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self'0: t_PeanoInt = self
     | & other'0: t_PeanoInt = other
     | & _4: t_Ordering = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:partial_cmp ensures] [%#speano] result = C_Some (cmp_log'0 self other)}
       (! return' {result}) ]
 
@@ -48882,12 +48882,12 @@ module M_creusot_contracts__peano__qyi18409208157518949721__cmp [#"../../creusot
       | s2 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Ordering = Any.any_l ()
     | & self'0: t_PeanoInt = self
     | & other'0: t_PeanoInt = other
     | & _6: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Ordering)-> {[@expl:cmp ensures] [%#speano] result = cmp_log'1 self other}
       (! return' {result}) ]
 
@@ -48912,7 +48912,7 @@ module M_creusot_contracts__peano__qyi14634619887680291373__eq [#"../../creusot-
   
   let rec eq[#"../../creusot-contracts/src/peano.rs" 103 4 103 38] (self:t_PeanoInt) (other:t_PeanoInt) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self'0.t_PeanoInt__0 = other'0.t_PeanoInt__0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & self'0: t_PeanoInt = self | & other'0: t_PeanoInt = other ] 
+     [ & _0: bool = Any.any_l () | & self'0: t_PeanoInt = self | & other'0: t_PeanoInt = other ] )
     [ return''0 (result:bool)-> {[@expl:eq ensures] [%#speano] result = (self = other)} (! return' {result}) ]
 
 end
@@ -48937,7 +48937,7 @@ module M_creusot_contracts__peano__qyi4712407557780062981__new [#"../../creusot-
   
   let rec new[#"../../creusot-contracts/src/peano.rs" 112 4 112 24] (return'  (x:t_PeanoInt))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- { t_PeanoInt__0 = ([%#speano] (0: UInt64.t)) } ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_PeanoInt = Any.any_l () ] 
+     [ & _0: t_PeanoInt = Any.any_l () ] )
     [ return''0 (result:t_PeanoInt)-> {[@expl:new ensures] [%#speano'0] result.t_PeanoInt__0 = (0: UInt64.t)}
       (! return' {result}) ]
 
@@ -48962,7 +48962,7 @@ module M_creusot_contracts__peano__qyi4712407557780062981__to_u64 [#"../../creus
   
   let rec to_u64[#"../../creusot-contracts/src/peano.rs" 143 4 143 30] (self:t_PeanoInt) (return'  (x:UInt64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self'0.t_PeanoInt__0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & self'0: t_PeanoInt = self ] 
+     [ & _0: UInt64.t = Any.any_l () | & self'0: t_PeanoInt = self ] )
     [ return''0 (result:UInt64.t)-> {[@expl:to_u64 ensures] [%#speano] result = self.t_PeanoInt__0}
       (! return' {result}) ]
 
@@ -48991,7 +48991,7 @@ module M_creusot_contracts__peano__qyi4712407557780062981__to_u128 [#"../../creu
       [ s0 = UInt128.of_int {UInt64.t'int self'0.t_PeanoInt__0} (fun (_ret_from:UInt128.t) ->  [ &_0 <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt128.t = Any.any_l () | & self'0: t_PeanoInt = self ] 
+     [ & _0: UInt128.t = Any.any_l () | & self'0: t_PeanoInt = self ] )
     [ return''0 (result:UInt128.t)-> {[@expl:to_u128 ensures] [%#speano] UInt128.t'int result
       = UInt64.t'int self.t_PeanoInt__0}
       (! return' {result}) ]
@@ -49021,7 +49021,7 @@ module M_creusot_contracts__peano__qyi4712407557780062981__to_i128 [#"../../creu
       [ s0 = Int128.of_int {UInt64.t'int self'0.t_PeanoInt__0} (fun (_ret_from:Int128.t) ->  [ &_0 <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int128.t = Any.any_l () | & self'0: t_PeanoInt = self ] 
+     [ & _0: Int128.t = Any.any_l () | & self'0: t_PeanoInt = self ] )
     [ return''0 (result:Int128.t)-> {[@expl:to_i128 ensures] [%#speano] Int128.to_int result
       = UInt64.t'int self.t_PeanoInt__0}
       (! return' {result}) ]
@@ -49053,7 +49053,7 @@ module M_creusot_contracts__peano__qyi924939193479538090__from [#"../../creusot-
   let rec from[#"../../creusot-contracts/src/peano.rs" 173 4 173 34] (val':t_PeanoInt) (return'  (x:UInt64.t))= (! bb0
     [ bb0 = s0 [ s0 = to_u64 {val''0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: UInt64.t = Any.any_l () | & val''0: t_PeanoInt = val' ] 
+     [ & _0: UInt64.t = Any.any_l () | & val''0: t_PeanoInt = val' ] )
     [ return''0 (result:UInt64.t)-> {[@expl:from ensures] [%#speano] result = val'.t_PeanoInt__0} (! return' {result}) ]
 
 end
@@ -49084,7 +49084,7 @@ module M_creusot_contracts__peano__qyi18279771819627139730__from [#"../../creuso
   
   let rec from[#"../../creusot-contracts/src/peano.rs" 181 4 181 34] (val':t_PeanoInt) (return'  (x:Int64.t))= (! bb0
     [ bb0 = s0 [ s0 = to_i64 {val''0} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: Int64.t = Any.any_l () | & val''0: t_PeanoInt = val' ] 
+     [ & _0: Int64.t = Any.any_l () | & val''0: t_PeanoInt = val' ] )
     [ return''0 (result:Int64.t)-> {[@expl:from ensures] [%#speano] Int64.to_int result
       = UInt64.t'int val'.t_PeanoInt__0}
       (! return' {result}) ]
@@ -49118,7 +49118,7 @@ module M_creusot_contracts__peano__qyi6128796959392123454__from [#"../../creusot
   let rec from[#"../../creusot-contracts/src/peano.rs" 189 4 189 34] (val':t_PeanoInt) (return'  (x:UInt128.t))= (! bb0
     [ bb0 = s0 [ s0 = to_u128 {val''0} (fun (_ret:UInt128.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: UInt128.t = Any.any_l () | & val''0: t_PeanoInt = val' ] 
+     [ & _0: UInt128.t = Any.any_l () | & val''0: t_PeanoInt = val' ] )
     [ return''0 (result:UInt128.t)-> {[@expl:from ensures] [%#speano] UInt128.t'int result
       = UInt64.t'int val'.t_PeanoInt__0}
       (! return' {result}) ]
@@ -49152,7 +49152,7 @@ module M_creusot_contracts__peano__qyi11594489632978387465__from [#"../../creuso
   let rec from[#"../../creusot-contracts/src/peano.rs" 197 4 197 34] (val':t_PeanoInt) (return'  (x:Int128.t))= (! bb0
     [ bb0 = s0 [ s0 = to_i128 {val''0} (fun (_ret:Int128.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: Int128.t = Any.any_l () | & val''0: t_PeanoInt = val' ] 
+     [ & _0: Int128.t = Any.any_l () | & val''0: t_PeanoInt = val' ] )
     [ return''0 (result:Int128.t)-> {[@expl:from ensures] [%#speano] Int128.to_int result
       = UInt64.t'int val'.t_PeanoInt__0}
       (! return' {result}) ]
@@ -49250,7 +49250,7 @@ module M_creusot_contracts__ptr_own__qyi13445900742793785996__new [#"../../creus
     [ bb0 = bb1
     | bb1 = s0 [ s0 = from_box {v'0} (fun (_ret:tuple) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: tuple = Any.any_l () | & v'0: t_T = v ] 
+     [ & _0: tuple = Any.any_l () | & v'0: t_T = v ] )
     [ return''0 (result:tuple)-> {[@expl:new result type invariant] [%#sptr_own'0] inv'3 result}
       {[@expl:new ensures] [%#sptr_own'1] ptr result._p1 = result._p0 /\ val' result._p1 = v}
       (! return' {result}) ]
@@ -49350,7 +49350,7 @@ module M_creusot_contracts__ptr_own__qyi13445900742793785996__drop [#"../../creu
     [ bb0 = s0 [ s0 = to_box {ptr'1} {own'0} (fun (_ret:t_T) ->  [ &_4 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'0 _4} s1 | s1 = -{resolve'1 _4}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & ptr'1: Opaque.ptr = ptr'0 | & own'0:  t_PtrOwn = own | & _4: t_T = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & ptr'1: Opaque.ptr = ptr'0 | & own'0:  t_PtrOwn = own | & _4: t_T = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -49968,14 +49968,14 @@ module M_creusot_contracts__resource__fmap_view__qyi505596245403307893__new [#".
       | s1 =  [ &_0 <- r ] s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0:  t_Authority = Any.any_l ()
     | & r:  t_Authority = Any.any_l ()
     | & _3: t_Authority = Any.any_l ()
     | & _4: t_Resource = Any.any_l ()
     | & _5:  t_Resource = Any.any_l ()
     | & _6: t_View = Any.any_l () ]
-    
+    )
     [ return''0 (result: t_Authority)-> {[@expl:new result type invariant] [%#sfmap_view'1] inv'0 result}
       {[@expl:new ensures] [%#sfmap_view'2] view'4 result = empty'0}
       (! return' {result}) ]
@@ -50676,7 +50676,7 @@ module M_creusot_contracts__resource__fmap_view__qyi505596245403307893__insert [
       | s2 =  [ &_0 <- { t_Fragment__0 = _20; t_Fragment__1 = k'0; t_Fragment__2 = v'0 } ] s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_Fragment = Any.any_l ()
     | & self'0: MutBorrow.t t_Authority = self
     | & k'0: t_K = k
@@ -50688,7 +50688,7 @@ module M_creusot_contracts__resource__fmap_view__qyi505596245403307893__insert [
     | & _14: t_FMapInsertLocalUpdate = Any.any_l ()
     | & _16: t_Ag = Any.any_l ()
     | & _20: t_Resource = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Fragment)-> {[@expl:insert result type invariant] [%#sfmap_view'4] inv'1 result}
       {[@expl:insert ensures #0] [%#sfmap_view'5] view'3 self.final = insert'0 (view'4 self) k v}
       {[@expl:insert ensures #1] [%#sfmap_view'6] id'0 self.final = id'0 self.current}
@@ -51268,13 +51268,13 @@ module M_creusot_contracts__resource__fmap_view__qyi505596245403307893__contains
         s1
       | s1 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: t_Authority = self
     | & frag'1: t_Fragment = frag'0
     | & new_resource: t_Resource = Any.any_l ()
     | & _8: t_Resource = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:contains ensures] [%#sfmap_view'3] get'0 (view'6 self) (view'3 frag'0)._p0'2
       = C_Some'3 ((view'3 frag'0)._p1'2)}
       (! return' {result}) ]
@@ -51763,7 +51763,7 @@ module M_creusot_contracts__resource__fmap_view__qyi10168537497030408938__clone 
         s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: t_Fragment = Any.any_l () | & self'0: t_Fragment = self | & _3: t_Resource = Any.any_l () ] 
+     [ & _0: t_Fragment = Any.any_l () | & self'0: t_Fragment = self | & _3: t_Resource = Any.any_l () ] )
     [ return''0 (result:t_Fragment)-> {[@expl:clone result type invariant] [%#sfmap_view'0] inv result}
       {[@expl:clone ensures] [%#sfmap_view'1] view'2 result = view'3 self}
       (! return' {result}) ]
@@ -51927,7 +51927,7 @@ module M_creusot_contracts__resource__m__qyi10819468878980253437__split_off [#".
       | s4 = bb4 ]
     
     | bb4 = s0 [ s0 = -{resolve'0 self'0}- s1 | s1 =  [ &_0 <- r'1 ] s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Resource = Any.any_l ()
     | & self'0: MutBorrow.t t_Resource = self
     | & r'0: t_R = r
@@ -51940,7 +51940,7 @@ module M_creusot_contracts__resource__m__qyi10819468878980253437__split_off [#".
     | & _13: tuple = Any.any_l ()
     | & _17: t_Resource = Any.any_l ()
     | & _18: MutBorrow.t t_Resource = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Resource)-> {[@expl:split_off ensures #0] [%#sresource'0] id self.final = id self.current
       /\ id result = id self.current}
       {[@expl:split_off ensures #1] [%#sresource'1] view self.final = s}
@@ -52089,7 +52089,7 @@ module M_creusot_contracts__resource__m__qyi10819468878980253437__join_in [#"../
       | s2 = bb4 ]
     
     | bb4 = s0 [ s0 = -{resolve'0 self'0}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Resource = self
     | & other'0: t_Resource = other
@@ -52099,7 +52099,7 @@ module M_creusot_contracts__resource__m__qyi10819468878980253437__join_in [#"../
     | & this'0: t_Resource = Any.any_l ()
     | & _12: t_Resource = Any.any_l ()
     | & _13: MutBorrow.t t_Resource = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:join_in ensures #0] [%#sresource'0] id self.final = id self.current}
       {[@expl:join_in ensures #1] [%#sresource'1] C_Some (view self.final) = op (view'0 self) (view other)}
       (! return' {result}) ]
@@ -52257,14 +52257,14 @@ module M_creusot_contracts__resource__m__qyi10819468878980253437__weaken [#"../.
       | s2 = bb2 ]
     
     | bb2 = s0 [ s0 = -{resolve'0 self'0}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Resource = self
     | & target'0: t_R = target
     | & f: t_R = Any.any_l ()
     | & _8: t_Resource = Any.any_l ()
     | & _9: MutBorrow.t t_Resource = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:weaken ensures #0] [%#sresource'1] id self.final = id self.current}
       {[@expl:weaken ensures #1] [%#sresource'2] view self.final = target}
       (! return' {result}) ]
@@ -52513,7 +52513,7 @@ module M_creusot_contracts__resource__m__qyi10819468878980253437__update [#"../.
       | s2 = bb6 ]
     
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Choice = Any.any_l ()
     | & self'0: MutBorrow.t t_Resource = self
     | & upd'0: t_U = upd
@@ -52522,7 +52522,7 @@ module M_creusot_contracts__resource__m__qyi10819468878980253437__update [#"../.
     | & _14: () = Any.any_l ()
     | & r: t_R = Any.any_l ()
     | & _17: MutBorrow.t t_Resource = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Choice)-> {[@expl:update ensures #0] [%#sresource'7] id self.final = id self.current}
       {[@expl:update ensures #1] [%#sresource'8] view self.final = update upd (view'0 self) result}
       (! return' {result}) ]
@@ -52546,7 +52546,7 @@ module M_creusot_contracts__snapshot__qyi17576604998327728858__clone [#"../../cr
   
   let rec clone'[#"../../creusot-contracts/src/snapshot.rs" 69 4 69 27] (self:t_T) (return'  (x:t_T))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_T = Any.any_l () | & self'0: t_T = self ] 
+     [ & _0: t_T = Any.any_l () | & self'0: t_T = self ] )
     [ return''0 (result:t_T)-> {[@expl:clone ensures] [%#ssnapshot] result = self} (! return' {result}) ]
 
 end

--- a/tests/should_fail/bug/01_resolve_unsoundness.coma
+++ b/tests/should_fail/bug/01_resolve_unsoundness.coma
@@ -140,7 +140,7 @@ module M_01_resolve_unsoundness__make_vec_of_size [#"01_resolve_unsoundness.rs" 
     
     | bb6 = s0 [ s0 =  [ &_0 <- out ] s1 | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Vec = Any.any_l ()
     | & n'0: UInt64.t = n
     | & out: t_Vec = Any.any_l ()
@@ -148,7 +148,7 @@ module M_01_resolve_unsoundness__make_vec_of_size [#"01_resolve_unsoundness.rs" 
     | & _10: bool = Any.any_l ()
     | & _13: () = Any.any_l ()
     | & _14: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Vec)-> {[@expl:make_vec_of_size ensures] [%#s01_resolve_unsoundness'3] Seq.length (view result)
       = UInt64.t'int n}
       (! return' {result}) ]

--- a/tests/should_fail/bug/222.coma
+++ b/tests/should_fail/bug/222.coma
@@ -116,10 +116,10 @@ module M_222__uses_invariant [#"222.rs" 40 0 40 41]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'3 x'0} s1 | s1 = -{resolve'3 x'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t t_Once = x
     | & _4: t_Option = Any.any_l ()
     | & _5: MutBorrow.t t_Option = Any.any_l () ]
-     [ return''0 (result:())-> {[@expl:uses_invariant ensures] [%#s222'1] invariant''1 x.final} (! return' {result}) ] 
+    ) [ return''0 (result:())-> {[@expl:uses_invariant ensures] [%#s222'1] invariant''1 x.final} (! return' {result}) ] 
 end

--- a/tests/should_fail/bug/492.coma
+++ b/tests/should_fail/bug/492.coma
@@ -53,7 +53,7 @@ module M_492__reborrow_tuple [#"492.rs" 6 0 6 52]
       | s3 = -{resolve'0 x'0}- s4
       | s4 = return''0 {_0} ]
      ]
-    ) [ & _0: tuple = Any.any_l () | & x'0: MutBorrow.t t_T = x | & _3: MutBorrow.t t_T = Any.any_l () ] 
+     [ & _0: tuple = Any.any_l () | & x'0: MutBorrow.t t_T = x | & _3: MutBorrow.t t_T = Any.any_l () ] )
     [ return''0 (result:tuple)-> {[@expl:reborrow_tuple result type invariant] [%#s492'1] inv'1 result}
       {[@expl:reborrow_tuple ensures] [%#s492'2] (result._p0).current = x.current}
       (! return' {result}) ]
@@ -107,12 +107,12 @@ module M_492__test [#"492.rs" 11 0 11 13]
       | s4 = -{resolve'0 res}- s5
       | s5 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & res: MutBorrow.t Int32.t = Any.any_l ()
     | & _4: tuple = Any.any_l ()
     | & _5: MutBorrow.t Int32.t = Any.any_l ()
     | & _6: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> {[@expl:test ensures] [%#s492'2] false} (! return' {result}) ] 
+    ) [ return''0 (result:())-> {[@expl:test ensures] [%#s492'2] false} (! return' {result}) ] 
 end

--- a/tests/should_fail/bug/692.coma
+++ b/tests/should_fail/bug/692.coma
@@ -91,7 +91,7 @@ module M_692__incorrect [#"692.rs" 9 0 9 76]
       | s4 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & cond'0: t_C = cond | & branch'0: t_B = branch ] 
+     [ & _0: () = Any.any_l () | & cond'0: t_C = cond | & branch'0: t_B = branch ] )
     [ return''0 (result:())-> {[@expl:incorrect ensures] [%#s692'2] false} (! return' {result}) ]
 
 end
@@ -193,7 +193,7 @@ module M_692__valid_normal [#"692.rs" 12 0 12 34]
       | s1 =  [ &_0'0 <- res ] s2
       | s2 = return''0 {_0'0} ]
      ]
-    ) [ & _0'0: bool = Any.any_l () | & _1: closure1 = self | & res: bool = Any.any_l () ] 
+     [ & _0'0: bool = Any.any_l () | & _1: closure1 = self | & res: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:closure ensures] [%#s692'2] result = UInt32.gt self._0 (7: UInt32.t)}
       (! return' {result}) ]
   
@@ -255,9 +255,9 @@ module M_692__valid_normal [#"692.rs" 12 0 12 34]
       | s1 = -{resolve'0 _1}- s2
       | s2 = return''0 {_0'1} ]
      ]
-    )
-    [ & _0'1: () = Any.any_l () | & _1: MutBorrow.t closure2 = self | & b'0: bool = b | & _4: UInt32.t = Any.any_l () ]
     
+    [ & _0'1: () = Any.any_l () | & _1: MutBorrow.t closure2 = self | & b'0: bool = b | & _4: UInt32.t = Any.any_l () ]
+    )
     [ return''0 (result:())-> {[@expl:closure ensures] [%#s692'5] b /\ ((self.final)._0'0).current = (2: UInt32.t)
       \/ not b /\ ((self.final)._0'0).current = (1: UInt32.t)}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
@@ -339,7 +339,7 @@ module M_692__valid_normal [#"692.rs" 12 0 12 34]
       | s5 = bb1 ]
     
     | bb1 = s0 [ s0 =  [ &_0'1 <- r ] s1 | s1 = return''0 {_0'1} ]  ]
-    )
+    
     [ & _0'1: UInt32.t = Any.any_l ()
     | & n'0: UInt32.t = n
     | & r: UInt32.t = Any.any_l ()
@@ -347,5 +347,5 @@ module M_692__valid_normal [#"692.rs" 12 0 12 34]
     | & branch: closure2 = Any.any_l ()
     | & _7: MutBorrow.t UInt32.t = Any.any_l ()
     | & _8: () = Any.any_l () ]
-     [ return''0 (result:UInt32.t)-> {[@expl:valid_normal ensures] [%#s692'0] false} (! return' {result}) ] 
+    ) [ return''0 (result:UInt32.t)-> {[@expl:valid_normal ensures] [%#s692'0] false} (! return' {result}) ] 
 end

--- a/tests/should_fail/bug/695.coma
+++ b/tests/should_fail/bug/695.coma
@@ -122,7 +122,7 @@ module M_695__inversed_if [#"695.rs" 7 0 7 78]
       | s2 = bb8 ]
     
     | bb8 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & cond'0: t_C = cond
     | & branch'0: t_B = branch
@@ -130,7 +130,7 @@ module M_695__inversed_if [#"695.rs" 7 0 7 78]
     | & _7: () = Any.any_l ()
     | & _9: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:inversed_if ensures] [%#s695'4] exists b: bool. postcondition cond () b
       /\ postcondition_once'0 branch (not b) ()}
       (! return' {result}) ]
@@ -235,7 +235,7 @@ module M_695__valid [#"695.rs" 12 0 12 27]
       | s1 =  [ &_0'0 <- res ] s2
       | s2 = return''0 {_0'0} ]
      ]
-    ) [ & _0'0: bool = Any.any_l () | & _1: closure1 = self | & res: bool = Any.any_l () ] 
+     [ & _0'0: bool = Any.any_l () | & _1: closure1 = self | & res: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:closure ensures] [%#s695'3] result = UInt32.gt self._0 (7: UInt32.t)}
       (! return' {result}) ]
   
@@ -297,9 +297,9 @@ module M_695__valid [#"695.rs" 12 0 12 27]
       | s1 = -{resolve'0 _1}- s2
       | s2 = return''0 {_0'1} ]
      ]
-    )
-    [ & _0'1: () = Any.any_l () | & _1: MutBorrow.t closure2 = self | & b'0: bool = b | & _4: UInt32.t = Any.any_l () ]
     
+    [ & _0'1: () = Any.any_l () | & _1: MutBorrow.t closure2 = self | & b'0: bool = b | & _4: UInt32.t = Any.any_l () ]
+    )
     [ return''0 (result:())-> {[@expl:closure ensures] [%#s695'6] b /\ ((self.final)._0'0).current = (2: UInt32.t)
       \/ not b /\ ((self.final)._0'0).current = (1: UInt32.t)}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
@@ -384,7 +384,7 @@ module M_695__valid [#"695.rs" 12 0 12 27]
       | s5 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:assertion] [%#s695'0] false} s1 | s1 =  [ &_0'1 <- r ] s2 | s2 = return''0 {_0'1} ]  ]
-    )
+    
     [ & _0'1: UInt32.t = Any.any_l ()
     | & n'0: UInt32.t = n
     | & r: UInt32.t = Any.any_l ()
@@ -392,7 +392,7 @@ module M_695__valid [#"695.rs" 12 0 12 27]
     | & branch: closure2 = Any.any_l ()
     | & _7: MutBorrow.t UInt32.t = Any.any_l ()
     | & _8: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:valid ensures] [%#s695'1] UInt32.gt n (7: UInt32.t)
       /\ result = (2: UInt32.t)
       \/ UInt32.le n (7: UInt32.t) /\ result = (1: UInt32.t)}

--- a/tests/should_fail/bug/869.coma
+++ b/tests/should_fail/bug/869.coma
@@ -56,7 +56,7 @@ module M_869__unsound [#"869.rs" 5 0 5 16]
       | s4 = {[@expl:assertion] [%#s869'5] evil.current = (not evil.current)} s5
       | s5 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: bool = Any.any_l ()
     | & xm: MutBorrow.t bool = Any.any_l ()
@@ -67,5 +67,5 @@ module M_869__unsound [#"869.rs" 5 0 5 16]
     | & evil: MutBorrow.t bool = Any.any_l ()
     | & _12: MutBorrow.t bool = Any.any_l ()
     | & _15: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_fail/bug/878.coma
+++ b/tests/should_fail/bug/878.coma
@@ -73,7 +73,7 @@ module M_878__test [#"878.rs" 5 0 5 13]
     
     | bb2 = s0 [ s0 = into_vec {_4} (fun (_ret:t_Vec) ->  [ &v <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = {[%#s878'3] false} any ]
-    ) [ & _0: () = Any.any_l () | & v: t_Vec = Any.any_l () | & _4: Slice64.array Int32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & v: t_Vec = Any.any_l () | & _4: Slice64.array Int32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -202,14 +202,14 @@ module M_878__test2 [#"878.rs" 20 0 20 14]
     
     | bb2 = s0 [ s0 = into_vec {_4} (fun (_ret:t_Vec) ->  [ &v <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = {[%#s878'0] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v: t_Vec = Any.any_l ()
     | & _4: Slice64.array t_S = Any.any_l ()
     | & _5: t_S = Any.any_l ()
     | & b: bool = Any.any_l ()
     | & _7: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_878__test3 [#"878.rs" 26 0 26 14]
   let%span s878 = "878.rs" 27 19 27 20
@@ -337,10 +337,10 @@ module M_878__test3 [#"878.rs" 26 0 26 14]
     | bb2 = s0 [ s0 = into_vec {_4} (fun (_ret:t_Vec) ->  [ &v <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = s0 [ s0 = {[@expl:assertion] [%#s878'0] (Seq.get (view'0 v) 0).t_S__0 = (0: UInt32.t)} s1 | s1 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v: t_Vec = Any.any_l ()
     | & _4: Slice64.array t_S = Any.any_l ()
     | & _5: t_S = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_fail/bug/specialize.coma
+++ b/tests/should_fail/bug/specialize.coma
@@ -36,7 +36,7 @@ module M_specialize__f [#"specialize.rs" 22 0 22 21]
     [ bb0 = s0 [ s0 = x {v'0} (fun (_ret:()) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:assertion] [%#sspecialize] false} s1 | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & v'0: t_Vec = v | & _2: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & v'0: t_Vec = v | & _2: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -126,7 +126,7 @@ module M_specialize__g [#"specialize.rs" 28 0 28 22]
     [ bb0 = s0 [ s0 = x {v'0} (fun (_ret:()) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:assertion] [%#sspecialize] false} s1 | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & v'0: t_Vec = v | & _2: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & v'0: t_Vec = v | & _2: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -168,7 +168,7 @@ module M_specialize__h [#"specialize.rs" 35 0 35 21]
     [ bb0 = s0 [ s0 = x {v'0} (fun (_ret:()) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:assertion] [%#sspecialize] false} s1 | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & v'0: t_Vec = v | & _2: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & v'0: t_Vec = v | & _2: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_fail/bug/subregion.coma
+++ b/tests/should_fail/bug/subregion.coma
@@ -30,12 +30,12 @@ module M_subregion__list_reversal_h [#"subregion.rs" 4 0 4 37]
        ]
     
     | bb4 = s0 [ s0 =  [ &_0 <- r ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & l'0: UInt64.t = l
     | & r: UInt64.t = Any.any_l ()
     | & _8: bool = Any.any_l ()
     | & x: UInt64.t = Any.any_l ()
     | & tmp: UInt64.t = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end

--- a/tests/should_fail/final_borrows.coma
+++ b/tests/should_fail/final_borrows.coma
@@ -54,12 +54,12 @@ module M_final_borrows__not_final_borrow [#"final_borrows.rs" 6 0 6 45]
       | s8 = {[@expl:assertion] [%#sfinal_borrows] b1 = bor'0} s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & bor'0: MutBorrow.t t_T = bor
     | & b1: MutBorrow.t t_T = Any.any_l ()
     | & _b2: MutBorrow.t t_T = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_final_borrows__store_changes_prophecy [#"final_borrows.rs" 12 0 12 51]
   let%span sfinal_borrows = "final_borrows.rs" 17 18 17 27
@@ -110,12 +110,12 @@ module M_final_borrows__store_changes_prophecy [#"final_borrows.rs" 12 0 12 51]
       | s7 = {[@expl:assertion] [%#sfinal_borrows] b1 = bor'0} s8
       | s8 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & bor'0: MutBorrow.t t_T = bor
     | & b1: MutBorrow.t t_T = Any.any_l ()
     | & val': t_T = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_final_borrows__store_changes_prophecy_2 [#"final_borrows.rs" 20 0 20 59]
   let%span sfinal_borrows = "final_borrows.rs" 25 18 25 27
@@ -168,9 +168,9 @@ module M_final_borrows__store_changes_prophecy_2 [#"final_borrows.rs" 20 0 20 59
       | s7 = {[@expl:assertion] [%#sfinal_borrows] b1 = bor'0} s8
       | s8 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l () | & bor'0: MutBorrow.t t_T = bor | & x'0: t_T = x | & b1: MutBorrow.t t_T = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_final_borrows__call_changes_prophecy [#"final_borrows.rs" 28 0 28 43]
   let%span sfinal_borrows = "final_borrows.rs" 34 19 34 33
@@ -218,7 +218,7 @@ module M_final_borrows__call_changes_prophecy [#"final_borrows.rs" 28 0 28 43]
       | s2 = {[@expl:assertion] [%#sfinal_borrows'1] b1_snap = bor_snap} s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & bor'0: MutBorrow.t Int32.t = bor
     | & bor_snap: MutBorrow.t Int32.t = Any.any_l ()
@@ -226,7 +226,7 @@ module M_final_borrows__call_changes_prophecy [#"final_borrows.rs" 28 0 28 43]
     | & b1_snap: MutBorrow.t Int32.t = Any.any_l ()
     | & _7: Int32.t = Any.any_l ()
     | & _8: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_final_borrows__unnesting_fails [#"final_borrows.rs" 43 0 43 24]
   let%span sfinal_borrows = "final_borrows.rs" 44 16 44 17
@@ -277,14 +277,14 @@ module M_final_borrows__unnesting_fails [#"final_borrows.rs" 43 0 43 24]
       | s9 = {[@expl:assertion] [%#sfinal_borrows'0] rebor1 = rebor2} s10
       | s10 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & bor: MutBorrow.t Int32.t = Any.any_l ()
     | & nested: MutBorrow.t (MutBorrow.t Int32.t) = Any.any_l ()
     | & rebor1: MutBorrow.t Int32.t = Any.any_l ()
     | & rebor2: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_final_borrows__move_place_without_deref [#"final_borrows.rs" 54 0 54 52]
   let%span sfinal_borrows = "final_borrows.rs" 58 19 58 34
@@ -353,11 +353,11 @@ module M_final_borrows__move_place_without_deref [#"final_borrows.rs" 54 0 54 52
       | s2 = bb3 ]
     
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & bor'0: MutBorrow.t t_T = bor
     | & bor_snap: MutBorrow.t t_T = Any.any_l ()
     | & b1: MutBorrow.t t_T = Any.any_l ()
     | & _5: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_fail/generic_deref_ghost.coma
+++ b/tests/should_fail/generic_deref_ghost.coma
@@ -111,7 +111,7 @@ module M_generic_deref_ghost__deref_wrap [#"generic_deref_ghost.rs" 8 0 8 48]
     (! bb0
     [ bb0 = s0 [ s0 =  [ &_6 <- x'0 ] s1 | s1 = deref {_6} (fun (_ret:t_Target) ->  [ &_4 <- _ret ] s2) | s2 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- _4 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Target = Any.any_l () | & x'0: t_T = x | & _4: t_Target = Any.any_l () | & _6: t_T = Any.any_l () ] 
+     [ & _0: t_Target = Any.any_l () | & x'0: t_T = x | & _4: t_Target = Any.any_l () | & _6: t_T = Any.any_l () ] )
     [ return''0 (result:t_Target)-> {[@expl:deref_wrap result type invariant] [%#sgeneric_deref_ghost'1] inv'0 result}
       {[@expl:deref_wrap ensures] [%#sgeneric_deref_ghost'2] postcondition () x result}
       (! return' {result}) ]
@@ -203,10 +203,10 @@ module M_generic_deref_ghost__bad [#"generic_deref_ghost.rs" 12 0 12 32]
       [ s0 =  [ &_4 <- x'0 ] s1 | s1 = deref_wrap {_4} (fun (_ret:Int32.t) ->  [ &_2 <- _ret ] s2) | s2 = bb1 ]
     
     | bb1 = s0 [ s0 =  [ &_0 <- _2 ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & x'0:  Int32.t = x
     | & _2: Int32.t = Any.any_l ()
     | & _4:  Int32.t = Any.any_l () ]
-     [ return''0 (result:Int32.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:Int32.t)-> (! return' {result}) ] 
 end

--- a/tests/should_fail/generic_deref_snap.coma
+++ b/tests/should_fail/generic_deref_snap.coma
@@ -111,7 +111,7 @@ module M_generic_deref_snap__deref_wrap [#"generic_deref_snap.rs" 8 0 8 48]
     (! bb0
     [ bb0 = s0 [ s0 =  [ &_6 <- x'0 ] s1 | s1 = deref {_6} (fun (_ret:t_Target) ->  [ &_4 <- _ret ] s2) | s2 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- _4 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Target = Any.any_l () | & x'0: t_T = x | & _4: t_Target = Any.any_l () | & _6: t_T = Any.any_l () ] 
+     [ & _0: t_Target = Any.any_l () | & x'0: t_T = x | & _4: t_Target = Any.any_l () | & _6: t_T = Any.any_l () ] )
     [ return''0 (result:t_Target)-> {[@expl:deref_wrap result type invariant] [%#sgeneric_deref_snap'1] inv'0 result}
       {[@expl:deref_wrap ensures] [%#sgeneric_deref_snap'2] postcondition () x result}
       (! return' {result}) ]
@@ -206,7 +206,7 @@ module M_generic_deref_snap__bad [#"generic_deref_snap.rs" 12 0 12 35]
       [ s0 =  [ &_4 <- x'0 ] s1 | s1 = deref_wrap {_4} (fun (_ret:Int32.t) ->  [ &_2 <- _ret ] s2) | s2 = bb1 ]
     
     | bb1 = s0 [ s0 =  [ &_0 <- _2 ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int32.t = Any.any_l () | & x'0: Int32.t = x | & _2: Int32.t = Any.any_l () | & _4: Int32.t = Any.any_l () ]
-     [ return''0 (result:Int32.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:Int32.t)-> (! return' {result}) ] 
 end

--- a/tests/should_fail/impl_trait.coma
+++ b/tests/should_fail/impl_trait.coma
@@ -10,7 +10,7 @@ module M_impl_trait__qyi16477135280894462799__a [#"impl_trait.rs" 11 4 11 23] (*
   
   let rec a[#"impl_trait.rs" 11 4 11 23] (self:()) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#simpl_trait] true ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:a ensures] [%#simpl_trait'0] result} (! return' {result}) ]
 
 end
@@ -21,9 +21,9 @@ module M_impl_trait__returns_iterator [#"impl_trait.rs" 16 0 16 41]
   
   meta "select_lsinst" "all"
   
-  let rec returns_iterator[#"impl_trait.rs" 16 0 16 41] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec returns_iterator[#"impl_trait.rs" 16 0 16 41] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_impl_trait__main [#"impl_trait.rs" 21 0 21 13]
   let%span simpl_trait = "impl_trait.rs" 24 18 24 19
@@ -70,7 +70,7 @@ module M_impl_trait__main [#"impl_trait.rs" 21 0 21 13]
     [ bb0 = s0 [ s0 = returns_iterator (fun (_ret:opaque0) ->  [ &_4 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = a {_4} (fun (_ret:bool) ->  [ &x <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = s0 [ s0 = {[@expl:assertion] [%#simpl_trait] x} s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & x: bool = Any.any_l () | & _4: opaque0 = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x: bool = Any.any_l () | & _4: opaque0 = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:main ensures] [%#simpl_trait'0] true} (! return' {result}) ]
 
 end

--- a/tests/should_fail/opaque_unproveable.coma
+++ b/tests/should_fail/opaque_unproveable.coma
@@ -11,5 +11,5 @@ module M_opaque_unproveable__test [#"opaque_unproveable.rs" 15 0 15 13]
   
   let rec test[#"opaque_unproveable.rs" 15 0 15 13] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = {[@expl:assertion] [%#sopaque_unproveable] opaque} s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_fail/traits/17_impl_refinement.coma
+++ b/tests/should_fail/traits/17_impl_refinement.coma
@@ -12,9 +12,9 @@ module M_17_impl_refinement__qyi370234707595078754__my_function [#"17_impl_refin
   meta "select_lsinst" "all"
   
   let rec my_function[#"17_impl_refinement.rs" 15 4 15 34] (self:()) (return'  (x:UInt64.t))= {[@expl:my_function requires] [%#s17_impl_refinement'0] true}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- [%#s17_impl_refinement] (20: UInt64.t) ] s1 | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- [%#s17_impl_refinement] (20: UInt64.t) ] s1 | s1 = return''0 {_0} ]  ] 
     [ & _0: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:my_function ensures] [%#s17_impl_refinement'1] UInt64.t'int result >= 15}
       (! return' {result}) ]
 

--- a/tests/should_fail/type_invariants/borrows.coma
+++ b/tests/should_fail/type_invariants/borrows.coma
@@ -27,9 +27,9 @@ module M_borrows__qyi5649894289181344863__new [#"borrows.rs" 18 4 18 30] (* NonZ
   
   let rec new[#"borrows.rs" 18 4 18 30] (n:Int32.t) (return'  (x:t_NonZero))= {[@expl:new requires] [%#sborrows] Int32.to_int n
     <> 0}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- { t_NonZero__0 = n'0 } ] s1 | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- { t_NonZero__0 = n'0 } ] s1 | s1 = return''0 {_0} ]  ] 
     [ & _0: t_NonZero = Any.any_l () | & n'0: Int32.t = n ]
-    
+    )
     [ return''0 (result:t_NonZero)-> {[@expl:new result type invariant] [%#sborrows'0] inv result}
       {[@expl:new ensures] [%#sborrows'1] result.t_NonZero__0 = n}
       (! return' {result}) ]
@@ -105,12 +105,12 @@ module M_borrows__qyi5649894289181344863__inner_mut [#"borrows.rs" 24 4 24 43] (
       | s6 = -{resolve'2 self'0}- s7
       | s7 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t Int32.t = Any.any_l ()
     | & self'0: MutBorrow.t t_NonZero = self
     | & _2: MutBorrow.t Int32.t = Any.any_l ()
     | & _5: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t Int32.t)-> {[@expl:inner_mut ensures #0] [%#sborrows'0] Int32.to_int (self.current).t_NonZero__0
       = Int32.to_int result.current}
       {[@expl:inner_mut ensures #1] [%#sborrows'1] Int32.to_int (self.final).t_NonZero__0 = Int32.to_int result.final}
@@ -203,13 +203,13 @@ module M_borrows__simple [#"borrows.rs" 32 0 32 30]
       | s2 = -{resolve'2 x'0}- s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t t_NonZero = x
     | & _4: () = Any.any_l ()
     | & _5: MutBorrow.t Int32.t = Any.any_l ()
     | & _6: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_borrows__hard [#"borrows.rs" 39 0 39 28]
   let%span sborrows = "borrows.rs" 39 12 39 13
@@ -311,14 +311,14 @@ module M_borrows__hard [#"borrows.rs" 39 0 39 28]
       | s2 = -{resolve'2 x'0}- s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t t_NonZero = x
     | & _4: () = Any.any_l ()
     | & _5: MutBorrow.t Int32.t = Any.any_l ()
     | & _6: MutBorrow.t Int32.t = Any.any_l ()
     | & _7: MutBorrow.t t_NonZero = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_borrows__tuple [#"borrows.rs" 46 0 46 44]
   let%span sborrows = "borrows.rs" 47 12 47 13
@@ -426,13 +426,13 @@ module M_borrows__tuple [#"borrows.rs" 46 0 46 44]
       | s2 = -{resolve'5 x'0}- s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: tuple = x
     | & _4: () = Any.any_l ()
     | & _5: MutBorrow.t Int32.t = Any.any_l ()
     | & _6: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_borrows__partial_move [#"borrows.rs" 54 0 54 47]
   let%span sborrows = "borrows.rs" 57 10 57 11
@@ -539,14 +539,14 @@ module M_borrows__partial_move [#"borrows.rs" 54 0 54 47]
       | s3 =  [ &a <- { t_NonZero__0 = ([%#sborrows] (0: Int32.t)) } ] s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: tuple = x
     | & a: t_NonZero = Any.any_l ()
     | & _5: () = Any.any_l ()
     | & _6: MutBorrow.t Int32.t = Any.any_l ()
     | & _7: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_borrows__destruct [#"borrows.rs" 62 0 62 43]
   let%span sborrows = "borrows.rs" 64 10 64 11
@@ -643,7 +643,7 @@ module M_borrows__destruct [#"borrows.rs" 62 0 62 43]
       | s2 = -{resolve'2 b}- s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: tuple = x
     | & a: t_NonZero = Any.any_l ()
@@ -651,7 +651,7 @@ module M_borrows__destruct [#"borrows.rs" 62 0 62 43]
     | & _6: () = Any.any_l ()
     | & _7: MutBorrow.t Int32.t = Any.any_l ()
     | & _8: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_borrows__frozen_dead [#"borrows.rs" 70 0 70 66]
   let%span sborrows = "borrows.rs" 70 27 70 28
@@ -753,7 +753,7 @@ module M_borrows__frozen_dead [#"borrows.rs" 70 0 70 66]
       | s2 = -{resolve'0 y'0}- s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t t_NonZero = x
     | & y'0: MutBorrow.t t_NonZero = y
@@ -761,7 +761,7 @@ module M_borrows__frozen_dead [#"borrows.rs" 70 0 70 66]
     | & _6: MutBorrow.t t_NonZero = Any.any_l ()
     | & _7: () = Any.any_l ()
     | & _8: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_borrows__qyi5556307355051076399__foo [#"borrows.rs" 94 4 94 25] (* SumTo10 *)
   let%span sborrows = "borrows.rs" 94 20 94 24
@@ -870,7 +870,7 @@ module M_borrows__qyi5556307355051076399__foo [#"borrows.rs" 94 4 94 25] (* SumT
       | s2 = -{resolve'2 self'0}- s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_SumTo10 = self
     | & _3: () = Any.any_l ()
@@ -879,7 +879,7 @@ module M_borrows__qyi5556307355051076399__foo [#"borrows.rs" 94 4 94 25] (* SumT
     | & _6: () = Any.any_l ()
     | & _7: MutBorrow.t Int32.t = Any.any_l ()
     | & _8: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_borrows__inc [#"borrows.rs" 102 0 102 23]
   let%span sborrows = "borrows.rs" 103 10 103 11
@@ -917,7 +917,7 @@ module M_borrows__inc [#"borrows.rs" 102 0 102 23]
       | s1 = -{resolve'0 x'0}- s2
       | s2 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & x'0: MutBorrow.t Int32.t = x ] 
+     [ & _0: () = Any.any_l () | & x'0: MutBorrow.t Int32.t = x ] )
     [ return''0 (result:())-> {[@expl:inc ensures] [%#sborrows'1] Int32.to_int x.final = view x + 1}
       (! return' {result}) ]
 
@@ -958,7 +958,7 @@ module M_borrows__dec [#"borrows.rs" 108 0 108 23]
       | s1 = -{resolve'0 x'0}- s2
       | s2 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & x'0: MutBorrow.t Int32.t = x ] 
+     [ & _0: () = Any.any_l () | & x'0: MutBorrow.t Int32.t = x ] )
     [ return''0 (result:())-> {[@expl:dec ensures] [%#sborrows'1] Int32.to_int x.final = view x - 1}
       (! return' {result}) ]
 

--- a/tests/should_fail/type_invariants/partial_instance.coma
+++ b/tests/should_fail/type_invariants/partial_instance.coma
@@ -38,7 +38,7 @@ module M_partial_instance__mk_s [#"partial_instance.rs" 17 0 17 26]
   let rec mk_s[#"partial_instance.rs" 17 0 17 26] (t:Int32.t) (return'  (x:t_S))= (! bb0
     [ bb0 = s0 [ s0 = null (fun (_ret:Opaque.ptr) ->  [ &_5 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- { t_S__0 = t'0; t_S__1 = _5 } ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_S = Any.any_l () | & t'0: Int32.t = t | & _5: Opaque.ptr = Any.any_l () ] 
+     [ & _0: t_S = Any.any_l () | & t'0: Int32.t = t | & _5: Opaque.ptr = Any.any_l () ] )
     [ return''0 (result:t_S)-> {[@expl:mk_s result type invariant] [%#spartial_instance] inv result}
       {[@expl:mk_s ensures] [%#spartial_instance'0] result.t_S__0 = t}
       (! return' {result}) ]
@@ -82,5 +82,5 @@ module M_partial_instance__evil [#"partial_instance.rs" 21 0 21 13]
   let rec evil[#"partial_instance.rs" 21 0 21 13] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = mk_s {[%#spartial_instance] (1: Int32.t)} (fun (_ret:t_S) ->  [ &_s <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:assertion] [%#spartial_instance'0] false} s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & _s: t_S = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & _s: t_S = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_fail/unsupported/hash_map.coma
+++ b/tests/should_fail/unsupported/hash_map.coma
@@ -33,9 +33,9 @@ module M_hash_map__qyi5744717520881225036__new [#"hash_map.rs" 19 4 19 24] (* Fo
   
   meta "select_lsinst" "all"
   
-  let rec new[#"hash_map.rs" 19 4 19 24] (return'  (x:t_Foo))= (! bb0 [ bb0 = {[%#shash_map] false} any ] )
+  let rec new[#"hash_map.rs" 19 4 19 24] (return'  (x:t_Foo))= (! bb0 [ bb0 = {[%#shash_map] false} any ] 
     [ & _0: t_Foo = Any.any_l () | & _1: t_HashMap'0 = Any.any_l () ]
-     [ return''0 (result:t_Foo)-> (! return' {result}) ] 
+    ) [ return''0 (result:t_Foo)-> (! return' {result}) ] 
 end
 module M_hash_map__qyi5744717520881225036__add [#"hash_map.rs" 24 4 24 44] (* Foo *)
   let%span shash_map = "hash_map.rs" 25 9 25 26
@@ -96,13 +96,13 @@ module M_hash_map__qyi5744717520881225036__add [#"hash_map.rs" 24 4 24 44] (* Fo
   
   let rec add[#"hash_map.rs" 24 4 24 44] (self:MutBorrow.t t_Foo) (num:UInt64.t) (bar:UInt8.t) (return'  (x:()))= (! bb0
     [ bb0 = {[%#shash_map] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Foo = self
     | & num'0: UInt64.t = num
     | & bar'0: UInt8.t = bar
     | & _6: MutBorrow.t UInt8.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:add ensures] [%#shash_map'0] get (view'1 self.final) (UInt64.t'int num)
       = C_Some bar}
       (! return' {result}) ]

--- a/tests/should_succeed/100doors.coma
+++ b/tests/should_succeed/100doors.coma
@@ -257,7 +257,7 @@ module M_100doors__f [#"100doors.rs" 18 0 18 10]
        ]
     
     | bb19 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & door_open: t_Vec = Any.any_l ()
     | & iter: t_Range = Any.any_l ()
@@ -277,5 +277,5 @@ module M_100doors__f [#"100doors.rs" 18 0 18 10]
     | & _33: MutBorrow.t bool = Any.any_l ()
     | & _34: MutBorrow.t t_Vec = Any.any_l ()
     | & _35: UInt64.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/all_zero.coma
+++ b/tests/should_succeed/all_zero.coma
@@ -105,7 +105,7 @@ module M_all_zero__all_zero [#"all_zero.rs" 34 0 34 29]
        ]
     
     | bb6 = s0 [ s0 = -{resolve'2 loop_l}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & l'0: MutBorrow.t t_List = l
     | & old_l: MutBorrow.t t_List = Any.any_l ()
@@ -113,7 +113,7 @@ module M_all_zero__all_zero [#"all_zero.rs" 34 0 34 29]
     | & value: MutBorrow.t UInt32.t = Any.any_l ()
     | & next: MutBorrow.t t_List = Any.any_l ()
     | & _14: MutBorrow.t t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:all_zero ensures #0] [%#sall_zero'3] forall i: int. 0 <= i /\ i < len l.current
        -> get l.final i = C_Some (0: UInt32.t)}
       {[@expl:all_zero ensures #1] [%#sall_zero'4] len l.current = len l.final}

--- a/tests/should_succeed/arc_and_rc.coma
+++ b/tests/should_succeed/arc_and_rc.coma
@@ -42,7 +42,7 @@ module M_arc_and_rc__rc [#"arc_and_rc.rs" 6 0 6 11]
     
     | bb2 = s0 [ s0 = {[@expl:assertion] [%#sarc_and_rc'1] view'0 inner = 1} s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & rc'0: t_Rc = Any.any_l () | & inner: Int32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & rc'0: t_Rc = Any.any_l () | & inner: Int32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -90,7 +90,7 @@ module M_arc_and_rc__arc [#"arc_and_rc.rs" 13 0 13 12]
     
     | bb2 = s0 [ s0 = {[@expl:assertion] [%#sarc_and_rc'1] view'0 inner = 2} s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & arc'0: t_Arc = Any.any_l () | & inner: Int32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & arc'0: t_Arc = Any.any_l () | & inner: Int32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bdd.coma
+++ b/tests/should_succeed/bdd.coma
@@ -130,13 +130,13 @@ module M_bdd__hashmap__qyi1953663170559623169__hash [#"bdd.rs" 80 8 80 29] (* <(
     
     | bb3 = s0 [ s0 = wrapping_add {_3} {_5} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: tuple = self
     | & _3: UInt64.t = Any.any_l ()
     | & _5: UInt64.t = Any.any_l ()
     | & _6: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:hash ensures] [%#sbdd'1] UInt64.t'int result
       = hash_log'1 (deep_model'4 self)}
       (! return' {result}) ]
@@ -159,7 +159,7 @@ module M_bdd__qyi2024536649982164874__assert_receiver_is_total_eq [#"bdd.rs" 93 
   
   let rec assert_receiver_is_total_eq[#"bdd.rs" 93 9 93 11] (self:t_Node) (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_bdd__qyi4854841669736991510__eq [#"bdd.rs" 93 13 93 22] (* <Node<'arena> as creusot_contracts::PartialEq> *)
   let%span sbdd = "bdd.rs" 93 13 93 22
@@ -269,7 +269,7 @@ module M_bdd__qyi4854841669736991510__eq [#"bdd.rs" 93 13 93 22] (* <Node<'arena
     | bb1 = s0 [ s0 =  [ &_0 <- [%#sbdd] false ] s1 | s1 = bb21 ] 
     | bb10 = s0 [ s0 =  [ &_0 <- [%#sbdd] true ] s1 | s1 = bb21 ] 
     | bb21 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self'0: t_Node = self
     | & rhs'0: t_Node = rhs
@@ -283,7 +283,7 @@ module M_bdd__qyi4854841669736991510__eq [#"bdd.rs" 93 13 93 22] (* <Node<'arena
     | & _17: bool = Any.any_l ()
     | & _20: bool = Any.any_l ()
     | & _23: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:eq ensures] [%#sbdd] result = (deep_model'1 self = deep_model'1 rhs)}
       (! return' {result}) ]
 
@@ -457,7 +457,7 @@ module M_bdd__qyi17981791245757283426__clone [#"bdd.rs" 93 24 93 29] (* <Node<'a
     | bb5 = s0 [ s0 =  [ &_0 <- C_True ] s1 | s1 = bb10 ] 
     | bb6 = s0 [ s0 =  [ &_0 <- C_False ] s1 | s1 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Node = Any.any_l ()
     | & self'0: t_Node = self
     | & v_1: UInt64.t = Any.any_l ()
@@ -469,7 +469,7 @@ module M_bdd__qyi17981791245757283426__clone [#"bdd.rs" 93 24 93 29] (* <Node<'a
     | & _12: t_Bdd = Any.any_l ()
     | & _13: t_Bdd = Any.any_l ()
     | & _15: t_Bdd = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Node)-> {[@expl:clone ensures] [%#sbdd] match { _p0 = self; _p1 = result } with
         | {_p0 = C_False ; _p1 = C_False} -> true
         | {_p0 = C_True ; _p1 = C_True} -> true
@@ -497,7 +497,7 @@ module M_bdd__qyi1284786238026687571__assert_receiver_is_total_eq [#"bdd.rs" 107
   
   let rec assert_receiver_is_total_eq[#"bdd.rs" 107 15 107 17] (self:t_Bdd) (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_bdd__qyi2820858787824331484__clone [#"bdd.rs" 112 4 112 27] (* <Bdd<'arena> as creusot_contracts::Clone> *)
   let%span sbdd = "bdd.rs" 111 14 111 29
@@ -518,7 +518,7 @@ module M_bdd__qyi2820858787824331484__clone [#"bdd.rs" 112 4 112 27] (* <Bdd<'ar
   
   let rec clone'[#"bdd.rs" 112 4 112 27] (self:t_Bdd) (return'  (x:t_Bdd))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Bdd = Any.any_l () | & self'0: t_Bdd = self ] 
+     [ & _0: t_Bdd = Any.any_l () | & self'0: t_Bdd = self ] )
     [ return''0 (result:t_Bdd)-> {[@expl:clone ensures] [%#sbdd] result = self} (! return' {result}) ]
 
 end
@@ -616,7 +616,7 @@ module M_bdd__qyi699402059438633899__hash [#"bdd.rs" 119 4 119 25] (* <Node<'are
     | bb5 = s0 [ s0 =  [ &_0 <- [%#sbdd'1] (2: UInt64.t) ] s1 | s1 = bb11 ] 
     | bb6 = s0 [ s0 =  [ &_0 <- [%#sbdd'2] (1: UInt64.t) ] s1 | s1 = bb11 ] 
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: t_Node = self
     | & v: UInt64.t = Any.any_l ()
@@ -625,7 +625,7 @@ module M_bdd__qyi699402059438633899__hash [#"bdd.rs" 119 4 119 25] (* <Node<'are
     | & _7: UInt64.t = Any.any_l ()
     | & _9: UInt64.t = Any.any_l ()
     | & _11: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:hash ensures] [%#sbdd'3] UInt64.t'int result = hash_log (view'0 self)}
       (! return' {result}) ]
 
@@ -665,7 +665,7 @@ module M_bdd__qyi14323183011761258016__hash [#"bdd.rs" 144 4 144 25] (* <Bdd<'ar
   
   let rec hash[#"bdd.rs" 144 4 144 25] (self:t_Bdd) (return'  (x:UInt64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self'0.t_Bdd__1 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & self'0: t_Bdd = self ] 
+     [ & _0: UInt64.t = Any.any_l () | & self'0: t_Bdd = self ] )
     [ return''0 (result:UInt64.t)-> {[@expl:hash ensures] [%#sbdd] UInt64.t'int result = hash_log (view'0 self)}
       (! return' {result}) ]
 
@@ -701,7 +701,7 @@ module M_bdd__qyi2581120635339165136__eq [#"bdd.rs" 199 4 199 34] (* <Bdd<'arena
   
   let rec eq[#"bdd.rs" 199 4 199 34] (self:t_Bdd) (o:t_Bdd) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self'0.t_Bdd__1 = o'0.t_Bdd__1 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & self'0: t_Bdd = self | & o'0: t_Bdd = o ] 
+     [ & _0: bool = Any.any_l () | & self'0: t_Bdd = self | & o'0: t_Bdd = o ] )
     [ return''0 (result:bool)-> {[@expl:eq ensures] [%#sbdd] result = (view'0 self = view'0 o)} (! return' {result}) ]
 
 end
@@ -2156,7 +2156,7 @@ module M_bdd__qyi11078426090797403070__new [#"bdd.rs" 418 4 418 52] (* Context<'
         s1
       | s1 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_Context = Any.any_l ()
     | & alloc'0: () = alloc
     | & t: t_Node = Any.any_l ()
@@ -2166,7 +2166,7 @@ module M_bdd__qyi11078426090797403070__new [#"bdd.rs" 418 4 418 52] (* Context<'
     | & _9: t_MyHashMap'1 = Any.any_l ()
     | & _10: t_PeanoInt = Any.any_l ()
     | & _11: t_Node = Any.any_l () ]
-     [ return''0 (result:t_Context)-> {[@expl:new result type invariant] [%#sbdd'0] inv result} (! return' {result}) ] 
+    ) [ return''0 (result:t_Context)-> {[@expl:new result type invariant] [%#sbdd'0] inv result} (! return' {result}) ] 
 end
 module M_bdd__qyi11078426090797403070__hashcons [#"bdd.rs" 434 4 434 58] (* Context<'arena> *)
   let%span sbdd = "bdd.rs" 441 30 441 77
@@ -2513,7 +2513,7 @@ module M_bdd__qyi11078426090797403070__hashcons [#"bdd.rs" 434 4 434 58] (* Cont
       | s5 = bb9 ]
     
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Bdd = Any.any_l ()
     | & self'0: MutBorrow.t t_Context = self
     | & n'0: t_Node = n
@@ -2526,7 +2526,7 @@ module M_bdd__qyi11078426090797403070__hashcons [#"bdd.rs" 434 4 434 58] (* Cont
     | & _24: MutBorrow.t t_MyHashMap = Any.any_l ()
     | & _27: Map.map UInt64.t t_Node = Any.any_l ()
     | & _29: t_PeanoInt = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Bdd)-> {[@expl:hashcons ensures #0] [%#sbdd'3] result.t_Bdd__0 = n}
       {[@expl:hashcons ensures #1] [%#sbdd'4] grows self}
       {[@expl:hashcons ensures #2] [%#sbdd'5] is_valid_bdd self.final result}
@@ -2830,7 +2830,7 @@ module M_bdd__qyi11078426090797403070__node [#"bdd.rs" 453 4 453 87] (* Context<
     
     | bb4 = s0 [ s0 = {[@expl:type invariant] inv'0 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Bdd = Any.any_l ()
     | & self'0: MutBorrow.t t_Context = self
     | & x'0: UInt64.t = x
@@ -2839,7 +2839,7 @@ module M_bdd__qyi11078426090797403070__node [#"bdd.rs" 453 4 453 87] (* Context<
     | & _13: bool = Any.any_l ()
     | & _17: MutBorrow.t t_Context = Any.any_l ()
     | & _18: t_Node = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Bdd)-> {[@expl:node ensures #0] [%#sbdd'3] grows self}
       {[@expl:node ensures #1] [%#sbdd'4] is_valid_bdd self.final result}
       {[@expl:node ensures #2] [%#sbdd'5] forall v: Map.map UInt64.t bool. interp result v
@@ -3114,12 +3114,12 @@ module M_bdd__qyi11078426090797403070__trueqy95z [#"bdd.rs" 464 4 464 42] (* Con
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'0 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Bdd = Any.any_l ()
     | & self'0: MutBorrow.t t_Context = self
     | & _6: MutBorrow.t t_Context = Any.any_l ()
     | & _7: t_Node = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Bdd)-> {[@expl:true_ ensures #0] [%#sbdd'0] grows self}
       {[@expl:true_ ensures #1] [%#sbdd'1] is_valid_bdd self.final result}
       {[@expl:true_ ensures #2] [%#sbdd'2] forall v: Map.map UInt64.t bool. interp result v}
@@ -3393,12 +3393,12 @@ module M_bdd__qyi11078426090797403070__falseqy95z [#"bdd.rs" 472 4 472 43] (* Co
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'0 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Bdd = Any.any_l ()
     | & self'0: MutBorrow.t t_Context = self
     | & _6: MutBorrow.t t_Context = Any.any_l ()
     | & _7: t_Node = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Bdd)-> {[@expl:false_ ensures #0] [%#sbdd'0] grows self}
       {[@expl:false_ ensures #1] [%#sbdd'1] is_valid_bdd self.final result}
       {[@expl:false_ ensures #2] [%#sbdd'2] forall v: Map.map UInt64.t bool. not interp result v}
@@ -3727,7 +3727,7 @@ module M_bdd__qyi11078426090797403070__v [#"bdd.rs" 479 4 479 46] (* Context<'ar
       | s2 = bb3 ]
     
     | bb3 = s0 [ s0 = {[@expl:type invariant] inv'0 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Bdd = Any.any_l ()
     | & self'0: MutBorrow.t t_Context = self
     | & x'0: UInt64.t = x
@@ -3736,7 +3736,7 @@ module M_bdd__qyi11078426090797403070__v [#"bdd.rs" 479 4 479 46] (* Context<'ar
     | & f: t_Bdd = Any.any_l ()
     | & _9: MutBorrow.t t_Context = Any.any_l ()
     | & _10: MutBorrow.t t_Context = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Bdd)-> {[@expl:v ensures #0] [%#sbdd'0] grows self}
       {[@expl:v ensures #1] [%#sbdd'1] is_valid_bdd self.final result}
       {[@expl:v ensures #2] [%#sbdd'2] forall v'0: Map.map UInt64.t bool. interp result v'0 = Map.get v'0 x}
@@ -4188,7 +4188,7 @@ module M_bdd__qyi11078426090797403070__not [#"bdd.rs" 491 4 491 56] (* Context<'
       | s4 = bb18 ]
     
     | bb18 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Bdd = Any.any_l ()
     | & self'0: MutBorrow.t t_Context = self
     | & x'0: t_Bdd = x
@@ -4208,7 +4208,7 @@ module M_bdd__qyi11078426090797403070__not [#"bdd.rs" 491 4 491 56] (* Context<'
     | & _30: MutBorrow.t t_Context = Any.any_l ()
     | & _34: () = Any.any_l ()
     | & _35: MutBorrow.t t_MyHashMap'0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Bdd)-> {[@expl:not ensures #0] [%#sbdd'1] grows self}
       {[@expl:not ensures #1] [%#sbdd'2] is_valid_bdd self.final result}
       {[@expl:not ensures #2] [%#sbdd'3] forall v: Map.map UInt64.t bool. interp result v = (not interp x v)}
@@ -4809,7 +4809,7 @@ module M_bdd__qyi11078426090797403070__and [#"bdd.rs" 515 4 515 72] (* Context<'
       | s4 = bb35 ]
     
     | bb35 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Bdd = Any.any_l ()
     | & self'0: MutBorrow.t t_Context = self
     | & a'0: t_Bdd = a
@@ -4848,7 +4848,7 @@ module M_bdd__qyi11078426090797403070__and [#"bdd.rs" 515 4 515 72] (* Context<'
     | & _78: () = Any.any_l ()
     | & _79: MutBorrow.t t_MyHashMap'1 = Any.any_l ()
     | & _80: tuple = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Bdd)-> {[@expl:and ensures #0] [%#sbdd'3] grows self}
       {[@expl:and ensures #1] [%#sbdd'4] is_valid_bdd self.final result}
       {[@expl:and ensures #2] [%#sbdd'5] forall v: Map.map UInt64.t bool. interp result v = (interp a v /\ interp b v)}

--- a/tests/should_succeed/binary_search.coma
+++ b/tests/should_succeed/binary_search.coma
@@ -136,7 +136,7 @@ module M_binary_search__qyi14442247409995256824__index [#"binary_search.rs" 45 4
     
     | bb7 = {false} any
     | bb6 = s0 [ s0 =  [ &_0 <- t ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_T = Any.any_l ()
     | & self'0: t_List = self
     | & ix'0: UInt64.t = ix
@@ -146,7 +146,7 @@ module M_binary_search__qyi14442247409995256824__index [#"binary_search.rs" 45 4
     | & ls: t_List = Any.any_l ()
     | & _16: bool = Any.any_l ()
     | & _19: t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:index result type invariant] [%#sbinary_search'6] inv'3 result}
       {[@expl:index ensures] [%#sbinary_search'7] C_Some result = get self (UInt64.t'int ix)}
       (! return' {result}) ]
@@ -298,13 +298,13 @@ module M_binary_search__qyi14442247409995256824__len [#"binary_search.rs" 67 4 6
        ]
     
     | bb5 = s0 [ s0 =  [ &_0 <- len'0 ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: t_List = self
     | & len'0: UInt64.t = Any.any_l ()
     | & l: t_List = Any.any_l ()
     | & ls: t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:len ensures #0] [%#sbinary_search'5] UInt64.ge result (0: UInt64.t)}
       {[@expl:len ensures #1] [%#sbinary_search'6] UInt64.t'int result = len_logic self}
       (! return' {result}) ]
@@ -588,7 +588,7 @@ module M_binary_search__binary_search [#"binary_search.rs" 111 0 111 72]
     
     | bb18 = s0 [ s0 =  [ &_0 <- C_Err base ] s1 | s1 = bb21 ] 
     | bb21 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Result = Any.any_l ()
     | & arr'0: t_List = arr
     | & elem'0: UInt32.t = elem
@@ -608,7 +608,7 @@ module M_binary_search__binary_search [#"binary_search.rs" 111 0 111 72]
     | & _43: bool = Any.any_l ()
     | & _47: bool = Any.any_l ()
     | & _50: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Result)-> {[@expl:binary_search ensures #0] [%#sbinary_search'11] forall x: UInt64.t. result
       = C_Ok x  -> get arr (UInt64.t'int x) = C_Some elem}
       {[@expl:binary_search ensures #1] [%#sbinary_search'12] forall x: UInt64.t. result = C_Err x

--- a/tests/should_succeed/bitvectors/bitwalker.coma
+++ b/tests/should_succeed/bitvectors/bitwalker.coma
@@ -82,14 +82,14 @@ module M_bitwalker__peek_bit_u8 [#"bitwalker.rs" 9 0 9 42]
       | s3 =  [ &_0 <- _7 <> ([%#sbitwalker'1] (0: UInt8.t)) ] s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & x'0: UInt8.t = x
     | & left'0: UInt64.t = left
     | & mask: UInt8.t = Any.any_l ()
     | & _5: UInt64.t = Any.any_l ()
     | & _7: UInt8.t = Any.any_l () ]
-     [ return''0 (result:bool)-> (! return' {result}) ] 
+    ) [ return''0 (result:bool)-> (! return' {result}) ] 
 end
 module M_bitwalker__peek_bit_array8 [#"bitwalker.rs" 15 0 15 52]
   let%span sbitwalker = "bitwalker.rs" 16 26 16 27
@@ -246,7 +246,7 @@ module M_bitwalker__peek_bit_array8 [#"bitwalker.rs" 15 0 15 52]
     | bb10 = s0 [ s0 =  [ &_0 <- [%#sbitwalker'4] false ] s1 | s1 = bb11 ] 
     | bb11 = return''0 {_0}
     | bb9 = {[%#sbitwalker'5] false} any ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & addr'0: Slice64.slice UInt8.t = addr
     | & left'0: UInt64.t = left
@@ -256,7 +256,7 @@ module M_bitwalker__peek_bit_array8 [#"bitwalker.rs" 15 0 15 52]
     | & v: UInt8.t = Any.any_l ()
     | & _12: UInt64.t = Any.any_l ()
     | & _14: bool = Any.any_l () ]
-     [ return''0 (result:bool)-> (! return' {result}) ] 
+    ) [ return''0 (result:bool)-> (! return' {result}) ] 
 end
 module M_bitwalker__poke_bit_64 [#"bitwalker.rs" 28 0 28 58]
   let%span sbitwalker = "bitwalker.rs" 29 29 29 36
@@ -342,7 +342,7 @@ module M_bitwalker__poke_bit_64 [#"bitwalker.rs" 28 0 28 58]
     | bb1 = s0 [ s0 =  [ &_0 <- UInt64.bw_or value'0 mask ] s1 | s1 = bb3 ] 
     | bb2 = s0 [ s0 =  [ &_14 <- UInt64.bw_not mask ] s1 | s1 =  [ &_0 <- UInt64.bw_and value'0 _14 ] s2 | s2 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & value'0: UInt64.t = value
     | & left'0: UInt64.t = left
@@ -350,7 +350,7 @@ module M_bitwalker__poke_bit_64 [#"bitwalker.rs" 28 0 28 58]
     | & mask: UInt64.t = Any.any_l ()
     | & _6: UInt64.t = Any.any_l ()
     | & _14: UInt64.t = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end
 module M_bitwalker__peek [#"bitwalker.rs" 44 0 44 56]
   let%span sbitwalker = "bitwalker.rs" 45 26 45 27
@@ -507,7 +507,7 @@ module M_bitwalker__peek [#"bitwalker.rs" 44 0 44 56]
        ]
     
     | bb9 = s0 [ s0 =  [ &_0 <- retval ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & start'0: UInt64.t = start
     | & length'0: UInt64.t = length
@@ -524,7 +524,7 @@ module M_bitwalker__peek [#"bitwalker.rs" 44 0 44 56]
     | & _29: UInt64.t = Any.any_l ()
     | & _31: UInt64.t = Any.any_l ()
     | & _32: UInt64.t = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end
 module M_bitwalker__peek_64bit [#"bitwalker.rs" 63 0 63 46]
   let%span sbitwalker = "bitwalker.rs" 64 29 64 36
@@ -610,14 +610,14 @@ module M_bitwalker__peek_64bit [#"bitwalker.rs" 63 0 63 46]
       | s3 =  [ &_0 <- _7 <> ([%#sbitwalker'1] (0: UInt64.t)) ] s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & value'0: UInt64.t = value
     | & left'0: UInt64.t = left
     | & mask: UInt64.t = Any.any_l ()
     | & _5: UInt64.t = Any.any_l ()
     | & _7: UInt64.t = Any.any_l () ]
-     [ return''0 (result:bool)-> (! return' {result}) ] 
+    ) [ return''0 (result:bool)-> (! return' {result}) ] 
 end
 module M_bitwalker__poke_8bit [#"bitwalker.rs" 69 0 69 53]
   let%span sbitwalker = "bitwalker.rs" 70 23 70 29
@@ -703,7 +703,7 @@ module M_bitwalker__poke_8bit [#"bitwalker.rs" 69 0 69 53]
     | bb1 = s0 [ s0 =  [ &_0 <- UInt8.bw_or byte'0 mask ] s1 | s1 = bb3 ] 
     | bb2 = s0 [ s0 =  [ &_14 <- UInt8.bw_not mask ] s1 | s1 =  [ &_0 <- UInt8.bw_and byte'0 _14 ] s2 | s2 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt8.t = Any.any_l ()
     | & byte'0: UInt8.t = byte
     | & left'0: UInt64.t = left
@@ -711,7 +711,7 @@ module M_bitwalker__poke_8bit [#"bitwalker.rs" 69 0 69 53]
     | & mask: UInt8.t = Any.any_l ()
     | & _6: UInt64.t = Any.any_l ()
     | & _14: UInt8.t = Any.any_l () ]
-     [ return''0 (result:UInt8.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt8.t)-> (! return' {result}) ] 
 end
 module M_bitwalker__poke_8bit_array [#"bitwalker.rs" 80 0 80 60]
   let%span sbitwalker = "bitwalker.rs" 81 26 81 27
@@ -866,7 +866,7 @@ module M_bitwalker__poke_8bit_array [#"bitwalker.rs" 80 0 80 60]
       | s1 = -{resolve'0 addr'0}- s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & addr'0: MutBorrow.t (Slice64.slice UInt8.t) = addr
     | & left'0: UInt64.t = left
@@ -884,7 +884,7 @@ module M_bitwalker__poke_8bit_array [#"bitwalker.rs" 80 0 80 60]
     | & _21: Opaque.ptr = Any.any_l ()
     | & _22: UInt64.t = Any.any_l ()
     | & _23: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:poke_8bit_array ensures] [%#sbitwalker'6] Seq.length (view addr.final)
       = Seq.length (view'0 addr)}
       (! return' {result}) ]
@@ -1095,7 +1095,7 @@ module M_bitwalker__poke [#"bitwalker.rs" 90 0 90 71]
     
     | bb15 = s0 [ s0 = -{resolve'0 addr'0}- s1 | s1 =  [ &_0 <- [%#sbitwalker'11] (0: Int8.t) ] s2 | s2 = bb16 ] 
     | bb16 = return''0 {_0} ]
-    )
+    
     [ & _0: Int8.t = Any.any_l ()
     | & start'0: UInt64.t = start
     | & length'0: UInt64.t = length
@@ -1118,7 +1118,7 @@ module M_bitwalker__poke [#"bitwalker.rs" 90 0 90 71]
     | & _48: MutBorrow.t (Slice64.slice UInt8.t) = Any.any_l ()
     | & _49: UInt64.t = Any.any_l ()
     | & old_10_0: MutBorrow.t (Slice64.slice UInt8.t) = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int8.t)-> {[@expl:poke ensures] [%#sbitwalker'15] Seq.length (view addr.final)
       = Seq.length (view'1 addr)}
       (! return' {result}) ]
@@ -1269,7 +1269,7 @@ module M_bitwalker__peekthenpoke [#"bitwalker.rs" 119 0 119 67]
       | s2 = bb2 ]
     
     | bb2 = s0 [ s0 = -{resolve'0 addr'0}- s1 | s1 =  [ &_0 <- res ] s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int8.t = Any.any_l ()
     | & start'0: UInt64.t = start
     | & length'0: UInt64.t = length
@@ -1277,7 +1277,7 @@ module M_bitwalker__peekthenpoke [#"bitwalker.rs" 119 0 119 67]
     | & value: UInt64.t = Any.any_l ()
     | & res: Int8.t = Any.any_l ()
     | & _14: MutBorrow.t (Slice64.slice UInt8.t) = Any.any_l () ]
-     [ return''0 (result:Int8.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:Int8.t)-> (! return' {result}) ] 
 end
 module M_bitwalker__pokethenpeek [#"bitwalker.rs" 133 0 133 84]
   let%span sbitwalker = "bitwalker.rs" 130 11 130 33
@@ -1425,7 +1425,7 @@ module M_bitwalker__pokethenpeek [#"bitwalker.rs" 133 0 133 84]
       | s1 = bb2 ]
     
     | bb2 = s0 [ s0 = -{resolve'0 addr'0}- s1 | s1 =  [ &_0 <- peek_result ] s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & start'0: UInt64.t = start
     | & length'0: UInt64.t = length
@@ -1434,5 +1434,5 @@ module M_bitwalker__pokethenpeek [#"bitwalker.rs" 133 0 133 84]
     | & _res: Int8.t = Any.any_l ()
     | & _11: MutBorrow.t (Slice64.slice UInt8.t) = Any.any_l ()
     | & peek_result: UInt64.t = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bitvectors/popcount.coma
+++ b/tests/should_succeed/bitvectors/popcount.coma
@@ -48,7 +48,7 @@ module M_popcount__count8 [#"popcount.rs" 29 0 29 26]
       | s11 =  [ &_0 <- x ] s12
       | s12 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: UInt8BW.t = Any.any_l ()
     | & n'0: UInt8BW.t = n
     | & x: UInt8BW.t = Any.any_l ()
@@ -59,7 +59,7 @@ module M_popcount__count8 [#"popcount.rs" 29 0 29 26]
     | & _12: UInt8BW.t = Any.any_l ()
     | & _14: UInt8BW.t = Any.any_l ()
     | & _16: UInt8BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt8BW.t)-> {[@expl:count8 ensures #0] [%#spopcount'6] UInt8BW.t'int result <= 8}
       {[@expl:count8 ensures #1] [%#spopcount'7] UInt8BW.t'int result = count8_log n}
       (! return' {result}) ]
@@ -108,7 +108,7 @@ module M_popcount__count16 [#"popcount.rs" 39 0 39 29]
       | s13 =  [ &_0 <- UInt16BW.bw_and x ([%#spopcount'7] (31: UInt16BW.t)) ] s14
       | s14 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: UInt16BW.t = Any.any_l ()
     | & n'0: UInt16BW.t = n
     | & x: UInt16BW.t = Any.any_l ()
@@ -120,7 +120,7 @@ module M_popcount__count16 [#"popcount.rs" 39 0 39 29]
     | & _13: UInt16BW.t = Any.any_l ()
     | & _15: UInt16BW.t = Any.any_l ()
     | & _18: UInt16BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt16BW.t)-> {[@expl:count16 ensures] [%#spopcount'8] UInt16BW.t'int result <= 16}
       (! return' {result}) ]
 
@@ -172,7 +172,7 @@ module M_popcount__count32 [#"popcount.rs" 50 0 50 29]
       | s15 =  [ &_0 <- UInt32BW.bw_and x ([%#spopcount'8] (63: UInt32BW.t)) ] s16
       | s16 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: UInt32BW.t = Any.any_l ()
     | & n'0: UInt32BW.t = n
     | & x: UInt32BW.t = Any.any_l ()
@@ -185,7 +185,7 @@ module M_popcount__count32 [#"popcount.rs" 50 0 50 29]
     | & _15: UInt32BW.t = Any.any_l ()
     | & _18: UInt32BW.t = Any.any_l ()
     | & _21: UInt32BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32BW.t)-> {[@expl:count32 ensures] [%#spopcount'9] UInt32BW.t'int result <= 32}
       (! return' {result}) ]
 
@@ -241,7 +241,7 @@ module M_popcount__count64 [#"popcount.rs" 62 0 62 29]
       | s17 =  [ &_0 <- UInt64BW.bw_and x ([%#spopcount'9] (127: UInt64BW.t)) ] s18
       | s18 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: UInt64BW.t = Any.any_l ()
     | & n'0: UInt64BW.t = n
     | & x: UInt64BW.t = Any.any_l ()
@@ -255,7 +255,7 @@ module M_popcount__count64 [#"popcount.rs" 62 0 62 29]
     | & _18: UInt64BW.t = Any.any_l ()
     | & _21: UInt64BW.t = Any.any_l ()
     | & _24: UInt64BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64BW.t)-> {[@expl:count64 ensures] [%#spopcount'10] UInt64BW.t'int result <= 64}
       (! return' {result}) ]
 

--- a/tests/should_succeed/bitvectors/rightmostbit.coma
+++ b/tests/should_succeed/bitvectors/rightmostbit.coma
@@ -95,7 +95,7 @@ module M_rightmostbit__rightmost_bit_8 [#"rightmostbit.rs" 28 0 28 35]
   let rec rightmost_bit_8[#"rightmostbit.rs" 28 0 28 35] (x:Int8BW.t) (return'  (x'0:Int8BW.t))= (! bb0
     [ bb0 = s0 [ s0 = wrapping_neg {x'0} (fun (_ret:Int8BW.t) ->  [ &_8 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- Int8BW.bw_and x'0 _8 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int8BW.t = Any.any_l () | & x'0: Int8BW.t = x | & _8: Int8BW.t = Any.any_l () ] 
+     [ & _0: Int8BW.t = Any.any_l () | & x'0: Int8BW.t = x | & _8: Int8BW.t = Any.any_l () ] )
     [ return''0 (result:Int8BW.t)-> {[@expl:rightmost_bit_8 ensures #0] [%#srightmostbit] Int8BW.ge x (0: Int8BW.t)
        -> Int8BW.le (0: Int8BW.t) result /\ Int8BW.le result x}
       {[@expl:rightmost_bit_8 ensures #1] [%#srightmostbit'0] Int8BW.le x (0: Int8BW.t) /\ Int8BW.gt x v_MIN
@@ -192,7 +192,7 @@ module M_rightmostbit__rightmost_bit_64 [#"rightmostbit.rs" 37 0 37 38]
   let rec rightmost_bit_64[#"rightmostbit.rs" 37 0 37 38] (x:Int64BW.t) (return'  (x'0:Int64BW.t))= (! bb0
     [ bb0 = s0 [ s0 = wrapping_neg {x'0} (fun (_ret:Int64BW.t) ->  [ &_7 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- Int64BW.bw_and x'0 _7 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & x'0: Int64BW.t = x | & _7: Int64BW.t = Any.any_l () ] 
+     [ & _0: Int64BW.t = Any.any_l () | & x'0: Int64BW.t = x | & _7: Int64BW.t = Any.any_l () ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:rightmost_bit_64 ensures #0] [%#srightmostbit] Int64BW.ge x (0: Int64BW.t)
        -> Int64BW.le (0: Int64BW.t) result /\ Int64BW.le result x}
       {[@expl:rightmost_bit_64 ensures #1] [%#srightmostbit'0] Int64BW.le x (0: Int64BW.t) /\ Int64BW.gt x v_MIN

--- a/tests/should_succeed/bug/02_derive.coma
+++ b/tests/should_succeed/bug/02_derive.coma
@@ -7,5 +7,5 @@ module M_02_derive__qyi1286730707956131195__clone [#"02_derive.rs" 3 9 3 14] (* 
   
   let rec clone'[#"02_derive.rs" 3 9 3 14] (self:()) (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- () ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/1312.coma
+++ b/tests/should_succeed/bug/1312.coma
@@ -39,5 +39,5 @@ module M_1312__foo99 [#"1312.rs" 3 0 3 14]
   
   let rec foo99[#"1312.rs" 3 0 3 14] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_my_closure <- () ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & _my_closure: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & _my_closure: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/1410.coma
+++ b/tests/should_succeed/bug/1410.coma
@@ -194,7 +194,7 @@ module M_1410__bar [#"1410.rs" 6 0 6 32]
     
     | bb9 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve'1 f'0}- s2 | s2 = bb13 ] 
     | bb13 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & f'0: t_F = f
     | & iter: t_Range = Any.any_l ()
@@ -209,5 +209,5 @@ module M_1410__bar [#"1410.rs" 6 0 6 32]
     | & _23: () = Any.any_l ()
     | & _24: MutBorrow.t t_F = Any.any_l ()
     | & _25: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/1504.coma
+++ b/tests/should_succeed/bug/1504.coma
@@ -14,7 +14,7 @@ module M_1504__h [#"1504.rs" 8 0 8 26]
   
   let rec h[#"1504.rs" 8 0 8 26] (return'  (x:t_Option))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- C_Some ([%#s1504] true) ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Option = Any.any_l () ] 
+     [ & _0: t_Option = Any.any_l () ] )
     [ return''0 (result:t_Option)-> {[@expl:h ensures] [%#s1504'0] match result with
         | C_Some (True) -> true
         | _ -> false

--- a/tests/should_succeed/bug/1562.coma
+++ b/tests/should_succeed/bug/1562.coma
@@ -168,7 +168,7 @@ module M_1562__qyi17754419174301240535__foo [#"1562.rs" 17 4 17 61] (* List<T> *
     
     | bb4 = s0 [ s0 = -{resolve'0 p}- s1 | s1 = -{resolve'5 perm'0}- s2 | s2 = bb16 ] 
     | bb16 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_List = self
     | & perm'0:  t_PCellOwn = perm
@@ -184,5 +184,5 @@ module M_1562__qyi17754419174301240535__foo [#"1562.rs" 17 4 17 61] (* List<T> *
     | & _17: t_PCell = Any.any_l ()
     | & _19:  (MutBorrow.t t_PCellOwn) = Any.any_l ()
     | & _20: MutBorrow.t ( t_PCellOwn) = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/164.coma
+++ b/tests/should_succeed/bug/164.coma
@@ -247,7 +247,7 @@ module M_164__main [#"164.rs" 5 0 5 13]
     
     | bb43 = s0 [ s0 =  [ &produced <- _72 ] s1 | s1 = bb44 ] 
     | bb44 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: UInt64.t = Any.any_l ()
     | & _6: bool = Any.any_l ()
@@ -265,5 +265,5 @@ module M_164__main [#"164.rs" 5 0 5 13]
     | & _69: MutBorrow.t t_Range = Any.any_l ()
     | & __creusot_proc_iter_elem: Int32.t = Any.any_l ()
     | & _72: Seq.seq Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/168.coma
+++ b/tests/should_succeed/bug/168.coma
@@ -10,5 +10,5 @@ module M_168__max_int [#"168.rs" 3 0 3 25]
   
   let rec max_int[#"168.rs" 3 0 3 25] (return'  (x:UInt64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#s168] (18446744073709551615: UInt64.t) ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () ]  [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+     [ & _0: UInt64.t = Any.any_l () ] ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/173.coma
+++ b/tests/should_succeed/bug/173.coma
@@ -19,7 +19,7 @@ module M_173__test_233 [#"173.rs" 19 0 19 17]
       | s3 = {[@expl:assertion] [%#s173'2] Int32.to_int x'0 = 42} s4
       | s4 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & x: Int32.t = Any.any_l () | & x'0: Int32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x: Int32.t = Any.any_l () | & x'0: Int32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/181_ident.coma
+++ b/tests/should_succeed/bug/181_ident.coma
@@ -20,7 +20,7 @@ module M_181_ident__max_usize [#"181_ident.rs" 13 0 13 45]
     | bb1 = s0 [ s0 =  [ &_0 <- b'0 ] s1 | s1 = bb3 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- a'0 ] s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: UInt64.t = Any.any_l () | & a'0: UInt64.t = a | & b'0: UInt64.t = b | & _4: bool = Any.any_l () ] 
+     [ & _0: UInt64.t = Any.any_l () | & a'0: UInt64.t = a | & b'0: UInt64.t = b | & _4: bool = Any.any_l () ] )
     [ return''0 (result:UInt64.t)-> {[@expl:max_usize ensures] [%#s181_ident] UInt64.t'int result
       = max_int (UInt64.t'int a) (UInt64.t'int b)}
       (! return' {result}) ]

--- a/tests/should_succeed/bug/195.coma
+++ b/tests/should_succeed/bug/195.coma
@@ -9,5 +9,5 @@ module M_195__example [#"195.rs" 4 0 4 40]
   
   let rec example[#"195.rs" 4 0 4 40] (_example_parameter:bool) (return'  (x:()))= {[@expl:example requires] [%#s195] _example_parameter
     = _example_parameter}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/206.coma
+++ b/tests/should_succeed/bug/206.coma
@@ -97,7 +97,7 @@ module M_206__ex [#"206.rs" 20 0 20 16]
   
   meta "select_lsinst" "all"
   
-  let rec ex[#"206.rs" 20 0 20 16] (a:t_A) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec ex[#"206.rs" 20 0 20 16] (a:t_A) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> {[@expl:ex ensures] [%#s206] u a = u a} (! return' {result}) ] 
+    ) [ return''0 (result:())-> {[@expl:ex ensures] [%#s206] u a = u a} (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/235.coma
+++ b/tests/should_succeed/bug/235.coma
@@ -16,5 +16,5 @@ module M_235__f [#"235.rs" 5 0 5 10]
         (! s0) [ s0 = bb2 ]  [ bb2 = any [ br0 -> {false} (! bb4) | br1 -> {true} (! bb1'0) ]  ]  ]
     
     | bb4 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/256.coma
+++ b/tests/should_succeed/bug/256.coma
@@ -12,7 +12,7 @@ module M_256__u8_safe [#"256.rs" 3 0 3 21]
     [ bb0 = s0
       [ s0 = UInt8.add {u'0} {[%#s256] (0: UInt8.t)} (fun (_ret:UInt8.t) ->  [ &_2 <- _ret ] s1) | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & u'0: UInt8.t = u | & _2: UInt8.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & u'0: UInt8.t = u | & _2: UInt8.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -46,7 +46,7 @@ module M_256__bug_256 [#"256.rs" 8 0 8 26]
   
   meta "select_lsinst" "all"
   
-  let rec bug_256[#"256.rs" 8 0 8 26] (_x:t_String) (return'  (x:()))= (! bb0 [ bb0 = bb1 | bb1 = return''0 {_0} ] )
+  let rec bug_256[#"256.rs" 8 0 8 26] (_x:t_String) (return'  (x:()))= (! bb0 [ bb0 = bb1 | bb1 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/258.coma
+++ b/tests/should_succeed/bug/258.coma
@@ -6,9 +6,9 @@ module M_258__err [#"258.rs" 3 0 3 22]
   
   meta "select_lsinst" "all"
   
-  let rec err[#"258.rs" 3 0 3 22] (_to:UInt64.t) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec err[#"258.rs" 3 0 3 22] (_to:UInt64.t) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_258__err2 [#"258.rs" 5 0 5 24]
   use creusot.int.UInt64
@@ -18,7 +18,7 @@ module M_258__err2 [#"258.rs" 5 0 5 24]
   
   meta "select_lsinst" "all"
   
-  let rec err2[#"258.rs" 5 0 5 24] (_bbb:UInt64.t) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec err2[#"258.rs" 5 0 5 24] (_bbb:UInt64.t) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/271.coma
+++ b/tests/should_succeed/bug/271.coma
@@ -10,7 +10,7 @@ module M_271__ex [#"271.rs" 5 0 5 11]
   
   let rec ex[#"271.rs" 5 0 5 11] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &a <- [%#s271] (0: Int32.t) ] s1 | s1 = bb5 ]  | bb5 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & a: Int32.t = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & a: Int32.t = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_271__ex2 [#"271.rs" 13 0 13 12]
   let%span s271 = "271.rs" 14 12 14 13
@@ -28,7 +28,7 @@ module M_271__ex2 [#"271.rs" 13 0 13 12]
       | s1 = any [ br0 -> {a = (0: Int32.t)} (! bb6) | br1 -> {a = (1: Int32.t)} (! bb6) | default -> (! bb6) ]  ]
     
     | bb6 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & a: Int32.t = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & a: Int32.t = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_271__ex3 [#"271.rs" 22 0 22 12]
   let%span s271 = "271.rs" 23 12 23 13
@@ -51,5 +51,5 @@ module M_271__ex3 [#"271.rs" 22 0 22 12]
        ]
     
     | bb6 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & a: Int32.t = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & a: Int32.t = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/273.coma
+++ b/tests/should_succeed/bug/273.coma
@@ -26,7 +26,7 @@ module M_273__ex [#"273.rs" 4 0 4 11]
       [ s0 = v_Some {_1} (fun (r0:bool) ->  [ &b <- r0 ] s1) | s1 = {[@expl:assertion] [%#s273'0] b} s2 | s2 = bb4 ]
     
     | bb4 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _1: t_Option = Any.any_l () | & b: bool = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & _1: t_Option = Any.any_l () | & b: bool = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/387.coma
+++ b/tests/should_succeed/bug/387.coma
@@ -14,9 +14,9 @@ module M_387__use_tree [#"387.rs" 15 0 15 25]
   
   meta "select_lsinst" "all"
   
-  let rec use_tree[#"387.rs" 15 0 15 25] (_0:t_Tree) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0'0} ] )
+  let rec use_tree[#"387.rs" 15 0 15 25] (_0:t_Tree) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0'0} ] 
     [ & _0'0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_387__qyi16446429885017832241__height [#"387.rs" 18 4 18 31] (* Tree *)
   let%span s387 = "387.rs" 21 69 21 70
@@ -78,12 +78,12 @@ module M_387__qyi16446429885017832241__height [#"387.rs" 18 4 18 31] (* Tree *)
     
     | bb4 = s0 [ s0 =  [ &_0 <- [%#s387'0] (0: UInt64.t) ] s1 | s1 = bb8 ] 
     | bb8 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: t_Tree = self
     | & n: t_Node = Any.any_l ()
     | & _4: UInt64.t = Any.any_l ()
     | & _5: UInt64.t = Any.any_l ()
     | & _7: UInt64.t = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/395.coma
+++ b/tests/should_succeed/bug/395.coma
@@ -37,7 +37,7 @@ module M_395__signed_division [#"395.rs" 3 0 3 24]
     
     | bb3 = return''0 {_0}
     | bb4 = {[%#s395'3] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & y: Int32.t = Any.any_l ()
@@ -49,5 +49,5 @@ module M_395__signed_division [#"395.rs" 3 0 3 24]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/463.coma
+++ b/tests/should_succeed/bug/463.coma
@@ -18,12 +18,12 @@ module M_463__test [#"463.rs" 3 0 3 13]
       | s2 =  [ &_0 <- res ] s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & x'0: UInt64.t = x
     | & res: UInt64.t = Any.any_l ()
     | & res'0: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:closure ensures] [%#s463'3] UInt64.t'int result = UInt64.t'int x + 1}
       (! return' {result}) ]
   
@@ -40,7 +40,7 @@ module M_463__test [#"463.rs" 3 0 3 13]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:assertion] [%#s463'0] UInt64.t'int y = 3} s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l () | & c: () = Any.any_l () | & y: UInt64.t = Any.any_l () | & _4: UInt64.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/486.coma
+++ b/tests/should_succeed/bug/486.coma
@@ -30,7 +30,7 @@ module M_486__test [#"486.rs" 7 0 7 34]
         s2
       | s2 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_HasMutRef = x ] 
+     [ & _0: () = Any.any_l () | & x'0: t_HasMutRef = x ] )
     [ return''0 (result:())-> {[@expl:test ensures] [%#s486'0] UInt32.t'int (x.t_HasMutRef__0).final = 5}
       (! return' {result}) ]
 

--- a/tests/should_succeed/bug/510.coma
+++ b/tests/should_succeed/bug/510.coma
@@ -8,7 +8,7 @@ module M_510__test_bool [#"510.rs" 3 0 3 27]
   
   let rec test_bool[#"510.rs" 3 0 3 27] (inp:bool) (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_bing <- UInt8.of_bool inp'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & inp'0: bool = inp | & _bing: UInt8.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & inp'0: bool = inp | & _bing: UInt8.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -28,5 +28,5 @@ module M_510__test_char [#"510.rs" 7 0 7 18]
       [ s0 = Char.of_int {UInt8.t'int ([%#s510] (22: UInt8.t))} (fun (_ret_from:Char.t) ->  [ &_1 <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & _1: Char.t = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & _1: Char.t = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/511.coma
+++ b/tests/should_succeed/bug/511.coma
@@ -12,7 +12,7 @@ module M_511__test_u8 [#"511.rs" 5 0 5 23]
       [ s0 = UInt64.of_int {UInt8.t'int inp'0} (fun (_ret_from:UInt64.t) ->  [ &_bing <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & inp'0: UInt8.t = inp | & _bing: UInt64.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & inp'0: UInt8.t = inp | & _bing: UInt64.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -30,7 +30,7 @@ module M_511__test_u16 [#"511.rs" 9 0 9 25]
       [ s0 = UInt64.of_int {UInt16.t'int inp'0} (fun (_ret_from:UInt64.t) ->  [ &_bing <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & inp'0: UInt16.t = inp | & _bing: UInt64.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & inp'0: UInt16.t = inp | & _bing: UInt64.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -48,7 +48,7 @@ module M_511__test_u128 [#"511.rs" 13 0 13 27]
       [ s0 = UInt64.of_int {UInt128.t'int inp'0} (fun (_ret_from:UInt64.t) ->  [ &_bing <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & inp'0: UInt128.t = inp | & _bing: UInt64.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & inp'0: UInt128.t = inp | & _bing: UInt64.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -66,7 +66,7 @@ module M_511__test_i8 [#"511.rs" 17 0 17 23]
       [ s0 = UInt64.of_int {Int8.to_int inp'0} (fun (_ret_from:UInt64.t) ->  [ &_bing <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & inp'0: Int8.t = inp | & _bing: UInt64.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & inp'0: Int8.t = inp | & _bing: UInt64.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -84,7 +84,7 @@ module M_511__test_i16 [#"511.rs" 21 0 21 25]
       [ s0 = UInt64.of_int {Int16.to_int inp'0} (fun (_ret_from:UInt64.t) ->  [ &_bing <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & inp'0: Int16.t = inp | & _bing: UInt64.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & inp'0: Int16.t = inp | & _bing: UInt64.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -102,7 +102,7 @@ module M_511__test_i128 [#"511.rs" 25 0 25 27]
       [ s0 = UInt64.of_int {Int128.to_int inp'0} (fun (_ret_from:UInt64.t) ->  [ &_bing <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & inp'0: Int128.t = inp | & _bing: UInt64.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & inp'0: Int128.t = inp | & _bing: UInt64.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/528.coma
+++ b/tests/should_succeed/bug/528.coma
@@ -7,7 +7,7 @@ module M_528__neq [#"528.rs" 3 0 3 36]
   
   let rec neq[#"528.rs" 3 0 3 36] (a:bool) (b:bool) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- a'0 <> b'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & a'0: bool = a | & b'0: bool = b ] 
+     [ & _0: bool = Any.any_l () | & a'0: bool = a | & b'0: bool = b ] )
     [ return''0 (result:bool)-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/545.coma
+++ b/tests/should_succeed/bug/545.coma
@@ -10,5 +10,5 @@ module M_545__negative_is_negative [#"545.rs" 4 0 4 29]
   
   let rec negative_is_negative[#"545.rs" 4 0 4 29] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = {[@expl:assertion] [%#s545] 0 > - 100} s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/552.coma
+++ b/tests/should_succeed/bug/552.coma
@@ -28,7 +28,7 @@ module M_552__qyi3871915588092409085__step [#"552.rs" 23 4 23 30] (* <Machine as
     (! bb0
     [ bb0 = s0 [ s0 = transition {self'0.current} (fun (_ret:()) ->  [ &_4 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = -{resolve'0 self'0}- s1 | s1 =  [ &_0 <- [%#s552] false ] s2 | s2 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & self'0: MutBorrow.t () = self | & _4: () = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () | & self'0: MutBorrow.t () = self | & _4: () = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:step ensures] [%#s552'0] invariants self.final} (! return' {result}) ]
 
 end
@@ -46,7 +46,7 @@ module M_552__qyi8357961562374244852__transition [#"552.rs" 31 4 31 42] (* Machi
   meta "select_lsinst" "all"
   
   let rec transition[#"552.rs" 31 4 31 42] (self:()) (return'  (x:()))= {[@expl:transition requires] [%#s552] invariants self}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- () ] s1 | s1 = return''0 {_0} ]  ] ) [ & _0: () = Any.any_l () ] 
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- () ] s1 | s1 = return''0 {_0} ]  ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/570.coma
+++ b/tests/should_succeed/bug/570.coma
@@ -12,9 +12,9 @@ module M_570__test_program [#"570.rs" 12 0 12 26]
   
   meta "select_lsinst" "all"
   
-  let rec test_program[#"570.rs" 12 0 12 26] (s:t_S2) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec test_program[#"570.rs" 12 0 12 26] (s:t_S2) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () | & s'0: t_S2 = s ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_570__test_assign [#"570.rs" 16 0 16 29]
   let%span s570 = "570.rs" 17 13 17 14
@@ -34,5 +34,5 @@ module M_570__test_assign [#"570.rs" 16 0 16 29]
   
   let rec test_assign[#"570.rs" 16 0 16 29] (s:t_S2) (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &s'0 <- { t_S2__s1 = { t_S1__f = ([%#s570] (2: Int32.t)) } } ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & s'0: t_S2 = s ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & s'0: t_S2 = s ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/594.coma
+++ b/tests/should_succeed/bug/594.coma
@@ -13,7 +13,7 @@ module M_594__test_program [#"594.rs" 11 0 11 46]
   
   let rec test_program[#"594.rs" 11 0 11 46] (_0:tuple) (return'  (x:UInt32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &x <- _1._p0 ] s1 | s1 =  [ &_0'0 <- x ] s2 | s2 = return''0 {_0'0} ]  ]
-    ) [ & _0'0: UInt32.t = Any.any_l () | & _1: tuple = _0 | & x: UInt32.t = Any.any_l () ] 
+     [ & _0'0: UInt32.t = Any.any_l () | & _1: tuple = _0 | & x: UInt32.t = Any.any_l () ] )
     [ return''0 (result:UInt32.t)-> {[@expl:test_program ensures] [%#s594] let {_p0 = x} = _0 in result = x}
       (! return' {result}) ]
 
@@ -41,13 +41,13 @@ module M_594__test_closure [#"594.rs" 15 0 15 21]
       | s3 =  [ &_0 <- res ] s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & _3: tuple = _1
     | & _a: Int32.t = Any.any_l ()
     | & b: Int32.t = Any.any_l ()
     | & res: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:closure ensures] [%#s594'4] let {_p0 = _a ; _p1 = b} = _1 in result = b}
       (! return' {result}) ]
   
@@ -60,13 +60,13 @@ module M_594__test_closure [#"594.rs" 15 0 15 21]
       | s3 =  [ &_0'0 <- res ] s4
       | s4 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: Int32.t = Any.any_l ()
     | & _2: tuple = _0
     | & _a: Int32.t = Any.any_l ()
     | & b: Int32.t = Any.any_l ()
     | & res: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:closure ensures] [%#s594'5] let {_p0 = _a ; _p1 = b} = _0 in result = b}
       (! return' {result}) ]
   
@@ -94,7 +94,7 @@ module M_594__test_closure [#"594.rs" 15 0 15 21]
       | s3 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & cl1: () = Any.any_l ()
     | & cl2: () = Any.any_l ()
@@ -104,7 +104,7 @@ module M_594__test_closure [#"594.rs" 15 0 15 21]
     | & _b: Int32.t = Any.any_l ()
     | & _9: tuple = Any.any_l ()
     | & _10: tuple = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_594__qyi1704796797730763899__test_method [#"594.rs" 33 4 33 55] (* T *)
   let%span s594 = "594.rs" 32 14 32 25
@@ -124,7 +124,7 @@ module M_594__qyi1704796797730763899__test_method [#"594.rs" 33 4 33 55] (* T *)
   
   let rec test_method[#"594.rs" 33 4 33 55] (self:t_T) (_1:tuple) (return'  (x:UInt32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &x <- _2._p0 ] s1 | s1 =  [ &_0 <- x ] s2 | s2 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32.t = Any.any_l () | & _2: tuple = _1 | & x: UInt32.t = Any.any_l () ] 
+     [ & _0: UInt32.t = Any.any_l () | & _2: tuple = _1 | & x: UInt32.t = Any.any_l () ] )
     [ return''0 (result:UInt32.t)-> {[@expl:test_method ensures] [%#s594] let {_p0 = x} = _1 in result = x}
       (! return' {result}) ]
 

--- a/tests/should_succeed/bug/641.coma
+++ b/tests/should_succeed/bug/641.coma
@@ -12,7 +12,7 @@ module M_641__test_maintains [#"641.rs" 16 0 16 23]
   meta "select_lsinst" "all"
   
   let rec test_maintains[#"641.rs" 16 0 16 23] (return'  (x:()))= {[@expl:test_maintains requires] [%#s641] test}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:test_maintains ensures] [%#s641] test} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/653.coma
+++ b/tests/should_succeed/bug/653.coma
@@ -11,7 +11,7 @@ module M_653__omg [#"653.rs" 8 0 8 29]
   
   let rec omg[#"653.rs" 8 0 8 29] (n:UInt64.t) (return'  (x:UInt64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- n'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] 
+     [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] )
     [ return''0 (result:UInt64.t)-> {[@expl:omg ensures] [%#s653] UInt64.t'int result
       = Int.div (UInt64.t'int n * (UInt64.t'int n + 1)) 2}
       (! return' {result}) ]

--- a/tests/should_succeed/bug/682.coma
+++ b/tests/should_succeed/bug/682.coma
@@ -91,7 +91,7 @@ module M_682__add_some [#"682.rs" 6 0 6 24]
       | s1 = -{resolve'0 a'0}- s2
       | s2 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & a'0: MutBorrow.t UInt64.t = a ] 
+     [ & _0: () = Any.any_l () | & a'0: MutBorrow.t UInt64.t = a ] )
     [ return''0 (result:())-> {[@expl:add_some ensures] [%#s682'1] UInt64.gt a.final a.current} (! return' {result}) ]
 
 end
@@ -201,11 +201,11 @@ module M_682__foo [#"682.rs" 12 0 12 23]
       | s1 = {[@expl:assertion] [%#s682'0] UInt64.gt a'0.current a_p} s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: MutBorrow.t UInt64.t = a
     | & a_p: UInt64.t = Any.any_l ()
     | & _6: () = Any.any_l ()
     | & _7: MutBorrow.t UInt64.t = Any.any_l () ]
-     [ return''0 (result:())-> {[@expl:foo ensures] [%#s682'2] UInt64.gt a.final a.current} (! return' {result}) ] 
+    ) [ return''0 (result:())-> {[@expl:foo ensures] [%#s682'2] UInt64.gt a.final a.current} (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/691.coma
+++ b/tests/should_succeed/bug/691.coma
@@ -13,5 +13,5 @@ module M_691__example [#"691.rs" 8 0 8 16]
   
   let rec example[#"691.rs" 8 0 8 16] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &c <- { t_Foo__bar = ([%#s691] (2: UInt32.t)) } ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & c: t_Foo = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & c: t_Foo = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/693.coma
+++ b/tests/should_succeed/bug/693.coma
@@ -15,7 +15,7 @@ module M_693__f [#"693.rs" 3 0 3 21]
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv _1} s1 | s1 = -{resolve _1}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0'0} ]
-    ) [ & _0'0: () = Any.any_l () | & _1: t_IfC = _0 ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0'0: () = Any.any_l () | & _1: t_IfC = _0 ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_693__g [#"693.rs" 5 0 5 10]
   let%span s693 = "693.rs" 6 6 6 7
@@ -32,5 +32,5 @@ module M_693__g [#"693.rs" 5 0 5 10]
   let rec g[#"693.rs" 5 0 5 10] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = f {[%#s693] (0: Int32.t)} (fun (_ret:()) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/761.coma
+++ b/tests/should_succeed/bug/761.coma
@@ -92,13 +92,13 @@ module M_761__try_option [#"761.rs" 5 0 5 47]
     | bb4 = s0 [ s0 = v_Continue {_4} (fun (r0:t_T) ->  [ &val' <- r0 ] s1) | s1 = bb7 ] 
     | bb7 = s0 [ s0 =  [ &_0 <- C_Some'0 val' ] s1 | s1 = bb11 ] 
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & x'0: t_Option'0 = x
     | & _4: t_ControlFlow = Any.any_l ()
     | & residual: t_Option = Any.any_l ()
     | & val': t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:try_option result type invariant] [%#s761'0] inv'0 result}
       {[@expl:try_option ensures] [%#s761'1] result = x}
       (! return' {result}) ]
@@ -275,13 +275,13 @@ module M_761__try_result [#"761.rs" 10 0 10 56]
     | bb4 = s0 [ s0 = v_Continue {_4} (fun (r0:t_T) ->  [ &val' <- r0 ] s1) | s1 = bb7 ] 
     | bb7 = s0 [ s0 =  [ &_0 <- C_Ok'0 val' ] s1 | s1 = bb12 ] 
     | bb12 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Result'0 = Any.any_l ()
     | & x'0: t_Result'0 = x
     | & _4: t_ControlFlow = Any.any_l ()
     | & residual: t_Result = Any.any_l ()
     | & val': t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Result'0)-> {[@expl:try_result result type invariant] [%#s761'0] inv'1 result}
       {[@expl:try_result ensures] [%#s761'1] result = x}
       (! return' {result}) ]

--- a/tests/should_succeed/bug/766.coma
+++ b/tests/should_succeed/bug/766.coma
@@ -74,7 +74,7 @@ module M_766__Trait__goo [#"766.rs" 10 4 10 21]
       | s2 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'0 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & self'0: MutBorrow.t t_Self = self | & _2: MutBorrow.t t_Self = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & self'0: MutBorrow.t t_Self = self | & _2: MutBorrow.t t_Self = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/789.coma
+++ b/tests/should_succeed/bug/789.coma
@@ -6,7 +6,7 @@ module M_789__meta [#"789.rs" 3 0 3 22]
   
   meta "select_lsinst" "all"
   
-  let rec meta'[#"789.rs" 3 0 3 22] (_x:UInt64.t) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec meta'[#"789.rs" 3 0 3 22] (_x:UInt64.t) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/791.coma
+++ b/tests/should_succeed/bug/791.coma
@@ -5,7 +5,7 @@ module M_791__i_love_floats [#"791.rs" 3 0 3 22]
   
   meta "select_lsinst" "all"
   
-  let rec i_love_floats[#"791.rs" 3 0 3 22] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec i_love_floats[#"791.rs" 3 0 3 22] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/793.coma
+++ b/tests/should_succeed/bug/793.coma
@@ -14,5 +14,5 @@ module M_793__div_err [#"793.rs" 5 0 5 30]
   
   let rec div_err[#"793.rs" 5 0 5 30] (f:Float64.t) (x:UInt32.t) (return'  (x'0:()))= {[@expl:div_err requires] [%#s793] UInt32.t'int x
     < Int.div (UInt32.t'int v_MAX) 1}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/874.coma
+++ b/tests/should_succeed/bug/874.coma
@@ -257,7 +257,7 @@ module M_874__can_extend [#"874.rs" 4 0 4 19]
     | bb9 = s0 [ s0 = into_vec {_15} (fun (_ret:t_Vec) ->  [ &z <- _ret ] s1) | s1 = bb10 ] 
     | bb10 = s0 [ s0 = {[@expl:assertion] [%#s874'11] Seq.(==) (view z) (view v)} s1 | s1 = bb13 ] 
     | bb13 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v: t_Vec = Any.any_l ()
     | & _4: Slice64.array Int32.t = Any.any_l ()
@@ -267,5 +267,5 @@ module M_874__can_extend [#"874.rs" 4 0 4 19]
     | & _10: MutBorrow.t t_Vec = Any.any_l ()
     | & z: t_Vec = Any.any_l ()
     | & _15: Slice64.array Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/922.coma
+++ b/tests/should_succeed/bug/922.coma
@@ -54,12 +54,12 @@ module M_922__g [#"922.rs" 5 0 5 57]
       | s5 = -{resolve'5 x'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t Int32.t = Any.any_l ()
     | & x'0: tuple'0 = x
     | & _2: MutBorrow.t Int32.t = Any.any_l ()
     | & _4: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t Int32.t)-> {[@expl:g ensures] [%#s922] result = (x._p0'0)._p1}
       (! return' {result}) ]
 
@@ -111,12 +111,12 @@ module M_922__f1 [#"922.rs" 12 0 12 59]
       | s5 = -{resolve'2 b'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t Int32.t = Any.any_l ()
     | & b'0: MutBorrow.t tuple = b
     | & _2: MutBorrow.t Int32.t = Any.any_l ()
     | & _6: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t Int32.t)-> {[@expl:f1 ensures #0] [%#s922] result.current
       = ((b.current)._p1).current}
       {[@expl:f1 ensures #1] [%#s922'0] result.final = ((b.final)._p1).current}
@@ -171,12 +171,12 @@ module M_922__f2 [#"922.rs" 19 0 19 60]
       | s5 = -{resolve'2 x0'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t Int32.t = Any.any_l ()
     | & x0'0: MutBorrow.t tuple = x0
     | & _2: MutBorrow.t Int32.t = Any.any_l ()
     | & _6: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t Int32.t)-> {[@expl:f2 ensures #0] [%#s922] result.current
       = ((x0.current)._p1).current}
       {[@expl:f2 ensures #1] [%#s922'0] result.final = ((x0.final)._p1).current}
@@ -231,12 +231,12 @@ module M_922__f3 [#"922.rs" 26 0 26 60]
       | s5 = -{resolve'2 x1'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t Int32.t = Any.any_l ()
     | & x1'0: MutBorrow.t tuple = x1
     | & _2: MutBorrow.t Int32.t = Any.any_l ()
     | & _6: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t Int32.t)-> {[@expl:f3 ensures #0] [%#s922] result.current
       = ((x1.current)._p1).current}
       {[@expl:f3 ensures #1] [%#s922'0] result.final = ((x1.final)._p1).current}
@@ -291,12 +291,12 @@ module M_922__f4 [#"922.rs" 33 0 33 60]
       | s5 = -{resolve'2 x2'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t Int32.t = Any.any_l ()
     | & x2'0: MutBorrow.t tuple = x2
     | & _2: MutBorrow.t Int32.t = Any.any_l ()
     | & _6: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t Int32.t)-> {[@expl:f4 ensures #0] [%#s922] result.current
       = ((x2.current)._p1).current}
       {[@expl:f4 ensures #1] [%#s922'0] result.final = ((x2.final)._p1).current}

--- a/tests/should_succeed/bug/991.coma
+++ b/tests/should_succeed/bug/991.coma
@@ -50,9 +50,9 @@ module M_991__qyi6256438357931963096__love_and_hope [#"991.rs" 22 4 22 27] (* Fo
   
   meta "select_lsinst" "all"
   
-  let rec love_and_hope[#"991.rs" 22 4 22 27] (self:t_Formula) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec love_and_hope[#"991.rs" 22 4 22 27] (self:t_Formula) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:love_and_hope ensures] [%#s991] view'1 self = view'1 self} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/box_borrow_resolve.coma
+++ b/tests/should_succeed/bug/box_borrow_resolve.coma
@@ -37,12 +37,12 @@ module M_box_borrow_resolve__borrow_in_box [#"box_borrow_resolve.rs" 6 0 6 50]
       | s6 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    )
+    
     [ & _0: MutBorrow.t Int32.t = Any.any_l ()
     | & x'0: MutBorrow.t Int32.t = x
     | & _2: MutBorrow.t Int32.t = Any.any_l ()
     | & _4: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t Int32.t)-> {[@expl:borrow_in_box ensures] [%#sbox_borrow_resolve] result = x}
       (! return' {result}) ]
 

--- a/tests/should_succeed/bug/eq_panic.coma
+++ b/tests/should_succeed/bug/eq_panic.coma
@@ -51,7 +51,7 @@ module M_eq_panic__omg [#"eq_panic.rs" 6 0 6 51]
     {[@expl:omg 'y' type invariant] [%#seq_panic'0] inv'0 y}
     (! bb0
     [ bb0 = s0 [ s0 = eq {x'0} {y'0} (fun (_ret:bool) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & x'0: t_T = x | & y'0: t_T = y ] 
+     [ & _0: bool = Any.any_l () | & x'0: t_T = x | & y'0: t_T = y ] )
     [ return''0 (result:bool)-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/final_borrows.coma
+++ b/tests/should_succeed/bug/final_borrows.coma
@@ -52,7 +52,7 @@ module M_final_borrows__reborrow_id [#"final_borrows.rs" 5 0 5 42]
       | s5 = -{resolve'0 r'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    ) [ & _0: MutBorrow.t t_T = Any.any_l () | & r'0: MutBorrow.t t_T = r | & _2: MutBorrow.t t_T = Any.any_l () ] 
+     [ & _0: MutBorrow.t t_T = Any.any_l () | & r'0: MutBorrow.t t_T = r | & _2: MutBorrow.t t_T = Any.any_l () ] )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:reborrow_id result type invariant] [%#sfinal_borrows'0] inv'0 result}
       {[@expl:reborrow_id ensures] [%#sfinal_borrows'1] result = r}
       (! return' {result}) ]
@@ -152,7 +152,7 @@ module M_final_borrows__select [#"final_borrows.rs" 10 0 10 72]
       | s9 = -{resolve'0 r1'0}- s10
       | s10 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & b'0: bool = b
     | & r1'0: MutBorrow.t t_T = r1
@@ -160,7 +160,7 @@ module M_final_borrows__select [#"final_borrows.rs" 10 0 10 72]
     | & _4: MutBorrow.t t_T = Any.any_l ()
     | & _6: MutBorrow.t t_T = Any.any_l ()
     | & _8: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:select result type invariant] [%#sfinal_borrows'1] inv'0 result}
       {[@expl:select ensures] [%#sfinal_borrows'2] if b then result = r1 else result = r2}
       (! return' {result}) ]
@@ -249,12 +249,12 @@ module M_final_borrows__reborrow_field [#"final_borrows.rs" 15 0 15 50]
       | s8 = -{resolve'2 r'0}- s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & r'0: MutBorrow.t tuple = r
     | & _2: MutBorrow.t t_T = Any.any_l ()
     | & _4: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:reborrow_field result type invariant] [%#sfinal_borrows'0] inv'0 result}
       {[@expl:reborrow_field ensures] [%#sfinal_borrows'1] result
       = MutBorrow.borrow_logic (r.current)._p0 (r.final)._p0 (MutBorrow.inherit_id (MutBorrow.get_id r) 1)}
@@ -361,14 +361,14 @@ module M_final_borrows__disjoint_fields [#"final_borrows.rs" 21 0 21 61]
       | s10 = -{resolve'2 r'0}- s11
       | s11 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: tuple'0 = Any.any_l ()
     | & r'0: MutBorrow.t tuple = r
     | & r0: MutBorrow.t t_T = Any.any_l ()
     | & r1: MutBorrow.t t_T = Any.any_l ()
     | & _6: MutBorrow.t t_T = Any.any_l ()
     | & _7: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:tuple'0)-> {[@expl:disjoint_fields result type invariant] [%#sfinal_borrows'0] inv'3 result}
       {[@expl:disjoint_fields ensures #0] [%#sfinal_borrows'1] result._p0'0
       = MutBorrow.borrow_logic (r.current)._p0 (r.final)._p0 (MutBorrow.inherit_id (MutBorrow.get_id r) 1)}
@@ -490,13 +490,13 @@ module M_final_borrows__nested_fields [#"final_borrows.rs" 28 0 28 54]
       | s11 = -{resolve'4 r'0}- s12
       | s12 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & r'0: MutBorrow.t tuple'0 = r
     | & _2: MutBorrow.t t_T = Any.any_l ()
     | & borrow1: MutBorrow.t tuple = Any.any_l ()
     | & _5: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:nested_fields result type invariant] [%#sfinal_borrows'0] inv'2 result}
       {[@expl:nested_fields ensures] [%#sfinal_borrows'1] result
       = MutBorrow.borrow_logic ((r.current)._p0'0)._p1 ((r.final)._p0'0)._p1 (MutBorrow.inherit_id (MutBorrow.inherit_id (MutBorrow.get_id r) 1) 2)}
@@ -606,12 +606,12 @@ module M_final_borrows__really_nested_fields [#"final_borrows.rs" 34 0 34 61]
       | s9 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & x'0: tuple'0 = x
     | & _2: MutBorrow.t t_T = Any.any_l ()
     | & borrow: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:really_nested_fields result type invariant] [%#sfinal_borrows'0] inv'0 result}
       {[@expl:really_nested_fields ensures] [%#sfinal_borrows'1] result
       = MutBorrow.borrow_logic ((x._p0'0).current)._p1 ((x._p0'0).final)._p1 (MutBorrow.inherit_id (MutBorrow.get_id x._p0'0) 2)}
@@ -756,13 +756,13 @@ module M_final_borrows__select_field [#"final_borrows.rs" 43 0 43 56]
       | s4 = bb5 ]
     
     | bb5 = s0 [ s0 = {[@expl:type invariant] inv'4 x'0} s1 | s1 = -{resolve'4 x'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & x'0: MutBorrow.t tuple = x
     | & _4: MutBorrow.t t_Option = Any.any_l ()
     | & r: MutBorrow.t t_T = Any.any_l ()
     | & _8: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:select_field result type invariant] [%#sfinal_borrows'0] inv'1 result}
       {[@expl:select_field ensures] [%#sfinal_borrows'1] match (x.current)._p0 with
         | C_None -> result
@@ -798,7 +798,7 @@ module M_final_borrows__set_7 [#"final_borrows.rs" 52 0 52 21]
       | s1 = -{resolve'0 r'0}- s2
       | s2 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & r'0: MutBorrow.t Int32.t = r ] 
+     [ & _0: () = Any.any_l () | & r'0: MutBorrow.t Int32.t = r ] )
     [ return''0 (result:())-> {[@expl:set_7 ensures] [%#sfinal_borrows'0] Int32.to_int r.final = 7}
       (! return' {result}) ]
 
@@ -848,7 +848,7 @@ module M_final_borrows__not_final_borrow_works [#"final_borrows.rs" 57 0 57 38]
       | s4 = Int32.add {x} {y} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s5)
       | s5 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & r: MutBorrow.t Int32.t = Any.any_l ()
@@ -856,7 +856,7 @@ module M_final_borrows__not_final_borrow_works [#"final_borrows.rs" 57 0 57 38]
     | & _6: () = Any.any_l ()
     | & _7: MutBorrow.t Int32.t = Any.any_l ()
     | & y: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:not_final_borrow_works ensures] [%#sfinal_borrows'1] Int32.to_int result = 9}
       (! return' {result}) ]
 
@@ -912,7 +912,7 @@ module M_final_borrows__branching [#"final_borrows.rs" 68 0 68 32]
       | s4 = bb3 ]
     
     | bb3 = s0 [ s0 =  [ &_0 <- y ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & b'0: bool = b
     | & x: Int32.t = Any.any_l ()
@@ -922,7 +922,7 @@ module M_final_borrows__branching [#"final_borrows.rs" 68 0 68 32]
     | & _10: MutBorrow.t Int32.t = Any.any_l ()
     | & _11: MutBorrow.t Int32.t = Any.any_l ()
     | & r2'0: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:branching ensures] [%#sfinal_borrows'0] Int32.to_int result = 3}
       (! return' {result}) ]
 
@@ -1004,12 +1004,12 @@ module M_final_borrows__unnesting_non_extensional [#"final_borrows.rs" 89 0 89 8
       | s8 = -{resolve'2 x'0}- s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & x'0: MutBorrow.t (MutBorrow.t t_T) = x
     | & _2: MutBorrow.t t_T = Any.any_l ()
     | & _5: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:unnesting_non_extensional result type invariant] [%#sfinal_borrows'0] inv'0 result}
       {[@expl:unnesting_non_extensional ensures #0] [%#sfinal_borrows'1] result.current = (x.current).current}
       {[@expl:unnesting_non_extensional ensures #1] [%#sfinal_borrows'2] result.final = (x.final).current}
@@ -1120,7 +1120,7 @@ module M_final_borrows__write_inner_borrow [#"final_borrows.rs" 93 0 93 75]
     
     | bb4 = s0 [ s0 = {[@expl:assertion] [%#sfinal_borrows'0] r = snap} s1 | s1 = bb5 ] 
     | bb5 = s0 [ s0 = {[@expl:type invariant] inv'0 b'0} s1 | s1 = -{resolve'0 b'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t (MutBorrow.t t_T) = x
     | & b'0: MutBorrow.t t_T = b
@@ -1128,7 +1128,7 @@ module M_final_borrows__write_inner_borrow [#"final_borrows.rs" 93 0 93 75]
     | & r: MutBorrow.t t_T = Any.any_l ()
     | & snap: MutBorrow.t t_T = Any.any_l ()
     | & _7: MutBorrow.t t_T = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_final_borrows__box_deref [#"final_borrows.rs" 106 0 106 35]
   let%span sfinal_borrows = "final_borrows.rs" 106 20 106 21
@@ -1154,9 +1154,9 @@ module M_final_borrows__box_deref [#"final_borrows.rs" 106 0 106 35]
   meta "select_lsinst" "all"
   
   let rec box_deref[#"final_borrows.rs" 106 0 106 35] (x:t_T) (return'  (x'0:t_T))= {[@expl:box_deref 'x' type invariant] [%#sfinal_borrows] inv'0 x}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- x'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- x'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ] 
     [ & _0: t_T = Any.any_l () | & x'0: t_T = x ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:box_deref result type invariant] [%#sfinal_borrows'0] inv result}
       {[@expl:box_deref ensures] [%#sfinal_borrows'1] result = x}
       (! return' {result}) ]
@@ -1233,12 +1233,12 @@ module M_final_borrows__box_reborrow_direct [#"final_borrows.rs" 111 0 111 44]
       | s9 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: t_T = x
     | & borrow: MutBorrow.t t_T = Any.any_l ()
     | & _4: MutBorrow.t t_T = Any.any_l () ]
-     [ return''0 (result:())-> {[@expl:box_reborrow_direct ensures] [%#sfinal_borrows'1] true} (! return' {result}) ] 
+    ) [ return''0 (result:())-> {[@expl:box_reborrow_direct ensures] [%#sfinal_borrows'1] true} (! return' {result}) ] 
 end
 module M_final_borrows__box_reborrow_indirect [#"final_borrows.rs" 119 0 119 58]
   let%span sfinal_borrows = "final_borrows.rs" 119 38 119 39
@@ -1318,12 +1318,12 @@ module M_final_borrows__box_reborrow_indirect [#"final_borrows.rs" 119 0 119 58]
       | s8 = -{resolve'2 x'0}- s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_T = Any.any_l ()
     | & x'0: MutBorrow.t t_T = x
     | & borrow: MutBorrow.t t_T = Any.any_l ()
     | & _4: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:box_reborrow_indirect result type invariant] [%#sfinal_borrows'0] inv result}
       {[@expl:box_reborrow_indirect ensures] [%#sfinal_borrows'1] result = x.current}
       (! return' {result}) ]
@@ -1376,12 +1376,12 @@ module M_final_borrows__box_reborrow_in_struct [#"final_borrows.rs" 126 0 126 66
       | s5 = -{resolve'2 x'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & x'0: MutBorrow.t tuple = x
     | & borrow: MutBorrow.t Int32.t = Any.any_l ()
     | & _5: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:box_reborrow_in_struct ensures] [%#sfinal_borrows'0] Int32.to_int result = 3}
       (! return' {result}) ]
 
@@ -1465,12 +1465,12 @@ module M_final_borrows__borrow_in_box [#"final_borrows.rs" 132 0 132 49]
       | s9 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & x'0: MutBorrow.t t_T = x
     | & _2: MutBorrow.t t_T = Any.any_l ()
     | & _4: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:borrow_in_box result type invariant] [%#sfinal_borrows'0] inv'0 result}
       {[@expl:borrow_in_box ensures] [%#sfinal_borrows'1] result = x}
       (! return' {result}) ]
@@ -1533,12 +1533,12 @@ module M_final_borrows__borrow_in_box_tuple_1 [#"final_borrows.rs" 138 0 138 60]
       | s6 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & x'0: tuple = x
     | & borrow: MutBorrow.t Int32.t = Any.any_l ()
     | & _5: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:borrow_in_box_tuple_1 ensures] [%#sfinal_borrows'0] Int32.to_int result = 2}
       (! return' {result}) ]
 
@@ -1600,12 +1600,12 @@ module M_final_borrows__borrow_in_box_tuple_2 [#"final_borrows.rs" 145 0 145 60]
       | s6 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & x'0: tuple = x
     | & borrow: MutBorrow.t Int32.t = Any.any_l ()
     | & _5: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:borrow_in_box_tuple_2 ensures] [%#sfinal_borrows'0] Int32.to_int result = 2}
       (! return' {result}) ]
 
@@ -1694,12 +1694,12 @@ module M_final_borrows__reborrow_in_box [#"final_borrows.rs" 151 0 151 51]
       | s8 = -{resolve'2 x'0}- s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & x'0: MutBorrow.t t_T = x
     | & _2: MutBorrow.t t_T = Any.any_l ()
     | & _4: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:reborrow_in_box result type invariant] [%#sfinal_borrows'0] inv'0 result}
       {[@expl:reborrow_in_box ensures] [%#sfinal_borrows'1] result
       = MutBorrow.borrow_logic x.current x.final (MutBorrow.get_id x)}
@@ -1754,12 +1754,12 @@ module M_final_borrows__shared_borrow_no_gen [#"final_borrows.rs" 166 0 166 43]
       | s6 = {[@expl:assertion] [%#sfinal_borrows] b1 = bor'0} s7
       | s7 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & bor'0: MutBorrow.t t_T = bor
     | & b1: MutBorrow.t t_T = Any.any_l ()
     | & _shared: MutBorrow.t t_T = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_final_borrows__inspect_no_gen [#"final_borrows.rs" 172 0 172 43]
   let%span sfinal_borrows = "final_borrows.rs" 178 18 178 24
@@ -1824,12 +1824,12 @@ module M_final_borrows__inspect_no_gen [#"final_borrows.rs" 172 0 172 43]
     | bb4 = any [ br0 -> {_4 = false} (! bb6) | br1 -> {_4} (! bb7) ] 
     | bb6 = s0 [ s0 = {[@expl:assertion] [%#sfinal_borrows] r = x'0} s1 | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t t_Option = x
     | & r: MutBorrow.t t_Option = Any.any_l ()
     | & _4: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_final_borrows__place_mention_no_gen [#"final_borrows.rs" 181 0 181 49]
   let%span sfinal_borrows = "final_borrows.rs" 184 18 184 25
@@ -1890,7 +1890,7 @@ module M_final_borrows__place_mention_no_gen [#"final_borrows.rs" 181 0 181 49]
       | s5 = {[@expl:assertion] [%#sfinal_borrows] _r = x'0} s6
       | s6 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & x'0: MutBorrow.t t_Option = x | & _r: MutBorrow.t t_Option = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x'0: MutBorrow.t t_Option = x | & _r: MutBorrow.t t_Option = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -1939,14 +1939,14 @@ module M_final_borrows__shallow_borrow_no_gen [#"final_borrows.rs" 187 0 187 49]
     | bb4 = s0 [ s0 = -{resolve'0 x'0}- s1 | s1 = {[@expl:assertion] [%#sfinal_borrows'0] _r = x'0} s2 | s2 = bb6 ] 
     | bb5 = s0 [ s0 = -{resolve'0 x'0}- s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t t_Option = x
     | & _r: MutBorrow.t t_Option = Any.any_l ()
     | & inner: Int32.t = Any.any_l ()
     | & inner'0: Int32.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_final_borrows__index_mut_slice [#"final_borrows.rs" 204 0 204 48]
   let%span sfinal_borrows = "final_borrows.rs" 205 11 205 13
@@ -2086,7 +2086,7 @@ module M_final_borrows__index_mut_slice [#"final_borrows.rs" 204 0 204 48]
       | s8 = -{resolve'2 v'0}- s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & v'0: MutBorrow.t (Slice64.slice t_T) = v
     | & _2: MutBorrow.t t_T = Any.any_l ()
@@ -2095,7 +2095,7 @@ module M_final_borrows__index_mut_slice [#"final_borrows.rs" 204 0 204 48]
     | & _7: Opaque.ptr = Any.any_l ()
     | & _8: UInt64.t = Any.any_l ()
     | & _9: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:index_mut_slice result type invariant] [%#sfinal_borrows'3] inv'0 result}
       {[@expl:index_mut_slice ensures] [%#sfinal_borrows'4] result
       = MutBorrow.borrow_logic (index_logic v.current 12) (index_logic v.final 12) (MutBorrow.inherit_id (MutBorrow.get_id v) 12)}
@@ -2226,14 +2226,14 @@ module M_final_borrows__index_mut_array [#"final_borrows.rs" 210 0 210 52]
       | s8 = -{resolve'2 v'0}- s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & v'0: MutBorrow.t (Slice64.array t_T) = v
     | & _2: MutBorrow.t t_T = Any.any_l ()
     | & _5: MutBorrow.t t_T = Any.any_l ()
     | & _6: UInt64.t = Any.any_l ()
     | & _7: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:index_mut_array result type invariant] [%#sfinal_borrows'3] inv'0 result}
       {[@expl:index_mut_array ensures] [%#sfinal_borrows'4] result
       = MutBorrow.borrow_logic (index_logic v.current (UInt64.t'int (12: UInt64.t))) (index_logic v.final (UInt64.t'int (12: UInt64.t))) (MutBorrow.inherit_id (MutBorrow.get_id v) (UInt64.t'int (12: UInt64.t)))}

--- a/tests/should_succeed/bug/minus_assoc.coma
+++ b/tests/should_succeed/bug/minus_assoc.coma
@@ -8,7 +8,7 @@ module M_minus_assoc__f [#"minus_assoc.rs" 6 0 6 10]
   
   meta "select_lsinst" "all"
   
-  let rec f[#"minus_assoc.rs" 6 0 6 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec f[#"minus_assoc.rs" 6 0 6 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> {[@expl:f ensures] [%#sminus_assoc] 0 - (1 - 1) = 0} (! return' {result}) ] 
+    ) [ return''0 (result:())-> {[@expl:f ensures] [%#sminus_assoc] 0 - (1 - 1) = 0} (! return' {result}) ] 
 end

--- a/tests/should_succeed/bug/nonreturning.coma
+++ b/tests/should_succeed/bug/nonreturning.coma
@@ -42,7 +42,7 @@ module M_nonreturning__g [#"nonreturning.rs" 11 0 11 17]
     [ bb0 = any [ br0 -> {b'0 = false} (! bb2) | br1 -> {b'0} (! bb1) ] 
     | bb1 = s0 [ s0 = f (fun (_ret:()) ->  [ &_5 <- _ret ] s1) | s1 = {[%#snonreturning] false} any ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & b'0: bool = b | & _5: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & b'0: bool = b | & _5: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:g ensures] [%#snonreturning'0] not b} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/bug/two_phase.coma
+++ b/tests/should_succeed/bug/two_phase.coma
@@ -75,13 +75,13 @@ module M_two_phase__test [#"two_phase.rs" 6 0 6 31]
       | s2 = bb2 ]
     
     | bb2 = s0 [ s0 = -{resolve'0 v'0}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & _3: () = Any.any_l ()
     | & _4: MutBorrow.t t_Vec = Any.any_l ()
     | & _5: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:test ensures] [%#stwo_phase] UInt64.t'int (index_logic v.final (Seq.length (view'1 v)))
       = Seq.length (view'1 v)}
       (! return' {result}) ]
@@ -251,10 +251,10 @@ module M_two_phase__qyi14099956410468907124__insert [#"two_phase.rs" 21 4 21 28]
       | s2 = bb2 ]
     
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv'6 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_VacantEntry = self
     | & _2: MutBorrow.t t_Vec = Any.any_l ()
     | & _4: t_K = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/cc/arithmetic.coma
+++ b/tests/should_succeed/cc/arithmetic.coma
@@ -17,5 +17,5 @@ module M_arithmetic__test [#"arithmetic.rs" 5 0 5 13]
       | s2 = {[@expl:assertion] [%#sarithmetic'1] UInt8BW.nth (42: UInt8BW.t) 1 = true} s3
       | s3 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/cc/array.coma
+++ b/tests/should_succeed/cc/array.coma
@@ -379,7 +379,7 @@ module M_array__test_array [#"array.rs" 3 0 3 19]
     | bb5 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_24 <- left_val ] s2 | s2 =  [ &_26 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: t_Iter = Any.any_l ()
     | & _6: tuple = Any.any_l ()
@@ -435,5 +435,5 @@ module M_array__test_array [#"array.rs" 3 0 3 19]
     | & _119: t_Option = Any.any_l ()
     | & _120: t_Option = Any.any_l ()
     | & _121: Slice64.array Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/cc/collections.coma
+++ b/tests/should_succeed/cc/collections.coma
@@ -339,14 +339,14 @@ module M_collections__roundtrip_hashmap_into_iter [#"collections.rs" 15 0 17 18]
       | s5 = bb7 ]
     
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: t_HashMap'0 = Any.any_l ()
     | & xs'0: t_HashMap'0 = xs
     | & xs_snap: t_HashMap'0 = Any.any_l ()
     | & it: t_IntoIter'0 = Any.any_l ()
     | & it0: t_IntoIter'0 = Any.any_l ()
     | & r: t_HashMap'0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_HashMap'0)-> {[@expl:roundtrip_hashmap_into_iter ensures] [%#scollections'5] view result
       = view xs}
       (! return' {result}) ]
@@ -587,13 +587,13 @@ module M_collections__roundtrip_hashmap_iter [#"collections.rs" 35 0 35 97]
       | s2 = bb4 ]
     
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: t_HashMap'2 = Any.any_l ()
     | & xs'0: t_HashMap'0 = xs
     | & it: t_Iter'0 = Any.any_l ()
     | & it0: t_Iter'0 = Any.any_l ()
     | & r: t_HashMap'2 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_HashMap'2)-> {[@expl:roundtrip_hashmap_iter ensures] [%#scollections'1] forall k: t_DeepModelTy, v: t_V. (get'0 (view'5 result) k
       = C_Some'0 v)
       = (get (view'0 xs) k = C_Some v)}
@@ -912,14 +912,14 @@ module M_collections__roundtrip_hashmap_iter_mut [#"collections.rs" 51 0 53 24]
       | s2 = bb4 ]
     
     | bb4 = s0 [ s0 = -{resolve'2 xs'0}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_HashMap'2 = Any.any_l ()
     | & xs'0: MutBorrow.t t_HashMap'0 = xs
     | & it: t_IterMut'0 = Any.any_l ()
     | & _6: MutBorrow.t t_HashMap'0 = Any.any_l ()
     | & it0: t_IterMut'0 = Any.any_l ()
     | & r: t_HashMap'2 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_HashMap'2)-> {[@expl:roundtrip_hashmap_iter_mut ensures #0] [%#scollections'1] forall k: t_DeepModelTy, v: MutBorrow.t t_V. get'0 (view'4 result) k
       = C_Some'0 v  -> get (view'5 xs) k = C_Some (v.current) /\ get (view'0 xs.final) k = C_Some (v.final)}
       {[@expl:roundtrip_hashmap_iter_mut ensures #1] [%#scollections'2] forall k: t_DeepModelTy, v: t_V. get (view'5 xs) k
@@ -1186,7 +1186,7 @@ module M_collections__roundtrip_hashset_into_iter [#"collections.rs" 67 0 67 90]
     [ bb0 = s0 [ s0 = into_iter {xs'0} (fun (_ret:t_IntoIter'1) ->  [ &_3 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = collect {_3} (fun (_ret:t_HashSet'0) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: t_HashSet'0 = Any.any_l () | & xs'0: t_HashSet'0 = xs | & _3: t_IntoIter'1 = Any.any_l () ] 
+     [ & _0: t_HashSet'0 = Any.any_l () | & xs'0: t_HashSet'0 = xs | & _3: t_IntoIter'1 = Any.any_l () ] )
     [ return''0 (result:t_HashSet'0)-> {[@expl:roundtrip_hashset_into_iter ensures] [%#scollections] view result
       = view xs}
       (! return' {result}) ]
@@ -1390,7 +1390,7 @@ module M_collections__roundtrip_hashset_iter [#"collections.rs" 72 0 72 87]
     [ bb0 = s0 [ s0 = iter {xs'0} (fun (_ret:t_Iter'1) ->  [ &_3 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = collect {_3} (fun (_ret:t_HashSet'2) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: t_HashSet'2 = Any.any_l () | & xs'0: t_HashSet'0 = xs | & _3: t_Iter'1 = Any.any_l () ] 
+     [ & _0: t_HashSet'2 = Any.any_l () | & xs'0: t_HashSet'0 = xs | & _3: t_Iter'1 = Any.any_l () ] )
     [ return''0 (result:t_HashSet'2)-> {[@expl:roundtrip_hashset_iter ensures] [%#scollections] view'3 result
       = view'0 xs}
       (! return' {result}) ]
@@ -1648,13 +1648,13 @@ module M_collections__hashset_intersection [#"collections.rs" 77 0 80 15]
     | bb1 = s0 [ s0 = copied {_5} (fun (_ret:t_Copied) ->  [ &_4 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = s0 [ s0 = collect {_4} (fun (_ret:t_HashSet'0) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: t_HashSet'0 = Any.any_l ()
     | & xs'0: t_HashSet'0 = xs
     | & ys'0: t_HashSet'0 = ys
     | & _4: t_Copied = Any.any_l ()
     | & _5: t_Intersection = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_HashSet'0)-> {[@expl:hashset_intersection ensures] [%#scollections] view'0 result
       = Fset.inter (view'1 xs) (view'1 ys)}
       (! return' {result}) ]
@@ -1911,13 +1911,13 @@ module M_collections__hashset_difference [#"collections.rs" 85 0 88 15]
     | bb1 = s0 [ s0 = copied {_5} (fun (_ret:t_Copied) ->  [ &_4 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = s0 [ s0 = collect {_4} (fun (_ret:t_HashSet'0) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: t_HashSet'0 = Any.any_l ()
     | & xs'0: t_HashSet'0 = xs
     | & ys'0: t_HashSet'0 = ys
     | & _4: t_Copied = Any.any_l ()
     | & _5: t_Difference = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_HashSet'0)-> {[@expl:hashset_difference ensures] [%#scollections] view'0 result
       = Fset.diff (view'1 xs) (view'1 ys)}
       (! return' {result}) ]

--- a/tests/should_succeed/cc/fset.coma
+++ b/tests/should_succeed/cc/fset.coma
@@ -24,9 +24,9 @@ module M_fset__map_spec [#"fset.rs" 8 0 8 23]
   
   meta "select_lsinst" "all"
   
-  let rec map_spec[#"fset.rs" 8 0 8 23] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec map_spec[#"fset.rs" 8 0 8 23] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:map_spec ensures] [%#sfset] forall xs: Fset.fset t_T, f: Map.map t_T t_U, y: t_U. contains (map xs f) y
       = (exists x: t_T. contains'0 xs x /\ Map.get f x = y)}
       (! return' {result}) ]
@@ -49,9 +49,9 @@ module M_fset__filter_spec [#"fset.rs" 11 0 11 23]
   
   meta "select_lsinst" "all"
   
-  let rec filter_spec[#"fset.rs" 11 0 11 23] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec filter_spec[#"fset.rs" 11 0 11 23] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:filter_spec ensures] [%#sfset] forall xs: Fset.fset t_T, f: Map.map t_T bool, x: t_T. contains (Fset.filter xs f) x
       = (contains xs x /\ Map.get f x)}
       (! return' {result}) ]
@@ -73,9 +73,9 @@ module M_fset__interval_spec [#"fset.rs" 14 0 14 22]
   
   meta "select_lsinst" "all"
   
-  let rec interval_spec[#"fset.rs" 14 0 14 22] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec interval_spec[#"fset.rs" 14 0 14 22] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:interval_spec ensures] [%#sfset] forall i: int, j: int, k: int. contains (FsetInt.interval i j) k
       = (i <= k /\ k < j)}
       (! return' {result}) ]

--- a/tests/should_succeed/cc/iter.coma
+++ b/tests/should_succeed/cc/iter.coma
@@ -243,7 +243,7 @@ module M_iter__test_mut_ref [#"iter.rs" 5 0 5 21]
     | bb5 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_25 <- left_val ] s2 | s2 =  [ &_27 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: t_Iter = Any.any_l ()
     | & _6: tuple = Any.any_l ()
@@ -280,7 +280,7 @@ module M_iter__test_mut_ref [#"iter.rs" 5 0 5 21]
     | & _76: t_Option = Any.any_l ()
     | & _77: t_Option = Any.any_l ()
     | & _78: Slice64.array Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_iter__test_filter [#"iter.rs" 12 0 12 20]
   let%span siter = "iter.rs" 13 17 13 21
@@ -413,7 +413,7 @@ module M_iter__test_filter [#"iter.rs" 12 0 12 20]
     [ bb0 = s0
       [ s0 = -{resolve'0 _1}- s1 | s1 =  [ &res <- b'0 ] s2 | s2 =  [ &_0 <- res ] s3 | s3 = return''0 {_0} ]
      ]
-    ) [ & _0: bool = Any.any_l () | & _1: MutBorrow.t () = self | & b'0: bool = b | & res: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () | & _1: MutBorrow.t () = self | & b'0: bool = b | & res: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:closure ensures] [%#siter'2] result = b}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
       (! return' {result}) ]
@@ -721,7 +721,7 @@ module M_iter__test_filter [#"iter.rs" 12 0 12 20]
       | s3 =  [ &_29 <- right_val ] s4
       | s4 = {false} any ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: t_Filter = Any.any_l ()
     | & _2: t_Iter = Any.any_l ()
@@ -760,7 +760,7 @@ module M_iter__test_filter [#"iter.rs" 12 0 12 20]
     | & _78: t_Option = Any.any_l ()
     | & _79: t_Option = Any.any_l ()
     | & _80: Slice64.array bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_iter__test_filter_map [#"iter.rs" 22 0 22 24]
   let%span siter = "iter.rs" 23 17 23 21
@@ -899,9 +899,9 @@ module M_iter__test_filter_map [#"iter.rs" 22 0 22 24]
     | bb1 = s0 [ s0 =  [ &res <- C_Some ([%#siter'2] false) ] s1 | s1 = bb3 ] 
     | bb2 = s0 [ s0 =  [ &res <- C_None ] s1 | s1 = bb3 ] 
     | bb3 = s0 [ s0 =  [ &_0 <- res ] s1 | s1 = return''0 {_0} ]  ]
-    )
-    [ & _0: t_Option = Any.any_l () | & _1: MutBorrow.t () = self | & b'0: bool = b | & res: t_Option = Any.any_l () ]
     
+    [ & _0: t_Option = Any.any_l () | & _1: MutBorrow.t () = self | & b'0: bool = b | & res: t_Option = Any.any_l () ]
+    )
     [ return''0 (result:t_Option)-> {[@expl:closure ensures] [%#siter'3] result = (if b then C_Some false else C_None)}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
       (! return' {result}) ]
@@ -1200,7 +1200,7 @@ module M_iter__test_filter_map [#"iter.rs" 22 0 22 24]
       | s3 =  [ &_27 <- right_val ] s4
       | s4 = {false} any ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: t_FilterMap = Any.any_l ()
     | & _2: t_Iter = Any.any_l ()
@@ -1239,5 +1239,5 @@ module M_iter__test_filter_map [#"iter.rs" 22 0 22 24]
     | & _74: t_Option = Any.any_l ()
     | & _75: t_Option = Any.any_l ()
     | & _76: Slice64.array bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/cc/string.coma
+++ b/tests/should_succeed/cc/string.coma
@@ -79,7 +79,7 @@ module M_string__test_string_len [#"string.rs" 7 0 7 42]
     = Seq.create 2 [|(195: UInt8.t);(131: UInt8.t)|]}
     (! bb0
     [ bb0 = s0 [ s0 = len {s'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ]  | bb2 = return''0 {_0} ]
-    ) [ & _0: UInt64.t = Any.any_l () | & s'0: t_String = s ] 
+     [ & _0: UInt64.t = Any.any_l () | & s'0: t_String = s ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_string_len ensures] [%#sstring'1] UInt64.t'int result = 2}
       (! return' {result}) ]
 
@@ -143,7 +143,7 @@ module M_string__test_str_len [#"string.rs" 14 0 14 37]
     = Seq.create 2 [|(195: UInt8.t);(131: UInt8.t)|]}
     (! bb0
     [ bb0 = s0 [ s0 = len {s'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: UInt64.t = Any.any_l () | & s'0: string = s ] 
+     [ & _0: UInt64.t = Any.any_l () | & s'0: string = s ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_str_len ensures] [%#sstring'1] UInt64.t'int result = 2}
       (! return' {result}) ]
 
@@ -232,7 +232,7 @@ module M_string__test_split_at [#"string.rs" 21 0 21 45]
       | s2 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: tuple = Any.any_l () | & s'0: string = s | & _5: () = Any.any_l () ] 
+     [ & _0: tuple = Any.any_l () | & s'0: string = s | & _5: () = Any.any_l () ] )
     [ return''0 (result:tuple)-> {[@expl:test_split_at ensures] [%#sstring'4] view'0 result._p0 = view'0 s
       /\ view'0 result._p1 = (Seq.empty: Seq.seq Char.t)}
       (! return' {result}) ]

--- a/tests/should_succeed/cell/01.coma
+++ b/tests/should_succeed/cell/01.coma
@@ -46,7 +46,7 @@ module M_01__adds_two [#"01.rs" 40 0 40 36]
     
     | bb4 = s0 [ s0 = set {c'0} {[%#s01'1] (0: UInt32.t)} (fun (_ret:()) ->  [ &_10 <- _ret ] s1) | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & c'0: t_Cell'0 = c
     | & v: UInt32.t = Any.any_l ()
@@ -54,5 +54,5 @@ module M_01__adds_two [#"01.rs" 40 0 40 36]
     | & _6: () = Any.any_l ()
     | & _8: UInt32.t = Any.any_l ()
     | & _10: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/cell/02.coma
+++ b/tests/should_succeed/cell/02.coma
@@ -239,7 +239,7 @@ module M_02__fib_memo [#"02.rs" 95 0 95 50]
     
     | bb18 = s0 [ s0 =  [ &_0 <- fib_i ] s1 | s1 = bb19 ] 
     | bb19 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & mem'0: t_Vec = mem
     | & i'0: UInt64.t = i
@@ -258,7 +258,7 @@ module M_02__fib_memo [#"02.rs" 95 0 95 50]
     | & _33: () = Any.any_l ()
     | & _35: t_Cell'0 = Any.any_l ()
     | & _38: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:fib_memo ensures] [%#s02'11] UInt64.t'int result = fib (UInt64.t'int i)}
       (! return' {result}) ]
 

--- a/tests/should_succeed/checked_ops.coma
+++ b/tests/should_succeed/checked_ops.coma
@@ -192,7 +192,7 @@ module M_checked_ops__test_u8_add_example [#"checked_ops.rs" 5 0 5 28]
     | bb11 = {[%#schecked_ops'29] false} any
     | bb8 = {[%#schecked_ops'30] false} any
     | bb4 = {[%#schecked_ops'31] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: bool = Any.any_l ()
     | & _3: UInt8.t = Any.any_l ()
@@ -213,7 +213,7 @@ module M_checked_ops__test_u8_add_example [#"checked_ops.rs" 5 0 5 28]
     | & res'0: tuple = Any.any_l ()
     | & _36: bool = Any.any_l ()
     | & _38: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_add_overflow [#"checked_ops.rs" 23 0 23 34]
   let%span schecked_ops = "checked_ops.rs" 24 12 24 17
@@ -337,7 +337,7 @@ module M_checked_ops__test_u8_add_overflow [#"checked_ops.rs" 23 0 23 34]
     | bb10 = {[%#schecked_ops'8] false} any
     | bb7 = {[%#schecked_ops'9] false} any
     | bb4 = {[%#schecked_ops'10] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt8.t = a
     | & _4: bool = Any.any_l ()
@@ -351,7 +351,7 @@ module M_checked_ops__test_u8_add_overflow [#"checked_ops.rs" 23 0 23 34]
     | & _24: bool = Any.any_l ()
     | & _26: UInt8.t = Any.any_l ()
     | & _28: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_wrapping_add [#"checked_ops.rs" 34 0 34 47]
   let%span schecked_ops = "checked_ops.rs" 33 10 33 56
@@ -372,7 +372,7 @@ module M_checked_ops__test_u8_wrapping_add [#"checked_ops.rs" 34 0 34 47]
   let rec test_u8_wrapping_add[#"checked_ops.rs" 34 0 34 47] (a:UInt8.t) (b:UInt8.t) (return'  (x:UInt8.t))= (! bb0
     [ bb0 = s0 [ s0 = wrapping_add {a'0} {b'0} (fun (_ret:UInt8.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: UInt8.t = Any.any_l () | & a'0: UInt8.t = a | & b'0: UInt8.t = b ] 
+     [ & _0: UInt8.t = Any.any_l () | & a'0: UInt8.t = a | & b'0: UInt8.t = b ] )
     [ return''0 (result:UInt8.t)-> {[@expl:test_u8_wrapping_add ensures] [%#schecked_ops] UInt8.t'int result
       = UInt8.t'int a + UInt8.t'int b
       \/ UInt8.t'int result = UInt8.t'int a + UInt8.t'int b - 256}
@@ -450,7 +450,7 @@ module M_checked_ops__test_u8_overflowing_add [#"checked_ops.rs" 39 0 39 44]
     | bb8 = return''0 {_0}
     | bb9 = {[%#schecked_ops] false} any
     | bb4 = {[%#schecked_ops'0] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt8.t = a
     | & b'0: UInt8.t = b
@@ -461,7 +461,7 @@ module M_checked_ops__test_u8_overflowing_add [#"checked_ops.rs" 39 0 39 44]
     | & _16: tuple = Any.any_l ()
     | & _19: bool = Any.any_l ()
     | & _21: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_sub_example [#"checked_ops.rs" 45 0 45 28]
   let%span schecked_ops = "checked_ops.rs" 46 12 46 15
@@ -655,7 +655,7 @@ module M_checked_ops__test_u8_sub_example [#"checked_ops.rs" 45 0 45 28]
     | bb11 = {[%#schecked_ops'29] false} any
     | bb8 = {[%#schecked_ops'30] false} any
     | bb4 = {[%#schecked_ops'31] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: bool = Any.any_l ()
     | & _4: t_Option = Any.any_l ()
@@ -676,7 +676,7 @@ module M_checked_ops__test_u8_sub_example [#"checked_ops.rs" 45 0 45 28]
     | & res'0: tuple = Any.any_l ()
     | & _36: bool = Any.any_l ()
     | & _38: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_sub_overflow [#"checked_ops.rs" 63 0 63 34]
   let%span schecked_ops = "checked_ops.rs" 64 12 64 15
@@ -803,7 +803,7 @@ module M_checked_ops__test_u8_sub_overflow [#"checked_ops.rs" 63 0 63 34]
     | bb10 = {[%#schecked_ops'10] false} any
     | bb7 = {[%#schecked_ops'11] false} any
     | bb4 = {[%#schecked_ops'12] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt8.t = a
     | & _4: bool = Any.any_l ()
@@ -819,7 +819,7 @@ module M_checked_ops__test_u8_sub_overflow [#"checked_ops.rs" 63 0 63 34]
     | & _27: UInt8.t = Any.any_l ()
     | & _28: UInt8.t = Any.any_l ()
     | & _30: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_wrapping_sub [#"checked_ops.rs" 74 0 74 47]
   let%span schecked_ops = "checked_ops.rs" 73 10 73 56
@@ -840,7 +840,7 @@ module M_checked_ops__test_u8_wrapping_sub [#"checked_ops.rs" 74 0 74 47]
   let rec test_u8_wrapping_sub[#"checked_ops.rs" 74 0 74 47] (a:UInt8.t) (b:UInt8.t) (return'  (x:UInt8.t))= (! bb0
     [ bb0 = s0 [ s0 = wrapping_sub {a'0} {b'0} (fun (_ret:UInt8.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: UInt8.t = Any.any_l () | & a'0: UInt8.t = a | & b'0: UInt8.t = b ] 
+     [ & _0: UInt8.t = Any.any_l () | & a'0: UInt8.t = a | & b'0: UInt8.t = b ] )
     [ return''0 (result:UInt8.t)-> {[@expl:test_u8_wrapping_sub ensures] [%#schecked_ops] UInt8.t'int result
       = UInt8.t'int a - UInt8.t'int b
       \/ UInt8.t'int result = UInt8.t'int a - UInt8.t'int b + 256}
@@ -918,7 +918,7 @@ module M_checked_ops__test_u8_overflowing_sub [#"checked_ops.rs" 79 0 79 44]
     | bb8 = return''0 {_0}
     | bb9 = {[%#schecked_ops] false} any
     | bb4 = {[%#schecked_ops'0] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt8.t = a
     | & b'0: UInt8.t = b
@@ -929,7 +929,7 @@ module M_checked_ops__test_u8_overflowing_sub [#"checked_ops.rs" 79 0 79 44]
     | & _16: tuple = Any.any_l ()
     | & _19: bool = Any.any_l ()
     | & _21: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_mul_example [#"checked_ops.rs" 85 0 85 28]
   let%span schecked_ops = "checked_ops.rs" 86 12 86 15
@@ -1125,7 +1125,7 @@ module M_checked_ops__test_u8_mul_example [#"checked_ops.rs" 85 0 85 28]
     | bb11 = {[%#schecked_ops'29] false} any
     | bb8 = {[%#schecked_ops'30] false} any
     | bb4 = {[%#schecked_ops'31] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: bool = Any.any_l ()
     | & _3: UInt8.t = Any.any_l ()
@@ -1146,7 +1146,7 @@ module M_checked_ops__test_u8_mul_example [#"checked_ops.rs" 85 0 85 28]
     | & res'0: tuple = Any.any_l ()
     | & _36: bool = Any.any_l ()
     | & _38: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_mul_zero [#"checked_ops.rs" 102 0 102 30]
   let%span schecked_ops = "checked_ops.rs" 103 12 103 15
@@ -1271,7 +1271,7 @@ module M_checked_ops__test_u8_mul_zero [#"checked_ops.rs" 102 0 102 30]
     | bb10 = {[%#schecked_ops'9] false} any
     | bb7 = {[%#schecked_ops'10] false} any
     | bb4 = {[%#schecked_ops'11] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt8.t = a
     | & _3: bool = Any.any_l ()
@@ -1284,7 +1284,7 @@ module M_checked_ops__test_u8_mul_zero [#"checked_ops.rs" 102 0 102 30]
     | & res: tuple = Any.any_l ()
     | & _21: bool = Any.any_l ()
     | & _23: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_overflowing_mul [#"checked_ops.rs" 111 0 111 44]
   let%span schecked_ops = "checked_ops.rs" 113 4 113 65
@@ -1357,7 +1357,7 @@ module M_checked_ops__test_u8_overflowing_mul [#"checked_ops.rs" 111 0 111 44]
     | bb8 = return''0 {_0}
     | bb9 = {[%#schecked_ops] false} any
     | bb4 = {[%#schecked_ops'0] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt8.t = a
     | & b'0: UInt8.t = b
@@ -1368,7 +1368,7 @@ module M_checked_ops__test_u8_overflowing_mul [#"checked_ops.rs" 111 0 111 44]
     | & _16: tuple = Any.any_l ()
     | & _19: bool = Any.any_l ()
     | & _21: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_div_example [#"checked_ops.rs" 117 0 117 28]
   let%span schecked_ops = "checked_ops.rs" 118 12 118 15
@@ -1525,7 +1525,7 @@ module M_checked_ops__test_u8_div_example [#"checked_ops.rs" 117 0 117 28]
     | bb11 = {[%#schecked_ops'16] false} any
     | bb8 = {[%#schecked_ops'17] false} any
     | bb4 = {[%#schecked_ops'18] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: bool = Any.any_l ()
     | & _4: t_Option = Any.any_l ()
@@ -1539,7 +1539,7 @@ module M_checked_ops__test_u8_div_example [#"checked_ops.rs" 117 0 117 28]
     | & res: tuple = Any.any_l ()
     | & _21: bool = Any.any_l ()
     | & _23: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_div_no_overflow [#"checked_ops.rs" 128 0 128 44]
   let%span schecked_ops = "checked_ops.rs" 129 41 129 46
@@ -1687,7 +1687,7 @@ module M_checked_ops__test_u8_div_no_overflow [#"checked_ops.rs" 128 0 128 44]
     | bb13 = {[%#schecked_ops'5] false} any
     | bb9 = {[%#schecked_ops'6] false} any
     | bb5 = {[%#schecked_ops'7] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt8.t = a
     | & b'0: UInt8.t = b
@@ -1713,7 +1713,7 @@ module M_checked_ops__test_u8_div_no_overflow [#"checked_ops.rs" 128 0 128 44]
     | & _43: UInt8.t = Any.any_l ()
     | & _44: bool = Any.any_l ()
     | & _45: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_u8_div_zero [#"checked_ops.rs" 137 0 137 30]
   let%span schecked_ops = "checked_ops.rs" 138 26 138 27
@@ -1756,7 +1756,7 @@ module M_checked_ops__test_u8_div_zero [#"checked_ops.rs" 137 0 137 30]
     | bb2 = any [ br0 -> {_3 = false} (! bb4) | br1 -> {_3} (! bb3) ] 
     | bb3 = return''0 {_0}
     | bb4 = {[%#schecked_ops'0] false} any ]
-    ) [ & _0: () = Any.any_l () | & a'0: UInt8.t = a | & _3: bool = Any.any_l () | & _5: t_Option = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & a'0: UInt8.t = a | & _3: bool = Any.any_l () | & _5: t_Option = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -2011,7 +2011,7 @@ module M_checked_ops__test_i8_add_example [#"checked_ops.rs" 142 0 142 28]
     | bb12 = {[%#schecked_ops'45] false} any
     | bb8 = {[%#schecked_ops'46] false} any
     | bb4 = {[%#schecked_ops'47] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: bool = Any.any_l ()
     | & _3: Int8.t = Any.any_l ()
@@ -2041,7 +2041,7 @@ module M_checked_ops__test_i8_add_example [#"checked_ops.rs" 142 0 142 28]
     | & res'1: tuple = Any.any_l ()
     | & _56: bool = Any.any_l ()
     | & _58: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_add_overflow_pos [#"checked_ops.rs" 165 0 165 38]
   let%span schecked_ops = "checked_ops.rs" 166 12 166 17
@@ -2169,7 +2169,7 @@ module M_checked_ops__test_i8_add_overflow_pos [#"checked_ops.rs" 165 0 165 38]
     | bb10 = {[%#schecked_ops'10] false} any
     | bb7 = {[%#schecked_ops'11] false} any
     | bb4 = {[%#schecked_ops'12] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: Int8.t = a
     | & _4: bool = Any.any_l ()
@@ -2185,7 +2185,7 @@ module M_checked_ops__test_i8_add_overflow_pos [#"checked_ops.rs" 165 0 165 38]
     | & _27: Int8.t = Any.any_l ()
     | & _28: Int8.t = Any.any_l ()
     | & _30: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_add_overflow_neg [#"checked_ops.rs" 175 0 175 38]
   let%span schecked_ops = "checked_ops.rs" 176 12 176 20
@@ -2313,7 +2313,7 @@ module M_checked_ops__test_i8_add_overflow_neg [#"checked_ops.rs" 175 0 175 38]
     | bb10 = {[%#schecked_ops'10] false} any
     | bb7 = {[%#schecked_ops'11] false} any
     | bb4 = {[%#schecked_ops'12] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: Int8.t = a
     | & _4: bool = Any.any_l ()
@@ -2329,7 +2329,7 @@ module M_checked_ops__test_i8_add_overflow_neg [#"checked_ops.rs" 175 0 175 38]
     | & _27: Int8.t = Any.any_l ()
     | & _28: Int8.t = Any.any_l ()
     | & _30: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_wrapping_add [#"checked_ops.rs" 186 0 186 47]
   let%span schecked_ops = "checked_ops.rs" 185 10 185 84
@@ -2350,7 +2350,7 @@ module M_checked_ops__test_i8_wrapping_add [#"checked_ops.rs" 186 0 186 47]
   let rec test_i8_wrapping_add[#"checked_ops.rs" 186 0 186 47] (a:Int8.t) (b:Int8.t) (return'  (x:Int8.t))= (! bb0
     [ bb0 = s0 [ s0 = wrapping_add {a'0} {b'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: Int8.t = Any.any_l () | & a'0: Int8.t = a | & b'0: Int8.t = b ] 
+     [ & _0: Int8.t = Any.any_l () | & a'0: Int8.t = a | & b'0: Int8.t = b ] )
     [ return''0 (result:Int8.t)-> {[@expl:test_i8_wrapping_add ensures] [%#schecked_ops] Int8.to_int result
       = Int8.to_int a + Int8.to_int b
       \/ Int8.to_int result = Int8.to_int a + Int8.to_int b - 256
@@ -2429,7 +2429,7 @@ module M_checked_ops__test_i8_overflowing_add [#"checked_ops.rs" 191 0 191 44]
     | bb8 = return''0 {_0}
     | bb9 = {[%#schecked_ops] false} any
     | bb4 = {[%#schecked_ops'0] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: Int8.t = a
     | & b'0: Int8.t = b
@@ -2440,7 +2440,7 @@ module M_checked_ops__test_i8_overflowing_add [#"checked_ops.rs" 191 0 191 44]
     | & _16: tuple = Any.any_l ()
     | & _19: bool = Any.any_l ()
     | & _21: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_sub_example [#"checked_ops.rs" 197 0 197 28]
   let%span schecked_ops = "checked_ops.rs" 198 12 198 15
@@ -2698,7 +2698,7 @@ module M_checked_ops__test_i8_sub_example [#"checked_ops.rs" 197 0 197 28]
     | bb12 = {[%#schecked_ops'46] false} any
     | bb8 = {[%#schecked_ops'47] false} any
     | bb4 = {[%#schecked_ops'48] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: bool = Any.any_l ()
     | & _3: Int8.t = Any.any_l ()
@@ -2729,7 +2729,7 @@ module M_checked_ops__test_i8_sub_example [#"checked_ops.rs" 197 0 197 28]
     | & res'1: tuple = Any.any_l ()
     | & _56: bool = Any.any_l ()
     | & _58: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_sub_overflow_pos [#"checked_ops.rs" 220 0 220 38]
   let%span schecked_ops = "checked_ops.rs" 221 12 221 20
@@ -2857,7 +2857,7 @@ module M_checked_ops__test_i8_sub_overflow_pos [#"checked_ops.rs" 220 0 220 38]
     | bb10 = {[%#schecked_ops'10] false} any
     | bb7 = {[%#schecked_ops'11] false} any
     | bb4 = {[%#schecked_ops'12] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: Int8.t = a
     | & _4: bool = Any.any_l ()
@@ -2873,7 +2873,7 @@ module M_checked_ops__test_i8_sub_overflow_pos [#"checked_ops.rs" 220 0 220 38]
     | & _27: Int8.t = Any.any_l ()
     | & _28: Int8.t = Any.any_l ()
     | & _30: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_sub_overflow_neg [#"checked_ops.rs" 230 0 230 38]
   let%span schecked_ops = "checked_ops.rs" 231 12 231 17
@@ -3003,7 +3003,7 @@ module M_checked_ops__test_i8_sub_overflow_neg [#"checked_ops.rs" 230 0 230 38]
     | bb10 = {[%#schecked_ops'10] false} any
     | bb7 = {[%#schecked_ops'11] false} any
     | bb4 = {[%#schecked_ops'12] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: Int8.t = a
     | & _4: bool = Any.any_l ()
@@ -3021,7 +3021,7 @@ module M_checked_ops__test_i8_sub_overflow_neg [#"checked_ops.rs" 230 0 230 38]
     | & _29: Int8.t = Any.any_l ()
     | & _30: Int8.t = Any.any_l ()
     | & _32: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_wrapping_sub [#"checked_ops.rs" 241 0 241 47]
   let%span schecked_ops = "checked_ops.rs" 240 10 240 84
@@ -3042,7 +3042,7 @@ module M_checked_ops__test_i8_wrapping_sub [#"checked_ops.rs" 241 0 241 47]
   let rec test_i8_wrapping_sub[#"checked_ops.rs" 241 0 241 47] (a:Int8.t) (b:Int8.t) (return'  (x:Int8.t))= (! bb0
     [ bb0 = s0 [ s0 = wrapping_sub {a'0} {b'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: Int8.t = Any.any_l () | & a'0: Int8.t = a | & b'0: Int8.t = b ] 
+     [ & _0: Int8.t = Any.any_l () | & a'0: Int8.t = a | & b'0: Int8.t = b ] )
     [ return''0 (result:Int8.t)-> {[@expl:test_i8_wrapping_sub ensures] [%#schecked_ops] Int8.to_int result
       = Int8.to_int a - Int8.to_int b
       \/ Int8.to_int result = Int8.to_int a - Int8.to_int b + 256
@@ -3121,7 +3121,7 @@ module M_checked_ops__test_i8_overflowing_sub [#"checked_ops.rs" 246 0 246 44]
     | bb8 = return''0 {_0}
     | bb9 = {[%#schecked_ops] false} any
     | bb4 = {[%#schecked_ops'0] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: Int8.t = a
     | & b'0: Int8.t = b
@@ -3132,7 +3132,7 @@ module M_checked_ops__test_i8_overflowing_sub [#"checked_ops.rs" 246 0 246 44]
     | & _16: tuple = Any.any_l ()
     | & _19: bool = Any.any_l ()
     | & _21: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_mul_example [#"checked_ops.rs" 252 0 252 28]
   let%span schecked_ops = "checked_ops.rs" 253 12 253 15
@@ -3385,7 +3385,7 @@ module M_checked_ops__test_i8_mul_example [#"checked_ops.rs" 252 0 252 28]
     | bb12 = {[%#schecked_ops'45] false} any
     | bb8 = {[%#schecked_ops'46] false} any
     | bb4 = {[%#schecked_ops'47] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: bool = Any.any_l ()
     | & _3: Int8.t = Any.any_l ()
@@ -3415,7 +3415,7 @@ module M_checked_ops__test_i8_mul_example [#"checked_ops.rs" 252 0 252 28]
     | & res'1: tuple = Any.any_l ()
     | & _56: bool = Any.any_l ()
     | & _58: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_mul_zero [#"checked_ops.rs" 274 0 274 30]
   let%span schecked_ops = "checked_ops.rs" 275 12 275 15
@@ -3540,7 +3540,7 @@ module M_checked_ops__test_i8_mul_zero [#"checked_ops.rs" 274 0 274 30]
     | bb10 = {[%#schecked_ops'9] false} any
     | bb7 = {[%#schecked_ops'10] false} any
     | bb4 = {[%#schecked_ops'11] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: Int8.t = a
     | & _3: bool = Any.any_l ()
@@ -3553,7 +3553,7 @@ module M_checked_ops__test_i8_mul_zero [#"checked_ops.rs" 274 0 274 30]
     | & res: tuple = Any.any_l ()
     | & _21: bool = Any.any_l ()
     | & _23: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_overflowing_mul [#"checked_ops.rs" 283 0 283 44]
   let%span schecked_ops = "checked_ops.rs" 285 4 285 65
@@ -3626,7 +3626,7 @@ module M_checked_ops__test_i8_overflowing_mul [#"checked_ops.rs" 283 0 283 44]
     | bb8 = return''0 {_0}
     | bb9 = {[%#schecked_ops] false} any
     | bb4 = {[%#schecked_ops'0] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: Int8.t = a
     | & b'0: Int8.t = b
@@ -3637,7 +3637,7 @@ module M_checked_ops__test_i8_overflowing_mul [#"checked_ops.rs" 283 0 283 44]
     | & _16: tuple = Any.any_l ()
     | & _19: bool = Any.any_l ()
     | & _21: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_div_example [#"checked_ops.rs" 289 0 289 28]
   let%span schecked_ops = "checked_ops.rs" 290 12 290 15
@@ -3912,7 +3912,7 @@ module M_checked_ops__test_i8_div_example [#"checked_ops.rs" 289 0 289 28]
     | bb12 = {[%#schecked_ops'49] false} any
     | bb8 = {[%#schecked_ops'50] false} any
     | bb4 = {[%#schecked_ops'51] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: bool = Any.any_l ()
     | & _4: t_Option = Any.any_l ()
@@ -3945,7 +3945,7 @@ module M_checked_ops__test_i8_div_example [#"checked_ops.rs" 289 0 289 28]
     | & res'1: tuple = Any.any_l ()
     | & _61: bool = Any.any_l ()
     | & _63: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_div_no_overflow [#"checked_ops.rs" 313 0 313 44]
   let%span schecked_ops = "checked_ops.rs" 314 41 314 46
@@ -4126,7 +4126,7 @@ module M_checked_ops__test_i8_div_no_overflow [#"checked_ops.rs" 313 0 313 44]
     | bb16 = {[%#schecked_ops'5] false} any
     | bb11 = {[%#schecked_ops'6] false} any
     | bb6 = {[%#schecked_ops'7] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: Int8.t = a
     | & b'0: Int8.t = b
@@ -4168,7 +4168,7 @@ module M_checked_ops__test_i8_div_no_overflow [#"checked_ops.rs" 313 0 313 44]
     | & _55: bool = Any.any_l ()
     | & _56: bool = Any.any_l ()
     | & _57: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_checked_ops__test_i8_div_zero [#"checked_ops.rs" 322 0 322 30]
   let%span schecked_ops = "checked_ops.rs" 323 26 323 27
@@ -4210,7 +4210,7 @@ module M_checked_ops__test_i8_div_zero [#"checked_ops.rs" 322 0 322 30]
     | bb2 = any [ br0 -> {_3 = false} (! bb4) | br1 -> {_3} (! bb3) ] 
     | bb3 = return''0 {_0}
     | bb4 = {[%#schecked_ops'0] false} any ]
-    ) [ & _0: () = Any.any_l () | & a'0: Int8.t = a | & _3: bool = Any.any_l () | & _5: t_Option = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & a'0: Int8.t = a | & _3: bool = Any.any_l () | & _5: t_Option = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/clones/01.coma
+++ b/tests/should_succeed/clones/01.coma
@@ -5,7 +5,7 @@ module M_01__func1 [#"01.rs" 6 0 6 10]
   
   meta "select_lsinst" "all"
   
-  let rec func1[#"01.rs" 6 0 6 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+  let rec func1[#"01.rs" 6 0 6 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -20,7 +20,7 @@ module M_01__func2 [#"01.rs" 8 0 8 10]
   
   let rec func2[#"01.rs" 8 0 8 10] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = func1 (fun (_ret:()) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01__func3 [#"01.rs" 12 0 12 14]
   use creusot.prelude.Any
@@ -33,5 +33,5 @@ module M_01__func3 [#"01.rs" 12 0 12 14]
   
   let rec func3[#"01.rs" 12 0 12 14] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = func2 (fun (_ret:()) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/clones/02.coma
+++ b/tests/should_succeed/clones/02.coma
@@ -17,7 +17,7 @@ module M_02__program [#"02.rs" 20 0 20 16]
   meta "select_lsinst" "all"
   
   let rec program[#"02.rs" 20 0 20 16] (return'  (x:()))= {[@expl:program requires] [%#s02] uses_simple}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:program ensures] [%#s02'0] simple} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/clones/03.coma
+++ b/tests/should_succeed/clones/03.coma
@@ -22,7 +22,7 @@ module M_03__prog [#"03.rs" 11 0 11 16]
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv x'0} s1 | s1 = -{resolve x'0}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_T = x ] 
+     [ & _0: () = Any.any_l () | & x'0: t_T = x ] )
     [ return''0 (result:())-> {[@expl:prog ensures] [%#s03'0] omg x} (! return' {result}) ]
 
 end
@@ -50,7 +50,7 @@ module M_03__prog2 [#"03.rs" 14 0 14 14]
   let rec prog2[#"03.rs" 14 0 14 14] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = prog {[%#s03] (0: Int32.t)} (fun (_ret:()) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _2: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & _2: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:prog2 ensures] [%#s03'0] omg'0 0} (! return' {result}) ]
 
 end
@@ -70,7 +70,7 @@ module M_03__prog3 [#"03.rs" 19 0 19 14]
   
   meta "select_lsinst" "all"
   
-  let rec prog3[#"03.rs" 19 0 19 14] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+  let rec prog3[#"03.rs" 19 0 19 14] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:prog3 ensures] [%#s03] omg { _p0 = 0; _p1 = 0 }} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/clones/04.coma
+++ b/tests/should_succeed/clones/04.coma
@@ -82,5 +82,5 @@ module M_04__f [#"04.rs" 21 0 21 16]
   meta "select_lsinst" "all"
   
   let rec f[#"04.rs" 21 0 21 16] (x:UInt32.t) (return'  (x'0:()))= {[@expl:f requires] [%#s04] c x}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/01_basic.coma
+++ b/tests/should_succeed/closures/01_basic.coma
@@ -22,13 +22,13 @@ module M_01_basic__uses_closure [#"01_basic.rs" 6 0 6 21]
       | s3 = bb1 ]
     
     | bb1 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & y: bool = Any.any_l ()
     | & _x: bool = Any.any_l ()
     | & _4: closure0 = Any.any_l ()
     | & _6: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_basic__multi_arg [#"01_basic.rs" 11 0 11 18]
   let%span s01_basic = "01_basic.rs" 13 17 13 18
@@ -56,7 +56,7 @@ module M_01_basic__multi_arg [#"01_basic.rs" 11 0 11 18]
       | s3 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x: () = Any.any_l () | & _a: Int32.t = Any.any_l () | & _4: tuple = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x: () = Any.any_l () | & _a: Int32.t = Any.any_l () | & _4: tuple = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -157,7 +157,7 @@ module M_01_basic__move_closure [#"01_basic.rs" 18 0 18 21]
       | s2 = bb2 ]
     
     | bb2 = s0 [ s0 = -{resolve'3 x}- s1 | s1 = return''0 {_0'0} ]  ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & a: MutBorrow.t Int32.t = Any.any_l ()
     | & _2: Int32.t = Any.any_l ()
@@ -168,7 +168,7 @@ module M_01_basic__move_closure [#"01_basic.rs" 18 0 18 21]
     | & _7: () = Any.any_l ()
     | & _8: MutBorrow.t closure0 = Any.any_l ()
     | & _9: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_basic__move_mut [#"01_basic.rs" 34 0 34 17]
   let%span s01_basic = "01_basic.rs" 36 21 36 25
@@ -283,7 +283,7 @@ module M_01_basic__move_mut [#"01_basic.rs" 34 0 34 17]
       | s2 = bb2 ]
     
     | bb2 = s0 [ s0 = -{resolve'3 a}- s1 | s1 = return''0 {_0'0} ]  ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x: MutBorrow.t UInt32.t = Any.any_l ()
     | & _2: UInt32.t = Any.any_l ()
@@ -294,5 +294,5 @@ module M_01_basic__move_mut [#"01_basic.rs" 34 0 34 17]
     | & _7: () = Any.any_l ()
     | & _8: MutBorrow.t closure0 = Any.any_l ()
     | & _9: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/02_nested.coma
+++ b/tests/should_succeed/closures/02_nested.coma
@@ -36,11 +36,11 @@ module M_02_nested__nested_closure [#"02_nested.rs" 3 0 3 23]
       | s3 = bb1 ]
     
     | bb1 = return''0 {_0'1} ]
-    )
+    
     [ & _0'1: () = Any.any_l ()
     | & a: bool = Any.any_l ()
     | & _a: bool = Any.any_l ()
     | & _4: closure0'0 = Any.any_l ()
     | & _6: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/03_generic_bound.coma
+++ b/tests/should_succeed/closures/03_generic_bound.coma
@@ -92,7 +92,7 @@ module M_03_generic_bound__closure_param [#"03_generic_bound.rs" 5 0 5 34]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & f'0: t_F = f | & _3: UInt32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & f'0: t_F = f | & _3: UInt32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -113,5 +113,5 @@ module M_03_generic_bound__caller [#"03_generic_bound.rs" 9 0 9 15]
   let rec caller[#"03_generic_bound.rs" 9 0 9 15] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_1 <- () ] s1 | s1 = closure_param {_1} (fun (_ret:()) ->  [ &_0 <- _ret ] s2) | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _1: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & _1: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/04_generic_closure.coma
+++ b/tests/should_succeed/closures/04_generic_closure.coma
@@ -103,7 +103,7 @@ module M_04_generic_closure__generic_closure [#"04_generic_closure.rs" 5 0 5 56]
     [ bb0 = s0 [ s0 =  [ &_4 <- a'0 ] s1 | s1 = call {f'0} {_4} (fun (_ret:t_B) ->  [ &_0 <- _ret ] s2) | s2 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    ) [ & _0: t_B = Any.any_l () | & f'0: t_F = f | & a'0: t_A = a | & _4: t_A = Any.any_l () ] 
+     [ & _0: t_B = Any.any_l () | & f'0: t_F = f | & a'0: t_A = a | & _4: t_A = Any.any_l () ] )
     [ return''0 (result:t_B)-> {[@expl:generic_closure result type invariant] [%#s04_generic_closure'1] inv'3 result}
       (! return' {result}) ]
 
@@ -139,7 +139,7 @@ module M_04_generic_closure__mapper [#"04_generic_closure.rs" 9 0 9 22]
       [ s0 =  [ &_3 <- () ] s1 | s1 = generic_closure {_3} {x'0} (fun (_ret:()) ->  [ &_2 <- _ret ] s2) | s2 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_A = x | & _2: () = Any.any_l () | & _3: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x'0: t_A = x | & _2: () = Any.any_l () | & _3: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/closures/05_map.coma
+++ b/tests/should_succeed/closures/05_map.coma
@@ -201,7 +201,7 @@ module M_05_map__qyi10775967587165326061__next [#"05_map.rs" 20 4 20 44] (* <Map
     | bb3 = s0 [ s0 = {[@expl:type invariant] inv'8 self'0} s1 | s1 = -{resolve'1 self'0}- s2 | s2 = bb5 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb11 ] 
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_Map = self
     | & _2: t_Option = Any.any_l ()
@@ -209,7 +209,7 @@ module M_05_map__qyi10775967587165326061__next [#"05_map.rs" 20 4 20 44] (* <Map
     | & e: t_A = Any.any_l ()
     | & _6: t_B = Any.any_l ()
     | & _8: t_A = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:next result type invariant] [%#s05_map'0] inv'9 result}
       (! return' {result}) ]
 

--- a/tests/should_succeed/closures/06_fn_specs.coma
+++ b/tests/should_succeed/closures/06_fn_specs.coma
@@ -98,7 +98,7 @@ module M_06_fn_specs__weaken_std [#"06_fn_specs.rs" 8 0 8 62]
     (! bb0
     [ bb0 = s0 [ s0 = weaken_2_std {f'0} {a'0} (fun (_ret:t_Output) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: t_Output = Any.any_l () | & f'0: t_F = f | & a'0: t_A = a ] 
+     [ & _0: t_Output = Any.any_l () | & f'0: t_F = f | & a'0: t_A = a ] )
     [ return''0 (result:t_Output)-> {[@expl:weaken_std result type invariant] [%#s06_fn_specs'2] inv'1 result}
       {[@expl:weaken_std ensures] [%#s06_fn_specs'3] postcondition f a result}
       (! return' {result}) ]
@@ -185,7 +185,7 @@ module M_06_fn_specs__weaken_2_std [#"06_fn_specs.rs" 14 0 14 63]
     (! bb0
     [ bb0 = s0 [ s0 = weaken_3_std {f'0} {a'0} (fun (_ret:t_Output) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: t_Output = Any.any_l () | & f'0: t_F = f | & a'0: t_A = a ] 
+     [ & _0: t_Output = Any.any_l () | & f'0: t_F = f | & a'0: t_A = a ] )
     [ return''0 (result:t_Output)-> {[@expl:weaken_2_std result type invariant] [%#s06_fn_specs'2] inv'1 result}
       {[@expl:weaken_2_std ensures] [%#s06_fn_specs'3] exists f2: t_F. postcondition_mut f a f2 result /\ resolve f2}
       (! return' {result}) ]
@@ -239,7 +239,7 @@ module M_06_fn_specs__weaken_3_std [#"06_fn_specs.rs" 20 0 20 64]
     (! bb0
     [ bb0 = s0 [ s0 = call_once {f'0} {a'0} (fun (_ret:t_Output) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: t_Output = Any.any_l () | & f'0: t_F = f | & a'0: t_A = a ] 
+     [ & _0: t_Output = Any.any_l () | & f'0: t_F = f | & a'0: t_A = a ] )
     [ return''0 (result:t_Output)-> {[@expl:weaken_3_std result type invariant] [%#s06_fn_specs'2] inv'1 result}
       {[@expl:weaken_3_std ensures] [%#s06_fn_specs'3] postcondition_once f a result}
       (! return' {result}) ]
@@ -281,7 +281,7 @@ module M_06_fn_specs__fn_once_user [#"06_fn_specs.rs" 26 0 26 43]
       | s2 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & f'0: t_F = f | & _4: UInt64.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & f'0: t_F = f | & _4: UInt64.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -309,5 +309,5 @@ module M_06_fn_specs__caller [#"06_fn_specs.rs" 30 0 30 15]
   let rec caller[#"06_fn_specs.rs" 30 0 30 15] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_1 <- () ] s1 | s1 = fn_once_user {_1} (fun (_ret:()) ->  [ &_0 <- _ret ] s2) | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _1: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & _1: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/07_mutable_capture.coma
+++ b/tests/should_succeed/closures/07_mutable_capture.coma
@@ -81,12 +81,12 @@ module M_07_mutable_capture__test_fnmut [#"07_mutable_capture.rs" 5 0 5 29]
       | s4 =  [ &_0'0 <- res ] s5
       | s5 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: Int32.t = Any.any_l ()
     | & _1: MutBorrow.t closure1 = self
     | & res: Int32.t = Any.any_l ()
     | & res'0: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:closure ensures] [%#s07_mutable_capture'4] UInt32.t'int ((self.final)._0).current
       = UInt32.t'int ((self.current)._0).current + 1}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
@@ -120,7 +120,7 @@ module M_07_mutable_capture__test_fnmut [#"07_mutable_capture.rs" 5 0 5 29]
       | s1 = {[@expl:assertion] [%#s07_mutable_capture] UInt32.t'int x'0 = 100002} s2
       | s2 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x'0: UInt32.t = x
     | & c: closure1 = Any.any_l ()
@@ -131,7 +131,7 @@ module M_07_mutable_capture__test_fnmut [#"07_mutable_capture.rs" 5 0 5 29]
     | & _8: Int32.t = Any.any_l ()
     | & _9: MutBorrow.t closure1 = Any.any_l ()
     | & _10: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_07_mutable_capture__call_fnmut [#"07_mutable_capture.rs" 26 0 26 49]
   let%span s07_mutable_capture = "07_mutable_capture.rs" 26 37 26 38
@@ -226,7 +226,7 @@ module M_07_mutable_capture__call_fnmut [#"07_mutable_capture.rs" 26 0 26 49]
     
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & f'0: t_F = f
     | & _5: Int32.t = Any.any_l ()
@@ -234,7 +234,7 @@ module M_07_mutable_capture__call_fnmut [#"07_mutable_capture.rs" 26 0 26 49]
     | & _7: () = Any.any_l ()
     | & _8: MutBorrow.t t_F = Any.any_l ()
     | & _9: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:call_fnmut ensures] [%#s07_mutable_capture'2] exists st1: t_F, st2: t_F, r: Int32.t. postcondition_mut f () st1 r
       /\ postcondition_mut st1 () st2 result /\ resolve st2}
       (! return' {result}) ]
@@ -272,7 +272,7 @@ module M_07_mutable_capture__call_fnonce [#"07_mutable_capture.rs" 33 0 33 47]
     (! bb0
     [ bb0 = s0 [ s0 = call_once {f'0} {_5} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: () = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: () = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:call_fnonce ensures] [%#s07_mutable_capture'1] postcondition_once f () result}
       (! return' {result}) ]
 
@@ -363,12 +363,12 @@ module M_07_mutable_capture__test_fnmut2 [#"07_mutable_capture.rs" 38 0 38 30]
       | s4 =  [ &_0'0 <- res ] s5
       | s5 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: Int32.t = Any.any_l ()
     | & _1: MutBorrow.t closure1 = self
     | & res: Int32.t = Any.any_l ()
     | & res'0: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:closure ensures] [%#s07_mutable_capture'4] UInt32.t'int ((self.final)._0).current
       = UInt32.t'int ((self.current)._0).current + 1}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
@@ -450,7 +450,7 @@ module M_07_mutable_capture__test_fnmut2 [#"07_mutable_capture.rs" 38 0 38 30]
     | bb2 = s0
       [ s0 = {[@expl:assertion] [%#s07_mutable_capture] UInt32.t'int x'0 = 100004} s1 | s1 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x'0: UInt32.t = x
     | & c: closure1 = Any.any_l ()
@@ -458,7 +458,7 @@ module M_07_mutable_capture__test_fnmut2 [#"07_mutable_capture.rs" 38 0 38 30]
     | & _5: Int32.t = Any.any_l ()
     | & _6: MutBorrow.t closure1 = Any.any_l ()
     | & _7: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_07_mutable_capture__test_fnmut3 [#"07_mutable_capture.rs" 53 0 53 30]
   let%span s07_mutable_capture = "07_mutable_capture.rs" 60 20 60 33
@@ -582,7 +582,7 @@ module M_07_mutable_capture__test_fnmut3 [#"07_mutable_capture.rs" 53 0 53 30]
     | bb2 = s0
       [ s0 = {[@expl:assertion] [%#s07_mutable_capture] UInt32.t'int x'0 = 100002} s1 | s1 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x'0: UInt32.t = x
     | & c: closure0 = Any.any_l ()
@@ -590,7 +590,7 @@ module M_07_mutable_capture__test_fnmut3 [#"07_mutable_capture.rs" 53 0 53 30]
     | & _5: Int32.t = Any.any_l ()
     | & _6: MutBorrow.t closure0 = Any.any_l ()
     | & _7: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_07_mutable_capture__test_fnmut2box [#"07_mutable_capture.rs" 64 0 64 33]
   let%span s07_mutable_capture = "07_mutable_capture.rs" 75 20 75 33
@@ -679,12 +679,12 @@ module M_07_mutable_capture__test_fnmut2box [#"07_mutable_capture.rs" 64 0 64 33
       | s4 =  [ &_0'0 <- res ] s5
       | s5 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: Int32.t = Any.any_l ()
     | & _1: MutBorrow.t closure1 = self
     | & res: Int32.t = Any.any_l ()
     | & res'0: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:closure ensures] [%#s07_mutable_capture'4] UInt32.t'int ((self.final)._0).current
       = UInt32.t'int ((self.current)._0).current + 1}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
@@ -880,7 +880,7 @@ module M_07_mutable_capture__test_fnmut2box [#"07_mutable_capture.rs" 64 0 64 33
     | bb5 = s0
       [ s0 = {[@expl:assertion] [%#s07_mutable_capture] UInt32.t'int x'0 = 100004} s1 | s1 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x'0: UInt32.t = x
     | & c: closure1 = Any.any_l ()
@@ -888,7 +888,7 @@ module M_07_mutable_capture__test_fnmut2box [#"07_mutable_capture.rs" 64 0 64 33
     | & _5: Int32.t = Any.any_l ()
     | & _7: MutBorrow.t closure1 = Any.any_l ()
     | & _8: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_07_mutable_capture__test_fnmut3box [#"07_mutable_capture.rs" 79 0 79 33]
   let%span s07_mutable_capture = "07_mutable_capture.rs" 86 20 86 33
@@ -1061,7 +1061,7 @@ module M_07_mutable_capture__test_fnmut3box [#"07_mutable_capture.rs" 79 0 79 33
     | bb4 = s0
       [ s0 = {[@expl:assertion] [%#s07_mutable_capture] UInt32.t'int x'0 = 100002} s1 | s1 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x'0: UInt32.t = x
     | & c: closure0 = Any.any_l ()
@@ -1070,5 +1070,5 @@ module M_07_mutable_capture__test_fnmut3box [#"07_mutable_capture.rs" 79 0 79 33
     | & _6: MutBorrow.t (MutBorrow.t closure0) = Any.any_l ()
     | & _7: MutBorrow.t closure0 = Any.any_l ()
     | & _8: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/08_multiple_calls.coma
+++ b/tests/should_succeed/closures/08_multiple_calls.coma
@@ -61,7 +61,7 @@ module M_08_multiple_calls__multi_use [#"08_multiple_calls.rs" 4 0 4 26]
       | s1 =  [ &_0'0 <- res ] s2
       | s2 = return''0 {_0'0} ]
      ]
-    ) [ & _0'0: UInt32.t = Any.any_l () | & res: UInt32.t = Any.any_l () ] 
+     [ & _0'0: UInt32.t = Any.any_l () | & res: UInt32.t = Any.any_l () ] )
     [ return''0 (result:UInt32.t)-> (! return' {result}) ]
   
   
@@ -184,7 +184,7 @@ module M_08_multiple_calls__multi_use [#"08_multiple_calls.rs" 4 0 4 26]
     (! bb0
     [ bb0 = s0 [ s0 =  [ &c <- { _0 = x'0 } ] s1 | s1 = uses_fn {c} (fun (_ret:()) ->  [ &_4 <- _ret ] s2) | s2 = bb1 ] 
     | bb1 = return''0 {_0'0} ]
-    ) [ & _0'0: () = Any.any_l () | & x'0: t_T = x | & c: closure0 = Any.any_l () | & _4: () = Any.any_l () ] 
+     [ & _0'0: () = Any.any_l () | & x'0: t_T = x | & c: closure0 = Any.any_l () | & _4: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/closures/09_fnonce_resolve.coma
+++ b/tests/should_succeed/closures/09_fnonce_resolve.coma
@@ -73,12 +73,12 @@ module M_09_fnonce_resolve__f [#"09_fnonce_resolve.rs" 4 0 4 17]
       | s6 = bb6 ]
     
     | bb6 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & _1'0: closure0 = self
     | & bx2: MutBorrow.t Int32.t = Any.any_l ()
     | & by2: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:closure ensures] [%#s09_fnonce_resolve'9] Int32.to_int (self._2).final
       + Int32.to_int (self._1).final
       = 3}
@@ -111,7 +111,7 @@ module M_09_fnonce_resolve__f [#"09_fnonce_resolve.rs" 4 0 4 17]
     
     | bb4 = s0 [ s0 = {[@expl:assertion] [%#s09_fnonce_resolve'1] Int32.to_int x + Int32.to_int y = 3} s1 | s1 = bb7 ] 
     | bb7 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & c'0: bool = c
     | & x: Int32.t = Any.any_l ()
@@ -123,5 +123,5 @@ module M_09_fnonce_resolve__f [#"09_fnonce_resolve.rs" 4 0 4 17]
     | & f'0: closure0 = Any.any_l ()
     | & _10: () = Any.any_l ()
     | & _12: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/10_tyinv.coma
+++ b/tests/should_succeed/closures/10_tyinv.coma
@@ -63,7 +63,7 @@ module M_10_tyinv__f [#"10_tyinv.rs" 13 0 13 35]
       | s2 =  [ &_0'1 <- res ] s3
       | s3 = return''0 {_0'1} ]
      ]
-    ) [ & _0'1: UInt32.t = Any.any_l () | & _1'0: closure1 = self | & res: UInt32.t = Any.any_l () ] 
+     [ & _0'1: UInt32.t = Any.any_l () | & _1'0: closure1 = self | & res: UInt32.t = Any.any_l () ] )
     [ return''0 (result:UInt32.t)-> {[@expl:closure ensures] [%#s10_tyinv'6] UInt32.t'int result = 0}
       (! return' {result}) ]
   
@@ -89,14 +89,14 @@ module M_10_tyinv__f [#"10_tyinv.rs" 13 0 13 35]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 =  [ &res <- (_1'0._0).t_Zero__0 ] s1 | s1 =  [ &_0'1 <- res ] s2 | s2 = return''0 {_0'1} ]  ]
-    )
+    
     [ & _0'1: UInt32.t = Any.any_l ()
     | & _1'0: closure0 = self
     | & res: UInt32.t = Any.any_l ()
     | & clos2: closure1 = Any.any_l ()
     | & _7: UInt32.t = Any.any_l ()
     | & _9: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:closure ensures] [%#s10_tyinv'3] UInt32.t'int result = 0}
       (! return' {result}) ]
   
@@ -115,12 +115,12 @@ module M_10_tyinv__f [#"10_tyinv.rs" 13 0 13 35]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'0 y'0} s1 | s1 = {[@expl:type invariant] inv'0 x'0} s2 | s2 = bb3 ] 
     | bb3 = return''0 {_0'1} ]
-    )
+    
     [ & _0'1: () = Any.any_l ()
     | & x'0: t_Zero = x
     | & y'0: t_Zero = y
     | & clos: closure0 = Any.any_l ()
     | & _6: UInt32.t = Any.any_l ()
     | & _8: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/11_proof_assert_in_closure.coma
+++ b/tests/should_succeed/closures/11_proof_assert_in_closure.coma
@@ -15,7 +15,7 @@ module M_11_proof_assert_in_closure__immutable_capture [#"11_proof_assert_in_clo
     [ bb0 = s0
       [ s0 = {[@expl:assertion] [%#s11_proof_assert_in_closure'0] _1._0 = (1: Int32.t)} s1 | s1 = return''0 {_0'0} ]
      ]
-    ) [ & _0'0: () = Any.any_l () | & _1: closure0 = self ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0'0: () = Any.any_l () | & _1: closure0 = self ] ) [ return''0 (result:())-> (! return' {result}) ] 
   
   meta "compute_max_steps" 1000000
   
@@ -29,13 +29,13 @@ module M_11_proof_assert_in_closure__immutable_capture [#"11_proof_assert_in_clo
       | s3 = bb1 ]
     
     | bb1 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & _2: () = Any.any_l ()
     | & _4: closure0 = Any.any_l ()
     | & _6: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_11_proof_assert_in_closure__mutable_capture [#"11_proof_assert_in_closure.rs" 12 0 12 24]
   let%span s11_proof_assert_in_closure = "11_proof_assert_in_closure.rs" 13 16 13 17
@@ -116,7 +116,7 @@ module M_11_proof_assert_in_closure__mutable_capture [#"11_proof_assert_in_closu
       | s3 = {[@expl:assertion] [%#s11_proof_assert_in_closure'2] ((_1.current)._0).current = (2: Int32.t)} s4
       | s4 = return''0 {_0'0} ]
      ]
-    ) [ & _0'0: () = Any.any_l () | & _1: MutBorrow.t closure0 = self ] 
+     [ & _0'0: () = Any.any_l () | & _1: MutBorrow.t closure0 = self ] )
     [ return''0 (result:())-> {[@expl:closure hist_inv post] hist_inv self.current self.final} (! return' {result}) ]
   
   
@@ -136,7 +136,7 @@ module M_11_proof_assert_in_closure__mutable_capture [#"11_proof_assert_in_closu
       | s5 = bb1 ]
     
     | bb1 = s0 [ s0 = -{resolve'3 _4}- s1 | s1 = return''0 {_0'0} ]  ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & _2: () = Any.any_l ()
@@ -144,7 +144,7 @@ module M_11_proof_assert_in_closure__mutable_capture [#"11_proof_assert_in_closu
     | & _4: closure0 = Any.any_l ()
     | & _5: MutBorrow.t Int32.t = Any.any_l ()
     | & _6: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_11_proof_assert_in_closure__captures_and_call [#"11_proof_assert_in_closure.rs" 29 0 29 26]
   let%span s11_proof_assert_in_closure = "11_proof_assert_in_closure.rs" 30 16 30 17
@@ -230,7 +230,7 @@ module M_11_proof_assert_in_closure__captures_and_call [#"11_proof_assert_in_clo
       | s3 = {[@expl:assertion] [%#s11_proof_assert_in_closure'3] ((_1.current)._0).current = (2: Int32.t)} s4
       | s4 = return''0 {_0'0} ]
      ]
-    ) [ & _0'0: () = Any.any_l () | & _1: MutBorrow.t closure0 = self ] 
+     [ & _0'0: () = Any.any_l () | & _1: MutBorrow.t closure0 = self ] )
     [ return''0 (result:())-> {[@expl:closure ensures] [%#s11_proof_assert_in_closure'5] ((self.final)._0).current
       = (2: Int32.t)}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
@@ -259,11 +259,11 @@ module M_11_proof_assert_in_closure__captures_and_call [#"11_proof_assert_in_clo
     | bb1 = s0
       [ s0 = {[@expl:assertion] [%#s11_proof_assert_in_closure'0] x = (2: Int32.t)} s1 | s1 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & clos: closure0 = Any.any_l ()
     | & _3: MutBorrow.t Int32.t = Any.any_l ()
     | & _4: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/13_ref_box.coma
+++ b/tests/should_succeed/closures/13_ref_box.coma
@@ -92,7 +92,7 @@ module M_13_ref_box__call_fn [#"13_ref_box.rs" 6 0 6 50]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _6: Int32.t = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _6: Int32.t = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:call_fn ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -181,13 +181,13 @@ module M_13_ref_box__call_fnmut [#"13_ref_box.rs" 12 0 12 60]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & f'0: t_F = f
     | & x'0: Int32.t = x
     | & _5: MutBorrow.t t_F = Any.any_l ()
     | & _6: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:call_fnmut ensures] [%#s13_ref_box'1] exists f2: t_F. postcondition_mut f x f2 result
       /\ resolve f2}
       (! return' {result}) ]
@@ -227,7 +227,7 @@ module M_13_ref_box__call_fnonce [#"13_ref_box.rs" 18 0 18 58]
       [ s0 =  [ &_6 <- x'0 ] s1 | s1 = call_once {f'0} {_6} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s2) | s2 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _6: Int32.t = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _6: Int32.t = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:call_fnonce ensures] [%#s13_ref_box'1] postcondition_once f x result}
       (! return' {result}) ]
 
@@ -374,7 +374,7 @@ module M_13_ref_box__test1 [#"13_ref_box.rs" 24 0 24 52]
     [ bb0 = s0 [ s0 = call_fn {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test1 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -526,7 +526,7 @@ module M_13_ref_box__test2 [#"13_ref_box.rs" 30 0 30 52]
     [ bb0 = bb1
     | bb1 = s0 [ s0 = call_fn {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test2 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -659,7 +659,7 @@ module M_13_ref_box__test3 [#"13_ref_box.rs" 36 0 36 52]
     [ bb0 = s0 [ s0 = call_fnmut {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test3 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -797,7 +797,7 @@ module M_13_ref_box__test4 [#"13_ref_box.rs" 42 0 42 52]
     [ bb0 = bb1
     | bb1 = s0 [ s0 = call_fnmut {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test4 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -946,7 +946,7 @@ module M_13_ref_box__test5 [#"13_ref_box.rs" 48 0 48 56]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _5: MutBorrow.t t_F = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _5: MutBorrow.t t_F = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:test5 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -1049,7 +1049,7 @@ module M_13_ref_box__test6 [#"13_ref_box.rs" 54 0 54 52]
     [ bb0 = s0 [ s0 = call_fnonce {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test6 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -1152,7 +1152,7 @@ module M_13_ref_box__test7 [#"13_ref_box.rs" 60 0 60 52]
     [ bb0 = bb1
     | bb1 = s0 [ s0 = call_fnonce {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test7 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -1262,7 +1262,7 @@ module M_13_ref_box__test8 [#"13_ref_box.rs" 66 0 66 56]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _5: MutBorrow.t t_F = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _5: MutBorrow.t t_F = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:test8 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -1381,7 +1381,7 @@ module M_13_ref_box__test9 [#"13_ref_box.rs" 72 0 72 55]
     [ bb0 = bb1
     | bb1 = s0 [ s0 = call_fnmut {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test9 ensures] [%#s13_ref_box'1] exists f2: t_F. postcondition_mut f x f2 result
       /\ resolve f2}
       (! return' {result}) ]
@@ -1512,7 +1512,7 @@ module M_13_ref_box__test10 [#"13_ref_box.rs" 78 0 78 60]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _5: MutBorrow.t t_F = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _5: MutBorrow.t t_F = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:test10 ensures] [%#s13_ref_box'1] exists f2: t_F. postcondition_mut f x f2 result
       /\ resolve f2}
       (! return' {result}) ]
@@ -1597,7 +1597,7 @@ module M_13_ref_box__test11 [#"13_ref_box.rs" 84 0 84 56]
     [ bb0 = bb1
     | bb1 = s0 [ s0 = call_fnonce {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test11 ensures] [%#s13_ref_box'1] exists f2: t_F. postcondition_mut f x f2 result
       /\ resolve f2}
       (! return' {result}) ]
@@ -1689,7 +1689,7 @@ module M_13_ref_box__test12 [#"13_ref_box.rs" 90 0 90 60]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _5: MutBorrow.t t_F = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x | & _5: MutBorrow.t t_F = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:test12 ensures] [%#s13_ref_box'1] exists f2: t_F. postcondition_mut f x f2 result
       /\ resolve f2}
       (! return' {result}) ]
@@ -1742,7 +1742,7 @@ module M_13_ref_box__test13 [#"13_ref_box.rs" 96 0 96 56]
     [ bb0 = bb1
     | bb1 = s0 [ s0 = call_fnonce {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test13 ensures] [%#s13_ref_box'1] postcondition_once f x result}
       (! return' {result}) ]
 
@@ -1833,7 +1833,7 @@ module M_13_ref_box__test14 [#"13_ref_box.rs" 102 0 102 53]
     (! bb0
     [ bb0 = s0 [ s0 = call_fnmut {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test14 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -1921,7 +1921,7 @@ module M_13_ref_box__test15 [#"13_ref_box.rs" 108 0 108 53]
     (! bb0
     [ bb0 = s0 [ s0 = call_fnonce {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test15 ensures] [%#s13_ref_box'1] postcondition f x result}
       (! return' {result}) ]
 
@@ -1990,7 +1990,7 @@ module M_13_ref_box__test16 [#"13_ref_box.rs" 114 0 114 56]
     (! bb0
     [ bb0 = s0 [ s0 = call_fnonce {f'0} {x'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & x'0: Int32.t = x ] )
     [ return''0 (result:Int32.t)-> {[@expl:test16 ensures] [%#s13_ref_box'1] exists f2: t_F. postcondition_mut f x f2 result
       /\ resolve f2}
       (! return' {result}) ]

--- a/tests/should_succeed/closures/14_move_resolve.coma
+++ b/tests/should_succeed/closures/14_move_resolve.coma
@@ -28,7 +28,7 @@ module M_14_move_resolve__f [#"14_move_resolve.rs" 5 0 5 17]
   
   let rec closure1[#"14_move_resolve.rs" 7 12 7 29] (self:closure1) (return'  (x:()))= {[@expl:closure 'self' type invariant] [%#s14_move_resolve'2] inv'1 self}
     {[@expl:closure requires] [%#s14_move_resolve'3] true}
-    (! bb0 [ bb0 = return''0 {_0'0} ] ) [ & _0'0: () = Any.any_l () | & _1: closure1 = self ] 
+    (! bb0 [ bb0 = return''0 {_0'0} ]  [ & _0'0: () = Any.any_l () | & _1: closure1 = self ] )
     [ return''0 (result:())-> (! return' {result}) ]
   
   
@@ -55,13 +55,13 @@ module M_14_move_resolve__f [#"14_move_resolve.rs" 5 0 5 17]
     
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv'0 f'0} s1 | s1 = -{resolve'0 f'0}- s2 | s2 = bb4 ] 
     | bb4 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x'0: t_T = x
     | & xx: t_T = Any.any_l ()
     | & f'0: closure1 = Any.any_l ()
     | & _8: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_14_move_resolve__g [#"14_move_resolve.rs" 16 0 16 17]
   let%span s14_move_resolve = "14_move_resolve.rs" 17 13 17 25
@@ -117,11 +117,11 @@ module M_14_move_resolve__g [#"14_move_resolve.rs" 16 0 16 17]
     
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv'0 f} s1 | s1 = -{resolve'0 f}- s2 | s2 = bb4 ] 
     | bb4 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & x'0: t_T = x
     | & xx: t_T = Any.any_l ()
     | & f: closure0 = Any.any_l ()
     | & _8: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/closures/inference.coma
+++ b/tests/should_succeed/closures/inference.coma
@@ -95,7 +95,7 @@ module M_inference__call_with_one [#"inference.rs" 6 0 6 52]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: Int32.t = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: Int32.t = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:call_with_one ensures] [%#sinference'2] postcondition f (1: Int32.t) result}
       (! return' {result}) ]
 
@@ -195,12 +195,12 @@ module M_inference__call_with_one_mut [#"inference.rs" 12 0 12 60]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'0 f'0} s1 | s1 = -{resolve'1 f'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & f'0: MutBorrow.t t_F = f
     | & _4: MutBorrow.t t_F = Any.any_l ()
     | & _5: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:call_with_one_mut ensures] [%#sinference'2] postcondition_mut f.current (1: Int32.t) f.final result}
       (! return' {result}) ]
 
@@ -242,7 +242,7 @@ module M_inference__call_with_one_once [#"inference.rs" 18 0 18 61]
       | s2 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: Int32.t = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: Int32.t = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:call_with_one_once ensures] [%#sinference'2] postcondition_once f (1: Int32.t) result}
       (! return' {result}) ]
 
@@ -389,7 +389,7 @@ module M_inference__closure_fn [#"inference.rs" 22 0 22 19]
     | bb9 = {[%#sinference'2] false} any
     | bb6 = {[%#sinference'3] false} any
     | bb3 = {[%#sinference'4] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & f: () = Any.any_l ()
     | & _3: bool = Any.any_l ()
@@ -400,7 +400,7 @@ module M_inference__closure_fn [#"inference.rs" 22 0 22 19]
     | & _11: MutBorrow.t () = Any.any_l ()
     | & _14: bool = Any.any_l ()
     | & _15: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_inference__closure_fn_mut [#"inference.rs" 30 0 30 23]
   let%span sinference = "inference.rs" 31 16 31 17
@@ -538,7 +538,7 @@ module M_inference__closure_fn_mut [#"inference.rs" 30 0 30 23]
     | bb8 = {[%#sinference'3] false} any
     | bb6 = {[%#sinference'4] false} any
     | bb3 = s0 [ s0 = -{resolve'3 f}- s1 | s1 = {[%#sinference'5] false} any ]  ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & y: Int32.t = Any.any_l ()
     | & f: closure0 = Any.any_l ()
@@ -550,7 +550,7 @@ module M_inference__closure_fn_mut [#"inference.rs" 30 0 30 23]
     | & _11: bool = Any.any_l ()
     | & _12: Int32.t = Any.any_l ()
     | & _16: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_inference__closure_fn_once [#"inference.rs" 42 0 42 24]
   let%span sinference = "inference.rs" 43 21 43 22
@@ -620,7 +620,7 @@ module M_inference__closure_fn_once [#"inference.rs" 42 0 42 24]
     | bb8 = return''0 {_0'0}
     | bb6 = {[%#sinference'3] false} any
     | bb4 = {[%#sinference'4] false} any ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & y: Int32.t = Any.any_l ()
     | & z: Int32.t = Any.any_l ()
@@ -628,5 +628,5 @@ module M_inference__closure_fn_once [#"inference.rs" 42 0 42 24]
     | & _5: bool = Any.any_l ()
     | & _6: Int32.t = Any.any_l ()
     | & _10: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/constrained_types.coma
+++ b/tests/should_succeed/constrained_types.coma
@@ -167,7 +167,7 @@ module M_constrained_types__uses_concrete_instance [#"constrained_types.rs" 14 0
   
   let rec uses_concrete_instance[#"constrained_types.rs" 14 0 14 67] (x:tuple) (y:tuple) (return'  (x'0:bool))= (! bb0
     [ bb0 = s0 [ s0 = lt {x'0} {y'0} (fun (_ret:bool) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & x'0: tuple = x | & y'0: tuple = y ] 
+     [ & _0: bool = Any.any_l () | & x'0: tuple = x | & y'0: tuple = y ] )
     [ return''0 (result:bool)-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/drop_pair.coma
+++ b/tests/should_succeed/drop_pair.coma
@@ -30,7 +30,7 @@ module M_drop_pair__drop_pair [#"drop_pair.rs" 7 0 7 42]
   
   let rec drop_pair[#"drop_pair.rs" 7 0 7 42] (_x:tuple) (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = -{resolve'2 _x'0}- s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & _x'0: tuple = _x ] 
+     [ & _0: () = Any.any_l () | & _x'0: tuple = _x ] )
     [ return''0 (result:())-> {[@expl:drop_pair ensures #0] [%#sdrop_pair] resolve'2 _x}
       {[@expl:drop_pair ensures #1] [%#sdrop_pair'0] (_x._p0).final = (_x._p0).current}
       {[@expl:drop_pair ensures #2] [%#sdrop_pair'1] (_x._p1).final = (_x._p1).current}
@@ -66,7 +66,7 @@ module M_drop_pair__drop_pair2 [#"drop_pair.rs" 9 0 9 42]
   
   let rec drop_pair2[#"drop_pair.rs" 9 0 9 42] (x:tuple) (return'  (x'0:()))= (! bb0
     [ bb0 = s0 [ s0 = -{resolve'2 x'0}- s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & x'0: tuple = x ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & x'0: tuple = x ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_drop_pair__drop [#"drop_pair.rs" 15 0 15 52]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 49 20 49 34
@@ -95,10 +95,10 @@ module M_drop_pair__drop [#"drop_pair.rs" 15 0 15 52]
       | s4 = -{resolve'0 y'0}- s5
       | s5 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _x'0: MutBorrow.t UInt32.t = _x
     | & y'0: MutBorrow.t UInt32.t = y
     | & _3: MutBorrow.t UInt32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/duration.coma
+++ b/tests/should_succeed/duration.coma
@@ -470,7 +470,7 @@ module M_duration__test_duration [#"duration.rs" 7 0 7 22]
     | bb18 = {[%#sduration'38] false} any
     | bb12 = {[%#sduration'39] false} any
     | bb4 = {[%#sduration'40] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & zero: t_Duration = Any.any_l ()
     | & _5: bool = Any.any_l ()
@@ -520,5 +520,5 @@ module M_duration__test_duration [#"duration.rs" 7 0 7 22]
     | & _123: t_Option = Any.any_l ()
     | & sum: t_Duration = Any.any_l ()
     | & difference: t_Duration = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/filter_positive.coma
+++ b/tests/should_succeed/filter_positive.coma
@@ -356,7 +356,7 @@ module M_filter_positive__m [#"filter_positive.rs" 82 0 82 33]
     
     | bb21 = s0 [ s0 =  [ &_0 <- u ] s1 | s1 = bb23 ] 
     | bb23 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Vec = Any.any_l ()
     | & t'0: t_Vec = t
     | & count: UInt64.t = Any.any_l ()
@@ -373,5 +373,5 @@ module M_filter_positive__m [#"filter_positive.rs" 82 0 82 33]
     | & _43: Int32.t = Any.any_l ()
     | & _46: MutBorrow.t Int32.t = Any.any_l ()
     | & _47: MutBorrow.t t_Vec = Any.any_l () ]
-     [ return''0 (result:t_Vec)-> (! return' {result}) ] 
+    ) [ return''0 (result:t_Vec)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/fmap_indexing.coma
+++ b/tests/should_succeed/fmap_indexing.coma
@@ -102,11 +102,11 @@ module M_fmap_indexing__foo [#"fmap_indexing.rs" 4 0 4 12]
       | s1 = {[@expl:assertion] [%#sfmap_indexing'5] index_logic'0 map 1 = 4 /\ index_logic'0 map 2 = 42} s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & map: t_FMap = Any.any_l ()
     | & _3: t_FMap = Any.any_l ()
     | & _7: t_FMap = Any.any_l ()
     | & _11: t_FMap = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/fn_ghost.coma
+++ b/tests/should_succeed/fn_ghost.coma
@@ -190,7 +190,7 @@ module M_fn_ghost__foo [#"fn_ghost.rs" 4 0 4 12]
     | bb10 = {[%#sfn_ghost'2] false} any
     | bb7 = {[%#sfn_ghost'3] false} any
     | bb4 = {[%#sfn_ghost'4] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & f: t_FnGhostWrapper = Any.any_l ()
     | & _2: () = Any.any_l ()
@@ -200,7 +200,7 @@ module M_fn_ghost__foo [#"fn_ghost.rs" 4 0 4 12]
     | & _12: bool = Any.any_l ()
     | & result'1: Int32.t = Any.any_l ()
     | & _18: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_fn_ghost__takes_ghost_fn [#"fn_ghost.rs" 18 0 18 63]
   let%span sfn_ghost = "fn_ghost.rs" 19 6 19 7
@@ -299,7 +299,7 @@ module M_fn_ghost__takes_ghost_fn [#"fn_ghost.rs" 18 0 18 63]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: Int32.t = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: Int32.t = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:takes_ghost_fn ensures] [%#sfn_ghost'2] postcondition f (1: Int32.t) result}
       (! return' {result}) ]
 
@@ -389,12 +389,12 @@ module M_fn_ghost__takes_ghost_fnmut [#"fn_ghost.rs" 25 0 25 73]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv f'0} s1 | s1 = -{resolve f'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & f'0: t_F = f
     | & _4: MutBorrow.t t_F = Any.any_l ()
     | & _5: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:takes_ghost_fnmut ensures] [%#sfn_ghost'2] exists f2: t_F. postcondition_mut f (1: Int32.t) f2 result}
       (! return' {result}) ]
 
@@ -436,7 +436,7 @@ module M_fn_ghost__takes_ghost_fnonce [#"fn_ghost.rs" 32 0 32 71]
       | s2 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: Int32.t = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () | & f'0: t_F = f | & _5: Int32.t = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:takes_ghost_fnonce ensures] [%#sfn_ghost'2] postcondition_once f (1: Int32.t) result}
       (! return' {result}) ]
 

--- a/tests/should_succeed/generic_deref.coma
+++ b/tests/should_succeed/generic_deref.coma
@@ -111,7 +111,7 @@ module M_generic_deref__deref_wrap [#"generic_deref.rs" 7 0 7 48]
     (! bb0
     [ bb0 = s0 [ s0 =  [ &_6 <- x'0 ] s1 | s1 = deref {_6} (fun (_ret:t_Target) ->  [ &_4 <- _ret ] s2) | s2 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- _4 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Target = Any.any_l () | & x'0: t_T = x | & _4: t_Target = Any.any_l () | & _6: t_T = Any.any_l () ] 
+     [ & _0: t_Target = Any.any_l () | & x'0: t_T = x | & _4: t_Target = Any.any_l () | & _6: t_T = Any.any_l () ] )
     [ return''0 (result:t_Target)-> {[@expl:deref_wrap result type invariant] [%#sgeneric_deref'1] inv'0 result}
       {[@expl:deref_wrap ensures] [%#sgeneric_deref'2] postcondition () x result}
       (! return' {result}) ]
@@ -287,14 +287,14 @@ module M_generic_deref__deref_mut_wrap [#"generic_deref.rs" 17 0 17 63]
       | s9 = -{resolve'0 x'0}- s10
       | s10 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_Target = Any.any_l ()
     | & x'0: MutBorrow.t t_T = x
     | & _2: MutBorrow.t t_Target = Any.any_l ()
     | & _5: MutBorrow.t t_Target = Any.any_l ()
     | & _6: MutBorrow.t t_T = Any.any_l ()
     | & _7: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_Target)-> {[@expl:deref_mut_wrap result type invariant] [%#sgeneric_deref'1] inv'1 result}
       {[@expl:deref_mut_wrap ensures] [%#sgeneric_deref'2] postcondition () x result}
       (! return' {result}) ]

--- a/tests/should_succeed/ghost/assert_in_ghost.coma
+++ b/tests/should_succeed/ghost/assert_in_ghost.coma
@@ -22,7 +22,7 @@ module M_assert_in_ghost__ghost_only [#"assert_in_ghost.rs" 4 0 4 19]
       | s3 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _1:  () = Any.any_l () | & _2: () = Any.any_l () | & x: Int32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & _1:  () = Any.any_l () | & _2: () = Any.any_l () | & x: Int32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -51,13 +51,13 @@ module M_assert_in_ghost__ghost_capture [#"assert_in_ghost.rs" 11 0 11 22]
       | s4 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & _2:  () = Any.any_l ()
     | & _3: () = Any.any_l ()
     | & y: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_assert_in_ghost__ghost_mutate [#"assert_in_ghost.rs" 20 0 20 21]
   let%span sassert_in_ghost = "assert_in_ghost.rs" 21 25 21 29
@@ -123,7 +123,7 @@ module M_assert_in_ghost__ghost_mutate [#"assert_in_ghost.rs" 20 0 20 21]
       | s3 = bb4 ]
     
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & p:  tuple = Any.any_l ()
     | & _2: tuple = Any.any_l ()
@@ -133,5 +133,5 @@ module M_assert_in_ghost__ghost_mutate [#"assert_in_ghost.rs" 20 0 20 21]
     | & _6: MutBorrow.t ( tuple) = Any.any_l ()
     | & _7:  () = Any.any_l ()
     | & _8: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/ghost/disjoint_raw_ptr.coma
+++ b/tests/should_succeed/ghost/disjoint_raw_ptr.coma
@@ -192,7 +192,7 @@ module M_disjoint_raw_ptr__foo [#"disjoint_raw_ptr.rs" 4 0 4 12]
       | s1 = {[@expl:assertion] [%#sdisjoint_raw_ptr'2] p1 <> p2} s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & p1: Opaque.ptr = Any.any_l ()
     | & own1:  t_PtrOwn = Any.any_l ()
@@ -209,5 +209,5 @@ module M_disjoint_raw_ptr__foo [#"disjoint_raw_ptr.rs" 4 0 4 12]
     | & _13: MutBorrow.t ( t_PtrOwn) = Any.any_l ()
     | & _15: t_PtrOwn = Any.any_l ()
     | & _17:  t_PtrOwn = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/ghost/ghost_map.coma
+++ b/tests/should_succeed/ghost/ghost_map.coma
@@ -556,7 +556,7 @@ module M_ghost_map__ghost_map [#"ghost_map.rs" 4 0 4 18]
       | s4 = bb44 ]
     
     | bb44 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & map:  t_FMap = Any.any_l ()
     | & _2:  () = Any.any_l ()
@@ -638,5 +638,5 @@ module M_ghost_map__ghost_map [#"ghost_map.rs" 4 0 4 18]
     | & _162: Int32.t = Any.any_l ()
     | & _163: Int32.t = Any.any_l ()
     | & _164: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/ghost/ghost_set.coma
+++ b/tests/should_succeed/ghost/ghost_set.coma
@@ -251,7 +251,7 @@ module M_ghost_set__ghost_map [#"ghost_set.rs" 4 0 4 18]
       | s4 = bb24 ]
     
     | bb24 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & set:  (Fset.fset Int32.t) = Any.any_l ()
     | & _2:  () = Any.any_l ()
@@ -300,5 +300,5 @@ module M_ghost_set__ghost_map [#"ghost_set.rs" 4 0 4 18]
     | & contains3: bool = Any.any_l ()
     | & _78: Fset.fset Int32.t = Any.any_l ()
     | & _81: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/ghost/ghost_vec.coma
+++ b/tests/should_succeed/ghost/ghost_vec.coma
@@ -501,7 +501,7 @@ module M_ghost_vec__ghost_vec [#"ghost_vec.rs" 4 0 4 18]
     
     | bb60 = return''0 {_0}
     | bb5 = {[%#sghost_vec'27] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v:  (Seq.seq Int32.t) = Any.any_l ()
     | & _4:  () = Any.any_l ()
@@ -590,5 +590,5 @@ module M_ghost_vec__ghost_vec [#"ghost_vec.rs" 4 0 4 18]
     | & _127: MutBorrow.t (Seq.seq Int32.t) = Any.any_l ()
     | & _128: MutBorrow.t (Seq.seq Int32.t) = Any.any_l ()
     | & _129: MutBorrow.t ( (Seq.seq Int32.t)) = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/ghost/integers.coma
+++ b/tests/should_succeed/ghost/integers.coma
@@ -84,7 +84,7 @@ module M_integers__in_ghost_block [#"integers.rs" 4 0 4 23]
       | s2 = bb19 ]
     
     | bb19 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x:  int = Any.any_l ()
     | & _2: int = Any.any_l ()
@@ -107,7 +107,7 @@ module M_integers__in_ghost_block [#"integers.rs" 4 0 4 23]
     | & _25:  int = Any.any_l ()
     | & _26: int = Any.any_l ()
     | & _27:  int = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_integers__ghost_function [#"integers.rs" 21 0 21 52]
   let%span sintegers = "integers.rs" 20 10 20 29
@@ -133,7 +133,7 @@ module M_integers__ghost_function [#"integers.rs" 21 0 21 52]
     [ bb0 = s0 [ s0 = rem {y'0} {z'0} (fun (_ret:int) ->  [ &_6 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = add {x'0} {_6} (fun (_ret:int) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: int = Any.any_l () | & x'0: int = x | & y'0: int = y | & z'0: int = z | & _6: int = Any.any_l () ] 
+     [ & _0: int = Any.any_l () | & x'0: int = x | & y'0: int = y | & z'0: int = z | & _6: int = Any.any_l () ] )
     [ return''0 (result:int)-> {[@expl:ghost_function ensures] [%#sintegers] result = x + Int.mod y z}
       (! return' {result}) ]
 

--- a/tests/should_succeed/ghost/snapshot_in_ghost.coma
+++ b/tests/should_succeed/ghost/snapshot_in_ghost.coma
@@ -21,7 +21,7 @@ module M_snapshot_in_ghost__foo [#"snapshot_in_ghost.rs" 5 0 5 12]
       | s2 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _1:  () = Any.any_l () | & _2: () = Any.any_l () | & x: int = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & _1:  () = Any.any_l () | & _2: () = Any.any_l () | & x: int = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -38,7 +38,7 @@ module M_snapshot_in_ghost__is_ghost [#"snapshot_in_ghost.rs" 14 0 14 17]
   let rec is_ghost[#"snapshot_in_ghost.rs" 14 0 14 17] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &x <- [%#ssnapshot_in_ghost] 1 ] s1 | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:assertion] [%#ssnapshot_in_ghost'0] x = 1} s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & x: int = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & x: int = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_snapshot_in_ghost__bar [#"snapshot_in_ghost.rs" 21 0 21 12]
   let%span ssnapshot_in_ghost = "snapshot_in_ghost.rs" 22 21 22 25
@@ -66,11 +66,11 @@ module M_snapshot_in_ghost__bar [#"snapshot_in_ghost.rs" 21 0 21 12]
       | s2 = bb4 ]
     
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & _2:  () = Any.any_l ()
     | & _3: () = Any.any_l ()
     | & _4: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/ghost/typing.coma
+++ b/tests/should_succeed/ghost/typing.coma
@@ -86,7 +86,7 @@ module M_typing__ghost_enter_ghost [#"typing.rs" 14 0 14 26]
       | s1 = {[@expl:assertion] [%#styping'4] view'0 g_mut = 4} s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & g_move:  t_NonCopy = Any.any_l ()
     | & _2: t_NonCopy = Any.any_l ()
@@ -100,7 +100,7 @@ module M_typing__ghost_enter_ghost [#"typing.rs" 14 0 14 26]
     | & _11: t_NonCopy = Any.any_l ()
     | & _12: MutBorrow.t t_NonCopy = Any.any_l ()
     | & _13: MutBorrow.t ( t_NonCopy) = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_typing__snapshot_enter_ghost [#"typing.rs" 29 0 29 29]
   let%span styping = "typing.rs" 30 17 30 41
@@ -152,7 +152,7 @@ module M_typing__snapshot_enter_ghost [#"typing.rs" 29 0 29 29]
       | s1 = {[@expl:assertion] [%#styping'4] view'1 g_mut = 4} s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & g_read: t_NonCopy = Any.any_l ()
     | & g_mut: t_NonCopy = Any.any_l ()
@@ -160,7 +160,7 @@ module M_typing__snapshot_enter_ghost [#"typing.rs" 29 0 29 29]
     | & _5: () = Any.any_l ()
     | & _6: t_NonCopy = Any.any_l ()
     | & _10: t_NonCopy = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_typing__copy_enter_ghost [#"typing.rs" 44 0 44 25]
   let%span styping = "typing.rs" 45 12 45 16
@@ -198,7 +198,7 @@ module M_typing__copy_enter_ghost [#"typing.rs" 44 0 44 25]
       | s1 = {[@expl:assertion] [%#styping'3] Int32.to_int pair._p0 = 6 /\ Int32.to_int pair._p1 = 42} s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & pair: tuple = Any.any_l ()
@@ -206,5 +206,5 @@ module M_typing__copy_enter_ghost [#"typing.rs" 44 0 44 25]
     | & _5: () = Any.any_l ()
     | & _x: Int32.t = Any.any_l ()
     | & _pair: tuple = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/hashmap.coma
+++ b/tests/should_succeed/hashmap.coma
@@ -108,7 +108,7 @@ module M_hashmap__qyi9060063638777358169__hash [#"hashmap.rs" 74 4 74 25] (* <us
       [ s0 = UInt64.of_int {UInt64.t'int self'0} (fun (_ret_from:UInt64.t) ->  [ &_0 <- _ret_from ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt64.t = Any.any_l () | & self'0: UInt64.t = self ] 
+     [ & _0: UInt64.t = Any.any_l () | & self'0: UInt64.t = self ] )
     [ return''0 (result:UInt64.t)-> {[@expl:hash ensures] [%#shashmap] UInt64.t'int result
       = hash_log (deep_model'0 self)}
       (! return' {result}) ]
@@ -486,13 +486,13 @@ module M_hashmap__qyi9690720112976707081__new [#"hashmap.rs" 145 4 145 46] (* My
     | bb1 = s0 [ s0 =  [ &res <- { t_MyHashMap__buckets = _5 } ] s1 | s1 = bb2 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- res ] s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: t_MyHashMap = Any.any_l ()
     | & size'0: UInt64.t = size
     | & res: t_MyHashMap = Any.any_l ()
     | & _5: t_Vec = Any.any_l ()
     | & _6: t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_MyHashMap)-> {[@expl:new result type invariant] [%#shashmap'0] inv'6 result}
       {[@expl:new ensures] [%#shashmap'1] forall i: t_DeepModelTy. Map.get (view'0 result) i = C_None}
       (! return' {result}) ]
@@ -1042,7 +1042,7 @@ module M_hashmap__qyi9690720112976707081__add [#"hashmap.rs" 151 4 151 41] (* My
       | s11 = bb20 ]
     
     | bb20 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_MyHashMap = self
     | & key'0: t_K = key
@@ -1069,7 +1069,7 @@ module M_hashmap__qyi9690720112976707081__add [#"hashmap.rs" 151 4 151 41] (* My
     | & _46: t_List = Any.any_l ()
     | & _47: tuple = Any.any_l ()
     | & _51: t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:add ensures] [%#shashmap'12] forall i: t_DeepModelTy. Map.get (view'2 self.final) i
       = (if i = deep_model key then C_Some val' else Map.get (view'3 self) i)}
       (! return' {result}) ]
@@ -1399,7 +1399,7 @@ module M_hashmap__qyi9690720112976707081__get [#"hashmap.rs" 183 4 183 43] (* My
     | bb12 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb13 ] 
     | bb10 = s0 [ s0 =  [ &_0 <- C_Some'0 v ] s1 | s1 = bb13 ] 
     | bb13 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: t_MyHashMap = self
     | & key'0: t_K = key
@@ -1415,7 +1415,7 @@ module M_hashmap__qyi9690720112976707081__get [#"hashmap.rs" 183 4 183 43] (* My
     | & tl: t_List = Any.any_l ()
     | & _26: bool = Any.any_l ()
     | & _32: t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:get result type invariant] [%#shashmap'4] inv'12 result}
       {[@expl:get ensures] [%#shashmap'5] match result with
         | C_Some'0 v -> Map.get (view'2 self) (deep_model key) = C_Some v
@@ -1905,7 +1905,7 @@ module M_hashmap__qyi9690720112976707081__resize [#"hashmap.rs" 202 4 202 24] (*
       | s5 = bb25 ]
     
     | bb25 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_MyHashMap = self
     | & old_self: MutBorrow.t t_MyHashMap = Any.any_l ()
@@ -1927,7 +1927,7 @@ module M_hashmap__qyi9690720112976707081__resize [#"hashmap.rs" 202 4 202 24] (*
     | & _45: () = Any.any_l ()
     | & _46: MutBorrow.t t_MyHashMap = Any.any_l ()
     | & old_4_0: MutBorrow.t t_MyHashMap = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:resize ensures] [%#shashmap'20] forall k: t_DeepModelTy. Map.get (view'1 self.final) k
       = Map.get (view'2 self) k}
       (! return' {result}) ]
@@ -2191,7 +2191,7 @@ module M_hashmap__main [#"hashmap.rs" 242 0 242 13]
     
     | bb16 = s0 [ s0 =  [ &_t <- _29 ] s1 | s1 = bb18 ] 
     | bb18 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & h1: t_MyHashMap = Any.any_l ()
     | & h2: t_MyHashMap = Any.any_l ()
@@ -2211,7 +2211,7 @@ module M_hashmap__main [#"hashmap.rs" 242 0 242 13]
     | & _25: t_Option'0 = Any.any_l ()
     | & _27: t_Option'0 = Any.any_l ()
     | & _29: t_Option'0 = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_hashmap__qyi891699778403859561__clone__refines [#"hashmap.rs" 16 4 16 27] (* <List<T> as creusot_contracts::Clone> *)
   let%span shashmap = "hashmap.rs" 16 4 16 27

--- a/tests/should_succeed/heapsort_generic.coma
+++ b/tests/should_succeed/heapsort_generic.coma
@@ -560,7 +560,7 @@ module M_heapsort_generic__sift_down [#"heapsort_generic.rs" 41 0 43 29]
     | bb5 = s0 [ s0 = {[@expl:type invariant] inv'3 v'0} s1 | s1 = -{resolve'2 v'0}- s2 | s2 = bb23 ] 
     | bb19 = s0 [ s0 = {[@expl:type invariant] inv'3 v'0} s1 | s1 = -{resolve'2 v'0}- s2 | s2 = bb23 ] 
     | bb23 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & start'0: UInt64.t = start
@@ -586,7 +586,7 @@ module M_heapsort_generic__sift_down [#"heapsort_generic.rs" 41 0 43 29]
     | & _63: MutBorrow.t (Slice64.slice t_T) = Any.any_l ()
     | & _64: MutBorrow.t t_Vec = Any.any_l ()
     | & old_2_0: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:sift_down ensures #0] [%#sheapsort_generic'19] heap_frag (deep_model'0 v.final) (UInt64.t'int start) (UInt64.t'int end')}
       {[@expl:sift_down ensures #1] [%#sheapsort_generic'20] permutation_of (view v.final) (view'0 v)}
       {[@expl:sift_down ensures #2] [%#sheapsort_generic'21] forall i: int. 0 <= i /\ i < UInt64.t'int start
@@ -1040,7 +1040,7 @@ module M_heapsort_generic__heap_sort [#"heapsort_generic.rs" 95 0 97 29]
        ]
     
     | bb17 = s0 [ s0 = {[@expl:type invariant] inv'4 v'0} s1 | s1 = -{resolve'2 v'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & old_v: MutBorrow.t t_Vec = Any.any_l ()
@@ -1061,7 +1061,7 @@ module M_heapsort_generic__heap_sort [#"heapsort_generic.rs" 95 0 97 29]
     | & _42: MutBorrow.t t_Vec = Any.any_l ()
     | & old_4_0: MutBorrow.t t_Vec = Any.any_l ()
     | & old_11_0: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:heap_sort ensures #0] [%#sheapsort_generic'18] sorted (deep_model'0 v.final)}
       {[@expl:heap_sort ensures #1] [%#sheapsort_generic'19] permutation_of (view v.final) (view'1 v)}
       (! return' {result}) ]

--- a/tests/should_succeed/hillel.coma
+++ b/tests/should_succeed/hillel.coma
@@ -170,7 +170,7 @@ module M_hillel__right_pad [#"hillel.rs" 17 0 17 59]
        ]
     
     | bb7 = s0 [ s0 = {[@expl:type invariant] inv'4 str'0} s1 | s1 = -{resolve'0 str'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & str'0: MutBorrow.t t_Vec = str
     | & len'1: UInt64.t = len'0
@@ -181,7 +181,7 @@ module M_hillel__right_pad [#"hillel.rs" 17 0 17 59]
     | & _23: () = Any.any_l ()
     | & _24: MutBorrow.t t_Vec = Any.any_l ()
     | & old_2_0: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:right_pad ensures #0] [%#shillel'7] Seq.length (view str.final)
       >= UInt64.t'int len'0
       /\ Seq.length (view str.final) >= Seq.length (view'0 str)}
@@ -386,7 +386,7 @@ module M_hillel__left_pad [#"hillel.rs" 34 0 34 58]
        ]
     
     | bb9 = s0 [ s0 = {[@expl:type invariant] inv'4 str'0} s1 | s1 = -{resolve'0 str'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & str'0: MutBorrow.t t_Vec = str
     | & len'1: UInt64.t = len'0
@@ -399,7 +399,7 @@ module M_hillel__left_pad [#"hillel.rs" 34 0 34 58]
     | & _25: MutBorrow.t t_Vec = Any.any_l ()
     | & _27: int = Any.any_l ()
     | & old_3_0: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:left_pad ensures #0] [%#shillel'11] Seq.length (view str.final)
       >= UInt64.t'int len'0
       /\ Seq.length (view str.final) >= Seq.length (view'0 str)}
@@ -862,7 +862,7 @@ module M_hillel__insert_unique [#"hillel.rs" 80 0 80 62]
     
     | bb19 = s0 [ s0 = {[@expl:type invariant] inv'12 vec'0} s1 | s1 = -{resolve'3 vec'0}- s2 | s2 = bb20 ] 
     | bb20 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & vec'0: MutBorrow.t t_Vec = vec
     | & elem'0: t_T = elem
@@ -882,7 +882,7 @@ module M_hillel__insert_unique [#"hillel.rs" 80 0 80 62]
     | & _40: bool = Any.any_l ()
     | & _52: () = Any.any_l ()
     | & _53: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:insert_unique ensures #0] [%#shillel'14] is_unique (deep_model'0 vec.final)}
       {[@expl:insert_unique ensures #1] [%#shillel'15] is_subset (deep_model'1 vec) (deep_model'0 vec.final)}
       {[@expl:insert_unique ensures #2] [%#shillel'16] is_subset (deep_model'0 vec.final) (Seq.snoc (deep_model'1 vec) (deep_model elem))}
@@ -1252,7 +1252,7 @@ module M_hillel__unique [#"hillel.rs" 102 0 102 56]
       | s3 = bb18 ]
     
     | bb18 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Vec = Any.any_l ()
     | & str'0: Slice64.slice t_T = str
     | & unique'0: t_Vec = Any.any_l ()
@@ -1276,7 +1276,7 @@ module M_hillel__unique [#"hillel.rs" 102 0 102 56]
     | & _39: MutBorrow.t t_Vec = Any.any_l ()
     | & _40: MutBorrow.t t_Vec = Any.any_l ()
     | & _42: Seq.seq t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Vec)-> {[@expl:unique result type invariant] [%#shillel'14] inv'2 result}
       {[@expl:unique ensures #0] [%#shillel'15] is_unique (deep_model'2 result)}
       {[@expl:unique ensures #1] [%#shillel'16] is_subset (deep_model'2 result) (deep_model'1 str)}
@@ -1821,7 +1821,7 @@ module M_hillel__fulcrum [#"hillel.rs" 159 0 159 30]
        ]
     
     | bb21 = s0 [ s0 =  [ &_0 <- min_i ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & s'0: Slice64.slice UInt32.t = s
     | & total: UInt32.t = Any.any_l ()
@@ -1854,7 +1854,7 @@ module M_hillel__fulcrum [#"hillel.rs" 159 0 159 30]
     | & _74: UInt64.t = Any.any_l ()
     | & _75: UInt64.t = Any.any_l ()
     | & _76: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:fulcrum ensures #0] [%#shillel'22] 0 <= UInt64.t'int result
       /\ UInt64.t'int result < Seq.length (view'1 s)}
       {[@expl:fulcrum ensures #1] [%#shillel'23] forall i: int. 0 <= i /\ i < Seq.length (view'1 s)

--- a/tests/should_succeed/immut.coma
+++ b/tests/should_succeed/immut.coma
@@ -25,10 +25,10 @@ module M_immut__f [#"immut.rs" 3 0 3 10]
       | s3 = -{resolve'0 b}- s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: UInt32.t = Any.any_l ()
     | & b: MutBorrow.t UInt32.t = Any.any_l ()
     | & _c: UInt32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/index_range.coma
+++ b/tests/should_succeed/index_range.coma
@@ -95,7 +95,7 @@ module M_index_range__create_arr [#"index_range.rs" 14 0 14 27]
     
     | bb6 = s0 [ s0 =  [ &_0 <- arr ] s1 | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Vec = Any.any_l ()
     | & arr: t_Vec = Any.any_l ()
     | & _3: () = Any.any_l ()
@@ -108,7 +108,7 @@ module M_index_range__create_arr [#"index_range.rs" 14 0 14 27]
     | & _10: MutBorrow.t t_Vec = Any.any_l ()
     | & _11: () = Any.any_l ()
     | & _12: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Vec)-> {[@expl:create_arr ensures] [%#sindex_range'4] Seq.length (view result) = 5
       /\ Int32.to_int (index_logic result 0) = 0
       /\ Int32.to_int (index_logic result 1) = 1
@@ -627,7 +627,7 @@ module M_index_range__test_range [#"index_range.rs" 27 0 27 19]
     | bb27 = {[%#sindex_range'67] false} any
     | bb23 = {[%#sindex_range'68] false} any
     | bb12 = {[%#sindex_range'69] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & arr: t_Vec = Any.any_l ()
     | & s: Slice64.slice Int32.t = Any.any_l ()
@@ -711,7 +711,7 @@ module M_index_range__test_range [#"index_range.rs" 27 0 27 19]
     | & _143: Int32.t = Any.any_l ()
     | & _147: bool = Any.any_l ()
     | & _149: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_index_range__test_range_to [#"index_range.rs" 78 0 78 22]
   let%span sindex_range = "index_range.rs" 85 19 85 20
@@ -1085,7 +1085,7 @@ module M_index_range__test_range_to [#"index_range.rs" 78 0 78 22]
     | bb21 = {[%#sindex_range'40] false} any
     | bb16 = {[%#sindex_range'41] false} any
     | bb12 = {[%#sindex_range'42] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & arr: t_Vec = Any.any_l ()
     | & s: Slice64.slice Int32.t = Any.any_l ()
@@ -1140,7 +1140,7 @@ module M_index_range__test_range_to [#"index_range.rs" 78 0 78 22]
     | & _89: Int32.t = Any.any_l ()
     | & _93: bool = Any.any_l ()
     | & _95: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_index_range__test_range_from [#"index_range.rs" 115 0 115 24]
   let%span sindex_range = "index_range.rs" 122 17 122 18
@@ -1525,7 +1525,7 @@ module M_index_range__test_range_from [#"index_range.rs" 115 0 115 24]
     | bb21 = {[%#sindex_range'42] false} any
     | bb16 = {[%#sindex_range'43] false} any
     | bb12 = {[%#sindex_range'44] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & arr: t_Vec = Any.any_l ()
     | & s: Slice64.slice Int32.t = Any.any_l ()
@@ -1584,7 +1584,7 @@ module M_index_range__test_range_from [#"index_range.rs" 115 0 115 24]
     | & _98: Int32.t = Any.any_l ()
     | & _102: bool = Any.any_l ()
     | & _104: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_index_range__test_range_full [#"index_range.rs" 154 0 154 24]
   let%span sindex_range = "index_range.rs" 162 23 162 24
@@ -1930,7 +1930,7 @@ module M_index_range__test_range_full [#"index_range.rs" 154 0 154 24]
     | bb30 = {[%#sindex_range'38] false} any
     | bb25 = s0 [ s0 = -{resolve'0 s'0}- s1 | s1 = -{resolve'0 _37}- s2 | s2 = {[%#sindex_range'39] false} any ] 
     | bb21 = {[%#sindex_range'40] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & arr: t_Vec = Any.any_l ()
     | & s: Slice64.slice Int32.t = Any.any_l ()
@@ -1984,7 +1984,7 @@ module M_index_range__test_range_full [#"index_range.rs" 154 0 154 24]
     | & _79: Int32.t = Any.any_l ()
     | & _83: bool = Any.any_l ()
     | & _85: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_index_range__test_range_to_inclusive [#"index_range.rs" 179 0 179 32]
   let%span sindex_range = "index_range.rs" 186 20 186 21
@@ -2344,7 +2344,7 @@ module M_index_range__test_range_to_inclusive [#"index_range.rs" 179 0 179 32]
     | bb21 = s0 [ s0 = -{resolve'0 s'0}- s1 | s1 = -{resolve'0 _31}- s2 | s2 = {[%#sindex_range'37] false} any ] 
     | bb17 = {[%#sindex_range'38] false} any
     | bb12 = {[%#sindex_range'39] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & arr: t_Vec = Any.any_l ()
     | & s: Slice64.slice Int32.t = Any.any_l ()
@@ -2395,5 +2395,5 @@ module M_index_range__test_range_to_inclusive [#"index_range.rs" 179 0 179 32]
     | & _81: Int32.t = Any.any_l ()
     | & _85: bool = Any.any_l ()
     | & _87: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/inferred_invariants.coma
+++ b/tests/should_succeed/inferred_invariants.coma
@@ -29,7 +29,7 @@ module M_inferred_invariants__f [#"inferred_invariants.rs" 4 0 4 18]
   let rec f[#"inferred_invariants.rs" 4 0 4 18] (_0:MutBorrow.t t_T) (return'  (x:()))= {[@expl:f '_0' type invariant] inv'0 _0}
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv'0 _1} s1 | s1 = -{resolve'0 _1}- s2 | s2 = return''0 {_0'0} ]  ]
-    ) [ & _0'0: () = Any.any_l () | & _1: MutBorrow.t t_T = _0 ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0'0: () = Any.any_l () | & _1: MutBorrow.t t_T = _0 ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_inferred_invariants__simple [#"inferred_invariants.rs" 6 0 6 27]
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 101 20 101 44
@@ -77,12 +77,12 @@ module M_inferred_invariants__simple [#"inferred_invariants.rs" 6 0 6 27]
          ]
        ]
      ]
-    )
+    
     [ & x'0: MutBorrow.t t_T = x
     | & _4: () = Any.any_l ()
     | & _6: MutBorrow.t t_T = Any.any_l ()
     | & old_1_0: MutBorrow.t t_T = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_inferred_invariants__swapper [#"inferred_invariants.rs" 13 0 13 57]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 49 20 49 34
@@ -150,13 +150,13 @@ module M_inferred_invariants__swapper [#"inferred_invariants.rs" 13 0 13 57]
          ]
        ]
      ]
-    )
+    
     [ & x'0: MutBorrow.t t_T = x
     | & y'0: MutBorrow.t t_T = y
     | & c: MutBorrow.t t_T = Any.any_l ()
     | & _9: MutBorrow.t t_T = Any.any_l ()
     | & _10: MutBorrow.t t_T = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_inferred_invariants__tuple [#"inferred_invariants.rs" 23 0 23 71]
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 101 20 101 44
@@ -201,7 +201,7 @@ module M_inferred_invariants__tuple [#"inferred_invariants.rs" 23 0 23 71]
         [ bb2 = s0 [ s0 =  [ &c <- d'0 ] s1 | s1 =  [ &d'0 <- e'0 ] s2 | s2 =  [ &e'0 <- c ] s3 | s3 = bb1'0 ]  ]
        ]
      ]
-    ) [ & d'0: tuple = d | & e'0: tuple = e | & c: tuple = Any.any_l () ] 
+     [ & d'0: tuple = d | & e'0: tuple = e | & c: tuple = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -257,7 +257,7 @@ module M_inferred_invariants__temp_move [#"inferred_invariants.rs" 33 0 33 41]
          ]
        ]
      ]
-    ) [ & x'0: MutBorrow.t t_T = x | & c: MutBorrow.t t_T = Any.any_l () | & _7: MutBorrow.t t_T = Any.any_l () ] 
+     [ & x'0: MutBorrow.t t_T = x | & c: MutBorrow.t t_T = Any.any_l () | & _7: MutBorrow.t t_T = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -400,7 +400,7 @@ module M_inferred_invariants__y [#"inferred_invariants.rs" 41 0 41 26]
        ]
     
     | bb9 = s0 [ s0 = -{resolve'2 v'0}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & old_v: MutBorrow.t t_Vec = Any.any_l ()
@@ -411,7 +411,7 @@ module M_inferred_invariants__y [#"inferred_invariants.rs" 41 0 41 26]
     | & _15: MutBorrow.t t_Vec = Any.any_l ()
     | & _17: bool = Any.any_l ()
     | & old_2_0: MutBorrow.t t_Vec = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_inferred_invariants__nested_loops [#"inferred_invariants.rs" 60 0 60 32]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 49 20 49 34
@@ -477,7 +477,7 @@ module M_inferred_invariants__nested_loops [#"inferred_invariants.rs" 60 0 60 32
        ]
     
     | bb3 = s0 [ s0 = -{resolve'0 x'0}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t Int32.t = x
     | & i: Int32.t = Any.any_l ()
@@ -486,7 +486,7 @@ module M_inferred_invariants__nested_loops [#"inferred_invariants.rs" 60 0 60 32
     | & _16: bool = Any.any_l ()
     | & old_5_0: MutBorrow.t Int32.t = Any.any_l ()
     | & old_1_0: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:nested_loops ensures] [%#sinferred_invariants'9] x.final = (0: Int32.t)}
       (! return' {result}) ]
 
@@ -578,7 +578,7 @@ module M_inferred_invariants__nested_borrows [#"inferred_invariants.rs" 86 0 86 
       | s3 = -{resolve'2 y'0}- s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t (MutBorrow.t Int32.t) = x
     | & y'0: MutBorrow.t Int32.t = y
@@ -589,7 +589,7 @@ module M_inferred_invariants__nested_borrows [#"inferred_invariants.rs" 86 0 86 
     | & _17: MutBorrow.t Int32.t = Any.any_l ()
     | & old_1_0: MutBorrow.t (MutBorrow.t Int32.t) = Any.any_l ()
     | & old_1_1: MutBorrow.t Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:nested_borrows ensures #0] [%#sinferred_invariants'6] x.final = y}
       {[@expl:nested_borrows ensures #1] [%#sinferred_invariants'7] (x.current).final = (1: Int32.t)}
       (! return' {result}) ]

--- a/tests/should_succeed/inplace_list_reversal.coma
+++ b/tests/should_succeed/inplace_list_reversal.coma
@@ -158,7 +158,7 @@ module M_inplace_list_reversal__rev [#"inplace_list_reversal.rs" 24 0 24 30]
       | s4 = bb24 ]
     
     | bb24 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & l'0: MutBorrow.t t_List = l
     | & old_l: MutBorrow.t t_List = Any.any_l ()
@@ -169,7 +169,7 @@ module M_inplace_list_reversal__rev [#"inplace_list_reversal.rs" 24 0 24 30]
     | & curr: tuple = Any.any_l ()
     | & next: t_List = Any.any_l ()
     | & _19: t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:rev ensures] [%#sinplace_list_reversal'4] l.final = rev_append l.current (C_Nil)}
       (! return' {result}) ]
 

--- a/tests/should_succeed/insertion_sort.coma
+++ b/tests/should_succeed/insertion_sort.coma
@@ -405,7 +405,7 @@ module M_insertion_sort__insertion_sort [#"insertion_sort.rs" 23 0 23 40]
       | s1 = {[@expl:assertion] [%#sinsertion_sort'19] sorted_range (view'1 array'0) 0 (Seq.length (view'1 array'0))} s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & array'0: MutBorrow.t (Slice64.slice Int32.t) = array
     | & original: MutBorrow.t (Slice64.slice Int32.t) = Any.any_l ()
@@ -436,7 +436,7 @@ module M_insertion_sort__insertion_sort [#"insertion_sort.rs" 23 0 23 40]
     | & _56: UInt64.t = Any.any_l ()
     | & old_14_0: MutBorrow.t (Slice64.slice Int32.t) = Any.any_l ()
     | & old_6_0: MutBorrow.t (Slice64.slice Int32.t) = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:insertion_sort ensures #0] [%#sinsertion_sort'20] permutation_of (view'1 array) (view array.final)}
       {[@expl:insertion_sort ensures #1] [%#sinsertion_sort'21] sorted (view array.final)}
       (! return' {result}) ]

--- a/tests/should_succeed/instant.coma
+++ b/tests/should_succeed/instant.coma
@@ -457,7 +457,7 @@ module M_instant__test_instant [#"instant.rs" 7 0 7 21]
     | bb15 = {[%#sinstant'15] false} any
     | bb11 = {[%#sinstant'16] false} any
     | bb6 = {[%#sinstant'17] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & instant: t_Instant'0 = Any.any_l ()
     | & zero_dur: t_Duration = Any.any_l ()
@@ -495,5 +495,5 @@ module M_instant__test_instant [#"instant.rs" 7 0 7 21]
     | & _117: t_Duration = Any.any_l ()
     | & _123: bool = Any.any_l ()
     | & _125: t_Duration = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/integer_ops.coma
+++ b/tests/should_succeed/integer_ops.coma
@@ -1508,7 +1508,7 @@ module M_integer_ops__test_bitwise_ops [#"integer_ops.rs" 5 0 5 25]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_17 <- left_val ] s2 | s2 =  [ &_19 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: tuple = Any.any_l ()
     | & left_val: UInt8BW.t = Any.any_l ()
@@ -1924,7 +1924,7 @@ module M_integer_ops__test_bitwise_ops [#"integer_ops.rs" 5 0 5 25]
     | & _1010: Int8BW.t = Any.any_l ()
     | & _1011: UInt8BW.t = Any.any_l ()
     | & _1012: UInt8BW.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_integer_ops__test_shift_ops [#"integer_ops.rs" 62 0 62 23]
   let%span sinteger_ops = "integer_ops.rs" 64 32 64 33
@@ -2421,7 +2421,7 @@ module M_integer_ops__test_shift_ops [#"integer_ops.rs" 62 0 62 23]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_17 <- left_val ] s2 | s2 =  [ &_19 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: tuple = Any.any_l ()
     | & left_val: UInt8BW.t = Any.any_l ()
@@ -2549,7 +2549,7 @@ module M_integer_ops__test_shift_ops [#"integer_ops.rs" 62 0 62 23]
     | & _307: Int8BW.t = Any.any_l ()
     | & _308: UInt8BW.t = Any.any_l ()
     | & _309: UInt8BW.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_integer_ops__u8__test_add [#"integer_ops.rs" 84 30 86 11]
   let%span sinteger_ops = "integer_ops.rs" 84 19 84 61
@@ -2573,7 +2573,7 @@ module M_integer_ops__u8__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ UInt8.t'int l + UInt8.t'int r <= UInt8.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt8.add {l'0} {r'0} (fun (_ret:UInt8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt8.t = Any.any_l () | & l'0: UInt8.t = l | & r'0: UInt8.t = r ] 
+     [ & _0: UInt8.t = Any.any_l () | & l'0: UInt8.t = l | & r'0: UInt8.t = r ] )
     [ return''0 (result:UInt8.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] UInt8.t'int result
       = UInt8.t'int l + UInt8.t'int r}
       (! return' {result}) ]
@@ -2601,7 +2601,7 @@ module M_integer_ops__u8__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ UInt8BW.t'int l + UInt8BW.t'int r <= UInt8BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt8BW.add {l'0} {r'0} (fun (_ret:UInt8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt8BW.t = Any.any_l () | & l'0: UInt8BW.t = l | & r'0: UInt8BW.t = r ] 
+     [ & _0: UInt8BW.t = Any.any_l () | & l'0: UInt8BW.t = l | & r'0: UInt8BW.t = r ] )
     [ return''0 (result:UInt8BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] UInt8BW.t'int result
       = UInt8BW.t'int l + UInt8BW.t'int r}
       (! return' {result}) ]
@@ -2629,7 +2629,7 @@ module M_integer_ops__u8__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ UInt8.t'int l - UInt8.t'int r <= UInt8.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt8.sub {l'0} {r'0} (fun (_ret:UInt8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt8.t = Any.any_l () | & l'0: UInt8.t = l | & r'0: UInt8.t = r ] 
+     [ & _0: UInt8.t = Any.any_l () | & l'0: UInt8.t = l | & r'0: UInt8.t = r ] )
     [ return''0 (result:UInt8.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] UInt8.t'int result
       = UInt8.t'int l - UInt8.t'int r}
       (! return' {result}) ]
@@ -2657,7 +2657,7 @@ module M_integer_ops__u8__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ UInt8BW.t'int l - UInt8BW.t'int r <= UInt8BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt8BW.sub {l'0} {r'0} (fun (_ret:UInt8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt8BW.t = Any.any_l () | & l'0: UInt8BW.t = l | & r'0: UInt8BW.t = r ] 
+     [ & _0: UInt8BW.t = Any.any_l () | & l'0: UInt8BW.t = l | & r'0: UInt8BW.t = r ] )
     [ return''0 (result:UInt8BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] UInt8BW.t'int result
       = UInt8BW.t'int l - UInt8BW.t'int r}
       (! return' {result}) ]
@@ -2685,7 +2685,7 @@ module M_integer_ops__u8__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ UInt8.t'int l * UInt8.t'int r <= UInt8.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt8.mul {l'0} {r'0} (fun (_ret:UInt8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt8.t = Any.any_l () | & l'0: UInt8.t = l | & r'0: UInt8.t = r ] 
+     [ & _0: UInt8.t = Any.any_l () | & l'0: UInt8.t = l | & r'0: UInt8.t = r ] )
     [ return''0 (result:UInt8.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] UInt8.t'int result
       = UInt8.t'int l * UInt8.t'int r}
       (! return' {result}) ]
@@ -2713,7 +2713,7 @@ module M_integer_ops__u8__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ UInt8BW.t'int l * UInt8BW.t'int r <= UInt8BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt8BW.mul {l'0} {r'0} (fun (_ret:UInt8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt8BW.t = Any.any_l () | & l'0: UInt8BW.t = l | & r'0: UInt8BW.t = r ] 
+     [ & _0: UInt8BW.t = Any.any_l () | & l'0: UInt8BW.t = l | & r'0: UInt8BW.t = r ] )
     [ return''0 (result:UInt8BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] UInt8BW.t'int result
       = UInt8BW.t'int l * UInt8BW.t'int r}
       (! return' {result}) ]
@@ -2749,13 +2749,13 @@ module M_integer_ops__u8__test_div [#"integer_ops.rs" 84 30 126 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt8.div {l'0} {_7} (fun (_ret:UInt8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt8.t = Any.any_l ()
     | & l'0: UInt8.t = l
     | & r'0: UInt8.t = r
     | & _7: UInt8.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt8.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] UInt8.t'int result
       = Int.div (UInt8.t'int l) (UInt8.t'int r)}
       (! return' {result}) ]
@@ -2792,13 +2792,13 @@ module M_integer_ops__u8__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt8BW.div {l'0} {_7} (fun (_ret:UInt8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt8BW.t = Any.any_l ()
     | & l'0: UInt8BW.t = l
     | & r'0: UInt8BW.t = r
     | & _7: UInt8BW.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt8BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] UInt8BW.t'int result
       = Int.div (UInt8BW.t'int l) (UInt8BW.t'int r)}
       (! return' {result}) ]
@@ -2875,7 +2875,7 @@ module M_integer_ops__u8__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt8.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -2896,7 +2896,7 @@ module M_integer_ops__u8__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: UInt8.t = Any.any_l ()
     | & _46: UInt8.t = Any.any_l ()
     | & _47: UInt8.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt8.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = UInt8.of_bool b}
       (! return' {result}) ]
 
@@ -2972,7 +2972,7 @@ module M_integer_ops__u8__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt8BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -2993,7 +2993,7 @@ module M_integer_ops__u8__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: UInt8BW.t = Any.any_l ()
     | & _46: UInt8BW.t = Any.any_l ()
     | & _47: UInt8BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt8BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = UInt8BW.of_bool b}
       (! return' {result}) ]
 
@@ -3016,7 +3016,7 @@ module M_integer_ops__u8__test_shl [#"integer_ops.rs" 84 30 155 11]
       [ s0 = UInt8.shl {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:UInt8.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt8.t = Any.any_l () | & n'0: UInt8.t = n ] 
+     [ & _0: UInt8.t = Any.any_l () | & n'0: UInt8.t = n ] )
     [ return''0 (result:UInt8.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = UInt8.lsl n (UInt8.t'int (3: UInt8.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = UInt8.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -3042,7 +3042,7 @@ module M_integer_ops__u8__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:UInt8BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt8BW.t = Any.any_l () | & n'0: UInt8BW.t = n ] 
+     [ & _0: UInt8BW.t = Any.any_l () | & n'0: UInt8BW.t = n ] )
     [ return''0 (result:UInt8BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = UInt8BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = UInt8BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -3067,7 +3067,7 @@ module M_integer_ops__u8__test_shr [#"integer_ops.rs" 84 30 168 11]
       [ s0 = UInt8.shr {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:UInt8.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt8.t = Any.any_l () | & n'0: UInt8.t = n ] 
+     [ & _0: UInt8.t = Any.any_l () | & n'0: UInt8.t = n ] )
     [ return''0 (result:UInt8.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = UInt8.shr n (UInt8.t'int (3: UInt8.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = UInt8.shr n (UInt8.t'int (3: UInt8.t))}
@@ -3093,7 +3093,7 @@ module M_integer_ops__u8__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:UInt8BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt8BW.t = Any.any_l () | & n'0: UInt8BW.t = n ] 
+     [ & _0: UInt8BW.t = Any.any_l () | & n'0: UInt8BW.t = n ] )
     [ return''0 (result:UInt8BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = UInt8BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = UInt8BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -3147,7 +3147,7 @@ module M_integer_ops__u8__test_to_char [#"integer_ops.rs" 185 4 185 25]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_18 <- left_val ] s2 | s2 =  [ &_20 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: tuple = Any.any_l ()
     | & left_val: Char.t = Any.any_l ()
@@ -3158,7 +3158,7 @@ module M_integer_ops__u8__test_to_char [#"integer_ops.rs" 185 4 185 25]
     | & _20: Char.t = Any.any_l ()
     | & _22: Char.t = Any.any_l ()
     | & _23: Char.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_integer_ops__u8__test_to_char_bw [#"integer_ops.rs" 190 4 190 28]
   let%span sinteger_ops = "integer_ops.rs" 191 20 191 24
@@ -3207,7 +3207,7 @@ module M_integer_ops__u8__test_to_char_bw [#"integer_ops.rs" 190 4 190 28]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_18 <- left_val ] s2 | s2 =  [ &_20 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: tuple = Any.any_l ()
     | & left_val: Char.t = Any.any_l ()
@@ -3218,7 +3218,7 @@ module M_integer_ops__u8__test_to_char_bw [#"integer_ops.rs" 190 4 190 28]
     | & _20: Char.t = Any.any_l ()
     | & _22: Char.t = Any.any_l ()
     | & _23: Char.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_integer_ops__i8__test_add [#"integer_ops.rs" 84 30 86 11]
   let%span sinteger_ops = "integer_ops.rs" 84 19 84 61
@@ -3240,9 +3240,9 @@ module M_integer_ops__i8__test_add [#"integer_ops.rs" 84 30 86 11]
     + Int8.to_int r
     >= Int8.to_int v_MIN
     /\ Int8.to_int l + Int8.to_int r <= Int8.to_int v_MAX}
-    (! bb0
-    [ bb0 = s0 [ s0 = Int8.add {l'0} {r'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int8.t = Any.any_l () | & l'0: Int8.t = l | & r'0: Int8.t = r ] 
+    (! bb0 [ bb0 = s0 [ s0 = Int8.add {l'0} {r'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ] 
+    [ & _0: Int8.t = Any.any_l () | & l'0: Int8.t = l | & r'0: Int8.t = r ]
+    )
     [ return''0 (result:Int8.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] Int8.to_int result
       = Int8.to_int l + Int8.to_int r}
       (! return' {result}) ]
@@ -3270,7 +3270,7 @@ module M_integer_ops__i8__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ Int8BW.to_int l + Int8BW.to_int r <= Int8BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int8BW.add {l'0} {r'0} (fun (_ret:Int8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int8BW.t = Any.any_l () | & l'0: Int8BW.t = l | & r'0: Int8BW.t = r ] 
+     [ & _0: Int8BW.t = Any.any_l () | & l'0: Int8BW.t = l | & r'0: Int8BW.t = r ] )
     [ return''0 (result:Int8BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] Int8BW.to_int result
       = Int8BW.to_int l + Int8BW.to_int r}
       (! return' {result}) ]
@@ -3296,9 +3296,9 @@ module M_integer_ops__i8__test_sub [#"integer_ops.rs" 84 30 99 11]
     - Int8.to_int r
     >= Int8.to_int v_MIN
     /\ Int8.to_int l - Int8.to_int r <= Int8.to_int v_MAX}
-    (! bb0
-    [ bb0 = s0 [ s0 = Int8.sub {l'0} {r'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int8.t = Any.any_l () | & l'0: Int8.t = l | & r'0: Int8.t = r ] 
+    (! bb0 [ bb0 = s0 [ s0 = Int8.sub {l'0} {r'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ] 
+    [ & _0: Int8.t = Any.any_l () | & l'0: Int8.t = l | & r'0: Int8.t = r ]
+    )
     [ return''0 (result:Int8.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] Int8.to_int result
       = Int8.to_int l - Int8.to_int r}
       (! return' {result}) ]
@@ -3326,7 +3326,7 @@ module M_integer_ops__i8__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ Int8BW.to_int l - Int8BW.to_int r <= Int8BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int8BW.sub {l'0} {r'0} (fun (_ret:Int8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int8BW.t = Any.any_l () | & l'0: Int8BW.t = l | & r'0: Int8BW.t = r ] 
+     [ & _0: Int8BW.t = Any.any_l () | & l'0: Int8BW.t = l | & r'0: Int8BW.t = r ] )
     [ return''0 (result:Int8BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] Int8BW.to_int result
       = Int8BW.to_int l - Int8BW.to_int r}
       (! return' {result}) ]
@@ -3352,9 +3352,9 @@ module M_integer_ops__i8__test_mul [#"integer_ops.rs" 84 30 112 11]
     * Int8.to_int r
     >= Int8.to_int v_MIN
     /\ Int8.to_int l * Int8.to_int r <= Int8.to_int v_MAX}
-    (! bb0
-    [ bb0 = s0 [ s0 = Int8.mul {l'0} {r'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int8.t = Any.any_l () | & l'0: Int8.t = l | & r'0: Int8.t = r ] 
+    (! bb0 [ bb0 = s0 [ s0 = Int8.mul {l'0} {r'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ] 
+    [ & _0: Int8.t = Any.any_l () | & l'0: Int8.t = l | & r'0: Int8.t = r ]
+    )
     [ return''0 (result:Int8.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] Int8.to_int result
       = Int8.to_int l * Int8.to_int r}
       (! return' {result}) ]
@@ -3382,7 +3382,7 @@ module M_integer_ops__i8__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ Int8BW.to_int l * Int8BW.to_int r <= Int8BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int8BW.mul {l'0} {r'0} (fun (_ret:Int8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int8BW.t = Any.any_l () | & l'0: Int8BW.t = l | & r'0: Int8BW.t = r ] 
+     [ & _0: Int8BW.t = Any.any_l () | & l'0: Int8BW.t = l | & r'0: Int8BW.t = r ] )
     [ return''0 (result:Int8BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] Int8BW.to_int result
       = Int8BW.to_int l * Int8BW.to_int r}
       (! return' {result}) ]
@@ -3427,7 +3427,7 @@ module M_integer_ops__i8__test_div [#"integer_ops.rs" 84 30 126 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int8.div {_6} {_7} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int8.t = Any.any_l ()
     | & l'0: Int8.t = l
     | & r'0: Int8.t = r
@@ -3437,7 +3437,7 @@ module M_integer_ops__i8__test_div [#"integer_ops.rs" 84 30 126 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int8.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] Int8.to_int result
       = Int.div (Int8.to_int l) (Int8.to_int r)}
       (! return' {result}) ]
@@ -3483,7 +3483,7 @@ module M_integer_ops__i8__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int8BW.div {_6} {_7} (fun (_ret:Int8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int8BW.t = Any.any_l ()
     | & l'0: Int8BW.t = l
     | & r'0: Int8BW.t = r
@@ -3493,7 +3493,7 @@ module M_integer_ops__i8__test_div_bw [#"integer_ops.rs" 84 30 134 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int8BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] Int8BW.to_int result
       = Int.div (Int8BW.to_int l) (Int8BW.to_int r)}
       (! return' {result}) ]
@@ -3570,7 +3570,7 @@ module M_integer_ops__i8__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int8.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -3591,7 +3591,7 @@ module M_integer_ops__i8__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: Int8.t = Any.any_l ()
     | & _46: Int8.t = Any.any_l ()
     | & _47: Int8.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int8.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = Int8.of_bool b}
       (! return' {result}) ]
 
@@ -3667,7 +3667,7 @@ module M_integer_ops__i8__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int8BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -3688,7 +3688,7 @@ module M_integer_ops__i8__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: Int8BW.t = Any.any_l ()
     | & _46: Int8BW.t = Any.any_l ()
     | & _47: Int8BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int8BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = Int8BW.of_bool b}
       (! return' {result}) ]
 
@@ -3712,7 +3712,7 @@ module M_integer_ops__i8__test_shl [#"integer_ops.rs" 84 30 155 11]
       [ s0 = Int8.shl {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int8.t = Any.any_l () | & n'0: Int8.t = n ] 
+     [ & _0: Int8.t = Any.any_l () | & n'0: Int8.t = n ] )
     [ return''0 (result:Int8.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = Int8.lsl n (Int8.t'int (3: Int8.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = Int8.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -3739,7 +3739,7 @@ module M_integer_ops__i8__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:Int8BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int8BW.t = Any.any_l () | & n'0: Int8BW.t = n ] 
+     [ & _0: Int8BW.t = Any.any_l () | & n'0: Int8BW.t = n ] )
     [ return''0 (result:Int8BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = Int8BW.lsl n (Int8BW.t'int (3: Int8BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = Int8BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -3765,7 +3765,7 @@ module M_integer_ops__i8__test_shr [#"integer_ops.rs" 84 30 168 11]
       [ s0 = Int8.shr {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int8.t = Any.any_l () | & n'0: Int8.t = n ] 
+     [ & _0: Int8.t = Any.any_l () | & n'0: Int8.t = n ] )
     [ return''0 (result:Int8.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = Int8.shr n (Int8.t'int (3: Int8.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = Int8.shr n (UInt8.t'int (3: UInt8.t))}
@@ -3792,7 +3792,7 @@ module M_integer_ops__i8__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:Int8BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int8BW.t = Any.any_l () | & n'0: Int8BW.t = n ] 
+     [ & _0: Int8BW.t = Any.any_l () | & n'0: Int8BW.t = n ] )
     [ return''0 (result:Int8BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = Int8BW.shr n (Int8BW.t'int (3: Int8BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = Int8BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -3874,9 +3874,9 @@ module M_integer_ops__i8__test_neg [#"integer_ops.rs" 201 4 201 32]
   meta "select_lsinst" "all"
   
   let rec test_neg[#"integer_ops.rs" 201 4 201 32] (n:Int8.t) (return'  (x:Int8.t))= {[@expl:test_neg requires] [%#sinteger_ops] Int8.gt n v_MIN}
-    (! bb0 [ bb0 = s0 [ s0 = Int8.neg {n'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 = Int8.neg {n'0} (fun (_ret:Int8.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ] 
     [ & _0: Int8.t = Any.any_l () | & n'0: Int8.t = n ]
-    
+    )
     [ return''0 (result:Int8.t)-> {[@expl:test_neg ensures] [%#sinteger_ops'0] result = Int8.neg n}
       (! return' {result}) ]
 
@@ -3956,9 +3956,9 @@ module M_integer_ops__i8__test_neg_bw [#"integer_ops.rs" 208 4 208 35]
   meta "select_lsinst" "all"
   
   let rec test_neg_bw[#"integer_ops.rs" 208 4 208 35] (n:Int8BW.t) (return'  (x:Int8BW.t))= {[@expl:test_neg_bw requires] [%#sinteger_ops] Int8BW.gt n v_MIN}
-    (! bb0 [ bb0 = s0 [ s0 = Int8BW.neg {n'0} (fun (_ret:Int8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 = Int8BW.neg {n'0} (fun (_ret:Int8BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ] 
     [ & _0: Int8BW.t = Any.any_l () | & n'0: Int8BW.t = n ]
-    
+    )
     [ return''0 (result:Int8BW.t)-> {[@expl:test_neg_bw ensures] [%#sinteger_ops'0] result = Int8BW.neg n}
       (! return' {result}) ]
 
@@ -3985,7 +3985,7 @@ module M_integer_ops__u16__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ UInt16.t'int l + UInt16.t'int r <= UInt16.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt16.add {l'0} {r'0} (fun (_ret:UInt16.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt16.t = Any.any_l () | & l'0: UInt16.t = l | & r'0: UInt16.t = r ] 
+     [ & _0: UInt16.t = Any.any_l () | & l'0: UInt16.t = l | & r'0: UInt16.t = r ] )
     [ return''0 (result:UInt16.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] UInt16.t'int result
       = UInt16.t'int l + UInt16.t'int r}
       (! return' {result}) ]
@@ -4013,7 +4013,7 @@ module M_integer_ops__u16__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ UInt16BW.t'int l + UInt16BW.t'int r <= UInt16BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt16BW.add {l'0} {r'0} (fun (_ret:UInt16BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt16BW.t = Any.any_l () | & l'0: UInt16BW.t = l | & r'0: UInt16BW.t = r ] 
+     [ & _0: UInt16BW.t = Any.any_l () | & l'0: UInt16BW.t = l | & r'0: UInt16BW.t = r ] )
     [ return''0 (result:UInt16BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] UInt16BW.t'int result
       = UInt16BW.t'int l + UInt16BW.t'int r}
       (! return' {result}) ]
@@ -4041,7 +4041,7 @@ module M_integer_ops__u16__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ UInt16.t'int l - UInt16.t'int r <= UInt16.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt16.sub {l'0} {r'0} (fun (_ret:UInt16.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt16.t = Any.any_l () | & l'0: UInt16.t = l | & r'0: UInt16.t = r ] 
+     [ & _0: UInt16.t = Any.any_l () | & l'0: UInt16.t = l | & r'0: UInt16.t = r ] )
     [ return''0 (result:UInt16.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] UInt16.t'int result
       = UInt16.t'int l - UInt16.t'int r}
       (! return' {result}) ]
@@ -4069,7 +4069,7 @@ module M_integer_ops__u16__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ UInt16BW.t'int l - UInt16BW.t'int r <= UInt16BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt16BW.sub {l'0} {r'0} (fun (_ret:UInt16BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt16BW.t = Any.any_l () | & l'0: UInt16BW.t = l | & r'0: UInt16BW.t = r ] 
+     [ & _0: UInt16BW.t = Any.any_l () | & l'0: UInt16BW.t = l | & r'0: UInt16BW.t = r ] )
     [ return''0 (result:UInt16BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] UInt16BW.t'int result
       = UInt16BW.t'int l - UInt16BW.t'int r}
       (! return' {result}) ]
@@ -4097,7 +4097,7 @@ module M_integer_ops__u16__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ UInt16.t'int l * UInt16.t'int r <= UInt16.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt16.mul {l'0} {r'0} (fun (_ret:UInt16.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt16.t = Any.any_l () | & l'0: UInt16.t = l | & r'0: UInt16.t = r ] 
+     [ & _0: UInt16.t = Any.any_l () | & l'0: UInt16.t = l | & r'0: UInt16.t = r ] )
     [ return''0 (result:UInt16.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] UInt16.t'int result
       = UInt16.t'int l * UInt16.t'int r}
       (! return' {result}) ]
@@ -4125,7 +4125,7 @@ module M_integer_ops__u16__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ UInt16BW.t'int l * UInt16BW.t'int r <= UInt16BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt16BW.mul {l'0} {r'0} (fun (_ret:UInt16BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt16BW.t = Any.any_l () | & l'0: UInt16BW.t = l | & r'0: UInt16BW.t = r ] 
+     [ & _0: UInt16BW.t = Any.any_l () | & l'0: UInt16BW.t = l | & r'0: UInt16BW.t = r ] )
     [ return''0 (result:UInt16BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] UInt16BW.t'int result
       = UInt16BW.t'int l * UInt16BW.t'int r}
       (! return' {result}) ]
@@ -4161,13 +4161,13 @@ module M_integer_ops__u16__test_div [#"integer_ops.rs" 84 30 126 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt16.div {l'0} {_7} (fun (_ret:UInt16.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt16.t = Any.any_l ()
     | & l'0: UInt16.t = l
     | & r'0: UInt16.t = r
     | & _7: UInt16.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt16.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] UInt16.t'int result
       = Int.div (UInt16.t'int l) (UInt16.t'int r)}
       (! return' {result}) ]
@@ -4204,13 +4204,13 @@ module M_integer_ops__u16__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt16BW.div {l'0} {_7} (fun (_ret:UInt16BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt16BW.t = Any.any_l ()
     | & l'0: UInt16BW.t = l
     | & r'0: UInt16BW.t = r
     | & _7: UInt16BW.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt16BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] UInt16BW.t'int result
       = Int.div (UInt16BW.t'int l) (UInt16BW.t'int r)}
       (! return' {result}) ]
@@ -4287,7 +4287,7 @@ module M_integer_ops__u16__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt16.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -4308,7 +4308,7 @@ module M_integer_ops__u16__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: UInt16.t = Any.any_l ()
     | & _46: UInt16.t = Any.any_l ()
     | & _47: UInt16.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt16.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = UInt16.of_bool b}
       (! return' {result}) ]
 
@@ -4384,7 +4384,7 @@ module M_integer_ops__u16__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt16BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -4405,7 +4405,7 @@ module M_integer_ops__u16__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: UInt16BW.t = Any.any_l ()
     | & _46: UInt16BW.t = Any.any_l ()
     | & _47: UInt16BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt16BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = UInt16BW.of_bool b}
       (! return' {result}) ]
 
@@ -4430,7 +4430,7 @@ module M_integer_ops__u16__test_shl [#"integer_ops.rs" 84 30 155 11]
           (fun (_ret:UInt16.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt16.t = Any.any_l () | & n'0: UInt16.t = n ] 
+     [ & _0: UInt16.t = Any.any_l () | & n'0: UInt16.t = n ] )
     [ return''0 (result:UInt16.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = UInt16.lsl n (UInt16.t'int (3: UInt16.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = UInt16.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -4457,7 +4457,7 @@ module M_integer_ops__u16__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:UInt16BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt16BW.t = Any.any_l () | & n'0: UInt16BW.t = n ] 
+     [ & _0: UInt16BW.t = Any.any_l () | & n'0: UInt16BW.t = n ] )
     [ return''0 (result:UInt16BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = UInt16BW.lsl n (UInt16BW.t'int (3: UInt16BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = UInt16BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -4484,7 +4484,7 @@ module M_integer_ops__u16__test_shr [#"integer_ops.rs" 84 30 168 11]
           (fun (_ret:UInt16.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt16.t = Any.any_l () | & n'0: UInt16.t = n ] 
+     [ & _0: UInt16.t = Any.any_l () | & n'0: UInt16.t = n ] )
     [ return''0 (result:UInt16.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = UInt16.shr n (UInt16.t'int (3: UInt16.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = UInt16.shr n (UInt8.t'int (3: UInt8.t))}
@@ -4511,7 +4511,7 @@ module M_integer_ops__u16__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:UInt16BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt16BW.t = Any.any_l () | & n'0: UInt16BW.t = n ] 
+     [ & _0: UInt16BW.t = Any.any_l () | & n'0: UInt16BW.t = n ] )
     [ return''0 (result:UInt16BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = UInt16BW.shr n (UInt16BW.t'int (3: UInt16BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = UInt16BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -4540,7 +4540,7 @@ module M_integer_ops__i16__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ Int16.to_int l + Int16.to_int r <= Int16.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int16.add {l'0} {r'0} (fun (_ret:Int16.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int16.t = Any.any_l () | & l'0: Int16.t = l | & r'0: Int16.t = r ] 
+     [ & _0: Int16.t = Any.any_l () | & l'0: Int16.t = l | & r'0: Int16.t = r ] )
     [ return''0 (result:Int16.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] Int16.to_int result
       = Int16.to_int l + Int16.to_int r}
       (! return' {result}) ]
@@ -4568,7 +4568,7 @@ module M_integer_ops__i16__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ Int16BW.to_int l + Int16BW.to_int r <= Int16BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int16BW.add {l'0} {r'0} (fun (_ret:Int16BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int16BW.t = Any.any_l () | & l'0: Int16BW.t = l | & r'0: Int16BW.t = r ] 
+     [ & _0: Int16BW.t = Any.any_l () | & l'0: Int16BW.t = l | & r'0: Int16BW.t = r ] )
     [ return''0 (result:Int16BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] Int16BW.to_int result
       = Int16BW.to_int l + Int16BW.to_int r}
       (! return' {result}) ]
@@ -4596,7 +4596,7 @@ module M_integer_ops__i16__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ Int16.to_int l - Int16.to_int r <= Int16.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int16.sub {l'0} {r'0} (fun (_ret:Int16.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int16.t = Any.any_l () | & l'0: Int16.t = l | & r'0: Int16.t = r ] 
+     [ & _0: Int16.t = Any.any_l () | & l'0: Int16.t = l | & r'0: Int16.t = r ] )
     [ return''0 (result:Int16.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] Int16.to_int result
       = Int16.to_int l - Int16.to_int r}
       (! return' {result}) ]
@@ -4624,7 +4624,7 @@ module M_integer_ops__i16__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ Int16BW.to_int l - Int16BW.to_int r <= Int16BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int16BW.sub {l'0} {r'0} (fun (_ret:Int16BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int16BW.t = Any.any_l () | & l'0: Int16BW.t = l | & r'0: Int16BW.t = r ] 
+     [ & _0: Int16BW.t = Any.any_l () | & l'0: Int16BW.t = l | & r'0: Int16BW.t = r ] )
     [ return''0 (result:Int16BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] Int16BW.to_int result
       = Int16BW.to_int l - Int16BW.to_int r}
       (! return' {result}) ]
@@ -4652,7 +4652,7 @@ module M_integer_ops__i16__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ Int16.to_int l * Int16.to_int r <= Int16.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int16.mul {l'0} {r'0} (fun (_ret:Int16.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int16.t = Any.any_l () | & l'0: Int16.t = l | & r'0: Int16.t = r ] 
+     [ & _0: Int16.t = Any.any_l () | & l'0: Int16.t = l | & r'0: Int16.t = r ] )
     [ return''0 (result:Int16.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] Int16.to_int result
       = Int16.to_int l * Int16.to_int r}
       (! return' {result}) ]
@@ -4680,7 +4680,7 @@ module M_integer_ops__i16__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ Int16BW.to_int l * Int16BW.to_int r <= Int16BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int16BW.mul {l'0} {r'0} (fun (_ret:Int16BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int16BW.t = Any.any_l () | & l'0: Int16BW.t = l | & r'0: Int16BW.t = r ] 
+     [ & _0: Int16BW.t = Any.any_l () | & l'0: Int16BW.t = l | & r'0: Int16BW.t = r ] )
     [ return''0 (result:Int16BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] Int16BW.to_int result
       = Int16BW.to_int l * Int16BW.to_int r}
       (! return' {result}) ]
@@ -4725,7 +4725,7 @@ module M_integer_ops__i16__test_div [#"integer_ops.rs" 84 30 126 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int16.div {_6} {_7} (fun (_ret:Int16.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int16.t = Any.any_l ()
     | & l'0: Int16.t = l
     | & r'0: Int16.t = r
@@ -4735,7 +4735,7 @@ module M_integer_ops__i16__test_div [#"integer_ops.rs" 84 30 126 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int16.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] Int16.to_int result
       = Int.div (Int16.to_int l) (Int16.to_int r)}
       (! return' {result}) ]
@@ -4781,7 +4781,7 @@ module M_integer_ops__i16__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int16BW.div {_6} {_7} (fun (_ret:Int16BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int16BW.t = Any.any_l ()
     | & l'0: Int16BW.t = l
     | & r'0: Int16BW.t = r
@@ -4791,7 +4791,7 @@ module M_integer_ops__i16__test_div_bw [#"integer_ops.rs" 84 30 134 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int16BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] Int16BW.to_int result
       = Int.div (Int16BW.to_int l) (Int16BW.to_int r)}
       (! return' {result}) ]
@@ -4868,7 +4868,7 @@ module M_integer_ops__i16__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int16.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -4889,7 +4889,7 @@ module M_integer_ops__i16__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: Int16.t = Any.any_l ()
     | & _46: Int16.t = Any.any_l ()
     | & _47: Int16.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int16.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = Int16.of_bool b}
       (! return' {result}) ]
 
@@ -4965,7 +4965,7 @@ module M_integer_ops__i16__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int16BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -4986,7 +4986,7 @@ module M_integer_ops__i16__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: Int16BW.t = Any.any_l ()
     | & _46: Int16BW.t = Any.any_l ()
     | & _47: Int16BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int16BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = Int16BW.of_bool b}
       (! return' {result}) ]
 
@@ -5010,7 +5010,7 @@ module M_integer_ops__i16__test_shl [#"integer_ops.rs" 84 30 155 11]
       [ s0 = Int16.shl {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int16.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int16.t = Any.any_l () | & n'0: Int16.t = n ] 
+     [ & _0: Int16.t = Any.any_l () | & n'0: Int16.t = n ] )
     [ return''0 (result:Int16.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = Int16.lsl n (Int16.t'int (3: Int16.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = Int16.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -5037,7 +5037,7 @@ module M_integer_ops__i16__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:Int16BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int16BW.t = Any.any_l () | & n'0: Int16BW.t = n ] 
+     [ & _0: Int16BW.t = Any.any_l () | & n'0: Int16BW.t = n ] )
     [ return''0 (result:Int16BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = Int16BW.lsl n (Int16BW.t'int (3: Int16BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = Int16BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -5063,7 +5063,7 @@ module M_integer_ops__i16__test_shr [#"integer_ops.rs" 84 30 168 11]
       [ s0 = Int16.shr {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int16.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int16.t = Any.any_l () | & n'0: Int16.t = n ] 
+     [ & _0: Int16.t = Any.any_l () | & n'0: Int16.t = n ] )
     [ return''0 (result:Int16.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = Int16.shr n (Int16.t'int (3: Int16.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = Int16.shr n (UInt8.t'int (3: UInt8.t))}
@@ -5090,7 +5090,7 @@ module M_integer_ops__i16__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:Int16BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int16BW.t = Any.any_l () | & n'0: Int16BW.t = n ] 
+     [ & _0: Int16BW.t = Any.any_l () | & n'0: Int16BW.t = n ] )
     [ return''0 (result:Int16BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = Int16BW.shr n (Int16BW.t'int (3: Int16BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = Int16BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -5119,7 +5119,7 @@ module M_integer_ops__u32__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ UInt32.t'int l + UInt32.t'int r <= UInt32.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt32.add {l'0} {r'0} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32.t = Any.any_l () | & l'0: UInt32.t = l | & r'0: UInt32.t = r ] 
+     [ & _0: UInt32.t = Any.any_l () | & l'0: UInt32.t = l | & r'0: UInt32.t = r ] )
     [ return''0 (result:UInt32.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] UInt32.t'int result
       = UInt32.t'int l + UInt32.t'int r}
       (! return' {result}) ]
@@ -5147,7 +5147,7 @@ module M_integer_ops__u32__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ UInt32BW.t'int l + UInt32BW.t'int r <= UInt32BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt32BW.add {l'0} {r'0} (fun (_ret:UInt32BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32BW.t = Any.any_l () | & l'0: UInt32BW.t = l | & r'0: UInt32BW.t = r ] 
+     [ & _0: UInt32BW.t = Any.any_l () | & l'0: UInt32BW.t = l | & r'0: UInt32BW.t = r ] )
     [ return''0 (result:UInt32BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] UInt32BW.t'int result
       = UInt32BW.t'int l + UInt32BW.t'int r}
       (! return' {result}) ]
@@ -5175,7 +5175,7 @@ module M_integer_ops__u32__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ UInt32.t'int l - UInt32.t'int r <= UInt32.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt32.sub {l'0} {r'0} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32.t = Any.any_l () | & l'0: UInt32.t = l | & r'0: UInt32.t = r ] 
+     [ & _0: UInt32.t = Any.any_l () | & l'0: UInt32.t = l | & r'0: UInt32.t = r ] )
     [ return''0 (result:UInt32.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] UInt32.t'int result
       = UInt32.t'int l - UInt32.t'int r}
       (! return' {result}) ]
@@ -5203,7 +5203,7 @@ module M_integer_ops__u32__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ UInt32BW.t'int l - UInt32BW.t'int r <= UInt32BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt32BW.sub {l'0} {r'0} (fun (_ret:UInt32BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32BW.t = Any.any_l () | & l'0: UInt32BW.t = l | & r'0: UInt32BW.t = r ] 
+     [ & _0: UInt32BW.t = Any.any_l () | & l'0: UInt32BW.t = l | & r'0: UInt32BW.t = r ] )
     [ return''0 (result:UInt32BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] UInt32BW.t'int result
       = UInt32BW.t'int l - UInt32BW.t'int r}
       (! return' {result}) ]
@@ -5231,7 +5231,7 @@ module M_integer_ops__u32__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ UInt32.t'int l * UInt32.t'int r <= UInt32.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt32.mul {l'0} {r'0} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32.t = Any.any_l () | & l'0: UInt32.t = l | & r'0: UInt32.t = r ] 
+     [ & _0: UInt32.t = Any.any_l () | & l'0: UInt32.t = l | & r'0: UInt32.t = r ] )
     [ return''0 (result:UInt32.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] UInt32.t'int result
       = UInt32.t'int l * UInt32.t'int r}
       (! return' {result}) ]
@@ -5259,7 +5259,7 @@ module M_integer_ops__u32__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ UInt32BW.t'int l * UInt32BW.t'int r <= UInt32BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt32BW.mul {l'0} {r'0} (fun (_ret:UInt32BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32BW.t = Any.any_l () | & l'0: UInt32BW.t = l | & r'0: UInt32BW.t = r ] 
+     [ & _0: UInt32BW.t = Any.any_l () | & l'0: UInt32BW.t = l | & r'0: UInt32BW.t = r ] )
     [ return''0 (result:UInt32BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] UInt32BW.t'int result
       = UInt32BW.t'int l * UInt32BW.t'int r}
       (! return' {result}) ]
@@ -5295,13 +5295,13 @@ module M_integer_ops__u32__test_div [#"integer_ops.rs" 84 30 126 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt32.div {l'0} {_7} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & l'0: UInt32.t = l
     | & r'0: UInt32.t = r
     | & _7: UInt32.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] UInt32.t'int result
       = Int.div (UInt32.t'int l) (UInt32.t'int r)}
       (! return' {result}) ]
@@ -5338,13 +5338,13 @@ module M_integer_ops__u32__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt32BW.div {l'0} {_7} (fun (_ret:UInt32BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt32BW.t = Any.any_l ()
     | & l'0: UInt32BW.t = l
     | & r'0: UInt32BW.t = r
     | & _7: UInt32BW.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] UInt32BW.t'int result
       = Int.div (UInt32BW.t'int l) (UInt32BW.t'int r)}
       (! return' {result}) ]
@@ -5421,7 +5421,7 @@ module M_integer_ops__u32__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -5442,7 +5442,7 @@ module M_integer_ops__u32__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: UInt32.t = Any.any_l ()
     | & _46: UInt32.t = Any.any_l ()
     | & _47: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = UInt32.of_bool b}
       (! return' {result}) ]
 
@@ -5518,7 +5518,7 @@ module M_integer_ops__u32__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt32BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -5539,7 +5539,7 @@ module M_integer_ops__u32__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: UInt32BW.t = Any.any_l ()
     | & _46: UInt32BW.t = Any.any_l ()
     | & _47: UInt32BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = UInt32BW.of_bool b}
       (! return' {result}) ]
 
@@ -5564,7 +5564,7 @@ module M_integer_ops__u32__test_shl [#"integer_ops.rs" 84 30 155 11]
           (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt32.t = Any.any_l () | & n'0: UInt32.t = n ] 
+     [ & _0: UInt32.t = Any.any_l () | & n'0: UInt32.t = n ] )
     [ return''0 (result:UInt32.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = UInt32.lsl n (UInt32.t'int (3: UInt32.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = UInt32.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -5591,7 +5591,7 @@ module M_integer_ops__u32__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:UInt32BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt32BW.t = Any.any_l () | & n'0: UInt32BW.t = n ] 
+     [ & _0: UInt32BW.t = Any.any_l () | & n'0: UInt32BW.t = n ] )
     [ return''0 (result:UInt32BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = UInt32BW.lsl n (UInt32BW.t'int (3: UInt32BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = UInt32BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -5618,7 +5618,7 @@ module M_integer_ops__u32__test_shr [#"integer_ops.rs" 84 30 168 11]
           (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt32.t = Any.any_l () | & n'0: UInt32.t = n ] 
+     [ & _0: UInt32.t = Any.any_l () | & n'0: UInt32.t = n ] )
     [ return''0 (result:UInt32.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = UInt32.shr n (UInt32.t'int (3: UInt32.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = UInt32.shr n (UInt8.t'int (3: UInt8.t))}
@@ -5645,7 +5645,7 @@ module M_integer_ops__u32__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:UInt32BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt32BW.t = Any.any_l () | & n'0: UInt32BW.t = n ] 
+     [ & _0: UInt32BW.t = Any.any_l () | & n'0: UInt32BW.t = n ] )
     [ return''0 (result:UInt32BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = UInt32BW.shr n (UInt32BW.t'int (3: UInt32BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = UInt32BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -5674,7 +5674,7 @@ module M_integer_ops__i32__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ Int32.to_int l + Int32.to_int r <= Int32.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int32.add {l'0} {r'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int32.t = Any.any_l () | & l'0: Int32.t = l | & r'0: Int32.t = r ] 
+     [ & _0: Int32.t = Any.any_l () | & l'0: Int32.t = l | & r'0: Int32.t = r ] )
     [ return''0 (result:Int32.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] Int32.to_int result
       = Int32.to_int l + Int32.to_int r}
       (! return' {result}) ]
@@ -5702,7 +5702,7 @@ module M_integer_ops__i32__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ Int32BW.to_int l + Int32BW.to_int r <= Int32BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int32BW.add {l'0} {r'0} (fun (_ret:Int32BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int32BW.t = Any.any_l () | & l'0: Int32BW.t = l | & r'0: Int32BW.t = r ] 
+     [ & _0: Int32BW.t = Any.any_l () | & l'0: Int32BW.t = l | & r'0: Int32BW.t = r ] )
     [ return''0 (result:Int32BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] Int32BW.to_int result
       = Int32BW.to_int l + Int32BW.to_int r}
       (! return' {result}) ]
@@ -5730,7 +5730,7 @@ module M_integer_ops__i32__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ Int32.to_int l - Int32.to_int r <= Int32.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int32.sub {l'0} {r'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int32.t = Any.any_l () | & l'0: Int32.t = l | & r'0: Int32.t = r ] 
+     [ & _0: Int32.t = Any.any_l () | & l'0: Int32.t = l | & r'0: Int32.t = r ] )
     [ return''0 (result:Int32.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] Int32.to_int result
       = Int32.to_int l - Int32.to_int r}
       (! return' {result}) ]
@@ -5758,7 +5758,7 @@ module M_integer_ops__i32__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ Int32BW.to_int l - Int32BW.to_int r <= Int32BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int32BW.sub {l'0} {r'0} (fun (_ret:Int32BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int32BW.t = Any.any_l () | & l'0: Int32BW.t = l | & r'0: Int32BW.t = r ] 
+     [ & _0: Int32BW.t = Any.any_l () | & l'0: Int32BW.t = l | & r'0: Int32BW.t = r ] )
     [ return''0 (result:Int32BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] Int32BW.to_int result
       = Int32BW.to_int l - Int32BW.to_int r}
       (! return' {result}) ]
@@ -5786,7 +5786,7 @@ module M_integer_ops__i32__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ Int32.to_int l * Int32.to_int r <= Int32.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int32.mul {l'0} {r'0} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int32.t = Any.any_l () | & l'0: Int32.t = l | & r'0: Int32.t = r ] 
+     [ & _0: Int32.t = Any.any_l () | & l'0: Int32.t = l | & r'0: Int32.t = r ] )
     [ return''0 (result:Int32.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] Int32.to_int result
       = Int32.to_int l * Int32.to_int r}
       (! return' {result}) ]
@@ -5814,7 +5814,7 @@ module M_integer_ops__i32__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ Int32BW.to_int l * Int32BW.to_int r <= Int32BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int32BW.mul {l'0} {r'0} (fun (_ret:Int32BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int32BW.t = Any.any_l () | & l'0: Int32BW.t = l | & r'0: Int32BW.t = r ] 
+     [ & _0: Int32BW.t = Any.any_l () | & l'0: Int32BW.t = l | & r'0: Int32BW.t = r ] )
     [ return''0 (result:Int32BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] Int32BW.to_int result
       = Int32BW.to_int l * Int32BW.to_int r}
       (! return' {result}) ]
@@ -5859,7 +5859,7 @@ module M_integer_ops__i32__test_div [#"integer_ops.rs" 84 30 126 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int32.div {_6} {_7} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & l'0: Int32.t = l
     | & r'0: Int32.t = r
@@ -5869,7 +5869,7 @@ module M_integer_ops__i32__test_div [#"integer_ops.rs" 84 30 126 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] Int32.to_int result
       = Int.div (Int32.to_int l) (Int32.to_int r)}
       (! return' {result}) ]
@@ -5915,7 +5915,7 @@ module M_integer_ops__i32__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int32BW.div {_6} {_7} (fun (_ret:Int32BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int32BW.t = Any.any_l ()
     | & l'0: Int32BW.t = l
     | & r'0: Int32BW.t = r
@@ -5925,7 +5925,7 @@ module M_integer_ops__i32__test_div_bw [#"integer_ops.rs" 84 30 134 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] Int32BW.to_int result
       = Int.div (Int32BW.to_int l) (Int32BW.to_int r)}
       (! return' {result}) ]
@@ -6002,7 +6002,7 @@ module M_integer_ops__i32__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -6023,7 +6023,7 @@ module M_integer_ops__i32__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: Int32.t = Any.any_l ()
     | & _46: Int32.t = Any.any_l ()
     | & _47: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = Int32.of_bool b}
       (! return' {result}) ]
 
@@ -6099,7 +6099,7 @@ module M_integer_ops__i32__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int32BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -6120,7 +6120,7 @@ module M_integer_ops__i32__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: Int32BW.t = Any.any_l ()
     | & _46: Int32BW.t = Any.any_l ()
     | & _47: Int32BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int32BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = Int32BW.of_bool b}
       (! return' {result}) ]
 
@@ -6143,7 +6143,7 @@ module M_integer_ops__i32__test_shl [#"integer_ops.rs" 84 30 155 11]
       [ s0 = Int32.shl {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int32.t = Any.any_l () | & n'0: Int32.t = n ] 
+     [ & _0: Int32.t = Any.any_l () | & n'0: Int32.t = n ] )
     [ return''0 (result:Int32.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = Int32.lsl n (Int32.t'int (3: Int32.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = Int32.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -6169,7 +6169,7 @@ module M_integer_ops__i32__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:Int32BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int32BW.t = Any.any_l () | & n'0: Int32BW.t = n ] 
+     [ & _0: Int32BW.t = Any.any_l () | & n'0: Int32BW.t = n ] )
     [ return''0 (result:Int32BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = Int32BW.lsl n (Int32BW.t'int (3: Int32BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = Int32BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -6194,7 +6194,7 @@ module M_integer_ops__i32__test_shr [#"integer_ops.rs" 84 30 168 11]
       [ s0 = Int32.shr {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int32.t = Any.any_l () | & n'0: Int32.t = n ] 
+     [ & _0: Int32.t = Any.any_l () | & n'0: Int32.t = n ] )
     [ return''0 (result:Int32.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = Int32.shr n (Int32.t'int (3: Int32.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = Int32.shr n (UInt8.t'int (3: UInt8.t))}
@@ -6220,7 +6220,7 @@ module M_integer_ops__i32__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:Int32BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int32BW.t = Any.any_l () | & n'0: Int32BW.t = n ] 
+     [ & _0: Int32BW.t = Any.any_l () | & n'0: Int32BW.t = n ] )
     [ return''0 (result:Int32BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = Int32BW.shr n (Int32BW.t'int (3: Int32BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = Int32BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -6249,7 +6249,7 @@ module M_integer_ops__u64__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ UInt64.t'int l + UInt64.t'int r <= UInt64.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64.add {l'0} {r'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] 
+     [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] UInt64.t'int result
       = UInt64.t'int l + UInt64.t'int r}
       (! return' {result}) ]
@@ -6277,7 +6277,7 @@ module M_integer_ops__u64__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ UInt64BW.t'int l + UInt64BW.t'int r <= UInt64BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64BW.add {l'0} {r'0} (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] UInt64BW.t'int result
       = UInt64BW.t'int l + UInt64BW.t'int r}
       (! return' {result}) ]
@@ -6305,7 +6305,7 @@ module M_integer_ops__u64__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ UInt64.t'int l - UInt64.t'int r <= UInt64.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64.sub {l'0} {r'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] 
+     [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] UInt64.t'int result
       = UInt64.t'int l - UInt64.t'int r}
       (! return' {result}) ]
@@ -6333,7 +6333,7 @@ module M_integer_ops__u64__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ UInt64BW.t'int l - UInt64BW.t'int r <= UInt64BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64BW.sub {l'0} {r'0} (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] UInt64BW.t'int result
       = UInt64BW.t'int l - UInt64BW.t'int r}
       (! return' {result}) ]
@@ -6361,7 +6361,7 @@ module M_integer_ops__u64__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ UInt64.t'int l * UInt64.t'int r <= UInt64.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64.mul {l'0} {r'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] 
+     [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] UInt64.t'int result
       = UInt64.t'int l * UInt64.t'int r}
       (! return' {result}) ]
@@ -6389,7 +6389,7 @@ module M_integer_ops__u64__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ UInt64BW.t'int l * UInt64BW.t'int r <= UInt64BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64BW.mul {l'0} {r'0} (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] UInt64BW.t'int result
       = UInt64BW.t'int l * UInt64BW.t'int r}
       (! return' {result}) ]
@@ -6425,13 +6425,13 @@ module M_integer_ops__u64__test_div [#"integer_ops.rs" 84 30 126 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt64.div {l'0} {_7} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & l'0: UInt64.t = l
     | & r'0: UInt64.t = r
     | & _7: UInt64.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] UInt64.t'int result
       = Int.div (UInt64.t'int l) (UInt64.t'int r)}
       (! return' {result}) ]
@@ -6468,13 +6468,13 @@ module M_integer_ops__u64__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt64BW.div {l'0} {_7} (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64BW.t = Any.any_l ()
     | & l'0: UInt64BW.t = l
     | & r'0: UInt64BW.t = r
     | & _7: UInt64BW.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] UInt64BW.t'int result
       = Int.div (UInt64BW.t'int l) (UInt64BW.t'int r)}
       (! return' {result}) ]
@@ -6551,7 +6551,7 @@ module M_integer_ops__u64__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -6572,7 +6572,7 @@ module M_integer_ops__u64__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: UInt64.t = Any.any_l ()
     | & _46: UInt64.t = Any.any_l ()
     | & _47: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = UInt64.of_bool b}
       (! return' {result}) ]
 
@@ -6648,7 +6648,7 @@ module M_integer_ops__u64__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt64BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -6669,7 +6669,7 @@ module M_integer_ops__u64__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: UInt64BW.t = Any.any_l ()
     | & _46: UInt64BW.t = Any.any_l ()
     | & _47: UInt64BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = UInt64BW.of_bool b}
       (! return' {result}) ]
 
@@ -6694,7 +6694,7 @@ module M_integer_ops__u64__test_shl [#"integer_ops.rs" 84 30 155 11]
           (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] 
+     [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = UInt64.lsl n (UInt64.t'int (3: UInt64.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = UInt64.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -6721,7 +6721,7 @@ module M_integer_ops__u64__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & n'0: UInt64BW.t = n ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & n'0: UInt64BW.t = n ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = UInt64BW.lsl n (UInt64BW.t'int (3: UInt64BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = UInt64BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -6748,7 +6748,7 @@ module M_integer_ops__u64__test_shr [#"integer_ops.rs" 84 30 168 11]
           (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] 
+     [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = UInt64.shr n (UInt64.t'int (3: UInt64.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = UInt64.shr n (UInt8.t'int (3: UInt8.t))}
@@ -6775,7 +6775,7 @@ module M_integer_ops__u64__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & n'0: UInt64BW.t = n ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & n'0: UInt64BW.t = n ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = UInt64BW.shr n (UInt64BW.t'int (3: UInt64BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = UInt64BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -6804,7 +6804,7 @@ module M_integer_ops__i64__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ Int64.to_int l + Int64.to_int r <= Int64.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64.add {l'0} {r'0} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] 
+     [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] Int64.to_int result
       = Int64.to_int l + Int64.to_int r}
       (! return' {result}) ]
@@ -6832,7 +6832,7 @@ module M_integer_ops__i64__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ Int64BW.to_int l + Int64BW.to_int r <= Int64BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64BW.add {l'0} {r'0} (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] 
+     [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] Int64BW.to_int result
       = Int64BW.to_int l + Int64BW.to_int r}
       (! return' {result}) ]
@@ -6860,7 +6860,7 @@ module M_integer_ops__i64__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ Int64.to_int l - Int64.to_int r <= Int64.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64.sub {l'0} {r'0} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] 
+     [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] Int64.to_int result
       = Int64.to_int l - Int64.to_int r}
       (! return' {result}) ]
@@ -6888,7 +6888,7 @@ module M_integer_ops__i64__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ Int64BW.to_int l - Int64BW.to_int r <= Int64BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64BW.sub {l'0} {r'0} (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] 
+     [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] Int64BW.to_int result
       = Int64BW.to_int l - Int64BW.to_int r}
       (! return' {result}) ]
@@ -6916,7 +6916,7 @@ module M_integer_ops__i64__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ Int64.to_int l * Int64.to_int r <= Int64.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64.mul {l'0} {r'0} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] 
+     [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] Int64.to_int result
       = Int64.to_int l * Int64.to_int r}
       (! return' {result}) ]
@@ -6944,7 +6944,7 @@ module M_integer_ops__i64__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ Int64BW.to_int l * Int64BW.to_int r <= Int64BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64BW.mul {l'0} {r'0} (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] 
+     [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] Int64BW.to_int result
       = Int64BW.to_int l * Int64BW.to_int r}
       (! return' {result}) ]
@@ -6989,7 +6989,7 @@ module M_integer_ops__i64__test_div [#"integer_ops.rs" 84 30 126 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int64.div {_6} {_7} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int64.t = Any.any_l ()
     | & l'0: Int64.t = l
     | & r'0: Int64.t = r
@@ -6999,7 +6999,7 @@ module M_integer_ops__i64__test_div [#"integer_ops.rs" 84 30 126 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int64.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] Int64.to_int result
       = Int.div (Int64.to_int l) (Int64.to_int r)}
       (! return' {result}) ]
@@ -7045,7 +7045,7 @@ module M_integer_ops__i64__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int64BW.div {_6} {_7} (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int64BW.t = Any.any_l ()
     | & l'0: Int64BW.t = l
     | & r'0: Int64BW.t = r
@@ -7055,7 +7055,7 @@ module M_integer_ops__i64__test_div_bw [#"integer_ops.rs" 84 30 134 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] Int64BW.to_int result
       = Int.div (Int64BW.to_int l) (Int64BW.to_int r)}
       (! return' {result}) ]
@@ -7132,7 +7132,7 @@ module M_integer_ops__i64__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int64.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -7153,7 +7153,7 @@ module M_integer_ops__i64__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: Int64.t = Any.any_l ()
     | & _46: Int64.t = Any.any_l ()
     | & _47: Int64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int64.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = Int64.of_bool b}
       (! return' {result}) ]
 
@@ -7229,7 +7229,7 @@ module M_integer_ops__i64__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int64BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -7250,7 +7250,7 @@ module M_integer_ops__i64__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: Int64BW.t = Any.any_l ()
     | & _46: Int64BW.t = Any.any_l ()
     | & _47: Int64BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = Int64BW.of_bool b}
       (! return' {result}) ]
 
@@ -7274,7 +7274,7 @@ module M_integer_ops__i64__test_shl [#"integer_ops.rs" 84 30 155 11]
       [ s0 = Int64.shl {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int64.t = Any.any_l () | & n'0: Int64.t = n ] 
+     [ & _0: Int64.t = Any.any_l () | & n'0: Int64.t = n ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = Int64.lsl n (Int64.t'int (3: Int64.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = Int64.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -7301,7 +7301,7 @@ module M_integer_ops__i64__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & n'0: Int64BW.t = n ] 
+     [ & _0: Int64BW.t = Any.any_l () | & n'0: Int64BW.t = n ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = Int64BW.lsl n (Int64BW.t'int (3: Int64BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = Int64BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -7327,7 +7327,7 @@ module M_integer_ops__i64__test_shr [#"integer_ops.rs" 84 30 168 11]
       [ s0 = Int64.shr {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int64.t = Any.any_l () | & n'0: Int64.t = n ] 
+     [ & _0: Int64.t = Any.any_l () | & n'0: Int64.t = n ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = Int64.shr n (Int64.t'int (3: Int64.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = Int64.shr n (UInt8.t'int (3: UInt8.t))}
@@ -7354,7 +7354,7 @@ module M_integer_ops__i64__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & n'0: Int64BW.t = n ] 
+     [ & _0: Int64BW.t = Any.any_l () | & n'0: Int64BW.t = n ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = Int64BW.shr n (Int64BW.t'int (3: Int64BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = Int64BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -7383,7 +7383,7 @@ module M_integer_ops__u128__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ UInt128.t'int l + UInt128.t'int r <= UInt128.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt128.add {l'0} {r'0} (fun (_ret:UInt128.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt128.t = Any.any_l () | & l'0: UInt128.t = l | & r'0: UInt128.t = r ] 
+     [ & _0: UInt128.t = Any.any_l () | & l'0: UInt128.t = l | & r'0: UInt128.t = r ] )
     [ return''0 (result:UInt128.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] UInt128.t'int result
       = UInt128.t'int l + UInt128.t'int r}
       (! return' {result}) ]
@@ -7413,7 +7413,7 @@ module M_integer_ops__u128__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     [ bb0 = s0
       [ s0 = UInt128BW.add {l'0} {r'0} (fun (_ret:UInt128BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt128BW.t = Any.any_l () | & l'0: UInt128BW.t = l | & r'0: UInt128BW.t = r ] 
+     [ & _0: UInt128BW.t = Any.any_l () | & l'0: UInt128BW.t = l | & r'0: UInt128BW.t = r ] )
     [ return''0 (result:UInt128BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] UInt128BW.t'int result
       = UInt128BW.t'int l + UInt128BW.t'int r}
       (! return' {result}) ]
@@ -7441,7 +7441,7 @@ module M_integer_ops__u128__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ UInt128.t'int l - UInt128.t'int r <= UInt128.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt128.sub {l'0} {r'0} (fun (_ret:UInt128.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt128.t = Any.any_l () | & l'0: UInt128.t = l | & r'0: UInt128.t = r ] 
+     [ & _0: UInt128.t = Any.any_l () | & l'0: UInt128.t = l | & r'0: UInt128.t = r ] )
     [ return''0 (result:UInt128.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] UInt128.t'int result
       = UInt128.t'int l - UInt128.t'int r}
       (! return' {result}) ]
@@ -7471,7 +7471,7 @@ module M_integer_ops__u128__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     [ bb0 = s0
       [ s0 = UInt128BW.sub {l'0} {r'0} (fun (_ret:UInt128BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt128BW.t = Any.any_l () | & l'0: UInt128BW.t = l | & r'0: UInt128BW.t = r ] 
+     [ & _0: UInt128BW.t = Any.any_l () | & l'0: UInt128BW.t = l | & r'0: UInt128BW.t = r ] )
     [ return''0 (result:UInt128BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] UInt128BW.t'int result
       = UInt128BW.t'int l - UInt128BW.t'int r}
       (! return' {result}) ]
@@ -7499,7 +7499,7 @@ module M_integer_ops__u128__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ UInt128.t'int l * UInt128.t'int r <= UInt128.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt128.mul {l'0} {r'0} (fun (_ret:UInt128.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt128.t = Any.any_l () | & l'0: UInt128.t = l | & r'0: UInt128.t = r ] 
+     [ & _0: UInt128.t = Any.any_l () | & l'0: UInt128.t = l | & r'0: UInt128.t = r ] )
     [ return''0 (result:UInt128.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] UInt128.t'int result
       = UInt128.t'int l * UInt128.t'int r}
       (! return' {result}) ]
@@ -7529,7 +7529,7 @@ module M_integer_ops__u128__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     [ bb0 = s0
       [ s0 = UInt128BW.mul {l'0} {r'0} (fun (_ret:UInt128BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt128BW.t = Any.any_l () | & l'0: UInt128BW.t = l | & r'0: UInt128BW.t = r ] 
+     [ & _0: UInt128BW.t = Any.any_l () | & l'0: UInt128BW.t = l | & r'0: UInt128BW.t = r ] )
     [ return''0 (result:UInt128BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] UInt128BW.t'int result
       = UInt128BW.t'int l * UInt128BW.t'int r}
       (! return' {result}) ]
@@ -7565,13 +7565,13 @@ module M_integer_ops__u128__test_div [#"integer_ops.rs" 84 30 126 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt128.div {l'0} {_7} (fun (_ret:UInt128.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt128.t = Any.any_l ()
     | & l'0: UInt128.t = l
     | & r'0: UInt128.t = r
     | & _7: UInt128.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt128.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] UInt128.t'int result
       = Int.div (UInt128.t'int l) (UInt128.t'int r)}
       (! return' {result}) ]
@@ -7610,13 +7610,13 @@ module M_integer_ops__u128__test_div_bw [#"integer_ops.rs" 84 30 134 11]
     | bb1 = s0
       [ s0 = UInt128BW.div {l'0} {_7} (fun (_ret:UInt128BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: UInt128BW.t = Any.any_l ()
     | & l'0: UInt128BW.t = l
     | & r'0: UInt128BW.t = r
     | & _7: UInt128BW.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt128BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] UInt128BW.t'int result
       = Int.div (UInt128BW.t'int l) (UInt128BW.t'int r)}
       (! return' {result}) ]
@@ -7693,7 +7693,7 @@ module M_integer_ops__u128__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt128.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -7714,7 +7714,7 @@ module M_integer_ops__u128__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: UInt128.t = Any.any_l ()
     | & _46: UInt128.t = Any.any_l ()
     | & _47: UInt128.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt128.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = UInt128.of_bool b}
       (! return' {result}) ]
 
@@ -7790,7 +7790,7 @@ module M_integer_ops__u128__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt128BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -7811,7 +7811,7 @@ module M_integer_ops__u128__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: UInt128BW.t = Any.any_l ()
     | & _46: UInt128BW.t = Any.any_l ()
     | & _47: UInt128BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt128BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = UInt128BW.of_bool b}
       (! return' {result}) ]
 
@@ -7836,7 +7836,7 @@ module M_integer_ops__u128__test_shl [#"integer_ops.rs" 84 30 155 11]
           (fun (_ret:UInt128.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt128.t = Any.any_l () | & n'0: UInt128.t = n ] 
+     [ & _0: UInt128.t = Any.any_l () | & n'0: UInt128.t = n ] )
     [ return''0 (result:UInt128.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = UInt128.lsl n (UInt128.t'int (3: UInt128.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = UInt128.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -7863,7 +7863,7 @@ module M_integer_ops__u128__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:UInt128BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt128BW.t = Any.any_l () | & n'0: UInt128BW.t = n ] 
+     [ & _0: UInt128BW.t = Any.any_l () | & n'0: UInt128BW.t = n ] )
     [ return''0 (result:UInt128BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = UInt128BW.lsl n (UInt128BW.t'int (3: UInt128BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = UInt128BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -7890,7 +7890,7 @@ module M_integer_ops__u128__test_shr [#"integer_ops.rs" 84 30 168 11]
           (fun (_ret:UInt128.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt128.t = Any.any_l () | & n'0: UInt128.t = n ] 
+     [ & _0: UInt128.t = Any.any_l () | & n'0: UInt128.t = n ] )
     [ return''0 (result:UInt128.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = UInt128.shr n (UInt128.t'int (3: UInt128.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = UInt128.shr n (UInt8.t'int (3: UInt8.t))}
@@ -7917,7 +7917,7 @@ module M_integer_ops__u128__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:UInt128BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt128BW.t = Any.any_l () | & n'0: UInt128BW.t = n ] 
+     [ & _0: UInt128BW.t = Any.any_l () | & n'0: UInt128BW.t = n ] )
     [ return''0 (result:UInt128BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = UInt128BW.shr n (UInt128BW.t'int (3: UInt128BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = UInt128BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -7946,7 +7946,7 @@ module M_integer_ops__i128__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ Int128.to_int l + Int128.to_int r <= Int128.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int128.add {l'0} {r'0} (fun (_ret:Int128.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int128.t = Any.any_l () | & l'0: Int128.t = l | & r'0: Int128.t = r ] 
+     [ & _0: Int128.t = Any.any_l () | & l'0: Int128.t = l | & r'0: Int128.t = r ] )
     [ return''0 (result:Int128.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] Int128.to_int result
       = Int128.to_int l + Int128.to_int r}
       (! return' {result}) ]
@@ -7974,7 +7974,7 @@ module M_integer_ops__i128__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ Int128BW.to_int l + Int128BW.to_int r <= Int128BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int128BW.add {l'0} {r'0} (fun (_ret:Int128BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int128BW.t = Any.any_l () | & l'0: Int128BW.t = l | & r'0: Int128BW.t = r ] 
+     [ & _0: Int128BW.t = Any.any_l () | & l'0: Int128BW.t = l | & r'0: Int128BW.t = r ] )
     [ return''0 (result:Int128BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] Int128BW.to_int result
       = Int128BW.to_int l + Int128BW.to_int r}
       (! return' {result}) ]
@@ -8002,7 +8002,7 @@ module M_integer_ops__i128__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ Int128.to_int l - Int128.to_int r <= Int128.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int128.sub {l'0} {r'0} (fun (_ret:Int128.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int128.t = Any.any_l () | & l'0: Int128.t = l | & r'0: Int128.t = r ] 
+     [ & _0: Int128.t = Any.any_l () | & l'0: Int128.t = l | & r'0: Int128.t = r ] )
     [ return''0 (result:Int128.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] Int128.to_int result
       = Int128.to_int l - Int128.to_int r}
       (! return' {result}) ]
@@ -8030,7 +8030,7 @@ module M_integer_ops__i128__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ Int128BW.to_int l - Int128BW.to_int r <= Int128BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int128BW.sub {l'0} {r'0} (fun (_ret:Int128BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int128BW.t = Any.any_l () | & l'0: Int128BW.t = l | & r'0: Int128BW.t = r ] 
+     [ & _0: Int128BW.t = Any.any_l () | & l'0: Int128BW.t = l | & r'0: Int128BW.t = r ] )
     [ return''0 (result:Int128BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] Int128BW.to_int result
       = Int128BW.to_int l - Int128BW.to_int r}
       (! return' {result}) ]
@@ -8058,7 +8058,7 @@ module M_integer_ops__i128__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ Int128.to_int l * Int128.to_int r <= Int128.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int128.mul {l'0} {r'0} (fun (_ret:Int128.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int128.t = Any.any_l () | & l'0: Int128.t = l | & r'0: Int128.t = r ] 
+     [ & _0: Int128.t = Any.any_l () | & l'0: Int128.t = l | & r'0: Int128.t = r ] )
     [ return''0 (result:Int128.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] Int128.to_int result
       = Int128.to_int l * Int128.to_int r}
       (! return' {result}) ]
@@ -8086,7 +8086,7 @@ module M_integer_ops__i128__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ Int128BW.to_int l * Int128BW.to_int r <= Int128BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int128BW.mul {l'0} {r'0} (fun (_ret:Int128BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int128BW.t = Any.any_l () | & l'0: Int128BW.t = l | & r'0: Int128BW.t = r ] 
+     [ & _0: Int128BW.t = Any.any_l () | & l'0: Int128BW.t = l | & r'0: Int128BW.t = r ] )
     [ return''0 (result:Int128BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] Int128BW.to_int result
       = Int128BW.to_int l * Int128BW.to_int r}
       (! return' {result}) ]
@@ -8131,7 +8131,7 @@ module M_integer_ops__i128__test_div [#"integer_ops.rs" 84 30 126 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int128.div {_6} {_7} (fun (_ret:Int128.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int128.t = Any.any_l ()
     | & l'0: Int128.t = l
     | & r'0: Int128.t = r
@@ -8141,7 +8141,7 @@ module M_integer_ops__i128__test_div [#"integer_ops.rs" 84 30 126 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int128.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] Int128.to_int result
       = Int.div (Int128.to_int l) (Int128.to_int r)}
       (! return' {result}) ]
@@ -8187,7 +8187,7 @@ module M_integer_ops__i128__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int128BW.div {_6} {_7} (fun (_ret:Int128BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int128BW.t = Any.any_l ()
     | & l'0: Int128BW.t = l
     | & r'0: Int128BW.t = r
@@ -8197,7 +8197,7 @@ module M_integer_ops__i128__test_div_bw [#"integer_ops.rs" 84 30 134 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int128BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] Int128BW.to_int result
       = Int.div (Int128BW.to_int l) (Int128BW.to_int r)}
       (! return' {result}) ]
@@ -8274,7 +8274,7 @@ module M_integer_ops__i128__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int128.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -8295,7 +8295,7 @@ module M_integer_ops__i128__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: Int128.t = Any.any_l ()
     | & _46: Int128.t = Any.any_l ()
     | & _47: Int128.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int128.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = Int128.of_bool b}
       (! return' {result}) ]
 
@@ -8371,7 +8371,7 @@ module M_integer_ops__i128__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int128BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -8392,7 +8392,7 @@ module M_integer_ops__i128__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: Int128BW.t = Any.any_l ()
     | & _46: Int128BW.t = Any.any_l ()
     | & _47: Int128BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int128BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = Int128BW.of_bool b}
       (! return' {result}) ]
 
@@ -8417,7 +8417,7 @@ module M_integer_ops__i128__test_shl [#"integer_ops.rs" 84 30 155 11]
           (fun (_ret:Int128.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int128.t = Any.any_l () | & n'0: Int128.t = n ] 
+     [ & _0: Int128.t = Any.any_l () | & n'0: Int128.t = n ] )
     [ return''0 (result:Int128.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = Int128.lsl n (Int128.t'int (3: Int128.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = Int128.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -8444,7 +8444,7 @@ module M_integer_ops__i128__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:Int128BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int128BW.t = Any.any_l () | & n'0: Int128BW.t = n ] 
+     [ & _0: Int128BW.t = Any.any_l () | & n'0: Int128BW.t = n ] )
     [ return''0 (result:Int128BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = Int128BW.lsl n (Int128BW.t'int (3: Int128BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = Int128BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -8471,7 +8471,7 @@ module M_integer_ops__i128__test_shr [#"integer_ops.rs" 84 30 168 11]
           (fun (_ret:Int128.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int128.t = Any.any_l () | & n'0: Int128.t = n ] 
+     [ & _0: Int128.t = Any.any_l () | & n'0: Int128.t = n ] )
     [ return''0 (result:Int128.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = Int128.shr n (Int128.t'int (3: Int128.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = Int128.shr n (UInt8.t'int (3: UInt8.t))}
@@ -8498,7 +8498,7 @@ module M_integer_ops__i128__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:Int128BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int128BW.t = Any.any_l () | & n'0: Int128BW.t = n ] 
+     [ & _0: Int128BW.t = Any.any_l () | & n'0: Int128BW.t = n ] )
     [ return''0 (result:Int128BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = Int128BW.shr n (Int128BW.t'int (3: Int128BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = Int128BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -8527,7 +8527,7 @@ module M_integer_ops__usize__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ UInt64.t'int l + UInt64.t'int r <= UInt64.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64.add {l'0} {r'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] 
+     [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] UInt64.t'int result
       = UInt64.t'int l + UInt64.t'int r}
       (! return' {result}) ]
@@ -8555,7 +8555,7 @@ module M_integer_ops__usize__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ UInt64BW.t'int l + UInt64BW.t'int r <= UInt64BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64BW.add {l'0} {r'0} (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] UInt64BW.t'int result
       = UInt64BW.t'int l + UInt64BW.t'int r}
       (! return' {result}) ]
@@ -8583,7 +8583,7 @@ module M_integer_ops__usize__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ UInt64.t'int l - UInt64.t'int r <= UInt64.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64.sub {l'0} {r'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] 
+     [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] UInt64.t'int result
       = UInt64.t'int l - UInt64.t'int r}
       (! return' {result}) ]
@@ -8611,7 +8611,7 @@ module M_integer_ops__usize__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ UInt64BW.t'int l - UInt64BW.t'int r <= UInt64BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64BW.sub {l'0} {r'0} (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] UInt64BW.t'int result
       = UInt64BW.t'int l - UInt64BW.t'int r}
       (! return' {result}) ]
@@ -8639,7 +8639,7 @@ module M_integer_ops__usize__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ UInt64.t'int l * UInt64.t'int r <= UInt64.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64.mul {l'0} {r'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] 
+     [ & _0: UInt64.t = Any.any_l () | & l'0: UInt64.t = l | & r'0: UInt64.t = r ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] UInt64.t'int result
       = UInt64.t'int l * UInt64.t'int r}
       (! return' {result}) ]
@@ -8667,7 +8667,7 @@ module M_integer_ops__usize__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ UInt64BW.t'int l * UInt64BW.t'int r <= UInt64BW.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64BW.mul {l'0} {r'0} (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & l'0: UInt64BW.t = l | & r'0: UInt64BW.t = r ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] UInt64BW.t'int result
       = UInt64BW.t'int l * UInt64BW.t'int r}
       (! return' {result}) ]
@@ -8703,13 +8703,13 @@ module M_integer_ops__usize__test_div [#"integer_ops.rs" 84 30 126 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt64.div {l'0} {_7} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & l'0: UInt64.t = l
     | & r'0: UInt64.t = r
     | & _7: UInt64.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] UInt64.t'int result
       = Int.div (UInt64.t'int l) (UInt64.t'int r)}
       (! return' {result}) ]
@@ -8746,13 +8746,13 @@ module M_integer_ops__usize__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt64BW.div {l'0} {_7} (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64BW.t = Any.any_l ()
     | & l'0: UInt64BW.t = l
     | & r'0: UInt64BW.t = r
     | & _7: UInt64BW.t = Any.any_l ()
     | & _8: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] UInt64BW.t'int result
       = Int.div (UInt64BW.t'int l) (UInt64BW.t'int r)}
       (! return' {result}) ]
@@ -8829,7 +8829,7 @@ module M_integer_ops__usize__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -8850,7 +8850,7 @@ module M_integer_ops__usize__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: UInt64.t = Any.any_l ()
     | & _46: UInt64.t = Any.any_l ()
     | & _47: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = UInt64.of_bool b}
       (! return' {result}) ]
 
@@ -8926,7 +8926,7 @@ module M_integer_ops__usize__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: UInt64BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -8947,7 +8947,7 @@ module M_integer_ops__usize__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: UInt64BW.t = Any.any_l ()
     | & _46: UInt64BW.t = Any.any_l ()
     | & _47: UInt64BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = UInt64BW.of_bool b}
       (! return' {result}) ]
 
@@ -8972,7 +8972,7 @@ module M_integer_ops__usize__test_shl [#"integer_ops.rs" 84 30 155 11]
           (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] 
+     [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = UInt64.lsl n (UInt64.t'int (3: UInt64.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = UInt64.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -8999,7 +8999,7 @@ module M_integer_ops__usize__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & n'0: UInt64BW.t = n ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & n'0: UInt64BW.t = n ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = UInt64BW.lsl n (UInt64BW.t'int (3: UInt64BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = UInt64BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -9026,7 +9026,7 @@ module M_integer_ops__usize__test_shr [#"integer_ops.rs" 84 30 168 11]
           (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] 
+     [ & _0: UInt64.t = Any.any_l () | & n'0: UInt64.t = n ] )
     [ return''0 (result:UInt64.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = UInt64.shr n (UInt64.t'int (3: UInt64.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = UInt64.shr n (UInt8.t'int (3: UInt8.t))}
@@ -9053,7 +9053,7 @@ module M_integer_ops__usize__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:UInt64BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt64BW.t = Any.any_l () | & n'0: UInt64BW.t = n ] 
+     [ & _0: UInt64BW.t = Any.any_l () | & n'0: UInt64BW.t = n ] )
     [ return''0 (result:UInt64BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = UInt64BW.shr n (UInt64BW.t'int (3: UInt64BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = UInt64BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -9082,7 +9082,7 @@ module M_integer_ops__isize__test_add [#"integer_ops.rs" 84 30 86 11]
     /\ Int64.to_int l + Int64.to_int r <= Int64.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64.add {l'0} {r'0} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] 
+     [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_add ensures] [%#sinteger_ops'0] Int64.to_int result
       = Int64.to_int l + Int64.to_int r}
       (! return' {result}) ]
@@ -9110,7 +9110,7 @@ module M_integer_ops__isize__test_add_bw [#"integer_ops.rs" 84 30 93 11]
     /\ Int64BW.to_int l + Int64BW.to_int r <= Int64BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64BW.add {l'0} {r'0} (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] 
+     [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_add_bw ensures] [%#sinteger_ops'0] Int64BW.to_int result
       = Int64BW.to_int l + Int64BW.to_int r}
       (! return' {result}) ]
@@ -9138,7 +9138,7 @@ module M_integer_ops__isize__test_sub [#"integer_ops.rs" 84 30 99 11]
     /\ Int64.to_int l - Int64.to_int r <= Int64.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64.sub {l'0} {r'0} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] 
+     [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_sub ensures] [%#sinteger_ops'0] Int64.to_int result
       = Int64.to_int l - Int64.to_int r}
       (! return' {result}) ]
@@ -9166,7 +9166,7 @@ module M_integer_ops__isize__test_sub_bw [#"integer_ops.rs" 84 30 106 11]
     /\ Int64BW.to_int l - Int64BW.to_int r <= Int64BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64BW.sub {l'0} {r'0} (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] 
+     [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_sub_bw ensures] [%#sinteger_ops'0] Int64BW.to_int result
       = Int64BW.to_int l - Int64BW.to_int r}
       (! return' {result}) ]
@@ -9194,7 +9194,7 @@ module M_integer_ops__isize__test_mul [#"integer_ops.rs" 84 30 112 11]
     /\ Int64.to_int l * Int64.to_int r <= Int64.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64.mul {l'0} {r'0} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] 
+     [ & _0: Int64.t = Any.any_l () | & l'0: Int64.t = l | & r'0: Int64.t = r ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_mul ensures] [%#sinteger_ops'0] Int64.to_int result
       = Int64.to_int l * Int64.to_int r}
       (! return' {result}) ]
@@ -9222,7 +9222,7 @@ module M_integer_ops__isize__test_mul_bw [#"integer_ops.rs" 84 30 119 11]
     /\ Int64BW.to_int l * Int64BW.to_int r <= Int64BW.to_int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = Int64BW.mul {l'0} {r'0} (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] 
+     [ & _0: Int64BW.t = Any.any_l () | & l'0: Int64BW.t = l | & r'0: Int64BW.t = r ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_mul_bw ensures] [%#sinteger_ops'0] Int64BW.to_int result
       = Int64BW.to_int l * Int64BW.to_int r}
       (! return' {result}) ]
@@ -9267,7 +9267,7 @@ module M_integer_ops__isize__test_div [#"integer_ops.rs" 84 30 126 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int64.div {_6} {_7} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int64.t = Any.any_l ()
     | & l'0: Int64.t = l
     | & r'0: Int64.t = r
@@ -9277,7 +9277,7 @@ module M_integer_ops__isize__test_div [#"integer_ops.rs" 84 30 126 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int64.t)-> {[@expl:test_div ensures] [%#sinteger_ops'2] Int64.to_int result
       = Int.div (Int64.to_int l) (Int64.to_int r)}
       (! return' {result}) ]
@@ -9323,7 +9323,7 @@ module M_integer_ops__isize__test_div_bw [#"integer_ops.rs" 84 30 134 11]
       | s4 = bb2 ]
     
     | bb2 = s0 [ s0 = Int64BW.div {_6} {_7} (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int64BW.t = Any.any_l ()
     | & l'0: Int64BW.t = l
     | & r'0: Int64BW.t = r
@@ -9333,7 +9333,7 @@ module M_integer_ops__isize__test_div_bw [#"integer_ops.rs" 84 30 134 11]
     | & _9: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _11: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_div_bw ensures] [%#sinteger_ops'2] Int64BW.to_int result
       = Int.div (Int64BW.to_int l) (Int64BW.to_int r)}
       (! return' {result}) ]
@@ -9410,7 +9410,7 @@ module M_integer_ops__isize__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int64.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -9431,7 +9431,7 @@ module M_integer_ops__isize__test_from_bool [#"integer_ops.rs" 84 30 139 11]
     | & _45: Int64.t = Any.any_l ()
     | & _46: Int64.t = Any.any_l ()
     | & _47: Int64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int64.t)-> {[@expl:test_from_bool ensures] [%#sinteger_ops] result = Int64.of_bool b}
       (! return' {result}) ]
 
@@ -9507,7 +9507,7 @@ module M_integer_ops__isize__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | bb2 = s0
       [ s0 =  [ &kind <- C_Eq ] s1 | s1 =  [ &_19 <- left_val ] s2 | s2 =  [ &_21 <- right_val ] s3 | s3 = {false} any ]
      ]
-    )
+    
     [ & _0: Int64BW.t = Any.any_l ()
     | & b'0: bool = b
     | & _4: tuple = Any.any_l ()
@@ -9528,7 +9528,7 @@ module M_integer_ops__isize__test_from_bool_bw [#"integer_ops.rs" 84 30 147 11]
     | & _45: Int64BW.t = Any.any_l ()
     | & _46: Int64BW.t = Any.any_l ()
     | & _47: Int64BW.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_from_bool_bw ensures] [%#sinteger_ops] result = Int64BW.of_bool b}
       (! return' {result}) ]
 
@@ -9552,7 +9552,7 @@ module M_integer_ops__isize__test_shl [#"integer_ops.rs" 84 30 155 11]
       [ s0 = Int64.shl {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int64.t = Any.any_l () | & n'0: Int64.t = n ] 
+     [ & _0: Int64.t = Any.any_l () | & n'0: Int64.t = n ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_shl ensures #0] [%#sinteger_ops'0] result
       = Int64.lsl n (Int64.t'int (3: Int64.t))}
       {[@expl:test_shl ensures #1] [%#sinteger_ops'1] result = Int64.lsl n (UInt8.t'int (3: UInt8.t))}
@@ -9579,7 +9579,7 @@ module M_integer_ops__isize__test_shl_bw [#"integer_ops.rs" 84 30 162 11]
           (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & n'0: Int64BW.t = n ] 
+     [ & _0: Int64BW.t = Any.any_l () | & n'0: Int64BW.t = n ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_shl_bw ensures #0] [%#sinteger_ops'0] result
       = Int64BW.lsl n (Int64BW.t'int (3: Int64BW.t))}
       {[@expl:test_shl_bw ensures #1] [%#sinteger_ops'1] result = Int64BW.lsl n (UInt8BW.t'int (3: UInt8BW.t))}
@@ -9605,7 +9605,7 @@ module M_integer_ops__isize__test_shr [#"integer_ops.rs" 84 30 168 11]
       [ s0 = Int64.shr {n'0} {Int32.to_int ([%#sinteger_ops] (3: Int32.t))} (fun (_ret:Int64.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int64.t = Any.any_l () | & n'0: Int64.t = n ] 
+     [ & _0: Int64.t = Any.any_l () | & n'0: Int64.t = n ] )
     [ return''0 (result:Int64.t)-> {[@expl:test_shr ensures #0] [%#sinteger_ops'0] result
       = Int64.shr n (Int64.t'int (3: Int64.t))}
       {[@expl:test_shr ensures #1] [%#sinteger_ops'1] result = Int64.shr n (UInt8.t'int (3: UInt8.t))}
@@ -9632,7 +9632,7 @@ module M_integer_ops__isize__test_shr_bw [#"integer_ops.rs" 84 30 175 11]
           (fun (_ret:Int64BW.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int64BW.t = Any.any_l () | & n'0: Int64BW.t = n ] 
+     [ & _0: Int64BW.t = Any.any_l () | & n'0: Int64BW.t = n ] )
     [ return''0 (result:Int64BW.t)-> {[@expl:test_shr_bw ensures #0] [%#sinteger_ops'0] result
       = Int64BW.shr n (Int64BW.t'int (3: Int64BW.t))}
       {[@expl:test_shr_bw ensures #1] [%#sinteger_ops'1] result = Int64BW.shr n (UInt8BW.t'int (3: UInt8BW.t))}

--- a/tests/should_succeed/invariant_moves.coma
+++ b/tests/should_succeed/invariant_moves.coma
@@ -83,11 +83,11 @@ module M_invariant_moves__test_invariant_move [#"invariant_moves.rs" 5 0 5 43]
        ]
     
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: t_Vec = x
     | & _5: t_Option = Any.any_l ()
     | & _6: MutBorrow.t t_Vec = Any.any_l ()
     | & _7: MutBorrow.t t_Vec = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/ite_normalize.coma
+++ b/tests/should_succeed/ite_normalize.coma
@@ -50,7 +50,7 @@ module M_ite_normalize__qyi15119799284333837974__clone [#"ite_normalize.rs" 64 4
     | bb12 = s0 [ s0 =  [ &_18 <- e ] s1 | s1 = clone' {_18} (fun (_ret:t_Expr) ->  [ &_16 <- _ret ] s2) | s2 = bb14 ] 
     | bb14 = s0 [ s0 =  [ &_0 <- C_IfThenElse _8 _12 _16 ] s1 | s1 = bb18 ] 
     | bb18 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Expr = Any.any_l ()
     | & self'0: t_Expr = self
     | & c: t_Expr = Any.any_l ()
@@ -63,7 +63,7 @@ module M_ite_normalize__qyi15119799284333837974__clone [#"ite_normalize.rs" 64 4
     | & _16: t_Expr = Any.any_l ()
     | & _18: t_Expr = Any.any_l ()
     | & v: UInt64.t = Any.any_l () ]
-     [ return''0 (result:t_Expr)-> {[@expl:clone ensures] [%#site_normalize] result = self} (! return' {result}) ] 
+    ) [ return''0 (result:t_Expr)-> {[@expl:clone ensures] [%#site_normalize] result = self} (! return' {result}) ] 
 end
 module M_ite_normalize__qyi12210208226808281580__from [#"ite_normalize.rs" 79 4 79 29] (* <Expr as std::convert::From<usize>> *)
   let%span site_normalize = "ite_normalize.rs" 96 14 96 39
@@ -87,7 +87,7 @@ module M_ite_normalize__qyi12210208226808281580__from [#"ite_normalize.rs" 79 4 
   
   let rec from[#"ite_normalize.rs" 79 4 79 29] (a:UInt64.t) (return'  (x:t_Expr))= (! bb0
     [ bb0 = s0 [ s0 = variable {a'0} (fun (_ret:t_Expr) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: t_Expr = Any.any_l () | & a'0: UInt64.t = a ]  [ return''0 (result:t_Expr)-> (! return' {result}) ] 
+     [ & _0: t_Expr = Any.any_l () | & a'0: UInt64.t = a ] ) [ return''0 (result:t_Expr)-> (! return' {result}) ] 
 end
 module M_ite_normalize__qyi1874907776010341903__from [#"ite_normalize.rs" 85 4 85 28] (* <Expr as std::convert::From<bool>> *)
   use creusot.int.UInt64
@@ -108,7 +108,7 @@ module M_ite_normalize__qyi1874907776010341903__from [#"ite_normalize.rs" 85 4 8
     | bb1 = s0 [ s0 =  [ &_0 <- C_True ] s1 | s1 = bb3 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- C_False ] s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: t_Expr = Any.any_l () | & b'0: bool = b ]  [ return''0 (result:t_Expr)-> (! return' {result}) ] 
+     [ & _0: t_Expr = Any.any_l () | & b'0: bool = b ] ) [ return''0 (result:t_Expr)-> (! return' {result}) ] 
 end
 module M_ite_normalize__qyi17570407315987535457__ite [#"ite_normalize.rs" 92 4 92 49] (* Expr *)
   let%span site_normalize = "ite_normalize.rs" 91 14 91 91
@@ -128,7 +128,7 @@ module M_ite_normalize__qyi17570407315987535457__ite [#"ite_normalize.rs" 92 4 9
   
   let rec ite[#"ite_normalize.rs" 92 4 92 49] (c:t_Expr) (t:t_Expr) (e:t_Expr) (return'  (x:t_Expr))= (! bb0
     [ bb0 = bb3 | bb3 = s0 [ s0 =  [ &_0 <- C_IfThenElse c'0 t'0 e'0 ] s1 | s1 = bb9 ]  | bb9 = return''0 {_0} ]
-    ) [ & _0: t_Expr = Any.any_l () | & c'0: t_Expr = c | & t'0: t_Expr = t | & e'0: t_Expr = e ] 
+     [ & _0: t_Expr = Any.any_l () | & c'0: t_Expr = c | & t'0: t_Expr = t | & e'0: t_Expr = e ] )
     [ return''0 (result:t_Expr)-> {[@expl:ite ensures] [%#site_normalize] result = C_IfThenElse c t e}
       (! return' {result}) ]
 
@@ -151,7 +151,7 @@ module M_ite_normalize__qyi17570407315987535457__variable [#"ite_normalize.rs" 9
   
   let rec variable[#"ite_normalize.rs" 97 4 97 37] (v:UInt64.t) (return'  (x:t_Expr))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- C_Var v'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Expr = Any.any_l () | & v'0: UInt64.t = v ] 
+     [ & _0: t_Expr = Any.any_l () | & v'0: UInt64.t = v ] )
     [ return''0 (result:t_Expr)-> {[@expl:variable ensures] [%#site_normalize] result = C_Var v} (! return' {result}) ]
 
 end
@@ -226,7 +226,7 @@ module M_ite_normalize__qyi17570407315987535457__transpose [#"ite_normalize.rs" 
     | bb12 = s0 [ s0 = transpose {e} {a'0} {b'0} (fun (_ret:t_Expr) ->  [ &_21 <- _ret ] s1) | s1 = bb14 ] 
     | bb14 = s0 [ s0 =  [ &_0 <- C_IfThenElse c _14 _21 ] s1 | s1 = bb30 ] 
     | bb30 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Expr = Any.any_l ()
     | & self'0: t_Expr = self
     | & a'0: t_Expr = a
@@ -238,7 +238,7 @@ module M_ite_normalize__qyi17570407315987535457__transpose [#"ite_normalize.rs" 
     | & _16: t_Expr = Any.any_l ()
     | & _18: t_Expr = Any.any_l ()
     | & _21: t_Expr = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Expr)-> {[@expl:transpose ensures] [%#site_normalize'2] is_normalized result}
       (! return' {result}) ]
 
@@ -316,7 +316,7 @@ module M_ite_normalize__qyi17570407315987535457__normalize [#"ite_normalize.rs" 
     | bb5 = s0 [ s0 = normalize {e} (fun (_ret:t_Expr) ->  [ &ep <- _ret ] s1) | s1 = bb6 ] 
     | bb6 = s0 [ s0 = transpose {cp} {tp} {ep} (fun (_ret:t_Expr) ->  [ &_0 <- _ret ] s1) | s1 = bb12 ] 
     | bb12 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Expr = Any.any_l ()
     | & self'0: t_Expr = self
     | & c: t_Expr = Any.any_l ()
@@ -326,7 +326,7 @@ module M_ite_normalize__qyi17570407315987535457__normalize [#"ite_normalize.rs" 
     | & tp: t_Expr = Any.any_l ()
     | & ep: t_Expr = Any.any_l ()
     | & e'0: t_Expr = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Expr)-> {[@expl:normalize ensures] [%#site_normalize] is_normalized result}
       (! return' {result}) ]
 
@@ -408,7 +408,7 @@ module M_ite_normalize__qyi17570407315987535457__simplify [#"ite_normalize.rs" 1
     [ bb0 = s0 [ s0 = new (fun (_ret:t_BTreeMap) ->  [ &_5 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = simplify_helper {self'0} {_5} (fun (_ret:t_Expr) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: t_Expr = Any.any_l () | & self'0: t_Expr = self | & _5: t_BTreeMap = Any.any_l () ] 
+     [ & _0: t_Expr = Any.any_l () | & self'0: t_Expr = self | & _5: t_BTreeMap = Any.any_l () ] )
     [ return''0 (result:t_Expr)-> {[@expl:simplify ensures] [%#site_normalize'0] is_simplified result}
       (! return' {result}) ]
 
@@ -604,7 +604,7 @@ module M_ite_normalize__qyi17570407315987535457__simplify_helper [#"ite_normaliz
     | bb12 = s0 [ s0 = simplify_helper {t} {state'0} (fun (_ret:t_Expr) ->  [ &_0 <- _ret ] s1) | s1 = bb51 ] 
     | bb14 = s0 [ s0 = simplify_helper {e} {state'0} (fun (_ret:t_Expr) ->  [ &_0 <- _ret ] s1) | s1 = bb51 ] 
     | bb51 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Expr = Any.any_l ()
     | & self'0: t_Expr = self
     | & state'0: t_BTreeMap = state
@@ -629,7 +629,7 @@ module M_ite_normalize__qyi17570407315987535457__simplify_helper [#"ite_normaliz
     | & _51: UInt64.t = Any.any_l ()
     | & b'0: bool = Any.any_l ()
     | & c'1: t_Expr = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Expr)-> {[@expl:simplify_helper ensures #0] [%#site_normalize'2] forall i: UInt64.t. (exists v: bool. Map.get (view state) (UInt64.t'int i)
       = C_Some'0 v)  -> does_not_contain result i}
       {[@expl:simplify_helper ensures #1] [%#site_normalize'3] is_simplified result}

--- a/tests/should_succeed/iterators/01_range.coma
+++ b/tests/should_succeed/iterators/01_range.coma
@@ -312,12 +312,12 @@ module M_01_range__qyi16572111325853806140__next [#"01_range.rs" 53 4 53 39] (* 
       | s4 = bb3 ]
     
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self'0: MutBorrow.t t_Range = self
     | & _3: bool = Any.any_l ()
     | & r: Int64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:next ensures] [%#s01_range'0] match result with
         | C_None -> completed self
         | C_Some v -> produces self.current (Seq.singleton v) self.final
@@ -340,7 +340,7 @@ module M_01_range__qyi2180657552132013455__into_iter [#"01_range.rs" 66 4 66 34]
   
   let rec into_iter[#"01_range.rs" 66 4 66 34] (self:t_Range) (return'  (x:t_Range))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Range = Any.any_l () | & self'0: t_Range = self ] 
+     [ & _0: t_Range = Any.any_l () | & self'0: t_Range = self ] )
     [ return''0 (result:t_Range)-> {[@expl:into_iter ensures] [%#s01_range] result = self} (! return' {result}) ]
 
 end
@@ -530,7 +530,7 @@ module M_01_range__sum_range [#"01_range.rs" 73 0 73 35]
        ]
     
     | bb9 = s0 [ s0 =  [ &_0 <- i ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int64.t = Any.any_l ()
     | & n'0: Int64.t = n
     | & i: Int64.t = Any.any_l ()
@@ -542,7 +542,7 @@ module M_01_range__sum_range [#"01_range.rs" 73 0 73 35]
     | & _19: MutBorrow.t t_Range = Any.any_l ()
     | & x: Int64.t = Any.any_l ()
     | & _22: Seq.seq Int64.t = Any.any_l () ]
-     [ return''0 (result:Int64.t)-> {[@expl:sum_range ensures] [%#s01_range'9] result = n} (! return' {result}) ] 
+    ) [ return''0 (result:Int64.t)-> {[@expl:sum_range ensures] [%#s01_range'9] result = n} (! return' {result}) ] 
 end
 module M_01_range__qyi16572111325853806140__produces_trans__refines [#"01_range.rs" 47 4 47 90] (* <Range as common::Iterator> *)
   let%span s01_range = "01_range.rs" 47 4 47 90

--- a/tests/should_succeed/iterators/02_iter_mut.coma
+++ b/tests/should_succeed/iterators/02_iter_mut.coma
@@ -383,11 +383,11 @@ module M_02_iter_mut__qyi17529651713103399036__next [#"02_iter_mut.rs" 64 4 64 4
       | s2 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'8 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self'0: MutBorrow.t t_IterMut = self
     | & _3: MutBorrow.t (MutBorrow.t (Slice64.slice t_T)) = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:next result type invariant] [%#s02_iter_mut'0] inv'6 result}
       {[@expl:next ensures] [%#s02_iter_mut'1] match result with
         | C_None -> completed self
@@ -475,9 +475,9 @@ module M_02_iter_mut__qyi13152079231411878505__into_iter [#"02_iter_mut.rs" 71 4
   meta "select_lsinst" "all"
   
   let rec into_iter[#"02_iter_mut.rs" 71 4 71 30] (self:t_IterMut) (return'  (x:t_IterMut))= {[@expl:into_iter 'self' type invariant] [%#s02_iter_mut] inv'4 self}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- self'0 ] s1 | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- self'0 ] s1 | s1 = return''0 {_0} ]  ] 
     [ & _0: t_IterMut = Any.any_l () | & self'0: t_IterMut = self ]
-    
+    )
     [ return''0 (result:t_IterMut)-> {[@expl:into_iter result type invariant] [%#s02_iter_mut'0] inv'4 result}
       {[@expl:into_iter ensures] [%#s02_iter_mut'1] result = self}
       (! return' {result}) ]
@@ -689,7 +689,7 @@ module M_02_iter_mut__iter_mut [#"02_iter_mut.rs" 79 0 79 55]
       | s8 = -{resolve'2 v'0}- s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_IterMut = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & _5: MutBorrow.t (Slice64.slice t_T) = Any.any_l ()
@@ -697,7 +697,7 @@ module M_02_iter_mut__iter_mut [#"02_iter_mut.rs" 79 0 79 55]
     | & _7: MutBorrow.t (Slice64.slice t_T) = Any.any_l ()
     | & _8: MutBorrow.t t_Vec = Any.any_l ()
     | & _9: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_IterMut)-> {[@expl:iter_mut result type invariant] [%#s02_iter_mut'0] inv'6 result}
       {[@expl:iter_mut ensures #0] [%#s02_iter_mut'1] view'2 result.t_IterMut__inner = view'0 v}
       {[@expl:iter_mut ensures #1] [%#s02_iter_mut'2] view'1 (result.t_IterMut__inner).final = view v.final}
@@ -965,7 +965,7 @@ module M_02_iter_mut__all_zero [#"02_iter_mut.rs" 85 0 85 35]
       | s2 = -{resolve'6 v'0}- s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & it: t_IterMut = Any.any_l ()
@@ -977,7 +977,7 @@ module M_02_iter_mut__all_zero [#"02_iter_mut.rs" 85 0 85 35]
     | & _17: MutBorrow.t t_IterMut = Any.any_l ()
     | & x: MutBorrow.t UInt64.t = Any.any_l ()
     | & _20: Seq.seq (MutBorrow.t UInt64.t) = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:all_zero ensures #0] [%#s02_iter_mut'6] Seq.length (view'1 v.final)
       = Seq.length (view'2 v)}
       {[@expl:all_zero ensures #1] [%#s02_iter_mut'7] forall i: int. 0 <= i /\ i < Seq.length (view'2 v)

--- a/tests/should_succeed/iterators/03_std_iterators.coma
+++ b/tests/should_succeed/iterators/03_std_iterators.coma
@@ -234,7 +234,7 @@ module M_03_std_iterators__slice_iter [#"03_std_iterators.rs" 7 0 7 42]
        ]
     
     | bb10 = s0 [ s0 =  [ &_0 <- i ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & slice'0: Slice64.slice t_T = slice
     | & i: UInt64.t = Any.any_l ()
@@ -247,7 +247,7 @@ module M_03_std_iterators__slice_iter [#"03_std_iterators.rs" 7 0 7 42]
     | & _21: MutBorrow.t t_Iter = Any.any_l ()
     | & __creusot_proc_iter_elem: t_T = Any.any_l ()
     | & _24: Seq.seq t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:slice_iter ensures] [%#s03_std_iterators'8] UInt64.t'int result
       = Seq.length (view'1 slice)}
       (! return' {result}) ]
@@ -509,7 +509,7 @@ module M_03_std_iterators__vec_iter [#"03_std_iterators.rs" 18 0 18 41]
        ]
     
     | bb9 = s0 [ s0 =  [ &_0 <- i ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & vec'0: t_Vec = vec
     | & i: UInt64.t = Any.any_l ()
@@ -521,7 +521,7 @@ module M_03_std_iterators__vec_iter [#"03_std_iterators.rs" 18 0 18 41]
     | & _20: MutBorrow.t t_Iter = Any.any_l ()
     | & __creusot_proc_iter_elem: t_T = Any.any_l ()
     | & _23: Seq.seq t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:vec_iter ensures] [%#s03_std_iterators'8] UInt64.t'int result
       = Seq.length (view'0 vec)}
       (! return' {result}) ]
@@ -788,7 +788,7 @@ module M_03_std_iterators__all_zero [#"03_std_iterators.rs" 29 0 29 35]
        ]
     
     | bb11 = s0 [ s0 = -{resolve'6 iter}- s1 | s1 = -{resolve'8 v'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & iter: t_IterMut = Any.any_l ()
@@ -804,7 +804,7 @@ module M_03_std_iterators__all_zero [#"03_std_iterators.rs" 29 0 29 35]
     | & __creusot_proc_iter_elem: MutBorrow.t UInt64.t = Any.any_l ()
     | & _24: Seq.seq (MutBorrow.t UInt64.t) = Any.any_l ()
     | & x: MutBorrow.t UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:all_zero ensures #0] [%#s03_std_iterators'5] Seq.length (view'1 v.final)
       = Seq.length (view'2 v)}
       {[@expl:all_zero ensures #1] [%#s03_std_iterators'6] forall i: int. 0 <= i /\ i < Seq.length (view'2 v)
@@ -1065,7 +1065,7 @@ module M_03_std_iterators__skip_take [#"03_std_iterators.rs" 36 0 36 48]
     
     | bb4 = s0 [ s0 = {[@expl:assertion] [%#s03_std_iterators] res = C_None} s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & iter'2: t_I = iter'1
     | & n'2: UInt64.t = n'1
@@ -1073,7 +1073,7 @@ module M_03_std_iterators__skip_take [#"03_std_iterators.rs" 36 0 36 48]
     | & _4: MutBorrow.t t_Skip = Any.any_l ()
     | & _5: t_Skip = Any.any_l ()
     | & _6: t_Take = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_03_std_iterators__counter [#"03_std_iterators.rs" 42 0 42 27]
   let%span s03_std_iterators = "03_std_iterators.rs" 43 25 43 26
@@ -1435,7 +1435,7 @@ module M_03_std_iterators__counter [#"03_std_iterators.rs" 42 0 42 27]
       | s3 = bb6 ]
     
     | bb6 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & v'0: t_Vec = v
     | & cnt: UInt64.t = Any.any_l ()
@@ -1445,7 +1445,7 @@ module M_03_std_iterators__counter [#"03_std_iterators.rs" 42 0 42 27]
     | & _7: Slice64.slice UInt32.t = Any.any_l ()
     | & _9: closure0 = Any.any_l ()
     | & _10: MutBorrow.t UInt64.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_03_std_iterators__sum_range [#"03_std_iterators.rs" 61 0 61 35]
   let%span s03_std_iterators = "03_std_iterators.rs" 62 16 62 17
@@ -1643,7 +1643,7 @@ module M_03_std_iterators__sum_range [#"03_std_iterators.rs" 61 0 61 35]
        ]
     
     | bb9 = s0 [ s0 =  [ &_0 <- i ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: Int64.t = Any.any_l ()
     | & n'0: Int64.t = n
     | & i: Int64.t = Any.any_l ()
@@ -1656,7 +1656,7 @@ module M_03_std_iterators__sum_range [#"03_std_iterators.rs" 61 0 61 35]
     | & _21: MutBorrow.t t_Range = Any.any_l ()
     | & __creusot_proc_iter_elem: Int64.t = Any.any_l ()
     | & _24: Seq.seq Int64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:Int64.t)-> {[@expl:sum_range ensures] [%#s03_std_iterators'8] result = n} (! return' {result}) ]
 
 end
@@ -1885,7 +1885,7 @@ module M_03_std_iterators__enumerate_range [#"03_std_iterators.rs" 70 0 70 24]
        ]
     
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & iter'0: t_Enumerate = Any.any_l ()
     | & _2: t_Enumerate = Any.any_l ()
@@ -1899,7 +1899,7 @@ module M_03_std_iterators__enumerate_range [#"03_std_iterators.rs" 70 0 70 24]
     | & _19: Seq.seq tuple = Any.any_l ()
     | & ix: UInt64.t = Any.any_l ()
     | & x: UInt64.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_03_std_iterators__my_reverse [#"03_std_iterators.rs" 92 0 92 37]
   let%span s03_std_iterators = "03_std_iterators.rs" 94 34 94 54
@@ -2336,7 +2336,7 @@ module M_03_std_iterators__my_reverse [#"03_std_iterators.rs" 92 0 92 37]
     | bb14 = s0
       [ s0 = {[@expl:type invariant] inv'8 slice'0} s1 | s1 = -{resolve'6 slice'0}- s2 | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & slice'0: MutBorrow.t (Slice64.slice t_T) = slice
     | & n: UInt64.t = Any.any_l ()
@@ -2363,7 +2363,7 @@ module M_03_std_iterators__my_reverse [#"03_std_iterators.rs" 92 0 92 37]
     | & _42: UInt64.t = Any.any_l ()
     | & _43: UInt64.t = Any.any_l ()
     | & old_9_0: MutBorrow.t (Slice64.slice t_T) = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:my_reverse ensures] [%#s03_std_iterators'19] Seq.(==) (view slice.final) (Reverse.reverse (view'1 slice))}
       (! return' {result}) ]
 

--- a/tests/should_succeed/iterators/04_skip.coma
+++ b/tests/should_succeed/iterators/04_skip.coma
@@ -442,7 +442,7 @@ module M_04_skip__qyi11393468722733824414__next [#"04_skip.rs" 65 4 65 41] (* <S
       | s3 = bb16 ]
     
     | bb16 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self'0: MutBorrow.t t_Skip = self
     | & old_self: MutBorrow.t t_Skip = Any.any_l ()
@@ -456,7 +456,7 @@ module M_04_skip__qyi11393468722733824414__next [#"04_skip.rs" 65 4 65 41] (* <S
     | & x: t_Item = Any.any_l ()
     | & _26: Seq.seq t_Item = Any.any_l ()
     | & old_4_0: MutBorrow.t t_Skip = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:next result type invariant] [%#s04_skip'10] inv'4 result}
       {[@expl:next ensures] [%#s04_skip'11] match result with
         | C_None -> completed'0 self

--- a/tests/should_succeed/iterators/05_map.coma
+++ b/tests/should_succeed/iterators/05_map.coma
@@ -549,7 +549,7 @@ module M_05_map__qyi14378821460689001001__next [#"05_map.rs" 63 4 63 44] (* <Map
       | s3 = bb12 ]
     
     | bb12 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_Map = self
     | & _3: t_Option = Any.any_l ()
@@ -559,7 +559,7 @@ module M_05_map__qyi14378821460689001001__next [#"05_map.rs" 63 4 63 44] (* <Map
     | & _11: t_B = Any.any_l ()
     | & _12: MutBorrow.t t_F = Any.any_l ()
     | & _13: t_Item = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:next result type invariant] [%#s05_map'2] inv'9 result}
       {[@expl:next ensures] [%#s05_map'3] match result with
         | C_None'0 -> completed'0 self
@@ -944,7 +944,7 @@ module M_05_map__map [#"05_map.rs" 158 0 158 81]
     [ bb0 = bb1
     | bb1 = s0 [ s0 =  [ &_0 <- { t_Map__iter = iter'0; t_Map__func = func'0 } ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: t_Map = Any.any_l () | & iter'0: t_I = iter | & func'0: t_F = func ] 
+     [ & _0: t_Map = Any.any_l () | & iter'0: t_I = iter | & func'0: t_F = func ] )
     [ return''0 (result:t_Map)-> {[@expl:map result type invariant] [%#s05_map'4] inv'1 result}
       {[@expl:map ensures] [%#s05_map'5] result = { t_Map__iter = iter; t_Map__func = func }}
       (! return' {result}) ]

--- a/tests/should_succeed/iterators/06_map_precond.coma
+++ b/tests/should_succeed/iterators/06_map_precond.coma
@@ -628,7 +628,7 @@ module M_06_map_precond__qyi13778860181180212516__next [#"06_map_precond.rs" 66 
       | s4 = bb15 ]
     
     | bb15 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_Map = self
     | & _3: t_Option = Any.any_l ()
@@ -640,7 +640,7 @@ module M_06_map_precond__qyi13778860181180212516__next [#"06_map_precond.rs" 66 
     | & _13: tuple = Any.any_l ()
     | & _17: () = Any.any_l ()
     | & _20: Seq.seq t_Item = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:next result type invariant] [%#s06_map_precond'4] inv'9 result}
       {[@expl:next ensures] [%#s06_map_precond'5] match result with
         | C_None'0 -> completed'0 self
@@ -1174,9 +1174,9 @@ module M_06_map_precond__map [#"06_map_precond.rs" 182 0 185 14]
     | bb1 = s0 [ s0 =  [ &_9 <- [%#s06_map_precond] Seq.empty: Seq.seq t_Item ] s1 | s1 = bb2 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- { t_Map__iter = iter'0; t_Map__func = func'0; t_Map__produced = _9 } ] s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
-    [ & _0: t_Map = Any.any_l () | & iter'0: t_I = iter | & func'0: t_F = func | & _9: Seq.seq t_Item = Any.any_l () ]
     
+    [ & _0: t_Map = Any.any_l () | & iter'0: t_I = iter | & func'0: t_F = func | & _9: Seq.seq t_Item = Any.any_l () ]
+    )
     [ return''0 (result:t_Map)-> {[@expl:map result type invariant] [%#s06_map_precond'5] inv'1 result}
       {[@expl:map ensures] [%#s06_map_precond'6] result
       = { t_Map__iter = iter; t_Map__func = func; t_Map__produced = Seq.empty: Seq.seq t_Item }}
@@ -1370,7 +1370,7 @@ module M_06_map_precond__identity [#"06_map_precond.rs" 189 0 189 37]
       | s4 = bb3 ]
     
     | bb3 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & iter'0: t_I = iter | & _2: t_Map = Any.any_l () | & _4: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & iter'0: t_I = iter | & _2: t_Map = Any.any_l () | & _4: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -1674,7 +1674,7 @@ module M_06_map_precond__increment [#"06_map_precond.rs" 197 0 197 50]
       | s3 = bb3 ]
     
     | bb3 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & iter'0: t_U = iter | & i: t_Map = Any.any_l () | & _6: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & iter'0: t_U = iter | & i: t_Map = Any.any_l () | & _6: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -1903,14 +1903,14 @@ module M_06_map_precond__counter [#"06_map_precond.rs" 208 0 208 48]
       | s6 = bb3 ]
     
     | bb3 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & iter'0: t_I = iter
     | & cnt: UInt64.t = Any.any_l ()
     | & _5: t_Map = Any.any_l ()
     | & _7: closure0 = Any.any_l ()
     | & _8: MutBorrow.t UInt64.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_06_map_precond__qyi6490470836283789663__resolve_coherence__refines [#"06_map_precond.rs" 10 9 10 16] (* <Map<I, F> as creusot_contracts::Resolve> *)
   let%span s06_map_precond = "06_map_precond.rs" 10 9 10 16

--- a/tests/should_succeed/iterators/07_fuse.coma
+++ b/tests/should_succeed/iterators/07_fuse.coma
@@ -291,7 +291,7 @@ module M_07_fuse__qyi15189554860034455533__next [#"07_fuse.rs" 41 4 41 44] (* <F
       | s3 = bb15 ]
     
     | bb15 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_Fuse = self
     | & _3: MutBorrow.t t_Option = Any.any_l ()
@@ -300,7 +300,7 @@ module M_07_fuse__qyi15189554860034455533__next [#"07_fuse.rs" 41 4 41 44] (* <F
     | & _7: MutBorrow.t t_I = Any.any_l ()
     | & _9: t_Option = Any.any_l ()
     | & x: t_Option'0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:next result type invariant] [%#s07_fuse'0] inv'3 result}
       {[@expl:next ensures] [%#s07_fuse'1] match result with
         | C_None'0 -> completed'0 self

--- a/tests/should_succeed/iterators/08_collect_extend.coma
+++ b/tests/should_succeed/iterators/08_collect_extend.coma
@@ -247,7 +247,7 @@ module M_08_collect_extend__extend [#"08_collect_extend.rs" 21 0 21 66]
       | s4 = bb19 ]
     
     | bb19 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & vec'0: MutBorrow.t t_Vec = vec
     | & iter'0: t_I = iter
@@ -264,7 +264,7 @@ module M_08_collect_extend__extend [#"08_collect_extend.rs" 21 0 21 66]
     | & _27: () = Any.any_l ()
     | & _28: MutBorrow.t t_Vec = Any.any_l ()
     | & old_5_0: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:extend ensures] [%#s08_collect_extend'8] exists done': MutBorrow.t t_I, prod: Seq.seq t_T. completed done'
       /\ produces iter prod done'.current /\ view vec.final = Seq.(++) (view'0 vec) prod}
       (! return' {result}) ]
@@ -497,7 +497,7 @@ module M_08_collect_extend__collect [#"08_collect_extend.rs" 39 0 39 52]
     | bb10 = s0 [ s0 = {[@expl:type invariant] inv'3 iter'1} s1 | s1 = -{resolve'1 iter'1}- s2 | s2 = bb18 ] 
     | bb18 = s0 [ s0 =  [ &_0 <- res ] s1 | s1 = bb20 ] 
     | bb20 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Vec = Any.any_l ()
     | & iter'0: t_I = iter
     | & res: t_Vec = Any.any_l ()
@@ -512,7 +512,7 @@ module M_08_collect_extend__collect [#"08_collect_extend.rs" 39 0 39 52]
     | & x: t_Item = Any.any_l ()
     | & _26: () = Any.any_l ()
     | & _27: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Vec)-> {[@expl:collect result type invariant] [%#s08_collect_extend'6] inv'2 result}
       {[@expl:collect ensures] [%#s08_collect_extend'7] exists done': MutBorrow.t t_I, prod: Seq.seq t_Item. resolve'1 done'.final
       /\ completed done' /\ produces iter prod done'.current /\ view result = prod}
@@ -663,7 +663,7 @@ module M_08_collect_extend__extend_index [#"08_collect_extend.rs" 50 0 50 51]
       | s2 = bb6 ]
     
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v1'0: t_Vec = v1
     | & v2'0: t_Vec = v2
@@ -673,7 +673,7 @@ module M_08_collect_extend__extend_index [#"08_collect_extend.rs" 50 0 50 51]
     | & _8: MutBorrow.t t_Vec = Any.any_l ()
     | & _9: MutBorrow.t t_Vec = Any.any_l ()
     | & _10: t_IntoIter = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_08_collect_extend__collect_example [#"08_collect_extend.rs" 60 0 60 56]
   let%span s08_collect_extend = "08_collect_extend.rs" 63 20 63 67
@@ -765,7 +765,7 @@ module M_08_collect_extend__collect_example [#"08_collect_extend.rs" 60 0 60 56]
       | s1 = bb3 ]
     
     | bb3 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & iter'0: t_I = iter | & v: t_Vec = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & iter'0: t_I = iter | & v: t_Vec = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/iterators/09_empty.coma
+++ b/tests/should_succeed/iterators/09_empty.coma
@@ -109,7 +109,7 @@ module M_09_empty__qyi7971881024803823682__next [#"09_empty.rs" 42 4 42 35] (* <
   
   let rec next[#"09_empty.rs" 42 4 42 35] (self:MutBorrow.t t_Empty) (return'  (x:t_Option))= (! bb0
     [ bb0 = s0 [ s0 = -{resolve'0 self'0}- s1 | s1 =  [ &_0 <- C_None ] s2 | s2 = return''0 {_0} ]  ]
-    ) [ & _0: t_Option = Any.any_l () | & self'0: MutBorrow.t t_Empty = self ] 
+     [ & _0: t_Option = Any.any_l () | & self'0: MutBorrow.t t_Empty = self ] )
     [ return''0 (result:t_Option)-> {[@expl:next result type invariant] [%#s09_empty] inv'0 result}
       {[@expl:next ensures] [%#s09_empty'0] match result with
         | C_None -> completed self

--- a/tests/should_succeed/iterators/10_once.coma
+++ b/tests/should_succeed/iterators/10_once.coma
@@ -210,9 +210,9 @@ module M_10_once__qyi13094531909677028354__next [#"10_once.rs" 46 4 46 35] (* <O
       | s2 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'3 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
-    [ & _0: t_Option = Any.any_l () | & self'0: MutBorrow.t t_Once = self | & _3: MutBorrow.t t_Option = Any.any_l () ]
     
+    [ & _0: t_Option = Any.any_l () | & self'0: MutBorrow.t t_Once = self | & _3: MutBorrow.t t_Option = Any.any_l () ]
+    )
     [ return''0 (result:t_Option)-> {[@expl:next result type invariant] [%#s10_once'0] inv'0 result}
       {[@expl:next ensures] [%#s10_once'1] match result with
         | C_None -> completed self

--- a/tests/should_succeed/iterators/11_repeat.coma
+++ b/tests/should_succeed/iterators/11_repeat.coma
@@ -384,7 +384,7 @@ module M_11_repeat__qyi12123383775959562970__next [#"11_repeat.rs" 47 4 47 35] (
       | s3 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: t_Option = Any.any_l () | & self'0: MutBorrow.t t_Repeat = self | & _3: t_A = Any.any_l () ] 
+     [ & _0: t_Option = Any.any_l () | & self'0: MutBorrow.t t_Repeat = self | & _3: t_A = Any.any_l () ] )
     [ return''0 (result:t_Option)-> {[@expl:next result type invariant] [%#s11_repeat'0] inv'3 result}
       {[@expl:next ensures] [%#s11_repeat'1] match result with
         | C_None -> completed self

--- a/tests/should_succeed/iterators/12_zip.coma
+++ b/tests/should_succeed/iterators/12_zip.coma
@@ -426,7 +426,7 @@ module M_12_zip__qyi5005316258240146725__next [#"12_zip.rs" 56 4 56 44] (* <Zip<
     | bb3 = s0 [ s0 = {[@expl:type invariant] inv'8 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = bb5 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- C_None'1 ] s1 | s1 = bb23 ] 
     | bb23 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'1 = Any.any_l ()
     | & self'0: MutBorrow.t t_Zip = self
     | & x: t_Item = Any.any_l ()
@@ -438,7 +438,7 @@ module M_12_zip__qyi5005316258240146725__next [#"12_zip.rs" 56 4 56 44] (* <Zip<
     | & _11: MutBorrow.t t_B = Any.any_l ()
     | & y'0: t_Item'0 = Any.any_l ()
     | & _15: tuple = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'1)-> {[@expl:next result type invariant] [%#s12_zip'0] inv'10 result}
       {[@expl:next ensures] [%#s12_zip'1] match result with
         | C_None'1 -> completed'1 self

--- a/tests/should_succeed/iterators/13_cloned.coma
+++ b/tests/should_succeed/iterators/13_cloned.coma
@@ -508,12 +508,12 @@ module M_13_cloned__qyi8249401513993331368__next [#"13_cloned.rs" 54 4 54 35] (*
       | s3 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_Cloned = self
     | & _3: t_Option = Any.any_l ()
     | & _4: MutBorrow.t t_I = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:next result type invariant] [%#s13_cloned'0] inv'6 result}
       {[@expl:next ensures] [%#s13_cloned'1] match result with
         | C_None'0 -> completed'0 self

--- a/tests/should_succeed/iterators/14_copied.coma
+++ b/tests/should_succeed/iterators/14_copied.coma
@@ -297,12 +297,12 @@ module M_14_copied__qyi9881593582958868314__next [#"14_copied.rs" 54 4 54 35] (*
       | s3 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_Copied = self
     | & _3: t_Option = Any.any_l ()
     | & _4: MutBorrow.t t_I = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:next result type invariant] [%#s14_copied'0] inv'6 result}
       {[@expl:next ensures] [%#s14_copied'1] match result with
         | C_None'0 -> completed'0 self

--- a/tests/should_succeed/iterators/15_enumerate.coma
+++ b/tests/should_succeed/iterators/15_enumerate.coma
@@ -339,7 +339,7 @@ module M_15_enumerate__qyi3289565171142109185__next [#"15_enumerate.rs" 55 4 55 
     | bb3 = s0 [ s0 = {[@expl:type invariant] inv'4 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = bb5 ] 
     | bb5 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_Enumerate = self
     | & _3: t_Option = Any.any_l ()
@@ -347,7 +347,7 @@ module M_15_enumerate__qyi3289565171142109185__next [#"15_enumerate.rs" 55 4 55 
     | & x: t_Item = Any.any_l ()
     | & n: UInt64.t = Any.any_l ()
     | & _8: tuple = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:next result type invariant] [%#s15_enumerate'1] inv'6 result}
       {[@expl:next ensures] [%#s15_enumerate'2] match result with
         | C_None'0 -> completed'0 self
@@ -428,7 +428,7 @@ module M_15_enumerate__enumerate [#"15_enumerate.rs" 88 0 88 54]
       | s1 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    ) [ & _0: t_Enumerate = Any.any_l () | & iter'0: t_I = iter ] 
+     [ & _0: t_Enumerate = Any.any_l () | & iter'0: t_I = iter ] )
     [ return''0 (result:t_Enumerate)-> {[@expl:enumerate result type invariant] [%#s15_enumerate'3] inv'0 result}
       {[@expl:enumerate ensures] [%#s15_enumerate'4] result.t_Enumerate__iter = iter
       /\ UInt64.t'int result.t_Enumerate__count = 0}

--- a/tests/should_succeed/iterators/16_take.coma
+++ b/tests/should_succeed/iterators/16_take.coma
@@ -282,12 +282,12 @@ module M_16_take__qyi12677911356865036795__next [#"16_take.rs" 54 4 54 41] (* <T
       | s3 = bb4 ]
     
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self'0: MutBorrow.t t_Take = self
     | & _3: bool = Any.any_l ()
     | & _5: MutBorrow.t t_I = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:next result type invariant] [%#s16_take'2] inv'2 result}
       {[@expl:next ensures] [%#s16_take'3] match result with
         | C_None -> completed'0 self

--- a/tests/should_succeed/iterators/17_filter.coma
+++ b/tests/should_succeed/iterators/17_filter.coma
@@ -536,7 +536,7 @@ module M_17_filter__qyi6180221713105948918__next [#"17_filter.rs" 85 4 85 41] (*
       | s3 = bb19 ]
     
     | bb19 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self'0: MutBorrow.t t_Filter = self
     | & old_self: MutBorrow.t t_Filter = Any.any_l ()
@@ -550,7 +550,7 @@ module M_17_filter__qyi6180221713105948918__next [#"17_filter.rs" 85 4 85 41] (*
     | & _25: t_Item = Any.any_l ()
     | & _27: t_Item = Any.any_l ()
     | & old_3_0: MutBorrow.t t_Filter = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:next result type invariant] [%#s17_filter'8] inv'5 result}
       {[@expl:next ensures] [%#s17_filter'9] match result with
         | C_None -> completed'0 self
@@ -676,7 +676,7 @@ module M_17_filter__filter [#"17_filter.rs" 111 0 113 39]
     (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- { t_Filter__iter = iter'0; t_Filter__func = f'0 } ] s1 | s1 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    ) [ & _0: t_Filter = Any.any_l () | & iter'0: t_I = iter | & f'0: t_P = f ] 
+     [ & _0: t_Filter = Any.any_l () | & iter'0: t_I = iter | & f'0: t_P = f ] )
     [ return''0 (result:t_Filter)-> {[@expl:filter result type invariant] [%#s17_filter'4] inv'1 result}
       {[@expl:filter ensures] [%#s17_filter'5] result.t_Filter__iter = iter /\ result.t_Filter__func = f}
       (! return' {result}) ]
@@ -888,12 +888,12 @@ module M_17_filter__less_than [#"17_filter.rs" 120 0 120 49]
       | s2 =  [ &_0'0 <- res ] s3
       | s3 = return''0 {_0'0} ]
      ]
-    )
+    
     [ & _0'0: bool = Any.any_l ()
     | & _1: MutBorrow.t closure2 = self
     | & i'0: UInt32.t = i
     | & res: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:closure ensures] [%#s17_filter'1] result = UInt32.lt i (self.final)._0}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
       (! return' {result}) ]
@@ -1034,14 +1034,14 @@ module M_17_filter__less_than [#"17_filter.rs" 120 0 120 49]
     
     | bb2 = s0 [ s0 = collect {_5} (fun (_ret:t_Vec) ->  [ &_0'0 <- _ret ] s1) | s1 = bb4 ] 
     | bb4 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: t_Vec = Any.any_l ()
     | & v'0: t_Vec = v
     | & n'0: UInt32.t = n
     | & _5: t_Filter = Any.any_l ()
     | & _6: t_IntoIter = Any.any_l ()
     | & _8: closure2 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Vec)-> {[@expl:less_than ensures #0] [%#s17_filter] forall i: int. 0 <= i
       /\ i < Seq.length (view result)  -> UInt32.lt (index_logic result i) n}
       {[@expl:less_than ensures #1] [%#s17_filter'0] forall i: int. 0 <= i /\ i < Seq.length (view result)

--- a/tests/should_succeed/knapsack.coma
+++ b/tests/should_succeed/knapsack.coma
@@ -18,7 +18,7 @@ module M_knapsack__max [#"knapsack.rs" 16 0 16 35]
     | bb1 = s0 [ s0 =  [ &_0 <- b'0 ] s1 | s1 = bb3 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- a'0 ] s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: UInt64.t = Any.any_l () | & a'0: UInt64.t = a | & b'0: UInt64.t = b | & _5: bool = Any.any_l () ] 
+     [ & _0: UInt64.t = Any.any_l () | & a'0: UInt64.t = a | & b'0: UInt64.t = b | & _5: bool = Any.any_l () ] )
     [ return''0 (result:UInt64.t)-> {[@expl:max ensures] [%#sknapsack'0] UInt64.t'int result
       = MinMax.max (UInt64.t'int a) (UInt64.t'int b)}
       (! return' {result}) ]
@@ -586,7 +586,7 @@ module M_knapsack__knapsack01_dyn [#"knapsack.rs" 45 0 45 91]
     
     | bb41 = s0 [ s0 =  [ &_0 <- result ] s1 | s1 = bb43 ] 
     | bb43 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Vec'2 = Any.any_l ()
     | & items'0: t_Vec'0 = items
     | & max_weight'0: UInt64.t = max_weight
@@ -632,7 +632,7 @@ module M_knapsack__knapsack01_dyn [#"knapsack.rs" 45 0 45 91]
     | & _106: t_Vec = Any.any_l ()
     | & _110: () = Any.any_l ()
     | & _111: MutBorrow.t t_Vec'2 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Vec'2)-> {[@expl:knapsack01_dyn result type invariant] [%#sknapsack'26] inv'8 result}
       (! return' {result}) ]
 

--- a/tests/should_succeed/knapsack_full.coma
+++ b/tests/should_succeed/knapsack_full.coma
@@ -16,7 +16,7 @@ module M_knapsack_full__max [#"knapsack_full.rs" 15 0 15 35]
     | bb1 = s0 [ s0 =  [ &_0 <- b'0 ] s1 | s1 = bb3 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- a'0 ] s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: UInt64.t = Any.any_l () | & a'0: UInt64.t = a | & b'0: UInt64.t = b | & _4: bool = Any.any_l () ] 
+     [ & _0: UInt64.t = Any.any_l () | & a'0: UInt64.t = a | & b'0: UInt64.t = b | & _4: bool = Any.any_l () ] )
     [ return''0 (result:UInt64.t)-> {[@expl:max ensures] [%#sknapsack_full] UInt64.t'int result
       = MinMax.max (UInt64.t'int a) (UInt64.t'int b)}
       (! return' {result}) ]
@@ -1065,7 +1065,7 @@ module M_knapsack_full__knapsack01_dyn [#"knapsack_full.rs" 84 0 84 91]
     
     | bb56 = s0 [ s0 =  [ &_0 <- result ] s1 | s1 = bb58 ] 
     | bb58 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Vec'2 = Any.any_l ()
     | & items'0: t_Vec'0 = items
     | & max_weight'0: UInt64.t = max_weight
@@ -1127,7 +1127,7 @@ module M_knapsack_full__knapsack01_dyn [#"knapsack_full.rs" 84 0 84 91]
     | & _139: t_Vec = Any.any_l ()
     | & _143: () = Any.any_l ()
     | & _144: MutBorrow.t t_Vec'2 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Vec'2)-> {[@expl:knapsack01_dyn result type invariant] [%#sknapsack_full'35] inv'11 result}
       {[@expl:knapsack01_dyn ensures #0] [%#sknapsack_full'36] sum_weights (view'7 result) (Seq.length (view'7 result))
       <= UInt64.t'int max_weight}

--- a/tests/should_succeed/lang/assoc_type.coma
+++ b/tests/should_succeed/lang/assoc_type.coma
@@ -30,7 +30,7 @@ module M_assoc_type__uses3 [#"assoc_type.rs" 37 0 37 33]
   meta "select_lsinst" "all"
   
   let rec uses3[#"assoc_type.rs" 37 0 37 33] (_0:t_Nested) (return'  (x:()))= {[@expl:uses3 '_0' type invariant] inv'1 _0}
-    (! bb0 [ bb0 = s0 [ s0 = {[@expl:type invariant] inv'1 _1} s1 | s1 = bb1 ]  | bb1 = return''0 {_0'0} ] )
+    (! bb0 [ bb0 = s0 [ s0 = {[@expl:type invariant] inv'1 _1} s1 | s1 = bb1 ]  | bb1 = return''0 {_0'0} ] 
     [ & _0'0: () = Any.any_l () | & _1: t_Nested = _0 ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/branch_borrow_2.coma
+++ b/tests/should_succeed/lang/branch_borrow_2.coma
@@ -75,7 +75,7 @@ module M_branch_borrow_2__f [#"branch_borrow_2.rs" 3 0 3 10]
     
     | bb7 = return''0 {_0}
     | bb8 = {[%#sbranch_borrow_2'8] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: Int32.t = Any.any_l ()
     | & b: Int32.t = Any.any_l ()
@@ -87,7 +87,7 @@ module M_branch_borrow_2__f [#"branch_borrow_2.rs" 3 0 3 10]
     | & _11: MutBorrow.t Int32.t = Any.any_l ()
     | & _12: MutBorrow.t Int32.t = Any.any_l ()
     | & _14: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_branch_borrow_2__g [#"branch_borrow_2.rs" 35 0 35 10]
   let%span sbranch_borrow_2 = "branch_borrow_2.rs" 36 23 36 25
@@ -141,7 +141,7 @@ module M_branch_borrow_2__g [#"branch_borrow_2.rs" 35 0 35 10]
       | s8 = -{resolve'2 b}- s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: tuple = Any.any_l ()
     | & _2: t_MyInt = Any.any_l ()
@@ -149,7 +149,7 @@ module M_branch_borrow_2__g [#"branch_borrow_2.rs" 35 0 35 10]
     | & b: MutBorrow.t tuple = Any.any_l ()
     | & c: MutBorrow.t t_MyInt = Any.any_l ()
     | & d: MutBorrow.t t_MyInt = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_branch_borrow_2__h [#"branch_borrow_2.rs" 45 0 45 10]
   let%span sbranch_borrow_2 = "branch_borrow_2.rs" 46 16 46 18
@@ -198,7 +198,7 @@ module M_branch_borrow_2__h [#"branch_borrow_2.rs" 45 0 45 10]
       | s4 = bb3 ]
     
     | bb3 = s0 [ s0 = -{resolve'0 w}- s1 | s1 = -{resolve'0 y}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: Int32.t = Any.any_l ()
     | & b: Int32.t = Any.any_l ()
@@ -206,5 +206,5 @@ module M_branch_borrow_2__h [#"branch_borrow_2.rs" 45 0 45 10]
     | & y: MutBorrow.t Int32.t = Any.any_l ()
     | & w: MutBorrow.t Int32.t = Any.any_l ()
     | & _9: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/cast_ptr.coma
+++ b/tests/should_succeed/lang/cast_ptr.coma
@@ -10,7 +10,7 @@ module M_cast_ptr__f [#"cast_ptr.rs" 4 0 4 32]
   
   let rec f[#"cast_ptr.rs" 4 0 4 32] (p:Opaque.ptr) (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = {[@expl:assertion] [%#scast_ptr] p'0 = p'0} s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & p'0: Opaque.ptr = p ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & p'0: Opaque.ptr = p ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_cast_ptr__thin [#"cast_ptr.rs" 9 0 9 41]
   let%span scast_ptr = "cast_ptr.rs" 8 10 8 33
@@ -24,7 +24,7 @@ module M_cast_ptr__thin [#"cast_ptr.rs" 9 0 9 41]
   
   let rec thin[#"cast_ptr.rs" 9 0 9 41] (p:Opaque.ptr) (return'  (x:Opaque.ptr))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- Opaque.thin p'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Opaque.ptr = Any.any_l () | & p'0: Opaque.ptr = p ] 
+     [ & _0: Opaque.ptr = Any.any_l () | & p'0: Opaque.ptr = p ] )
     [ return''0 (result:Opaque.ptr)-> {[@expl:thin ensures] [%#scast_ptr] result = Opaque.thin p} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/lang/const.coma
+++ b/tests/should_succeed/lang/const.coma
@@ -11,7 +11,7 @@ module M_const__foo [#"const.rs" 8 0 8 21]
   
   let rec foo[#"const.rs" 8 0 8 21] (return'  (x:UInt64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#sconst] (42: UInt64.t) ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () ] 
+     [ & _0: UInt64.t = Any.any_l () ] )
     [ return''0 (result:UInt64.t)-> {[@expl:foo ensures] [%#sconst'0] result = (42: UInt64.t)} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/lang/empty.coma
+++ b/tests/should_succeed/lang/empty.coma
@@ -5,7 +5,7 @@ module M_empty__f [#"empty.rs" 3 0 3 10]
   
   meta "select_lsinst" "all"
   
-  let rec f[#"empty.rs" 3 0 3 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+  let rec f[#"empty.rs" 3 0 3 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/lang/float_ops.coma
+++ b/tests/should_succeed/lang/float_ops.coma
@@ -15,7 +15,7 @@ module M_float_ops__eq [#"float_ops.rs" 8 0 8 19]
       [ s0 =  [ &_0 <- Float64.eq ([%#sfloat_ops'0] (1.0: Float64.t)) ([%#sfloat_ops] (2.0: Float64.t)) ] s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:eq ensures] [%#sfloat_ops'1] result = false} (! return' {result}) ]
 
 end
@@ -36,7 +36,7 @@ module M_float_ops__lt [#"float_ops.rs" 13 0 13 19]
       [ s0 =  [ &_0 <- Float64.lt ([%#sfloat_ops'0] (1.0: Float64.t)) ([%#sfloat_ops] (2.0: Float64.t)) ] s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:lt ensures] [%#sfloat_ops'1] result = true} (! return' {result}) ]
 
 end
@@ -57,7 +57,7 @@ module M_float_ops__le [#"float_ops.rs" 18 0 18 19]
       [ s0 =  [ &_0 <- Float64.le ([%#sfloat_ops'0] (1.0: Float64.t)) ([%#sfloat_ops] (2.0: Float64.t)) ] s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:le ensures] [%#sfloat_ops'1] result = true} (! return' {result}) ]
 
 end
@@ -78,7 +78,7 @@ module M_float_ops__gt [#"float_ops.rs" 23 0 23 19]
       [ s0 =  [ &_0 <- Float64.gt ([%#sfloat_ops'0] (2.0: Float64.t)) ([%#sfloat_ops] (1.0: Float64.t)) ] s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:gt ensures] [%#sfloat_ops'1] result = true} (! return' {result}) ]
 
 end
@@ -99,7 +99,7 @@ module M_float_ops__ge [#"float_ops.rs" 28 0 28 19]
       [ s0 =  [ &_0 <- Float64.ge ([%#sfloat_ops'0] (2.0: Float64.t)) ([%#sfloat_ops] (1.0: Float64.t)) ] s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:ge ensures] [%#sfloat_ops'1] result = true} (! return' {result}) ]
 
 end
@@ -120,7 +120,7 @@ module M_float_ops__neg [#"float_ops.rs" 33 0 33 20]
       [ s0 =  [ &_0 <- Float64.le ([%#sfloat_ops'0] (-2.0: Float64.t)) ([%#sfloat_ops] (1.0: Float64.t)) ] s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:neg ensures] [%#sfloat_ops'1] result = true} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/lang/literals.coma
+++ b/tests/should_succeed/lang/literals.coma
@@ -28,10 +28,10 @@ module M_literals__float_operation [#"literals.rs" 3 0 3 31]
     
     | bb2 = s0 [ s0 =  [ &_0 <- [%#sliterals'4] (0.0: Float32.t) ] s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: Float32.t = Any.any_l ()
     | & x: Float32.t = Any.any_l ()
     | & _2: bool = Any.any_l ()
     | & _3: Float32.t = Any.any_l () ]
-     [ return''0 (result:Float32.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:Float32.t)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/module_paths.coma
+++ b/tests/should_succeed/lang/module_paths.coma
@@ -20,5 +20,5 @@ module M_module_paths__test [#"module_paths.rs" 22 0 22 51]
   
   let rec test[#"module_paths.rs" 22 0 22 51] (_a:t_T) (_b:t_S) (_c:t_O) (_d:t_T'0) (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/modules.coma
+++ b/tests/should_succeed/lang/modules.coma
@@ -37,7 +37,7 @@ module M_modules__nested__inner_func [#"modules.rs" 13 4 13 31]
   
   let rec inner_func[#"modules.rs" 13 4 13 31] (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#smodules] true ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:inner_func ensures] [%#smodules'0] result = true} (! return' {result}) ]
 
 end
@@ -52,7 +52,7 @@ module M_modules__nested__further__another [#"modules.rs" 19 8 19 32]
   
   let rec another[#"modules.rs" 19 8 19 32] (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#smodules] false ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () ]  [ return''0 (result:bool)-> (! return' {result}) ] 
+     [ & _0: bool = Any.any_l () ] ) [ return''0 (result:bool)-> (! return' {result}) ] 
 end
 module M_modules__f [#"modules.rs" 25 0 25 10]
   let%span smodules = "modules.rs" 12 14 12 28
@@ -73,7 +73,7 @@ module M_modules__f [#"modules.rs" 25 0 25 10]
     [ bb0 = s0 [ s0 = inner_func (fun (_ret:bool) ->  [ &_1 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = another (fun (_ret:bool) ->  [ &_2 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _1: bool = Any.any_l () | & _2: bool = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & _1: bool = Any.any_l () | & _2: bool = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/lang/move_path.coma
+++ b/tests/should_succeed/lang/move_path.coma
@@ -28,11 +28,11 @@ module M_move_path__f [#"move_path.rs" 3 0 3 10]
       | s5 = -{resolve'0 z}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & y: MutBorrow.t Int32.t = Any.any_l ()
     | & d: MutBorrow.t Int32.t = Any.any_l ()
     | & z: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/multiple_scopes.coma
+++ b/tests/should_succeed/lang/multiple_scopes.coma
@@ -18,10 +18,10 @@ module M_multiple_scopes__multiple_scopes [#"multiple_scopes.rs" 4 0 4 24]
       | s3 =  [ &_x <- _y'0 ] s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _x: Int32.t = Any.any_l ()
     | & _y: Int32.t = Any.any_l ()
     | & _y'0: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/promoted_constants.coma
+++ b/tests/should_succeed/lang/promoted_constants.coma
@@ -44,13 +44,13 @@ module M_promoted_constants__promoted_none [#"promoted_constants.rs" 3 0 3 22]
     | bb2 = any [ br0 -> {_2._p1 = C_None} (! bb4) | br1 (x0:Int32.t)-> {_2._p1 = C_Some x0} (! bb1) ] 
     | bb1 = return''0 {_0}
     | bb4 = {false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _ix: t_Option = Any.any_l ()
     | & _2: tuple = Any.any_l ()
     | & _10: t_Option = Any.any_l ()
     | & _11: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_promoted_constants__promoted_int [#"promoted_constants.rs" 12 0 12 21]
   let%span spromoted_constants = "promoted_constants.rs" 15 14 15 16
@@ -84,12 +84,12 @@ module M_promoted_constants__promoted_int [#"promoted_constants.rs" 12 0 12 21]
     
     | bb1 = {false} any
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & ix: Int32.t = Any.any_l ()
     | & _4: bool = Any.any_l ()
     | & _9: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_promoted_constants__string [#"promoted_constants.rs" 20 0 20 25]
   use creusot.prelude.Opaque
@@ -123,7 +123,7 @@ module M_promoted_constants__string [#"promoted_constants.rs" 20 0 20 25]
   
   let rec string'[#"promoted_constants.rs" 20 0 20 25] (_s:t_String) (return'  (x:()))= (! bb0
     [ bb0 = bb1 | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_promoted_constants__str [#"promoted_constants.rs" 22 0 22 12]
   let%span spromoted_constants = "promoted_constants.rs" 23 13 23 115
@@ -142,5 +142,5 @@ module M_promoted_constants__str [#"promoted_constants.rs" 22 0 22 12]
         s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & _s: string = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & _s: string = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/size_of.coma
+++ b/tests/should_succeed/lang/size_of.coma
@@ -54,7 +54,7 @@ module M_size_of__f [#"size_of.rs" 4 0 4 10]
       | s6 = {[@expl:assertion] [%#ssize_of'5] size_of_array_unit_5 = 0} s7
       | s7 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_size_of__g [#"size_of.rs" 14 0 14 13]
   let%span ssize_of = "size_of.rs" 16 18 16 49
@@ -133,5 +133,5 @@ module M_size_of__g [#"size_of.rs" 14 0 14 13]
       | s7 = {[@expl:assertion] [%#ssize_of'6] size_of_array_T_0 = 0} s8
       | s8 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & t2: UInt64.t = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & t2: UInt64.t = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/unary_op.coma
+++ b/tests/should_succeed/lang/unary_op.coma
@@ -12,5 +12,5 @@ module M_unary_op__f [#"unary_op.rs" 4 0 4 10]
     [ bb0 = any [ br0 -> {([%#sunary_op] false) = false} (! bb2) | br1 -> {[%#sunary_op] false} (! bb1) ] 
     | bb1 = {[%#sunary_op'0] false} any
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/unions.coma
+++ b/tests/should_succeed/lang/unions.coma
@@ -10,7 +10,7 @@ module M_unions__x [#"unions.rs" 11 0 11 23]
   
   meta "select_lsinst" "all"
   
-  let rec x[#"unions.rs" 11 0 11 23] (_0:t_DummyUnion) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0'0} ] )
+  let rec x[#"unions.rs" 11 0 11 23] (_0:t_DummyUnion) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0'0} ] 
     [ & _0'0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/lang/while_let.coma
+++ b/tests/should_succeed/lang/while_let.coma
@@ -38,11 +38,11 @@ module M_while_let__f [#"while_let.rs" 4 0 4 10]
        ]
     
     | bb5 = s0 [ s0 = -{resolve'0 b}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: t_Option = Any.any_l ()
     | & b: MutBorrow.t t_Option = Any.any_l ()
     | & _7: t_Option = Any.any_l ()
     | & old_1_0: MutBorrow.t t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/linked_list.coma
+++ b/tests/should_succeed/linked_list.coma
@@ -136,12 +136,12 @@ module M_linked_list__qyi10858349784728989480__new [#"linked_list.rs" 58 4 58 27
     | bb3 = s0
       [ s0 =  [ &_0 <- { t_List__first = _2; t_List__last = _3; t_List__seq = _4 } ] s1 | s1 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_List = Any.any_l ()
     | & _2: Opaque.ptr = Any.any_l ()
     | & _3: Opaque.ptr = Any.any_l ()
     | & _4:  (Seq.seq t_PtrOwn) = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_List)-> {[@expl:new result type invariant] [%#slinked_list] inv'6 result}
       {[@expl:new ensures] [%#slinked_list'0] view result = (Seq.empty: Seq.seq t_T)}
       (! return' {result}) ]
@@ -646,7 +646,7 @@ module M_linked_list__qyi10858349784728989480__push_back [#"linked_list.rs" 63 4
       | s5 = bb24 ]
     
     | bb24 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_List = self
     | & x'0: t_T = x
@@ -678,7 +678,7 @@ module M_linked_list__qyi10858349784728989480__push_back [#"linked_list.rs" 63 4
     | & _41: MutBorrow.t (Seq.seq t_PtrOwn) = Any.any_l ()
     | & _42: MutBorrow.t ( (Seq.seq t_PtrOwn)) = Any.any_l ()
     | & _43: t_PtrOwn = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:push_back ensures] [%#slinked_list'2] view self.final
       = Seq.snoc (view self.current) x}
       (! return' {result}) ]
@@ -954,7 +954,7 @@ module M_linked_list__qyi10858349784728989480__push_front [#"linked_list.rs" 83 
       | s5 = bb11 ]
     
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_List = self
     | & x'0: t_T = x
@@ -969,7 +969,7 @@ module M_linked_list__qyi10858349784728989480__push_front [#"linked_list.rs" 83 
     | & _18: MutBorrow.t (Seq.seq t_PtrOwn) = Any.any_l ()
     | & _19: MutBorrow.t ( (Seq.seq t_PtrOwn)) = Any.any_l ()
     | & _20: t_PtrOwn = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:push_front ensures] [%#slinked_list'1] view self.final
       = push_front'0 (view self.current) x}
       (! return' {result}) ]

--- a/tests/should_succeed/list_index_mut.coma
+++ b/tests/should_succeed/list_index_mut.coma
@@ -223,7 +223,7 @@ module M_list_index_mut__index_mut [#"list_index_mut.rs" 37 0 37 61]
       | s5 = -{resolve'0 l'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t UInt32.t = Any.any_l ()
     | & l'0: MutBorrow.t t_List = l
     | & ix'0: UInt64.t = ix
@@ -236,7 +236,7 @@ module M_list_index_mut__index_mut [#"list_index_mut.rs" 37 0 37 61]
     | & _25: t_Option'1 = Any.any_l ()
     | & _26: MutBorrow.t t_Option = Any.any_l ()
     | & _28: MutBorrow.t UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t UInt32.t)-> {[@expl:index_mut ensures #0] [%#slist_index_mut'9] C_Some'0 (result.current)
       = get l.current (UInt64.t'int ix)}
       {[@expl:index_mut ensures #1] [%#slist_index_mut'10] C_Some'0 (result.final) = get l.final (UInt64.t'int ix)}
@@ -336,14 +336,14 @@ module M_list_index_mut__write [#"list_index_mut.rs" 63 0 63 45]
       | s2 = -{resolve'2 l'0}- s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & l'0: MutBorrow.t t_List = l
     | & ix'0: UInt64.t = ix
     | & v'0: UInt32.t = v
     | & _9: MutBorrow.t UInt32.t = Any.any_l ()
     | & _10: MutBorrow.t t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:write ensures #0] [%#slist_index_mut'0] C_Some'0 v
       = get l.final (UInt64.t'int ix)}
       {[@expl:write ensures #1] [%#slist_index_mut'1] len l.final = len l.current}
@@ -437,7 +437,7 @@ module M_list_index_mut__f [#"list_index_mut.rs" 67 0 67 10]
     
     | bb5 = s0 [ s0 = -{resolve'0 _8}- s1 | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & l: t_List = Any.any_l ()
     | & _2: t_Option = Any.any_l ()
@@ -446,5 +446,5 @@ module M_list_index_mut__f [#"list_index_mut.rs" 67 0 67 10]
     | & _6: () = Any.any_l ()
     | & _7: MutBorrow.t t_List = Any.any_l ()
     | & _8: MutBorrow.t t_List = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/list_reversal_lasso.coma
+++ b/tests/should_succeed/list_reversal_lasso.coma
@@ -74,13 +74,13 @@ module M_list_reversal_lasso__qyi13715866738248475091__index [#"list_reversal_la
     (! bb0
     [ bb0 = s0 [ s0 = index {self'0.t_Memory__0} {i'0} (fun (_ret:UInt64.t) ->  [ &_6 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_5 <- _6 ] s1 | s1 =  [ &_0 <- _5 ] s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: t_Memory = self
     | & i'0: UInt64.t = i
     | & _5: UInt64.t = Any.any_l ()
     | & _6: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:index ensures] [%#slist_reversal_lasso'0] result = index_logic'0 self i}
       (! return' {result}) ]
 
@@ -215,7 +215,7 @@ module M_list_reversal_lasso__qyi14823043098042356205__index_mut [#"list_reversa
       | s6 = -{resolve'2 self'0}- s7
       | s7 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t UInt64.t = Any.any_l ()
     | & self'0: MutBorrow.t t_Memory = self
     | & i'0: UInt64.t = i
@@ -223,7 +223,7 @@ module M_list_reversal_lasso__qyi14823043098042356205__index_mut [#"list_reversa
     | & _9: MutBorrow.t UInt64.t = Any.any_l ()
     | & _10: MutBorrow.t UInt64.t = Any.any_l ()
     | & _11: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t UInt64.t)-> {[@expl:index_mut ensures #0] [%#slist_reversal_lasso'0] result.current
       = index_logic'0 self.current i}
       {[@expl:index_mut ensures #1] [%#slist_reversal_lasso'1] result.final = index_logic'0 self.final i}
@@ -382,7 +382,7 @@ module M_list_reversal_lasso__qyi2644757663130641572__list_reversal_safe [#"list
        ]
     
     | bb6 = s0 [ s0 = -{resolve'2 self'0}- s1 | s1 =  [ &_0 <- r ] s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: MutBorrow.t t_Memory = self
     | & l'0: UInt64.t = l
@@ -393,7 +393,7 @@ module M_list_reversal_lasso__qyi2644757663130641572__list_reversal_safe [#"list
     | & _21: MutBorrow.t UInt64.t = Any.any_l ()
     | & _22: MutBorrow.t t_Memory = Any.any_l ()
     | & old_1_0: MutBorrow.t t_Memory = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end
 module M_list_reversal_lasso__qyi2644757663130641572__list_reversal_list [#"list_reversal_lasso.rs" 95 4 95 82] (* Memory *)
   let%span slist_reversal_lasso = "list_reversal_lasso.rs" 96 20 96 24
@@ -570,7 +570,7 @@ module M_list_reversal_lasso__qyi2644757663130641572__list_reversal_list [#"list
        ]
     
     | bb9 = s0 [ s0 = -{resolve'2 self'0}- s1 | s1 =  [ &_0 <- r ] s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: MutBorrow.t t_Memory = self
     | & l'0: UInt64.t = l
@@ -588,7 +588,7 @@ module M_list_reversal_lasso__qyi2644757663130641572__list_reversal_list [#"list
     | & _26: MutBorrow.t UInt64.t = Any.any_l ()
     | & _28: int = Any.any_l ()
     | & old_2_0: MutBorrow.t t_Memory = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:list_reversal_list ensures] [%#slist_reversal_lasso'7] list self.final result (Reverse.reverse s)}
       (! return' {result}) ]
 
@@ -802,7 +802,7 @@ module M_list_reversal_lasso__qyi2644757663130641572__list_reversal_loop [#"list
       | s2 =  [ &_0 <- r ] s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: MutBorrow.t t_Memory = self
     | & l'0: UInt64.t = l
@@ -820,7 +820,7 @@ module M_list_reversal_lasso__qyi2644757663130641572__list_reversal_loop [#"list
     | & _30: MutBorrow.t UInt64.t = Any.any_l ()
     | & _32: int = Any.any_l ()
     | & old_2_0: MutBorrow.t t_Memory = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:list_reversal_loop ensures] [%#slist_reversal_lasso'11] loopqy95z self.final result (push_front (Reverse.reverse (Seq.([..]) s 1 (Seq.length s))) (index_logic'1 s 0))}
       (! return' {result}) ]
 
@@ -1039,7 +1039,7 @@ module M_list_reversal_lasso__qyi2644757663130641572__list_reversal_lasso [#"lis
        ]
     
     | bb9 = s0 [ s0 = -{resolve'2 self'0}- s1'1 | s1'1 =  [ &_0 <- r ] s2'1 | s2'1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: MutBorrow.t t_Memory = self
     | & l'0: UInt64.t = l
@@ -1058,7 +1058,7 @@ module M_list_reversal_lasso__qyi2644757663130641572__list_reversal_lasso [#"lis
     | & _28: MutBorrow.t UInt64.t = Any.any_l ()
     | & _30: int = Any.any_l ()
     | & old_2_0: MutBorrow.t t_Memory = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:list_reversal_lasso ensures] [%#slist_reversal_lasso'8] lasso self.final result s1 (Reverse.reverse s2)}
       (! return' {result}) ]
 

--- a/tests/should_succeed/local_invariant_cellinv.coma
+++ b/tests/should_succeed/local_invariant_cellinv.coma
@@ -370,13 +370,13 @@ module M_local_invariant_cellinv__qyi5959203038510030748__read [#"local_invarian
       | s2 = bb1 ]
     
     | bb1 = s0 [ s0 =  [ &_0'0 <- _4 ] s1 | s1 = return''0 {_0'0} ]  ]
-    )
+    
     [ & _0'0: t_T = Any.any_l ()
     | & self'0: t_CellInv = self
     | & namespaces'1:  t_Namespaces = namespaces'0
     | & _4: t_T = Any.any_l ()
     | & _7: closure0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:read result type invariant] [%#slocal_invariant_cellinv'1] inv'0 result}
       (! return' {result}) ]
 
@@ -833,11 +833,11 @@ module M_local_invariant_cellinv__qyi5959203038510030748__write [#"local_invaria
       | s2 = bb2 ]
     
     | bb2 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: () = Any.any_l ()
     | & self'0: t_CellInv = self
     | & x'0: t_T = x
     | & namespaces'1:  t_Namespaces = namespaces'0
     | & _7: closure0 = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/loop.coma
+++ b/tests/should_succeed/loop.coma
@@ -29,7 +29,7 @@ module M_loop__f [#"loop.rs" 3 0 3 10]
     
     | bb2 = bb2'0 [ bb2'0 = (! any [ br0 -> {false} (! bb2'0) | br1 -> {true} (! bb3) ] ) ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & a: Int32.t = Any.any_l () | & b: MutBorrow.t Int32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & a: Int32.t = Any.any_l () | & b: MutBorrow.t Int32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/mapping_indexing.coma
+++ b/tests/should_succeed/mapping_indexing.coma
@@ -44,11 +44,11 @@ module M_mapping_indexing__foo [#"mapping_indexing.rs" 4 0 4 12]
       | s2 = {[@expl:assertion] [%#smapping_indexing'8] index_logic mapping 1 = 11} s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & mapping: Map.map int int = Any.any_l ()
     | & _3: Map.map int int = Any.any_l ()
     | & _9: Map.map int int = Any.any_l ()
     | & _15: Map.map int int = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/mapping_test.coma
+++ b/tests/should_succeed/mapping_test.coma
@@ -58,7 +58,7 @@ module M_mapping_test__incr [#"mapping_test.rs" 29 0 29 18]
         s3
       | s3 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & t'0: MutBorrow.t t_T = t | & old_t: MutBorrow.t t_T = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & t'0: MutBorrow.t t_T = t | & old_t: MutBorrow.t t_T = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:incr ensures] [%#smapping_test'4] view t.final
       = Map.set (view'0 t) (Int32.to_int (t.current).t_T__a) 1}
       (! return' {result}) ]
@@ -130,11 +130,11 @@ module M_mapping_test__f [#"mapping_test.rs" 37 0 37 10]
       | s2 = {[@expl:assertion] [%#smapping_test'3] Map.get (view x) 42 = 1} s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: t_T = Any.any_l ()
     | & _6: () = Any.any_l ()
     | & _7: MutBorrow.t t_T = Any.any_l ()
     | & _8: MutBorrow.t t_T = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/match_int.coma
+++ b/tests/should_succeed/match_int.coma
@@ -33,7 +33,7 @@ module M_match_int__f [#"match_int.rs" 6 0 6 10]
     | bb6 = any [ br0 -> {([%#smatch_int'5] false) = false} (! bb10) | br1 -> {[%#smatch_int'5] false} (! bb14) ] 
     | bb14 = return''0 {_0}
     | bb10 = {[%#smatch_int'6] false} any ]
-    )
+    
     [ & _0: () = Any.any_l () | & _1: Int32.t = Any.any_l () | & _2: bool = Any.any_l () | & _3: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/mc91.coma
+++ b/tests/should_succeed/mc91.coma
@@ -88,13 +88,13 @@ module M_mc91__mc91 [#"mc91.rs" 7 0 7 26]
     
     | bb3 = s0 [ s0 = mc91 {_6} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & x'0: UInt32.t = x
     | & _3: bool = Any.any_l ()
     | & _6: UInt32.t = Any.any_l ()
     | & _7: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:mc91 ensures] [%#smc91'2] UInt32.le x (100: UInt32.t)
        -> UInt32.t'int result = 91 /\ UInt32.gt x (100: UInt32.t)  -> UInt32.t'int result = UInt32.t'int x - 10}
       (! return' {result}) ]

--- a/tests/should_succeed/mutex.coma
+++ b/tests/should_succeed/mutex.coma
@@ -65,7 +65,7 @@ module M_mutex__qyi5425553346843331945__call [#"mutex.rs" 100 4 100 23] (* <Adds
       | s2 = bb8 ]
     
     | bb8 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: t_AddsTwo = self
     | & v: t_MutexGuard = Any.any_l ()
@@ -77,7 +77,7 @@ module M_mutex__qyi5425553346843331945__call [#"mutex.rs" 100 4 100 23] (* <Adds
     | & _11: UInt32.t = Any.any_l ()
     | & _13: () = Any.any_l ()
     | & _14: MutBorrow.t t_MutexGuard = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_mutex__concurrent [#"mutex.rs" 157 0 157 19]
   let%span smutex = "mutex.rs" 158 49 158 50
@@ -180,7 +180,7 @@ module M_mutex__concurrent [#"mutex.rs" 157 0 157 19]
     | bb5 = s0 [ s0 = join {j1} (fun (_ret:t_Result) ->  [ &_16 <- _ret ] s1) | s1 = bb6 ] 
     | bb6 = s0 [ s0 = join {j2} (fun (_ret:t_Result) ->  [ &_18 <- _ret ] s1) | s1 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & m: t_Mutex = Any.any_l ()
     | & _2: MutBorrow.t t_Mutex = Any.any_l ()
@@ -194,7 +194,7 @@ module M_mutex__concurrent [#"mutex.rs" 157 0 157 19]
     | & j2: t_JoinHandle = Any.any_l ()
     | & _16: t_Result = Any.any_l ()
     | & _18: t_Result = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_mutex__qyi5425553346843331945__call__refines [#"mutex.rs" 100 4 100 23] (* <AddsTwo<'a> as FakeFnOnce> *)
   let%span smutex = "mutex.rs" 100 4 100 23

--- a/tests/should_succeed/one_side_update.coma
+++ b/tests/should_succeed/one_side_update.coma
@@ -36,10 +36,10 @@ module M_one_side_update__f [#"one_side_update.rs" 5 0 5 10]
       | s3 = bb3 ]
     
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: t_MyInt = Any.any_l ()
     | & b: MutBorrow.t t_MyInt = Any.any_l ()
     | & _6: t_MyInt = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/open_inv.coma
+++ b/tests/should_succeed/open_inv.coma
@@ -11,7 +11,7 @@ module M_open_inv__test_open_inv_param [#"open_inv.rs" 15 0 15 58]
   
   let rec test_open_inv_param[#"open_inv.rs" 15 0 15 58] (_0:t_IsZero) (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0'0} ]
-    ) [ & _0'0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0'0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_open_inv__test_open_inv_param_call [#"open_inv.rs" 16 0 16 33]
   let%span sopen_inv = "open_inv.rs" 17 23 17 24
@@ -38,7 +38,7 @@ module M_open_inv__test_open_inv_param_call [#"open_inv.rs" 16 0 16 33]
       | s3 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & a: t_IsZero = Any.any_l () | & _2: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & a: t_IsZero = Any.any_l () | & _2: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -64,7 +64,7 @@ module M_open_inv__test_open_inv_result [#"open_inv.rs" 23 0 23 39]
       | s2 =  [ &_0 <- a ] s3
       | s3 = return''0 {_0} ]
      ]
-    ) [ & _0: t_IsZero = Any.any_l () | & a: t_IsZero = Any.any_l () ] 
+     [ & _0: t_IsZero = Any.any_l () | & a: t_IsZero = Any.any_l () ] )
     [ return''0 (result:t_IsZero)-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/option.coma
+++ b/tests/should_succeed/option.coma
@@ -41,7 +41,7 @@ module M_option__is_some_none [#"option.rs" 4 0 4 21]
     | bb12 = return''0 {_0}
     | bb14 = {[%#soption'0] false} any
     | bb7 = {[%#soption'1] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -49,7 +49,7 @@ module M_option__is_some_none [#"option.rs" 4 0 4 21]
     | & _6: bool = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _12: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__unwrap [#"option.rs" 12 0 12 15]
   let%span soption = "option.rs" 14 33 14 34
@@ -307,7 +307,7 @@ module M_option__unwrap [#"option.rs" 12 0 12 15]
     | bb9 = {[%#soption'18] false} any
     | bb6 = {[%#soption'19] false} any
     | bb3 = {[%#soption'20] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -332,7 +332,7 @@ module M_option__unwrap [#"option.rs" 12 0 12 15]
     | & _45: () = Any.any_l ()
     | & _48: bool = Any.any_l ()
     | & _49: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__map [#"option.rs" 31 0 31 12]
   let%span soption = "option.rs" 33 33 33 34
@@ -526,7 +526,7 @@ module M_option__map [#"option.rs" 31 0 31 12]
     | bb12 = {[%#soption'0] false} any
     | bb8 = {[%#soption'1] false} any
     | bb4 = {[%#soption'2] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -542,7 +542,7 @@ module M_option__map [#"option.rs" 31 0 31 12]
     | & _30: t_Option = Any.any_l ()
     | & _31: t_Option = Any.any_l ()
     | & _32: t_Option'0 = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__inspect [#"option.rs" 40 0 40 16]
   let%span soption = "option.rs" 42 33 42 34
@@ -672,7 +672,7 @@ module M_option__inspect [#"option.rs" 40 0 40 16]
     | bb7 = return''0 {_0}
     | bb8 = {[%#soption'0] false} any
     | bb4 = {[%#soption'1] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -684,7 +684,7 @@ module M_option__inspect [#"option.rs" 40 0 40 16]
     | & _17: () = Any.any_l ()
     | & _21: t_Option = Any.any_l ()
     | & _22: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__map_or [#"option.rs" 48 0 48 15]
   let%span soption = "option.rs" 50 33 50 34
@@ -920,7 +920,7 @@ module M_option__map_or [#"option.rs" 48 0 48 15]
     | bb9 = {[%#soption'10] false} any
     | bb6 = {[%#soption'11] false} any
     | bb3 = {[%#soption'12] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -941,7 +941,7 @@ module M_option__map_or [#"option.rs" 48 0 48 15]
     | & _30: Int32.t = Any.any_l ()
     | & _32: () = Any.any_l ()
     | & _33: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__ok_or [#"option.rs" 62 0 62 14]
   let%span soption = "option.rs" 64 33 64 34
@@ -1050,7 +1050,7 @@ module M_option__ok_or [#"option.rs" 62 0 62 14]
       | s3 = bb4 ]
     
     | bb4 = s0 [ s0 = {[@expl:assertion] [%#soption'5] ok'0 = C_Ok (1: Int32.t)} s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -1060,7 +1060,7 @@ module M_option__ok_or [#"option.rs" 62 0 62 14]
     | & _13: () = Any.any_l ()
     | & ok'0: t_Result = Any.any_l ()
     | & _18: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__as_mut [#"option.rs" 77 0 77 15]
   let%span soption = "option.rs" 79 37 79 38
@@ -1179,7 +1179,7 @@ module M_option__as_mut [#"option.rs" 77 0 77 15]
     | bb14 = {[%#soption'4] false} any
     | bb9 = {[%#soption'5] false} any
     | bb4 = {[%#soption'6] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -1196,7 +1196,7 @@ module M_option__as_mut [#"option.rs" 77 0 77 15]
     | & _19: MutBorrow.t t_Option = Any.any_l ()
     | & _21: bool = Any.any_l ()
     | & _22: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__as_ref [#"option.rs" 88 0 88 15]
   let%span soption = "option.rs" 90 33 90 34
@@ -1255,7 +1255,7 @@ module M_option__as_ref [#"option.rs" 88 0 88 15]
     | bb7 = return''0 {_0}
     | bb8 = {[%#soption'1] false} any
     | bb4 = {[%#soption'2] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -1264,7 +1264,7 @@ module M_option__as_ref [#"option.rs" 88 0 88 15]
     | & _10: bool = Any.any_l ()
     | & _12: Int32.t = Any.any_l ()
     | & _13: t_Option'0 = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__replace [#"option.rs" 96 0 96 16]
   let%span soption = "option.rs" 98 37 98 38
@@ -1366,7 +1366,7 @@ module M_option__replace [#"option.rs" 96 0 96 16]
     | bb11 = {[%#soption'11] false} any
     | bb7 = {[%#soption'12] false} any
     | bb4 = {[%#soption'13] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -1387,7 +1387,7 @@ module M_option__replace [#"option.rs" 96 0 96 16]
     | & _29: MutBorrow.t t_Option = Any.any_l ()
     | & _32: bool = Any.any_l ()
     | & _33: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__and_or_xor [#"option.rs" 108 0 108 19]
   let%span soption = "option.rs" 110 33 110 34
@@ -1678,7 +1678,7 @@ module M_option__and_or_xor [#"option.rs" 108 0 108 19]
     | bb12 = {[%#soption'15] false} any
     | bb8 = {[%#soption'16] false} any
     | bb4 = {[%#soption'17] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -1724,7 +1724,7 @@ module M_option__and_or_xor [#"option.rs" 108 0 108 19]
     | & _120: t_Option = Any.any_l ()
     | & _121: t_Option = Any.any_l ()
     | & _122: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__and_then [#"option.rs" 129 0 129 17]
   let%span soption = "option.rs" 131 34 131 35
@@ -1811,13 +1811,13 @@ module M_option__and_then [#"option.rs" 129 0 129 17]
     
     | bb2 = s0 [ s0 =  [ &res <- C_None ] s1 | s1 = bb3 ] 
     | bb3 = s0 [ s0 =  [ &_0 <- res ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & x'0: Int32.t = x
     | & res: t_Option = Any.any_l ()
     | & _4: bool = Any.any_l ()
     | & _6: Int32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:closure ensures] [%#soption'9] Int32.to_int x = 1
       /\ (exists y: Int32.t. result = C_Some y /\ Int32.to_int y = Int32.to_int x + 1)
       \/ Int32.to_int x <> 1 /\ result = C_None}
@@ -1895,7 +1895,7 @@ module M_option__and_then [#"option.rs" 129 0 129 17]
     | bb12 = {[%#soption'1] false} any
     | bb8 = {[%#soption'2] false} any
     | bb4 = {[%#soption'3] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some1: t_Option = Any.any_l ()
@@ -1911,7 +1911,7 @@ module M_option__and_then [#"option.rs" 129 0 129 17]
     | & _32: t_Option = Any.any_l ()
     | & _33: t_Option = Any.any_l ()
     | & _34: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__filter [#"option.rs" 146 0 146 15]
   let%span soption = "option.rs" 148 33 148 34
@@ -2090,7 +2090,7 @@ module M_option__filter [#"option.rs" 146 0 146 15]
     | bb12 = {[%#soption'0] false} any
     | bb8 = {[%#soption'1] false} any
     | bb4 = {[%#soption'2] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -2106,7 +2106,7 @@ module M_option__filter [#"option.rs" 146 0 146 15]
     | & _30: t_Option = Any.any_l ()
     | & _31: t_Option = Any.any_l ()
     | & _32: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__is_some_and [#"option.rs" 155 0 155 20]
   let%span soption = "option.rs" 157 34 157 35
@@ -2224,7 +2224,7 @@ module M_option__is_some_and [#"option.rs" 155 0 155 20]
     | bb8 = {[%#soption'2] false} any
     | bb9 = return''0 {_0}
     | bb3 = {[%#soption'3] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some1: t_Option = Any.any_l ()
@@ -2235,7 +2235,7 @@ module M_option__is_some_and [#"option.rs" 155 0 155 20]
     | & _12: () = Any.any_l ()
     | & _15: bool = Any.any_l ()
     | & _17: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__or_else [#"option.rs" 165 0 165 16]
   let%span soption = "option.rs" 167 33 167 34
@@ -2398,7 +2398,7 @@ module M_option__or_else [#"option.rs" 165 0 165 16]
     | bb12 = {[%#soption'0] false} any
     | bb8 = {[%#soption'1] false} any
     | bb4 = {[%#soption'2] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -2414,7 +2414,7 @@ module M_option__or_else [#"option.rs" 165 0 165 16]
     | & _30: t_Option = Any.any_l ()
     | & _31: t_Option = Any.any_l ()
     | & _32: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__insert [#"option.rs" 174 0 174 15]
   let%span soption = "option.rs" 176 37 176 38
@@ -2544,7 +2544,7 @@ module M_option__insert [#"option.rs" 174 0 174 15]
     | bb9 = s0 [ s0 = -{resolve'1 i2}- s1 | s1 = {[%#soption'7] false} any ] 
     | bb6 = {[%#soption'8] false} any
     | bb3 = s0 [ s0 = -{resolve'1 i1}- s1 | s1 = {[%#soption'9] false} any ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -2558,7 +2558,7 @@ module M_option__insert [#"option.rs" 174 0 174 15]
     | & _22: bool = Any.any_l ()
     | & _27: t_Option = Any.any_l ()
     | & _28: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__get_or_insert [#"option.rs" 188 0 188 22]
   let%span soption = "option.rs" 190 37 190 38
@@ -2800,7 +2800,7 @@ module M_option__get_or_insert [#"option.rs" 188 0 188 22]
     | bb9 = s0 [ s0 = -{resolve'1 i2}- s1 | s1 = {[%#soption'16] false} any ] 
     | bb6 = {[%#soption'17] false} any
     | bb3 = s0 [ s0 = -{resolve'1 i1}- s1 | s1 = {[%#soption'18] false} any ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -2828,7 +2828,7 @@ module M_option__get_or_insert [#"option.rs" 188 0 188 22]
     | & _56: t_Option = Any.any_l ()
     | & _57: t_Option = Any.any_l ()
     | & _58: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__take [#"option.rs" 216 0 216 13]
   let%span soption = "option.rs" 218 37 218 38
@@ -2897,7 +2897,7 @@ module M_option__take [#"option.rs" 216 0 216 13]
     | bb11 = {[%#soption'2] false} any
     | bb7 = {[%#soption'3] false} any
     | bb4 = {[%#soption'4] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -2910,7 +2910,7 @@ module M_option__take [#"option.rs" 216 0 216 13]
     | & _16: t_Option = Any.any_l ()
     | & _17: MutBorrow.t t_Option = Any.any_l ()
     | & _20: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__take_if [#"option.rs" 226 0 226 16]
   let%span soption = "option.rs" 228 37 228 38
@@ -3156,7 +3156,7 @@ module M_option__take_if [#"option.rs" 226 0 226 16]
     | bb11 = {[%#soption'2] false} any
     | bb8 = {[%#soption'3] false} any
     | bb4 = {[%#soption'4] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -3179,7 +3179,7 @@ module M_option__take_if [#"option.rs" 226 0 226 16]
     | & _44: t_Option = Any.any_l ()
     | & _45: t_Option = Any.any_l ()
     | & _46: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__copied_cloned [#"option.rs" 243 0 243 22]
   let%span soption = "option.rs" 245 37 245 38
@@ -3431,7 +3431,7 @@ module M_option__copied_cloned [#"option.rs" 243 0 243 22]
     | bb15 = {[%#soption'9] false} any
     | bb10 = {[%#soption'10] false} any
     | bb5 = {[%#soption'11] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some: t_Option = Any.any_l ()
@@ -3467,7 +3467,7 @@ module M_option__copied_cloned [#"option.rs" 243 0 243 22]
     | & _55: t_Option = Any.any_l ()
     | & _56: t_Option'1 = Any.any_l ()
     | & _57: MutBorrow.t t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__zip_unzip [#"option.rs" 259 0 259 18]
   let%span soption = "option.rs" 262 37 262 38
@@ -3731,7 +3731,7 @@ module M_option__zip_unzip [#"option.rs" 259 0 259 18]
     | bb12 = {[%#soption'8] false} any
     | bb8 = {[%#soption'9] false} any
     | bb4 = {[%#soption'10] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none_int: t_Option = Any.any_l ()
     | & none_bool: t_Option'0 = Any.any_l ()
@@ -3762,7 +3762,7 @@ module M_option__zip_unzip [#"option.rs" 259 0 259 18]
     | & _78: t_Option'1 = Any.any_l ()
     | & _79: t_Option'1 = Any.any_l ()
     | & _80: t_Option'1 = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__transpose [#"option.rs" 281 0 281 18]
   let%span soption = "option.rs" 283 53 283 54
@@ -3884,7 +3884,7 @@ module M_option__transpose [#"option.rs" 281 0 281 18]
     | bb14 = {[%#soption'2] false} any
     | bb10 = {[%#soption'3] false} any
     | bb5 = {[%#soption'4] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & none: t_Option = Any.any_l ()
     | & some_ok: t_Option = Any.any_l ()
@@ -3902,7 +3902,7 @@ module M_option__transpose [#"option.rs" 281 0 281 18]
     | & _27: t_Result'0 = Any.any_l ()
     | & _30: t_Option'0 = Any.any_l ()
     | & _31: t_Option'0 = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__flatten [#"option.rs" 291 0 291 16]
   let%span soption = "option.rs" 296 45 296 46
@@ -3973,7 +3973,7 @@ module M_option__flatten [#"option.rs" 291 0 291 16]
     | bb12 = {[%#soption'1] false} any
     | bb8 = {[%#soption'2] false} any
     | bb4 = {[%#soption'3] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & opt: t_Option'0 = Any.any_l ()
     | & _3: bool = Any.any_l ()
@@ -3987,7 +3987,7 @@ module M_option__flatten [#"option.rs" 291 0 291 16]
     | & _19: bool = Any.any_l ()
     | & _20: Int32.t = Any.any_l ()
     | & _21: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_option__resolve [#"option.rs" 300 0 300 16]
   let%span soption = "option.rs" 302 16 302 17
@@ -4490,7 +4490,7 @@ module M_option__resolve [#"option.rs" 300 0 300 16]
     | bb8 = {[%#soption'37] false} any
     | bb5 = {[%#soption'38] false} any
     | bb3 = {[%#soption'39] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & opt: t_Option = Any.any_l ()
@@ -4563,5 +4563,5 @@ module M_option__resolve [#"option.rs" 300 0 300 16]
     | & _110: MutBorrow.t Int32.t = Any.any_l ()
     | & _111: t_Option'0 = Any.any_l ()
     | & _114: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/ord_trait.coma
+++ b/tests/should_succeed/ord_trait.coma
@@ -118,7 +118,7 @@ module M_ord_trait__x [#"ord_trait.rs" 5 0 7 29]
   let rec x[#"ord_trait.rs" 5 0 7 29] (x'0:t_T) (return'  (x'1:bool))= {[@expl:x 'x' type invariant] [%#sord_trait] inv'0 x'0}
     (! bb0
     [ bb0 = s0 [ s0 = le {x'1} {x'1} (fun (_ret:bool) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & x'1: t_T = x'0 ] 
+     [ & _0: bool = Any.any_l () | & x'1: t_T = x'0 ] )
     [ return''0 (result:bool)-> {[@expl:x ensures] [%#sord_trait'0] result = true} (! return' {result}) ]
 
 end
@@ -244,7 +244,7 @@ module M_ord_trait__gt_or_le [#"ord_trait.rs" 13 0 15 29]
     {[@expl:gt_or_le 'y' type invariant] [%#sord_trait'0] inv'0 y}
     (! bb0
     [ bb0 = s0 [ s0 = ge {x'0} {y'0} (fun (_ret:bool) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & x'0: t_T = x | & y'0: t_T = y ] 
+     [ & _0: bool = Any.any_l () | & x'0: t_T = x | & y'0: t_T = y ] )
     [ return''0 (result:bool)-> {[@expl:gt_or_le ensures] [%#sord_trait'1] result
       = le_log (deep_model y) (deep_model x)}
       (! return' {result}) ]
@@ -263,7 +263,7 @@ module M_ord_trait__gt_or_le_int [#"ord_trait.rs" 21 0 21 47]
   
   let rec gt_or_le_int[#"ord_trait.rs" 21 0 21 47] (x:UInt64.t) (y:UInt64.t) (return'  (x'0:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- UInt64.le x'0 y'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & x'0: UInt64.t = x | & y'0: UInt64.t = y ] 
+     [ & _0: bool = Any.any_l () | & x'0: UInt64.t = x | & y'0: UInt64.t = y ] )
     [ return''0 (result:bool)-> {[@expl:gt_or_le_int ensures] [%#sord_trait] result
       = (UInt64.t'int x <= UInt64.t'int y)}
       (! return' {result}) ]

--- a/tests/should_succeed/pair_bor_mut.coma
+++ b/tests/should_succeed/pair_bor_mut.coma
@@ -99,14 +99,14 @@ module M_pair_bor_mut__pair_bor_mut [#"pair_bor_mut.rs" 6 0 6 84]
       | s7 = -{resolve'2 p'0}- s8
       | s8 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & p'0: tuple = p
     | & take_first'0: bool = take_first
     | & _3: MutBorrow.t t_T = Any.any_l ()
     | & _5: MutBorrow.t t_T = Any.any_l ()
     | & _7: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:pair_bor_mut result type invariant] [%#spair_bor_mut'0] inv'0 result}
       {[@expl:pair_bor_mut ensures] [%#spair_bor_mut'1] if take_first then
         result = p._p0 /\ (p._p1).final = (p._p1).current

--- a/tests/should_succeed/pcell.coma
+++ b/tests/should_succeed/pcell.coma
@@ -172,7 +172,7 @@ module M_pcell__foo [#"pcell.rs" 5 0 5 19]
     | bb15 = {[%#spcell'5] false} any
     | bb11 = {[%#spcell'6] false} any
     | bb5 = {[%#spcell'7] false} any ]
-    )
+    
     [ & _0: Int32.t = Any.any_l ()
     | & p: t_PCell = Any.any_l ()
     | & own:  t_PCellOwn = Any.any_l ()
@@ -190,5 +190,5 @@ module M_pcell__foo [#"pcell.rs" 5 0 5 19]
     | & _28: Int32.t = Any.any_l ()
     | & _30:  (MutBorrow.t t_PCellOwn) = Any.any_l ()
     | & _31: MutBorrow.t ( t_PCellOwn) = Any.any_l () ]
-     [ return''0 (result:Int32.t)-> {[@expl:foo ensures] [%#spcell'8] Int32.to_int result = 3} (! return' {result}) ] 
+    ) [ return''0 (result:Int32.t)-> {[@expl:foo ensures] [%#spcell'8] Int32.to_int result = 3} (! return' {result}) ] 
 end

--- a/tests/should_succeed/persistent_array.coma
+++ b/tests/should_succeed/persistent_array.coma
@@ -177,13 +177,13 @@ module M_persistent_array__implementation__qyi15164097500274694161__clone [#"per
       | s1 = bb4 ]
     
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: t_PersistentArray = Any.any_l ()
     | & self'0: t_PersistentArray = self
     | & _3: t_Rc = Any.any_l ()
     | & _5:  t_Rc'0 = Any.any_l ()
     | & _7:  t_Rc'1 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_PersistentArray)-> {[@expl:clone result type invariant] [%#spersistent_array'0] inv result}
       {[@expl:clone ensures] [%#spersistent_array'1] view'6 result = view'7 self}
       (! return' {result}) ]
@@ -995,7 +995,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__new [#"persis
       | s1 = bb32 ]
     
     | bb32 = return''0 {_0} ]
-    )
+    
     [ & _0: t_PersistentArray = Any.any_l ()
     | & v'0: t_Vec = v
     | & logical_value: Seq.seq t_T = Any.any_l ()
@@ -1033,7 +1033,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__new [#"persis
     | & _52:  t_Rc'1 = Any.any_l ()
     | & _53: t_Rc'1 = Any.any_l ()
     | & _54: t_Fragment = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_PersistentArray)-> {[@expl:new result type invariant] [%#spersistent_array'7] inv'24 result}
       {[@expl:new ensures] [%#spersistent_array'8] view'13 result = view v}
       (! return' {result}) ]
@@ -2245,7 +2245,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__set [#"persis
       | s1 = bb13 ]
     
     | bb13 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: t_PersistentArray = Any.any_l ()
     | & self'0: t_PersistentArray = self
     | & index'0: UInt64.t = index
@@ -2263,7 +2263,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__set [#"persis
     | & _23: closure0 = Any.any_l ()
     | & _27: t_Rc = Any.any_l ()
     | & _30:  t_Rc'1 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_PersistentArray)-> {[@expl:set result type invariant] [%#spersistent_array'4] inv'31 result}
       {[@expl:set ensures] [%#spersistent_array'5] view'3 result = Seq.set (view'4 self) (UInt64.t'int index) value}
       (! return' {result}) ]
@@ -3072,14 +3072,14 @@ module M_persistent_array__implementation__qyi7256199225841846155__get_immut [#"
       | s2 = bb2 ]
     
     | bb2 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: t_Option'1 = Any.any_l ()
     | & self'0: t_PersistentArray = self
     | & i'0: UInt64.t = i
     | & namespaces'1:  t_Namespaces = namespaces'0
     | & _6:  t_Rc'1 = Any.any_l ()
     | & _9: closure0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'1)-> {[@expl:get_immut result type invariant] [%#spersistent_array'1] inv'20 result}
       {[@expl:get_immut ensures] [%#spersistent_array'2] result
       = (if UInt64.t'int i < Seq.length (view'16 self) then
@@ -3680,7 +3680,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get_inner_imm
     | bb16 = s0 [ s0 = v_Some {_24} (fun (r0:t_T) ->  [ &x <- r0 ] s1) | s1 =  [ &_0 <- C_Some'1 x ] s2 | s2 = bb23 ] 
     | bb17 = s0 [ s0 =  [ &_0 <- C_None'1 ] s1 | s1 = bb23 ] 
     | bb23 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'1 = Any.any_l ()
     | & inner'0: t_Rc = inner
     | & i'0: UInt64.t = i
@@ -3701,7 +3701,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get_inner_imm
     | & value: t_T = Any.any_l ()
     | & next: t_Rc = Any.any_l ()
     | & _35: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'1)-> {[@expl:get_inner_immut result type invariant] [%#spersistent_array'3] inv'25 result}
       {[@expl:get_inner_immut ensures] [%#spersistent_array'4] if UInt64.t'int i < tokens.t_CompleteMap__length then
         result
@@ -4817,7 +4817,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get [#"persis
       | s2 = bb3 ]
     
     | bb3 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: t_Option'2 = Any.any_l ()
     | & self'0: t_PersistentArray = self
     | & index'0: UInt64.t = index
@@ -4825,7 +4825,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get [#"persis
     | & public'0: t_Id = Any.any_l ()
     | & _8:  t_Rc = Any.any_l ()
     | & _11: closure0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'2)-> {[@expl:get result type invariant] [%#spersistent_array'2] inv'30 result}
       {[@expl:get ensures] [%#spersistent_array'3] if UInt64.t'int index < Seq.length (view'22 self) then
         result = C_Some'2 (Seq.get (view'22 self) (UInt64.t'int index))
@@ -5967,7 +5967,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__reroot [#"per
       | s3 = bb47 ]
     
     | bb47 = return''0 {_0} ]
-    )
+    
     [ & _0: int = Any.any_l ()
     | & inner'0: t_Rc = inner
     | & invariant_id'0: t_Id = invariant_id
@@ -6037,7 +6037,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__reroot [#"per
     | & _106: Map.map t_Id int = Any.any_l ()
     | & _108: MutBorrow.t (MutBorrow.t t_CompleteMap) = Any.any_l ()
     | & _109: MutBorrow.t ( (MutBorrow.t t_CompleteMap)) = Any.any_l () ]
-    
+    )
     [ return''0 (result:int)-> {[@expl:reroot ensures #0] [%#spersistent_array'8] invariant_with_data tokens.final invariant_id}
       {[@expl:reroot ensures #1] [%#spersistent_array'9] forall id'2: t_Id. contains (tokens.current).t_CompleteMap__own_map id'2
       = contains (tokens.final).t_CompleteMap__own_map id'2}
@@ -6354,7 +6354,7 @@ module M_persistent_array__testing [#"persistent_array.rs" 383 0 383 49]
       | s4 = bb20 ]
     
     | bb20 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & namespaces'1:  t_Namespaces = namespaces'0
     | & a: t_PersistentArray = Any.any_l ()
@@ -6376,7 +6376,7 @@ module M_persistent_array__testing [#"persistent_array.rs" 383 0 383 49]
     | & a_model: Seq.seq Int32.t = Any.any_l ()
     | & a2_model: Seq.seq Int32.t = Any.any_l ()
     | & a3_model: Seq.seq Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_persistent_array__implementation__qyi15164097500274694161__clone__refines [#"persistent_array.rs" 46 8 46 31] (* <implementation::PersistentArray<T> as creusot_contracts::Clone> *)
   type namespace_other

--- a/tests/should_succeed/printing.coma
+++ b/tests/should_succeed/printing.coma
@@ -152,7 +152,7 @@ module M_printing__f [#"printing.rs" 4 0 4 10]
     
     | bb7 = s0 [ s0 = qy95zeprint {_21} (fun (_ret:()) ->  [ &_20 <- _ret ] s1) | s1 = bb8 ] 
     | bb8 = s0 [ s0 = {[@expl:assertion] [%#sprinting] 1 + 1 = 2} s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _2: () = Any.any_l ()
     | & _3: t_Arguments = Any.any_l ()
@@ -170,5 +170,5 @@ module M_printing__f [#"printing.rs" 4 0 4 10]
     | & _28: Slice64.array string = Any.any_l ()
     | & _29: Slice64.array string = Any.any_l ()
     | & _30: Slice64.array string = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/projection_toggle.coma
+++ b/tests/should_succeed/projection_toggle.coma
@@ -92,7 +92,7 @@ module M_projection_toggle__proj_toggle [#"projection_toggle.rs" 5 0 5 87]
       | s9 = -{resolve'0 a'0}- s10
       | s10 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t t_T = Any.any_l ()
     | & toggle'0: bool = toggle
     | & a'0: MutBorrow.t t_T = a
@@ -100,7 +100,7 @@ module M_projection_toggle__proj_toggle [#"projection_toggle.rs" 5 0 5 87]
     | & _4: MutBorrow.t t_T = Any.any_l ()
     | & _6: MutBorrow.t t_T = Any.any_l ()
     | & _8: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_T)-> {[@expl:proj_toggle result type invariant] [%#sprojection_toggle'1] inv'0 result}
       {[@expl:proj_toggle ensures] [%#sprojection_toggle'2] if toggle then
         result = a /\ b.final = b.current
@@ -170,7 +170,7 @@ module M_projection_toggle__f [#"projection_toggle.rs" 9 0 9 10]
     
     | bb2 = return''0 {_0}
     | bb3 = {[%#sprojection_toggle'4] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: Int32.t = Any.any_l ()
     | & b: Int32.t = Any.any_l ()
@@ -180,5 +180,5 @@ module M_projection_toggle__f [#"projection_toggle.rs" 9 0 9 10]
     | & _6: MutBorrow.t Int32.t = Any.any_l ()
     | & _7: MutBorrow.t Int32.t = Any.any_l ()
     | & _9: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/projections.coma
+++ b/tests/should_succeed/projections.coma
@@ -8,7 +8,7 @@ module M_projections__copy_out_of_ref [#"projections.rs" 5 0 5 38]
   
   let rec copy_out_of_ref[#"projections.rs" 5 0 5 38] (x:UInt32.t) (return'  (x'0:UInt32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- x'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32.t = Any.any_l () | & x'0: UInt32.t = x ]  [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
+     [ & _0: UInt32.t = Any.any_l () | & x'0: UInt32.t = x ] ) [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
 end
 module M_projections__copy_out_of_sum [#"projections.rs" 9 0 9 60]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 49 20 49 34
@@ -59,12 +59,12 @@ module M_projections__copy_out_of_sum [#"projections.rs" 9 0 9 60]
       | s3 = bb5 ]
     
     | bb5 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & x'0: t_Result = x
     | & x'1: MutBorrow.t UInt32.t = Any.any_l ()
     | & y: MutBorrow.t UInt32.t = Any.any_l () ]
-     [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
 end
 module M_projections__write_into_sum [#"projections.rs" 16 0 16 42]
   let%span sresolve = "../../creusot-contracts/src/resolve.rs" 49 20 49 34
@@ -116,7 +116,7 @@ module M_projections__write_into_sum [#"projections.rs" 16 0 16 42]
     
     | bb3 = s0 [ s0 = -{resolve'2 x'0}- s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x'0: MutBorrow.t t_Option = x | & y: MutBorrow.t UInt32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x'0: MutBorrow.t t_Option = x | & y: MutBorrow.t UInt32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -153,10 +153,10 @@ module M_projections__f [#"projections.rs" 23 0 23 10]
     
     | bb3 = s0 [ s0 =  [ &_1 <- [%#sprojections'1] false ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & _1: bool = Any.any_l ()
     | & _2: t_Option = Any.any_l ()
     | & x: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/prophecy.coma
+++ b/tests/should_succeed/prophecy.coma
@@ -26,7 +26,7 @@ module M_prophecy__f [#"prophecy.rs" 3 0 3 10]
       | s3 = -{resolve'0 y}- s4
       | s4 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & x: Int32.t = Any.any_l () | & y: MutBorrow.t Int32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x: Int32.t = Any.any_l () | & y: MutBorrow.t Int32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/purity.coma
+++ b/tests/should_succeed/purity.coma
@@ -5,7 +5,7 @@ module M_purity__qyi14899607085053415061__f [#"purity.rs" 12 4 12 10] (* <i32 as
   
   meta "select_lsinst" "all"
   
-  let rec f[#"purity.rs" 12 4 12 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+  let rec f[#"purity.rs" 12 4 12 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -20,7 +20,7 @@ module M_purity__calls_f [#"purity.rs" 16 0 16 16]
   
   let rec calls_f[#"purity.rs" 16 0 16 16] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = f (fun (_ret:()) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_purity__result [#"purity.rs" 39 0 39 15]
   let%span spurity = "purity.rs" 40 18 40 32
@@ -39,7 +39,7 @@ module M_purity__result [#"purity.rs" 39 0 39 15]
   
   let rec result[#"purity.rs" 39 0 39 15] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = {[@expl:assertion] [%#spurity] calls_g = 1} s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result'0:())-> (! return' {result'0}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result'0:())-> (! return' {result'0}) ] 
 end
 module M_purity__clone_id [#"purity.rs" 45 0 45 22]
   let%span sid = "../../creusot-contracts/src/logic/id.rs" 19 14 19 29
@@ -58,7 +58,7 @@ module M_purity__clone_id [#"purity.rs" 45 0 45 22]
   
   let rec clone_id[#"purity.rs" 45 0 45 22] (i:t_Id) (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = clone' {i'0} (fun (_ret:t_Id) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & i'0: t_Id = i | & _2: t_Id = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & i'0: t_Id = i | & _2: t_Id = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/red_black_tree.coma
+++ b/tests/should_succeed/red_black_tree.coma
@@ -19,7 +19,7 @@ module M_red_black_tree__qyi11959472507597060150__clone [#"red_black_tree.rs" 13
     | bb3 = s0 [ s0 =  [ &_0 <- C_Black ] s1 | s1 = bb5 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- C_Red ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: t_Color = Any.any_l () | & self'0: t_Color = self ] 
+     [ & _0: t_Color = Any.any_l () | & self'0: t_Color = self ] )
     [ return''0 (result:t_Color)-> {[@expl:clone ensures] [%#sred_black_tree] match { _p0 = self; _p1 = result } with
         | {_p0 = C_Red ; _p1 = C_Red} -> true
         | {_p0 = C_Black ; _p1 = C_Black} -> true
@@ -1062,7 +1062,7 @@ module M_red_black_tree__qyi3529752165842986389__is_red [#"red_black_tree.rs" 40
     | bb1 = s0 [ s0 =  [ &_0 <- [%#sred_black_tree] false ] s1 | s1 = bb5 ] 
     | bb4 = s0 [ s0 =  [ &_0 <- [%#sred_black_tree'0] true ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & self'0: t_Tree = self ] 
+     [ & _0: bool = Any.any_l () | & self'0: t_Tree = self ] )
     [ return''0 (result:bool)-> {[@expl:is_red ensures] [%#sred_black_tree'2] result = (color self = C_Red)}
       (! return' {result}) ]
 
@@ -1610,7 +1610,7 @@ module M_red_black_tree__qyi3665871523867809084__rotate_right [#"red_black_tree.
       | s5 = bb12 ]
     
     | bb12 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Node = self
     | & old_self: MutBorrow.t t_Node = Any.any_l ()
@@ -1634,7 +1634,7 @@ module M_red_black_tree__qyi3665871523867809084__rotate_right [#"red_black_tree.
     | & _30: MutBorrow.t t_Color = Any.any_l ()
     | & _33: t_Tree = Any.any_l ()
     | & _34: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:rotate_right ensures #0] [%#sred_black_tree'4] same_mappings self.current self.final}
       {[@expl:rotate_right ensures #1] [%#sred_black_tree'5] internal_invariant self.final}
       {[@expl:rotate_right ensures #2] [%#sred_black_tree'6] height'0 self.current = height'0 self.final}
@@ -2193,7 +2193,7 @@ module M_red_black_tree__qyi3665871523867809084__rotate_left [#"red_black_tree.r
       | s5 = bb12 ]
     
     | bb12 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Node = self
     | & old_self: MutBorrow.t t_Node = Any.any_l ()
@@ -2217,7 +2217,7 @@ module M_red_black_tree__qyi3665871523867809084__rotate_left [#"red_black_tree.r
     | & _30: MutBorrow.t t_Color = Any.any_l ()
     | & _33: t_Tree = Any.any_l ()
     | & _34: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:rotate_left ensures #0] [%#sred_black_tree'4] same_mappings self.current self.final}
       {[@expl:rotate_left ensures #1] [%#sred_black_tree'5] internal_invariant self.final}
       {[@expl:rotate_left ensures #2] [%#sred_black_tree'6] height'0 self.current = height'0 self.final}
@@ -2628,7 +2628,7 @@ module M_red_black_tree__qyi3665871523867809084__flip_colors [#"red_black_tree.r
       | s5 = -{resolve'4 self'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Node = self
     | & _13: MutBorrow.t t_Node = Any.any_l ()
@@ -2642,7 +2642,7 @@ module M_red_black_tree__qyi3665871523867809084__flip_colors [#"red_black_tree.r
     | & _21: MutBorrow.t t_Node = Any.any_l ()
     | & _22: t_Option'0 = Any.any_l ()
     | & _23: MutBorrow.t t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:flip_colors ensures #0] [%#sred_black_tree'4] internal_invariant self.final}
       {[@expl:flip_colors ensures #1] [%#sred_black_tree'5] height'0 self.current = height'0 self.final}
       {[@expl:flip_colors ensures #2] [%#sred_black_tree'6] same_mappings self.current self.final}
@@ -3175,7 +3175,7 @@ module M_red_black_tree__qyi3665871523867809084__balance [#"red_black_tree.rs" 5
     | bb26 = s0 [ s0 = {[@expl:type invariant] inv'6 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = bb29 ] 
     | bb27 = s0 [ s0 = {[@expl:type invariant] inv'6 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = bb29 ] 
     | bb29 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Node = self
     | & _15: bool = Any.any_l ()
@@ -3192,7 +3192,7 @@ module M_red_black_tree__qyi3665871523867809084__balance [#"red_black_tree.rs" 5
     | & _33: bool = Any.any_l ()
     | & _35: () = Any.any_l ()
     | & _36: MutBorrow.t t_Node = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:balance ensures #0] [%#sred_black_tree'4] same_mappings self.current self.final}
       {[@expl:balance ensures #1] [%#sred_black_tree'5] internal_invariant self.final}
       {[@expl:balance ensures #2] [%#sred_black_tree'6] height'0 self.current = height'0 self.final}
@@ -3786,7 +3786,7 @@ module M_red_black_tree__qyi3665871523867809084__move_red_left [#"red_black_tree
     | bb16 = s0 [ s0 = {[@expl:type invariant] inv'5 self'0} s1 | s1 = -{resolve'2 self'0}- s2 | s2 = bb14 ] 
     | bb13 = s0 [ s0 =  [ &_0 <- self'0 ] s1 | s1 = bb14 ] 
     | bb14 = return''0 {_0} ]
-    )
+    
     [ & _0: MutBorrow.t t_Node = Any.any_l ()
     | & self'0: MutBorrow.t t_Node = self
     | & _15: () = Any.any_l ()
@@ -3807,7 +3807,7 @@ module M_red_black_tree__qyi3665871523867809084__move_red_left [#"red_black_tree
     | & _33: MutBorrow.t t_Node = Any.any_l ()
     | & _34: t_Option'0 = Any.any_l ()
     | & _35: MutBorrow.t t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_Node)-> {[@expl:move_red_left result type invariant] [%#sred_black_tree'3] inv'5 result}
       {[@expl:move_red_left ensures #0] [%#sred_black_tree'4] internal_invariant result.current}
       {[@expl:move_red_left ensures #1] [%#sred_black_tree'5] internal_invariant result.final
@@ -4353,7 +4353,7 @@ module M_red_black_tree__qyi3665871523867809084__move_red_right [#"red_black_tre
     | bb13 = s0 [ s0 = {[@expl:type invariant] inv'5 self'0} s1 | s1 = -{resolve'2 self'0}- s2 | s2 = bb11 ] 
     | bb10 = s0 [ s0 =  [ &_0 <- self'0 ] s1 | s1 = bb11 ] 
     | bb11 = return''0 {_0} ]
-    )
+    
     [ & _0: MutBorrow.t t_Node = Any.any_l ()
     | & self'0: MutBorrow.t t_Node = self
     | & _15: () = Any.any_l ()
@@ -4369,7 +4369,7 @@ module M_red_black_tree__qyi3665871523867809084__move_red_right [#"red_black_tre
     | & _28: MutBorrow.t t_Node = Any.any_l ()
     | & _29: t_Option'0 = Any.any_l ()
     | & _30: MutBorrow.t t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t t_Node)-> {[@expl:move_red_right result type invariant] [%#sred_black_tree'3] inv'5 result}
       {[@expl:move_red_right ensures #0] [%#sred_black_tree'4] internal_invariant result.current}
       {[@expl:move_red_right ensures #1] [%#sred_black_tree'5] internal_invariant result.final
@@ -4956,7 +4956,7 @@ module M_red_black_tree__qyi3529752165842986389__insert_rec [#"red_black_tree.rs
       | s6 = bb32 ]
     
     | bb32 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Tree = self
     | & key'0: t_K = key
@@ -4977,7 +4977,7 @@ module M_red_black_tree__qyi3529752165842986389__insert_rec [#"red_black_tree.rs
     | & _36: t_Color = Any.any_l ()
     | & _39: t_Tree = Any.any_l ()
     | & _40: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:insert_rec ensures #0] [%#sred_black_tree'4] internal_invariant'0 self.final}
       {[@expl:insert_rec ensures #1] [%#sred_black_tree'5] height self.current = height self.final}
       {[@expl:insert_rec ensures #2] [%#sred_black_tree'6] match_t (cpn (C_Red) (C_CPL (C_Red)) (C_CPL (C_Black))) self.final
@@ -5800,7 +5800,7 @@ module M_red_black_tree__qyi3529752165842986389__delete_max_rec [#"red_black_tre
       | s5 = bb31 ]
     
     | bb31 = return''0 {_0} ]
-    )
+    
     [ & _0: tuple'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_Tree = self
     | & node: MutBorrow.t t_Node = Any.any_l ()
@@ -5826,7 +5826,7 @@ module M_red_black_tree__qyi3529752165842986389__delete_max_rec [#"red_black_tre
     | & _41: MutBorrow.t t_Tree = Any.any_l ()
     | & _42: () = Any.any_l ()
     | & _43: MutBorrow.t t_Node = Any.any_l () ]
-    
+    )
     [ return''0 (result:tuple'0)-> {[@expl:delete_max_rec result type invariant] [%#sred_black_tree'2] inv'14 result}
       {[@expl:delete_max_rec ensures #0] [%#sred_black_tree'3] internal_invariant'0 self.final}
       {[@expl:delete_max_rec ensures #1] [%#sred_black_tree'4] height self.current = height self.final}
@@ -6607,7 +6607,7 @@ module M_red_black_tree__qyi3529752165842986389__delete_min_rec [#"red_black_tre
       | s5 = bb26 ]
     
     | bb26 = return''0 {_0} ]
-    )
+    
     [ & _0: tuple = Any.any_l ()
     | & self'0: MutBorrow.t t_Tree = self
     | & node: MutBorrow.t t_Node = Any.any_l ()
@@ -6630,7 +6630,7 @@ module M_red_black_tree__qyi3529752165842986389__delete_min_rec [#"red_black_tre
     | & _37: MutBorrow.t t_Tree = Any.any_l ()
     | & _38: () = Any.any_l ()
     | & _39: MutBorrow.t t_Node = Any.any_l () ]
-    
+    )
     [ return''0 (result:tuple)-> {[@expl:delete_min_rec result type invariant] [%#sred_black_tree'2] inv'14 result}
       {[@expl:delete_min_rec ensures #0] [%#sred_black_tree'3] internal_invariant'0 self.final}
       {[@expl:delete_min_rec ensures #1] [%#sred_black_tree'4] height self.current = height self.final}
@@ -7871,7 +7871,7 @@ module M_red_black_tree__qyi3529752165842986389__delete_rec [#"red_black_tree.rs
       | s5 = bb76 ]
     
     | bb76 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'1 = Any.any_l ()
     | & self'0: MutBorrow.t t_Tree = self
     | & key'0: t_K = key
@@ -7929,7 +7929,7 @@ module M_red_black_tree__qyi3529752165842986389__delete_rec [#"red_black_tree.rs
     | & _90: MutBorrow.t t_Tree = Any.any_l ()
     | & _92: () = Any.any_l ()
     | & _93: MutBorrow.t t_Node = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'1)-> {[@expl:delete_rec result type invariant] [%#sred_black_tree'4] inv'18 result}
       {[@expl:delete_rec ensures #0] [%#sred_black_tree'5] internal_invariant'0 self.final}
       {[@expl:delete_rec ensures #1] [%#sred_black_tree'6] height self.current = height self.final}
@@ -8409,7 +8409,7 @@ module M_red_black_tree__qyi1722927563742988856__new [#"red_black_tree.rs" 792 4
     [ bb0 = s0 [ s0 =  [ &_3 <- C_None ] s1 | s1 =  [ &_2 <- { t_Tree__node = _3 } ] s2 | s2 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- { t_Map__0 = _2 } ] s1 | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: t_Map = Any.any_l () | & _2: t_Tree = Any.any_l () | & _3: t_Option = Any.any_l () ] 
+     [ & _0: t_Map = Any.any_l () | & _2: t_Tree = Any.any_l () | & _3: t_Option = Any.any_l () ] )
     [ return''0 (result:t_Map)-> {[@expl:new result type invariant] [%#sred_black_tree] inv'5 result}
       {[@expl:new ensures] [%#sred_black_tree'0] view'0 result = Const.const (C_None'0)}
       (! return' {result}) ]
@@ -8865,7 +8865,7 @@ module M_red_black_tree__qyi1722927563742988856__insert [#"red_black_tree.rs" 79
       | s6 = bb6 ]
     
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Map = self
     | & key'0: t_K = key
@@ -8877,7 +8877,7 @@ module M_red_black_tree__qyi1722927563742988856__insert [#"red_black_tree.rs" 79
     | & _11: t_Option'0 = Any.any_l ()
     | & _12: MutBorrow.t t_Option = Any.any_l ()
     | & _13: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:insert ensures] [%#sred_black_tree'3] view'0 self.final
       = Map.set (view'1 self) (deep_model key) (C_Some'1 val')}
       (! return' {result}) ]
@@ -9437,7 +9437,7 @@ module M_red_black_tree__qyi1722927563742988856__delete_max [#"red_black_tree.rs
     | bb15 = s0 [ s0 =  [ &_24 <- [%#sred_black_tree'1] () ] s1 | s1 = bb16 ] 
     | bb16 = s0 [ s0 =  [ &_0 <- C_Some'0 r ] s1 | s1 = bb19 ] 
     | bb19 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_Map = self
     | & old_self: MutBorrow.t t_Map = Any.any_l ()
@@ -9453,7 +9453,7 @@ module M_red_black_tree__qyi1722927563742988856__delete_max [#"red_black_tree.rs
     | & _22: t_Option'1 = Any.any_l ()
     | & _23: MutBorrow.t t_Option = Any.any_l ()
     | & _24: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:delete_max result type invariant] [%#sred_black_tree'3] inv'13 result}
       {[@expl:delete_max ensures] [%#sred_black_tree'4] match result with
         | C_Some'0 {_p0 = k ; _p1 = v} -> Map.get (view'1 self) (deep_model k) = C_Some'2 v
@@ -10009,7 +10009,7 @@ module M_red_black_tree__qyi1722927563742988856__delete_min [#"red_black_tree.rs
     | bb14 = s0 [ s0 = {[@expl:type invariant] inv'7 self'0} s1 | s1 = -{resolve'2 self'0}- s2 | s2 = bb15 ] 
     | bb15 = s0 [ s0 =  [ &_0 <- C_Some'1 r ] s1 | s1 = bb18 ] 
     | bb18 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'1 = Any.any_l ()
     | & self'0: MutBorrow.t t_Map = self
     | & _3: () = Any.any_l ()
@@ -10024,7 +10024,7 @@ module M_red_black_tree__qyi1722927563742988856__delete_min [#"red_black_tree.rs
     | & _19: MutBorrow.t t_Node = Any.any_l ()
     | & _20: t_Option'2 = Any.any_l ()
     | & _21: MutBorrow.t t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'1)-> {[@expl:delete_min result type invariant] [%#sred_black_tree'1] inv'13 result}
       {[@expl:delete_min ensures] [%#sred_black_tree'2] match result with
         | C_Some'1 {_p0 = k ; _p1 = v} -> Map.get (view'1 self) (deep_model k) = C_Some'0 v
@@ -10596,7 +10596,7 @@ module M_red_black_tree__qyi1722927563742988856__delete [#"red_black_tree.rs" 85
     | bb14 = s0 [ s0 = {[@expl:type invariant] inv'7 self'0} s1 | s1 = -{resolve'2 self'0}- s2 | s2 = bb15 ] 
     | bb15 = s0 [ s0 =  [ &_0 <- r ] s1 | s1 = bb17 ] 
     | bb17 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'1 = Any.any_l ()
     | & self'0: MutBorrow.t t_Map = self
     | & key'0: t_K = key
@@ -10612,7 +10612,7 @@ module M_red_black_tree__qyi1722927563742988856__delete [#"red_black_tree.rs" 85
     | & _22: MutBorrow.t t_Node = Any.any_l ()
     | & _23: t_Option'2 = Any.any_l ()
     | & _24: MutBorrow.t t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'1)-> {[@expl:delete result type invariant] [%#sred_black_tree'2] inv'13 result}
       {[@expl:delete ensures #0] [%#sred_black_tree'3] match result with
         | C_Some'1 {_p0 = k ; _p1 = v} -> deep_model k = deep_model'0 key
@@ -11015,7 +11015,7 @@ module M_red_black_tree__qyi1722927563742988856__get [#"red_black_tree.rs" 878 4
     | bb14 = s0 [ s0 =  [ &_0 <- C_None'1 ] s1 | s1 = bb15 ] 
     | bb11 = s0 [ s0 =  [ &_26 <- node.t_Node__val ] s1 | s1 =  [ &_0 <- C_Some'1 _26 ] s2 | s2 = bb15 ] 
     | bb15 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'1 = Any.any_l ()
     | & self'0: t_Map = self
     | & key'0: t_K = key
@@ -11028,7 +11028,7 @@ module M_red_black_tree__qyi1722927563742988856__get [#"red_black_tree.rs" 878 4
     | & _23: t_Tree = Any.any_l ()
     | & _26: t_V = Any.any_l ()
     | & _28: t_Tree = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'1)-> {[@expl:get result type invariant] [%#sred_black_tree'5] inv'10 result}
       {[@expl:get ensures] [%#sred_black_tree'6] match result with
         | C_Some'1 v -> Map.get (view'1 self) (deep_model'0 key) = C_Some'0 v
@@ -11624,7 +11624,7 @@ module M_red_black_tree__qyi1722927563742988856__get_mut [#"red_black_tree.rs" 8
       | s3 = -{resolve'8 self'0}- s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_Option'1 = Any.any_l ()
     | & self'0: MutBorrow.t t_Map = self
     | & key'0: t_K = key
@@ -11641,7 +11641,7 @@ module M_red_black_tree__qyi1722927563742988856__get_mut [#"red_black_tree.rs" 8
     | & _35: MutBorrow.t t_V = Any.any_l ()
     | & _36: MutBorrow.t t_Tree = Any.any_l ()
     | & _37: MutBorrow.t t_Tree = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'1)-> {[@expl:get_mut result type invariant] [%#sred_black_tree'13] inv'12 result}
       {[@expl:get_mut ensures] [%#sred_black_tree'14] match result with
         | C_Some'1 v -> Map.get (view'1 self) (deep_model'0 key) = C_Some'0 (v.current)

--- a/tests/should_succeed/replace.coma
+++ b/tests/should_succeed/replace.coma
@@ -14,7 +14,7 @@ module M_replace__test [#"replace.rs" 8 0 8 44]
   
   let rec test[#"replace.rs" 8 0 8 44] (_a:t_Something) (b:t_Something) (return'  (x:()))= (! bb0
     [ bb0 = bb1 | bb1 = s0 [ s0 =  [ &_a'0 <- b'0 ] s1 | s1 = bb5 ]  | bb5 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _a'0: t_Something = _a | & b'0: t_Something = b ] 
+     [ & _0: () = Any.any_l () | & _a'0: t_Something = _a | & b'0: t_Something = b ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/resolve_drop.coma
+++ b/tests/should_succeed/resolve_drop.coma
@@ -34,10 +34,10 @@ module M_resolve_drop__f [#"resolve_drop.rs" 4 0 4 10]
       | s3 = bb2 ]
     
     | bb2 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & b: MutBorrow.t Int32.t = Any.any_l ()
     | & _3: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/resolve_uninit.coma
+++ b/tests/should_succeed/resolve_uninit.coma
@@ -36,9 +36,9 @@ module M_resolve_uninit__maybe_uninit [#"resolve_uninit.rs" 5 0 5 51]
     | bb8 = s0 [ s0 =  [ &x <- y'0 ] s1 | s1 = bb10 ] 
     | bb10 = s0 [ s0 =  [ &_0 <- x ] s1 | s1 = bb12 ] 
     | bb12 = return''0 {_0} ]
-    )
-    [ & _0: t_T = Any.any_l () | & b'0: bool = b | & y'0: t_T = y | & x: t_T = Any.any_l () | & _6: t_T = Any.any_l () ]
     
+    [ & _0: t_T = Any.any_l () | & b'0: bool = b | & y'0: t_T = y | & x: t_T = Any.any_l () | & _6: t_T = Any.any_l () ]
+    )
     [ return''0 (result:t_T)-> {[@expl:maybe_uninit result type invariant] [%#sresolve_uninit'0] inv result}
       (! return' {result}) ]
 
@@ -98,7 +98,7 @@ module M_resolve_uninit__init_join [#"resolve_uninit.rs" 15 0 15 37]
     
     | bb4 = return''0 {_0}
     | bb5 = {[%#sresolve_uninit'1] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & b'0: bool = b
     | & x'0: Int32.t = x
@@ -111,5 +111,5 @@ module M_resolve_uninit__init_join [#"resolve_uninit.rs" 15 0 15 37]
     | & _11: MutBorrow.t Int32.t = Any.any_l ()
     | & _12: MutBorrow.t Int32.t = Any.any_l ()
     | & _14: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/resource_algebras/agree.coma
+++ b/tests/should_succeed/resource_algebras/agree.coma
@@ -104,7 +104,7 @@ module M_agree__agreement [#"agree.rs" 6 0 6 62]
     (! bb0
     [ bb0 = s0 [ s0 = join_shared {x'0} {y'0} (fun (_ret:t_Resource) ->  [ &_5 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_Resource = x | & y'0: t_Resource = y | & _5: t_Resource = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x'0: t_Resource = x | & y'0: t_Resource = y | & _5: t_Resource = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:agreement ensures] [%#sagree'0] view'0 x = view'0 y} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/resource_algebras/excl.coma
+++ b/tests/should_succeed/resource_algebras/excl.coma
@@ -108,7 +108,7 @@ module M_excl__exclusivity [#"excl.rs" 6 0 6 72]
     | bb6 = {[%#sexcl'0] false} any
     | bb8 = s0 [ s0 = -{resolve'0 x'0}- s1 | s1 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x'0: MutBorrow.t t_Resource = x
     | & y'0: t_Resource = y
@@ -117,7 +117,7 @@ module M_excl__exclusivity [#"excl.rs" 6 0 6 72]
     | & _10: t_Id = Any.any_l ()
     | & _12: () = Any.any_l ()
     | & _13: MutBorrow.t t_Resource = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:exclusivity ensures #0] [%#sexcl'1] id x.current <> id y}
       {[@expl:exclusivity ensures #1] [%#sexcl'2] x.current = x.final}
       (! return' {result}) ]

--- a/tests/should_succeed/resource_algebras/fmap_view_view.coma
+++ b/tests/should_succeed/resource_algebras/fmap_view_view.coma
@@ -912,13 +912,13 @@ module M_fmap_view_view__qyi16747555808275470465__new [#"fmap_view_view.rs" 112 
       | s2 = bb4 ]
     
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0:  t_Authority = Any.any_l ()
     | & resource:  t_Resource = Any.any_l ()
     | & _3: t_View = Any.any_l ()
     | & _5: t_Authority = Any.any_l ()
     | & _6: t_Resource = Any.any_l () ]
-    
+    )
     [ return''0 (result: t_Authority)-> {[@expl:new result type invariant] [%#sfmap_view_view'0] inv'0 result}
       {[@expl:new ensures] [%#sfmap_view_view'1] view'4 result = empty'0}
       (! return' {result}) ]
@@ -1551,7 +1551,7 @@ module M_fmap_view_view__qyi16747555808275470465__insert [#"fmap_view_view.rs" 1
     | bb8 = s0
       [ s0 =  [ &_0 <- { t_Fragment__0 = _18; t_Fragment__1 = _24; t_Fragment__2 = _26 } ] s1 | s1 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_Fragment = Any.any_l ()
     | & self'0: MutBorrow.t t_Authority = self
     | & k'0: t_K = k
@@ -1567,7 +1567,7 @@ module M_fmap_view_view__qyi16747555808275470465__insert [#"fmap_view_view.rs" 1
     | & _22: t_View = Any.any_l ()
     | & _24: t_K = Any.any_l ()
     | & _26: t_V = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Fragment)-> {[@expl:insert result type invariant] [%#sfmap_view_view'7] inv'1 result}
       {[@expl:insert ensures #0] [%#sfmap_view_view'8] view'1 self.final = insert (view'2 self) k v}
       {[@expl:insert ensures #1] [%#sfmap_view_view'9] id'0 self.final = id'0 self.current}
@@ -2115,13 +2115,13 @@ module M_fmap_view_view__qyi16747555808275470465__contains [#"fmap_view_view.rs"
         s1
       | s1 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: t_Authority = self
     | & frag'1: t_Fragment = frag'0
     | & new_resource: t_Resource = Any.any_l ()
     | & _8: t_Resource = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:contains ensures] [%#sfmap_view_view'3] get'0 (view'6 self) (view'4 frag'0)._p0'2
       = C_Some'4 ((view'4 frag'0)._p1'2)}
       (! return' {result}) ]
@@ -2641,7 +2641,7 @@ module M_fmap_view_view__qyi9127813262067876198__clone [#"fmap_view_view.rs" 159
         s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: t_Fragment = Any.any_l () | & self'0: t_Fragment = self | & _3: t_Resource = Any.any_l () ] 
+     [ & _0: t_Fragment = Any.any_l () | & self'0: t_Fragment = self | & _3: t_Resource = Any.any_l () ] )
     [ return''0 (result:t_Fragment)-> {[@expl:clone result type invariant] [%#sfmap_view_view'0] inv result}
       {[@expl:clone ensures] [%#sfmap_view_view'1] view'3 result = view'4 self}
       (! return' {result}) ]

--- a/tests/should_succeed/result/own.coma
+++ b/tests/should_succeed/result/own.coma
@@ -83,7 +83,7 @@ module M_own__qyi9370700355788413623__is_ok [#"own.rs" 30 4 30 31] (* OwnResult<
     | bb1 = s0 [ s0 =  [ &_0 <- false ] s1 | s1 = bb4 ] 
     | bb3 = s0 [ s0 =  [ &_0 <- true ] s1 | s1 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & self'0: t_OwnResult = self ] 
+     [ & _0: bool = Any.any_l () | & self'0: t_OwnResult = self ] )
     [ return''0 (result:bool)-> {[@expl:is_ok ensures] [%#sown'0] result = (exists t: t_T. self = C_Ok t)}
       (! return' {result}) ]
 
@@ -135,7 +135,7 @@ module M_own__qyi9370700355788413623__is_err [#"own.rs" 35 4 35 32] (* OwnResult
     (! bb0
     [ bb0 = s0 [ s0 = is_ok {self'0} (fun (_ret:bool) ->  [ &_3 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_0 <- not _3 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & self'0: t_OwnResult = self | & _3: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () | & self'0: t_OwnResult = self | & _3: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:is_err ensures] [%#sown'0] result = (exists e: t_E. self = C_Err e)}
       (! return' {result}) ]
 
@@ -208,12 +208,12 @@ module M_own__qyi9370700355788413623__ok [#"own.rs" 41 4 41 32] (* OwnResult<T, 
     
     | bb4 = s0 [ s0 = v_Ok {self'0} (fun (r0:t_T) ->  [ &x <- r0 ] s1) | s1 =  [ &_0 <- C_Some x ] s2 | s2 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & x: t_T = Any.any_l ()
     | & x'0: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:ok result type invariant] [%#sown'0] inv'2 result}
       {[@expl:ok ensures #0] [%#sown'1] forall t: t_T. self = C_Ok t  -> result = C_Some t}
       {[@expl:ok ensures #1] [%#sown'2] (exists e: t_E. self = C_Err e)  -> result = C_None}
@@ -288,12 +288,12 @@ module M_own__qyi9370700355788413623__err [#"own.rs" 51 4 51 33] (* OwnResult<T,
       | s4 = bb9 ]
     
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & x: t_T = Any.any_l ()
     | & x'0: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:err result type invariant] [%#sown'0] inv'2 result}
       {[@expl:err ensures #0] [%#sown'1] (exists t: t_T. self = C_Ok t)  -> result = C_None}
       {[@expl:err ensures #1] [%#sown'2] forall e: t_E. self = C_Err e  -> result = C_Some e}
@@ -384,12 +384,12 @@ module M_own__qyi9370700355788413623__as_ref [#"own.rs" 61 4 61 45] (* OwnResult
     
     | bb4 = s0 [ s0 = v_Ok {self'0} (fun (r0:t_T) ->  [ &x <- r0 ] s1) | s1 =  [ &_0 <- C_Ok'0 x ] s2 | s2 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    )
+    
     [ & _0: t_OwnResult'0 = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & x: t_T = Any.any_l ()
     | & x'0: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_OwnResult'0)-> {[@expl:as_ref result type invariant] [%#sown'0] inv'5 result}
       {[@expl:as_ref ensures #0] [%#sown'1] forall t: t_T. self = C_Ok t  -> result = C_Ok'0 t}
       {[@expl:as_ref ensures #1] [%#sown'2] forall e: t_E. self = C_Err e  -> result = C_Err'0 e}
@@ -541,14 +541,14 @@ module M_own__qyi9370700355788413623__as_mut [#"own.rs" 76 4 76 57] (* OwnResult
       | s5 = bb5 ]
     
     | bb5 = s0 [ s0 = {[@expl:type invariant] inv'4 self'0} s1 | s1 = -{resolve'4 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_OwnResult'0 = Any.any_l ()
     | & self'0: MutBorrow.t t_OwnResult = self
     | & x: MutBorrow.t t_T = Any.any_l ()
     | & _5: MutBorrow.t t_T = Any.any_l ()
     | & x'0: MutBorrow.t t_E = Any.any_l ()
     | & _7: MutBorrow.t t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_OwnResult'0)-> {[@expl:as_mut result type invariant] [%#sown'0] inv'5 result}
       {[@expl:as_mut ensures] [%#sown'1] exists t: MutBorrow.t t_T. self.current = C_Ok (t.current)
       /\ self.final = C_Ok (t.final) /\ result = C_Ok'0 t
@@ -613,7 +613,7 @@ module M_own__qyi9370700355788413623__unwrap [#"own.rs" 85 4 87 29] (* OwnResult
     
     | bb4 = s0 [ s0 = v_Ok {self'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- t ] s2 | s2 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    ) [ & _0: t_T = Any.any_l () | & self'0: t_OwnResult = self | & t: t_T = Any.any_l () | & _e: t_E = Any.any_l () ] 
+     [ & _0: t_T = Any.any_l () | & self'0: t_OwnResult = self | & t: t_T = Any.any_l () | & _e: t_E = Any.any_l () ] )
     [ return''0 (result:t_T)-> {[@expl:unwrap result type invariant] [%#sown'1] inv'0 result}
       {[@expl:unwrap ensures] [%#sown'2] C_Ok result = self}
       (! return' {result}) ]
@@ -675,7 +675,7 @@ module M_own__qyi9370700355788413623__expect [#"own.rs" 97 4 99 29] (* OwnResult
     
     | bb4 = s0 [ s0 = v_Ok {self'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- t ] s2 | s2 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    ) [ & _0: t_T = Any.any_l () | & self'0: t_OwnResult = self | & t: t_T = Any.any_l () | & _e: t_E = Any.any_l () ] 
+     [ & _0: t_T = Any.any_l () | & self'0: t_OwnResult = self | & t: t_T = Any.any_l () | & _e: t_E = Any.any_l () ] )
     [ return''0 (result:t_T)-> {[@expl:expect result type invariant] [%#sown'1] inv'0 result}
       {[@expl:expect ensures] [%#sown'2] C_Ok result = self}
       (! return' {result}) ]
@@ -737,7 +737,7 @@ module M_own__qyi9370700355788413623__unwrap_err [#"own.rs" 109 4 111 29] (* Own
       | s2 = -{resolve _t}- s3
       | s3 = {false} any ]
      ]
-    ) [ & _0: t_E = Any.any_l () | & self'0: t_OwnResult = self | & _t: t_T = Any.any_l () | & e: t_E = Any.any_l () ] 
+     [ & _0: t_E = Any.any_l () | & self'0: t_OwnResult = self | & _t: t_T = Any.any_l () | & e: t_E = Any.any_l () ] )
     [ return''0 (result:t_E)-> {[@expl:unwrap_err result type invariant] [%#sown'1] inv'0 result}
       {[@expl:unwrap_err ensures] [%#sown'2] C_Err result = self}
       (! return' {result}) ]
@@ -804,13 +804,13 @@ module M_own__qyi9370700355788413623__unwrap_or [#"own.rs" 121 4 121 43] (* OwnR
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv'0 default'0} s1 | s1 = -{resolve'0 default'0}- s2 | s2 = bb4 ] 
     | bb4 = s0 [ s0 = v_Ok {self'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- t ] s2 | s2 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: t_T = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & default'0: t_T = default
     | & t: t_T = Any.any_l ()
     | & e: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:unwrap_or result type invariant] [%#sown'1] inv'0 result}
       {[@expl:unwrap_or ensures #0] [%#sown'2] forall t: t_T. self = C_Ok t  -> result = t}
       {[@expl:unwrap_or ensures #1] [%#sown'3] (exists e: t_E. self = C_Err e)  -> result = default}
@@ -952,7 +952,7 @@ module M_own__qyi9370700355788413623__unwrap_or_default [#"own.rs" 131 4 133 19]
     
     | bb4 = s0 [ s0 = v_Ok {self'0} (fun (r0:t_T) ->  [ &x <- r0 ] s1) | s1 =  [ &_0 <- x ] s2 | s2 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    ) [ & _0: t_T = Any.any_l () | & self'0: t_OwnResult = self | & x: t_T = Any.any_l () ] 
+     [ & _0: t_T = Any.any_l () | & self'0: t_OwnResult = self | & x: t_T = Any.any_l () ] )
     [ return''0 (result:t_T)-> {[@expl:unwrap_or_default result type invariant] [%#sown'0] inv result}
       {[@expl:unwrap_or_default ensures #0] [%#sown'1] forall t: t_T. self = C_Ok t  -> result = t}
       {[@expl:unwrap_or_default ensures #1] [%#sown'2] (exists e: t_E. self = C_Err e)  -> postcondition () () result}
@@ -1053,13 +1053,13 @@ module M_own__qyi9370700355788413623__and [#"own.rs" 143 4 143 64] (* OwnResult<
       | s4 = bb10 ]
     
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_OwnResult'0 = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & res'0: t_OwnResult'0 = res
     | & x: t_T = Any.any_l ()
     | & e: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_OwnResult'0)-> {[@expl:and result type invariant] [%#sown'1] inv'1 result}
       {[@expl:and ensures #0] [%#sown'2] (exists t: t_T. self = C_Ok t)  -> result = res}
       {[@expl:and ensures #1] [%#sown'3] forall e: t_E. self = C_Err e  -> result = C_Err'0 e}
@@ -1155,13 +1155,13 @@ module M_own__qyi9370700355788413623__or [#"own.rs" 153 4 153 63] (* OwnResult<T
     | bb2 = s0 [ s0 = {[@expl:type invariant] inv'2 res'0} s1 | s1 = -{resolve'3 res'0}- s2 | s2 = bb4 ] 
     | bb4 = s0 [ s0 = v_Ok {self'0} (fun (r0:t_T) ->  [ &v <- r0 ] s1) | s1 =  [ &_0 <- C_Ok'0 v ] s2 | s2 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_OwnResult'0 = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & res'0: t_OwnResult'0 = res
     | & v: t_T = Any.any_l ()
     | & e: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_OwnResult'0)-> {[@expl:or result type invariant] [%#sown'1] inv'2 result}
       {[@expl:or ensures #0] [%#sown'2] forall t: t_T. self = C_Ok t  -> result = C_Ok'0 t}
       {[@expl:or ensures #1] [%#sown'3] (exists e: t_E. self = C_Err e)  -> result = res}
@@ -1236,12 +1236,12 @@ module M_own__qyi1738359920797260731__copied [#"own.rs" 165 4 167 16] (* OwnResu
     | bb3 = s0 [ s0 = v_Err {self'0} (fun (r0:t_E) ->  [ &e <- r0 ] s1) | s1 =  [ &_0 <- C_Err'0 e ] s2 | s2 = bb8 ] 
     | bb4 = s0 [ s0 = v_Ok {self'0} (fun (r0:t_T) ->  [ &t <- r0 ] s1) | s1 =  [ &_0 <- C_Ok'0 t ] s2 | s2 = bb8 ] 
     | bb8 = return''0 {_0} ]
-    )
+    
     [ & _0: t_OwnResult'0 = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & t: t_T = Any.any_l ()
     | & e: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_OwnResult'0)-> {[@expl:copied result type invariant] [%#sown'0] inv'3 result}
       {[@expl:copied ensures #0] [%#sown'1] forall t: t_T. self = C_Ok t  -> result = C_Ok'0 t}
       {[@expl:copied ensures #1] [%#sown'2] forall e: t_E. self = C_Err e  -> result = C_Err'0 e}
@@ -1396,13 +1396,13 @@ module M_own__qyi1738359920797260731__cloned [#"own.rs" 181 4 183 17] (* OwnResu
     
     | bb5 = s0 [ s0 =  [ &_0 <- C_Ok'0 _5 ] s1 | s1 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_OwnResult'0 = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & t: t_T = Any.any_l ()
     | & _5: t_T = Any.any_l ()
     | & e: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_OwnResult'0)-> {[@expl:cloned result type invariant] [%#sown'0] inv'3 result}
       {[@expl:cloned ensures] [%#sown'1] match { _p0 = self; _p1 = result } with
         | {_p0 = C_Ok s ; _p1 = C_Ok'0 r} -> postcondition () s r
@@ -1494,12 +1494,12 @@ module M_own__qyi10690551671874530681__copied [#"own.rs" 196 4 198 16] (* OwnRes
       | s4 = bb8 ]
     
     | bb8 = return''0 {_0} ]
-    )
+    
     [ & _0: t_OwnResult'0 = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & t: MutBorrow.t t_T = Any.any_l ()
     | & e: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_OwnResult'0)-> {[@expl:copied result type invariant] [%#sown'0] inv'3 result}
       {[@expl:copied ensures #0] [%#sown'1] forall t: MutBorrow.t t_T. self = C_Ok t
        -> result = C_Ok'0 (t.current) /\ resolve'0 t}
@@ -1673,13 +1673,13 @@ module M_own__qyi10690551671874530681__cloned [#"own.rs" 212 4 214 17] (* OwnRes
       [ s0 = {[@expl:type invariant] inv'1 t} s1 | s1 = -{resolve'0 t}- s2 | s2 =  [ &_0 <- C_Ok'0 _5 ] s3 | s3 = bb10 ]
     
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_OwnResult'0 = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & t: MutBorrow.t t_T = Any.any_l ()
     | & _5: t_T = Any.any_l ()
     | & e: t_E = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_OwnResult'0)-> {[@expl:cloned result type invariant] [%#sown'0] inv'4 result}
       {[@expl:cloned ensures] [%#sown'1] match { _p0 = self; _p1 = result } with
         | {_p0 = C_Ok s ; _p1 = C_Ok'0 r} -> postcondition () s.current r
@@ -1788,14 +1788,14 @@ module M_own__qyi11106003418932042655__transpose [#"own.rs" 228 4 228 53] (* Own
     | bb8 = s0 [ s0 =  [ &_0 <- C_Some'0 _8 ] s1 | s1 = bb15 ] 
     | bb6 = s0 [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = bb15 ] 
     | bb15 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self'0: t_OwnResult = self
     | & x: t_T = Any.any_l ()
     | & _8: t_OwnResult'0 = Any.any_l ()
     | & e: t_E = Any.any_l ()
     | & _11: t_OwnResult'0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:transpose result type invariant] [%#sown'0] inv'4 result}
       {[@expl:transpose ensures #0] [%#sown'1] self = C_Ok (C_None)  -> result = C_None'0}
       {[@expl:transpose ensures #1] [%#sown'2] forall t: t_T. self = C_Ok (C_Some t)  -> result = C_Some'0 (C_Ok'0 t)}

--- a/tests/should_succeed/result/result.coma
+++ b/tests/should_succeed/result/result.coma
@@ -750,7 +750,7 @@ module M_result__test_result [#"result.rs" 3 0 3 20]
     | bb18 = {[%#sresult'83] false} any
     | bb14 = {[%#sresult'84] false} any
     | bb7 = {[%#sresult'85] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & ok'0: t_Result = Any.any_l ()
     | & err'0: t_Result = Any.any_l ()
@@ -889,5 +889,5 @@ module M_result__test_result [#"result.rs" 3 0 3 20]
     | & _251: Int32.t = Any.any_l ()
     | & _252: t_Result = Any.any_l ()
     | & _253: t_Option'0 = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/rusthorn/inc_max.coma
+++ b/tests/should_succeed/rusthorn/inc_max.coma
@@ -108,7 +108,7 @@ module M_inc_max__take_max [#"inc_max.rs" 6 0 6 64]
       | s5 = -{resolve'0 ma'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t UInt32.t = Any.any_l ()
     | & ma'0: MutBorrow.t UInt32.t = ma
     | & mb'0: MutBorrow.t UInt32.t = mb
@@ -116,7 +116,7 @@ module M_inc_max__take_max [#"inc_max.rs" 6 0 6 64]
     | & _5: MutBorrow.t UInt32.t = Any.any_l ()
     | & _6: bool = Any.any_l ()
     | & _9: MutBorrow.t UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t UInt32.t)-> {[@expl:take_max ensures] [%#sinc_max] if UInt32.ge ma.current mb.current then
         mb.current = mb.final /\ result = ma
       else
@@ -242,7 +242,7 @@ module M_inc_max__inc_max [#"inc_max.rs" 11 0 11 38]
     
     | bb2 = return''0 {_0}
     | bb3 = {[%#sinc_max'0] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt32.t = a
     | & b'0: UInt32.t = b
@@ -252,5 +252,5 @@ module M_inc_max__inc_max [#"inc_max.rs" 11 0 11 38]
     | & _7: MutBorrow.t UInt32.t = Any.any_l ()
     | & _8: MutBorrow.t UInt32.t = Any.any_l ()
     | & _10: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/rusthorn/inc_max_3.coma
+++ b/tests/should_succeed/rusthorn/inc_max_3.coma
@@ -174,7 +174,7 @@ module M_inc_max_3__inc_max_3 [#"inc_max_3.rs" 12 0 12 79]
       | s3 = -{resolve'2 mb'0}- s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & ma'0: MutBorrow.t UInt32.t = ma
     | & mb'0: MutBorrow.t UInt32.t = mb
@@ -197,7 +197,7 @@ module M_inc_max_3__inc_max_3 [#"inc_max_3.rs" 12 0 12 79]
     | & _30: MutBorrow.t (MutBorrow.t UInt32.t) = Any.any_l ()
     | & _31: MutBorrow.t (MutBorrow.t UInt32.t) = Any.any_l ()
     | & _32: MutBorrow.t (MutBorrow.t UInt32.t) = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:inc_max_3 ensures] [%#sinc_max_3'2] ma.final <> mb.final
       /\ mb.final <> mc.final /\ mc.final <> ma.final}
       (! return' {result}) ]
@@ -322,7 +322,7 @@ module M_inc_max_3__test_inc_max_3 [#"inc_max_3.rs" 27 0 27 57]
     | bb3 = s0 [ s0 =  [ &_19 <- c'0 <> a'0 ] s1 | s1 = any [ br0 -> {_19 = false} (! bb8) | br1 -> {_19} (! bb4) ]  ] 
     | bb4 = return''0 {_0}
     | bb8 = {[%#sinc_max_3] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt32.t = a
     | & b'0: UInt32.t = b
@@ -337,5 +337,5 @@ module M_inc_max_3__test_inc_max_3 [#"inc_max_3.rs" 27 0 27 57]
     | & _13: bool = Any.any_l ()
     | & _16: bool = Any.any_l ()
     | & _19: bool = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/rusthorn/inc_max_many.coma
+++ b/tests/should_succeed/rusthorn/inc_max_many.coma
@@ -108,7 +108,7 @@ module M_inc_max_many__take_max [#"inc_max_many.rs" 6 0 6 64]
       | s5 = -{resolve'0 ma'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t UInt32.t = Any.any_l ()
     | & ma'0: MutBorrow.t UInt32.t = ma
     | & mb'0: MutBorrow.t UInt32.t = mb
@@ -116,7 +116,7 @@ module M_inc_max_many__take_max [#"inc_max_many.rs" 6 0 6 64]
     | & _5: MutBorrow.t UInt32.t = Any.any_l ()
     | & _6: bool = Any.any_l ()
     | & _9: MutBorrow.t UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t UInt32.t)-> {[@expl:take_max ensures] [%#sinc_max_many] if UInt32.ge ma.current mb.current then
         mb.current = mb.final /\ result = ma
       else
@@ -246,7 +246,7 @@ module M_inc_max_many__inc_max_many [#"inc_max_many.rs" 11 0 11 51]
     
     | bb6 = return''0 {_0}
     | bb5 = {[%#sinc_max_many] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt32.t = a
     | & b'0: UInt32.t = b
@@ -260,5 +260,5 @@ module M_inc_max_many__inc_max_many [#"inc_max_many.rs" 11 0 11 51]
     | & _14: UInt32.t = Any.any_l ()
     | & _17: bool = Any.any_l ()
     | & _19: UInt32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/rusthorn/inc_max_repeat.coma
+++ b/tests/should_succeed/rusthorn/inc_max_repeat.coma
@@ -108,7 +108,7 @@ module M_inc_max_repeat__take_max [#"inc_max_repeat.rs" 6 0 6 64]
       | s5 = -{resolve'0 ma'0}- s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t UInt32.t = Any.any_l ()
     | & ma'0: MutBorrow.t UInt32.t = ma
     | & mb'0: MutBorrow.t UInt32.t = mb
@@ -116,7 +116,7 @@ module M_inc_max_repeat__take_max [#"inc_max_repeat.rs" 6 0 6 64]
     | & _5: MutBorrow.t UInt32.t = Any.any_l ()
     | & _6: bool = Any.any_l ()
     | & _9: MutBorrow.t UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t UInt32.t)-> {[@expl:take_max ensures] [%#sinc_max_repeat] if UInt32.ge ma.current mb.current then
         mb.current = mb.final /\ result = ma
       else
@@ -366,7 +366,7 @@ module M_inc_max_repeat__inc_max_repeat [#"inc_max_repeat.rs" 11 0 11 53]
     
     | bb17 = return''0 {_0}
     | bb16 = {[%#sinc_max_repeat'7] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: UInt32.t = a
     | & b'0: UInt32.t = b
@@ -389,5 +389,5 @@ module M_inc_max_repeat__inc_max_repeat [#"inc_max_repeat.rs" 11 0 11 53]
     | & _36: UInt32.t = Any.any_l ()
     | & _39: bool = Any.any_l ()
     | & _41: UInt32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/rusthorn/inc_some_2_list.coma
+++ b/tests/should_succeed/rusthorn/inc_some_2_list.coma
@@ -75,13 +75,13 @@ module M_inc_some_2_list__qyi7504674480942992291__sum_x [#"inc_some_2_list.rs" 4
     
     | bb5 = s0 [ s0 = UInt32.add {a} {_8} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & self'0: t_List = self
     | & a: UInt32.t = Any.any_l ()
     | & l: t_List = Any.any_l ()
     | & _8: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:sum_x ensures] [%#sinc_some_2_list'1] UInt32.t'int result = sum self}
       (! return' {result}) ]
 
@@ -203,7 +203,7 @@ module M_inc_some_2_list__qyi7504674480942992291__take_some_rest [#"inc_some_2_l
     | bb10 = s0
       [ s0 = -{resolve'4 ml}- s1 | s1 = -{resolve'2 ma}- s2 | s2 = -{resolve'0 self'0}- s3 | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: tuple = Any.any_l ()
     | & self'0: MutBorrow.t t_List = self
     | & ma: MutBorrow.t UInt32.t = Any.any_l ()
@@ -213,7 +213,7 @@ module M_inc_some_2_list__qyi7504674480942992291__take_some_rest [#"inc_some_2_l
     | & _11: MutBorrow.t UInt32.t = Any.any_l ()
     | & _12: MutBorrow.t t_List = Any.any_l ()
     | & _13: MutBorrow.t t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:tuple)-> {[@expl:take_some_rest ensures #0] [%#sinc_some_2_list'0] sum self.final
       - sum self.current
       = UInt32.t'int (result._p0).final + sum (result._p1).final - view result._p0 - sum (result._p1).current}
@@ -326,7 +326,7 @@ module M_inc_some_2_list__inc_some_2_list [#"inc_some_2_list.rs" 65 0 65 51]
     
     | bb7 = return''0 {_0}
     | bb6 = {[%#sinc_some_2_list] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & l'0: t_List = l
     | & j'0: UInt32.t = j
@@ -343,5 +343,5 @@ module M_inc_some_2_list__inc_some_2_list [#"inc_some_2_list.rs" 65 0 65 51]
     | & _18: UInt32.t = Any.any_l ()
     | & _20: UInt32.t = Any.any_l ()
     | & _21: UInt32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/rusthorn/inc_some_2_tree.coma
+++ b/tests/should_succeed/rusthorn/inc_some_2_tree.coma
@@ -99,7 +99,7 @@ module M_inc_some_2_tree__qyi9454558703362393917__sum_x [#"inc_some_2_tree.rs" 4
     
     | bb6 = s0 [ s0 = UInt32.add {_10} {_14} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & self'0: t_Tree = self
     | & tl: t_Tree = Any.any_l ()
@@ -108,7 +108,7 @@ module M_inc_some_2_tree__qyi9454558703362393917__sum_x [#"inc_some_2_tree.rs" 4
     | & _10: UInt32.t = Any.any_l ()
     | & _11: UInt32.t = Any.any_l ()
     | & _14: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:sum_x ensures] [%#sinc_some_2_tree'2] UInt32.t'int result = sum self}
       (! return' {result}) ]
 
@@ -273,7 +273,7 @@ module M_inc_some_2_tree__qyi9454558703362393917__take_some_rest [#"inc_some_2_t
       | s3 = -{resolve'0 self'0}- s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: tuple = Any.any_l ()
     | & self'0: MutBorrow.t t_Tree = self
     | & mtl: MutBorrow.t t_Tree = Any.any_l ()
@@ -288,7 +288,7 @@ module M_inc_some_2_tree__qyi9454558703362393917__take_some_rest [#"inc_some_2_t
     | & _17: bool = Any.any_l ()
     | & _18: MutBorrow.t t_Tree = Any.any_l ()
     | & _19: MutBorrow.t t_Tree = Any.any_l () ]
-    
+    )
     [ return''0 (result:tuple)-> {[@expl:take_some_rest ensures #0] [%#sinc_some_2_tree'0] sum self.final
       - sum self.current
       = UInt32.t'int (result._p0).final + sum (result._p1).final - view result._p0 - sum (result._p1).current}
@@ -401,7 +401,7 @@ module M_inc_some_2_tree__inc_some_2_tree [#"inc_some_2_tree.rs" 85 0 85 51]
     
     | bb7 = return''0 {_0}
     | bb6 = {[%#sinc_some_2_tree] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & t'0: t_Tree = t
     | & j'0: UInt32.t = j
@@ -418,5 +418,5 @@ module M_inc_some_2_tree__inc_some_2_tree [#"inc_some_2_tree.rs" 85 0 85 51]
     | & _18: UInt32.t = Any.any_l ()
     | & _20: UInt32.t = Any.any_l ()
     | & _21: UInt32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/rusthorn/inc_some_list.coma
+++ b/tests/should_succeed/rusthorn/inc_some_list.coma
@@ -75,13 +75,13 @@ module M_inc_some_list__qyi14489061725823948544__sum_x [#"inc_some_list.rs" 42 4
     
     | bb5 = s0 [ s0 = UInt32.add {a} {_8} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb6 ] 
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & self'0: t_List = self
     | & a: UInt32.t = Any.any_l ()
     | & l: t_List = Any.any_l ()
     | & _8: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:sum_x ensures] [%#sinc_some_list'1] UInt32.t'int result = sum self}
       (! return' {result}) ]
 
@@ -221,7 +221,7 @@ module M_inc_some_list__qyi14489061725823948544__take_some [#"inc_some_list.rs" 
       | s10 = -{resolve'0 self'0}- s11
       | s11 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t UInt32.t = Any.any_l ()
     | & self'0: MutBorrow.t t_List = self
     | & _2: MutBorrow.t UInt32.t = Any.any_l ()
@@ -235,7 +235,7 @@ module M_inc_some_list__qyi14489061725823948544__take_some [#"inc_some_list.rs" 
     | & _14: MutBorrow.t UInt32.t = Any.any_l ()
     | & _15: MutBorrow.t UInt32.t = Any.any_l ()
     | & _16: MutBorrow.t t_List = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t UInt32.t)-> {[@expl:take_some ensures #0] [%#sinc_some_list'0] sum self.final
       - sum self.current
       = UInt32.t'int result.final - view result}
@@ -316,7 +316,7 @@ module M_inc_some_list__inc_some_list [#"inc_some_list.rs" 63 0 63 41]
     
     | bb6 = return''0 {_0}
     | bb5 = {[%#sinc_some_list] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & l'0: t_List = l
     | & k'0: UInt32.t = k
@@ -326,5 +326,5 @@ module M_inc_some_list__inc_some_list [#"inc_some_list.rs" 63 0 63 41]
     | & _10: bool = Any.any_l ()
     | & _11: UInt32.t = Any.any_l ()
     | & _13: UInt32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/rusthorn/inc_some_tree.coma
+++ b/tests/should_succeed/rusthorn/inc_some_tree.coma
@@ -99,7 +99,7 @@ module M_inc_some_tree__qyi12127997673864742005__sum_x [#"inc_some_tree.rs" 45 4
     
     | bb6 = s0 [ s0 = UInt32.add {_10} {_14} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb7 ] 
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & self'0: t_Tree = self
     | & tl: t_Tree = Any.any_l ()
@@ -108,7 +108,7 @@ module M_inc_some_tree__qyi12127997673864742005__sum_x [#"inc_some_tree.rs" 45 4
     | & _10: UInt32.t = Any.any_l ()
     | & _11: UInt32.t = Any.any_l ()
     | & _14: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:sum_x ensures] [%#sinc_some_tree'2] UInt32.t'int result = sum self}
       (! return' {result}) ]
 
@@ -277,7 +277,7 @@ module M_inc_some_tree__qyi12127997673864742005__take_some [#"inc_some_tree.rs" 
       | s11 = -{resolve'0 self'0}- s12
       | s12 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t UInt32.t = Any.any_l ()
     | & self'0: MutBorrow.t t_Tree = self
     | & _2: MutBorrow.t UInt32.t = Any.any_l ()
@@ -295,7 +295,7 @@ module M_inc_some_tree__qyi12127997673864742005__take_some [#"inc_some_tree.rs" 
     | & _19: MutBorrow.t t_Tree = Any.any_l ()
     | & _20: MutBorrow.t UInt32.t = Any.any_l ()
     | & _21: MutBorrow.t t_Tree = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t UInt32.t)-> {[@expl:take_some ensures #0] [%#sinc_some_tree'0] sum self.final
       - sum self.current
       = UInt32.t'int result.final - view result}
@@ -376,7 +376,7 @@ module M_inc_some_tree__inc_some_tree [#"inc_some_tree.rs" 83 0 83 41]
     
     | bb6 = return''0 {_0}
     | bb5 = {[%#sinc_some_tree] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & t'0: t_Tree = t
     | & k'0: UInt32.t = k
@@ -386,5 +386,5 @@ module M_inc_some_tree__inc_some_tree [#"inc_some_tree.rs" 83 0 83 41]
     | & _10: bool = Any.any_l ()
     | & _11: UInt32.t = Any.any_l ()
     | & _13: UInt32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/selection_sort_generic.coma
+++ b/tests/should_succeed/selection_sort_generic.coma
@@ -545,7 +545,7 @@ module M_selection_sort_generic__selection_sort [#"selection_sort_generic.rs" 31
        ]
     
     | bb11 = s0 [ s0 = {[@expl:type invariant] inv'7 v'0} s1 | s1 = -{resolve'4 v'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & old_v: MutBorrow.t t_Vec = Any.any_l ()
@@ -581,7 +581,7 @@ module M_selection_sort_generic__selection_sort [#"selection_sort_generic.rs" 31
     | & _69: MutBorrow.t (Slice64.slice t_T) = Any.any_l ()
     | & _70: MutBorrow.t t_Vec = Any.any_l ()
     | & old_6_0: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:selection_sort ensures #0] [%#sselection_sort_generic'17] sorted (deep_model'0 v.final)}
       {[@expl:selection_sort ensures #1] [%#sselection_sort_generic'18] permutation_of (view v.final) (view'1 v)}
       (! return' {result}) ]

--- a/tests/should_succeed/simple_trigger.coma
+++ b/tests/should_succeed/simple_trigger.coma
@@ -50,7 +50,7 @@ module M_simple_trigger__test [#"simple_trigger.rs" 15 0 15 13]
   
   meta "select_lsinst" "all"
   
-  let rec test[#"simple_trigger.rs" 15 0 15 13] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec test[#"simple_trigger.rs" 15 0 15 13] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> {[@expl:test ensures] [%#ssimple_trigger] id 1 = 1} (! return' {result}) ] 
+    ) [ return''0 (result:())-> {[@expl:test ensures] [%#ssimple_trigger] id 1 = 1} (! return' {result}) ] 
 end

--- a/tests/should_succeed/slices/01.coma
+++ b/tests/should_succeed/slices/01.coma
@@ -41,13 +41,13 @@ module M_01__index_slice [#"01.rs" 6 0 6 36]
     | bb1 = s0
       [ s0 = Slice64.get <UInt32.t> {a'0} {_3} (fun (r:UInt32.t) ->  [ &_0 <- r ] s1) | s1 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & a'0: Slice64.slice UInt32.t = a
     | & _3: UInt64.t = Any.any_l ()
     | & _4: UInt64.t = Any.any_l ()
     | & _5: bool = Any.any_l () ]
-     [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
 end
 module M_01__index_mut_slice [#"01.rs" 12 0 12 37]
   let%span s01 = "01.rs" 13 6 13 7
@@ -112,14 +112,14 @@ module M_01__index_mut_slice [#"01.rs" 12 0 12 37]
       | s1 = -{resolve'0 a'0}- s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: MutBorrow.t (Slice64.slice UInt32.t) = a
     | & _4: UInt64.t = Any.any_l ()
     | & _5: Opaque.ptr = Any.any_l ()
     | & _6: UInt64.t = Any.any_l ()
     | & _7: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:index_mut_slice ensures] [%#s01'3] UInt32.t'int (index_logic a.final 2) = 3}
       (! return' {result}) ]
 
@@ -242,7 +242,7 @@ module M_01__slice_first [#"01.rs" 20 0 20 44]
     
     | bb4 = s0 [ s0 =  [ &_0 <- C_None ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & a'0: Slice64.slice t_T = a
     | & _3: bool = Any.any_l ()
@@ -251,7 +251,7 @@ module M_01__slice_first [#"01.rs" 20 0 20 44]
     | & _8: UInt64.t = Any.any_l ()
     | & _9: UInt64.t = Any.any_l ()
     | & _10: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:slice_first result type invariant] [%#s01'3] inv'5 result}
       {[@expl:slice_first ensures] [%#s01'4] match result with
         | C_Some v -> v = index_logic a 0

--- a/tests/should_succeed/slices/02_std.coma
+++ b/tests/should_succeed/slices/02_std.coma
@@ -172,12 +172,12 @@ module M_02_std__binary_search [#"02_std.rs" 8 0 8 40]
     | bb2 = s0
       [ s0 = {[@expl:assertion] [%#s02_std] UInt64.t'int ix < 5} s1 | s1 =  [ &_0 <- ix ] s2 | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & s'0: Slice64.slice UInt32.t = s
     | & ix: UInt64.t = Any.any_l ()
     | & _5: t_Result = Any.any_l ()
     | & _8: UInt32.t = Any.any_l ()
     | & _12: UInt32.t = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/slices/range.coma
+++ b/tests/should_succeed/slices/range.coma
@@ -163,7 +163,7 @@ module M_range__slice_range_inclusive [#"range.rs" 6 0 6 43]
       | s3 = -{resolve'0 a'0}- s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: MutBorrow.t (Slice64.slice UInt32.t) = a
     | & s: MutBorrow.t (Slice64.slice UInt32.t) = Any.any_l ()
@@ -178,7 +178,7 @@ module M_range__slice_range_inclusive [#"range.rs" 6 0 6 43]
     | & _13: Opaque.ptr = Any.any_l ()
     | & _14: UInt64.t = Any.any_l ()
     | & _15: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:slice_range_inclusive ensures] [%#srange'8] view a.final
       = Seq.create 4 [|(0: UInt32.t);(1: UInt32.t);(1: UInt32.t);(0: UInt32.t)|]}
       (! return' {result}) ]

--- a/tests/should_succeed/sparse_array.coma
+++ b/tests/should_succeed/sparse_array.coma
@@ -390,7 +390,7 @@ module M_sparse_array__qyi16402981711463100202__get [#"sparse_array.rs" 101 4 10
     | bb5 = s0 [ s0 =  [ &_20 <- _21 ] s1 | s1 =  [ &_0 <- C_Some _20 ] s2 | s2 = bb9 ] 
     | bb8 = s0 [ s0 =  [ &_0 <- C_None ] s1 | s1 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & self'0: t_Sparse = self
     | & i'0: UInt64.t = i
@@ -401,7 +401,7 @@ module M_sparse_array__qyi16402981711463100202__get [#"sparse_array.rs" 101 4 10
     | & _15: UInt64.t = Any.any_l ()
     | & _20: t_T = Any.any_l ()
     | & _21: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:get result type invariant] [%#ssparse_array'1] inv'7 result}
       {[@expl:get ensures #0] [%#ssparse_array'2] match result with
         | C_None -> Seq.get (view'4 self) (UInt64.t'int i) = C_None'0
@@ -1308,7 +1308,7 @@ module M_sparse_array__qyi16402981711463100202__set [#"sparse_array.rs" 157 4 15
       | s5 = bb16 ]
     
     | bb16 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Sparse = self
     | & i'0: UInt64.t = i
@@ -1325,7 +1325,7 @@ module M_sparse_array__qyi16402981711463100202__set [#"sparse_array.rs" 157 4 15
     | & _31: MutBorrow.t t_Vec'0 = Any.any_l ()
     | & _34: MutBorrow.t UInt64.t = Any.any_l ()
     | & _35: MutBorrow.t t_Vec'0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:set ensures #0] [%#ssparse_array'5] Seq.length (view'4 self.final)
       = Seq.length (view'5 self)}
       {[@expl:set ensures #1] [%#ssparse_array'6] forall j: int. 0 <= j
@@ -1507,14 +1507,14 @@ module M_sparse_array__create [#"sparse_array.rs" 179 0 179 56]
       | s1 = bb6 ]
     
     | bb6 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Sparse = Any.any_l ()
     | & sz'0: UInt64.t = sz
     | & dummy'0: t_T = dummy
     | & _6: t_Vec = Any.any_l ()
     | & _9: t_Vec'0 = Any.any_l ()
     | & _11: t_Vec'0 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Sparse)-> {[@expl:create result type invariant] [%#ssparse_array'3] inv'3 result}
       {[@expl:create ensures #0] [%#ssparse_array'4] Seq.length (view'1 result) = UInt64.t'int sz}
       {[@expl:create ensures #1] [%#ssparse_array'5] forall i: int. 0 <= i /\ i < UInt64.t'int sz
@@ -1807,7 +1807,7 @@ module M_sparse_array__f [#"sparse_array.rs" 185 0 185 10]
       | s2 = bb16 ]
     
     | bb16 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & default: Int32.t = Any.any_l ()
     | & a: t_Sparse = Any.any_l ()
@@ -1826,7 +1826,7 @@ module M_sparse_array__f [#"sparse_array.rs" 185 0 185 10]
     | & _32: t_Option'0 = Any.any_l ()
     | & _36: t_Option'0 = Any.any_l ()
     | & _38: t_Option'0 = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_sparse_array__qyi1509881402265219485__resolve_coherence__refines [#"sparse_array.rs" 60 4 60 30] (* <Sparse<T> as creusot_contracts::Resolve> *)
   let%span ssparse_array = "sparse_array.rs" 60 4 60 30

--- a/tests/should_succeed/spec_tests.coma
+++ b/tests/should_succeed/spec_tests.coma
@@ -16,9 +16,9 @@ module M_spec_tests__test_specs [#"spec_tests.rs" 20 0 20 19]
   
   meta "select_lsinst" "all"
   
-  let rec test_specs[#"spec_tests.rs" 20 0 20 19] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec test_specs[#"spec_tests.rs" 20 0 20 19] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:test_specs ensures #0] [%#sspec_tests] C_A = C_B}
       {[@expl:test_specs ensures #1] [%#sspec_tests'0] { t_S__0 = (0: UInt32.t); t_S__1 = true }
       = { t_S__0 = (1: UInt32.t); t_S__1 = false }}

--- a/tests/should_succeed/specification/division.coma
+++ b/tests/should_succeed/specification/division.coma
@@ -19,11 +19,11 @@ module M_division__divide [#"division.rs" 6 0 6 36]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt32.div {y'0} {_5} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & y'0: UInt32.t = y
     | & x'0: UInt32.t = x
     | & _5: UInt32.t = Any.any_l ()
     | & _6: bool = Any.any_l () ]
-     [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/specification/forall.coma
+++ b/tests/should_succeed/specification/forall.coma
@@ -8,7 +8,7 @@ module M_forall__f [#"forall.rs" 6 0 6 10]
   
   meta "select_lsinst" "all"
   
-  let rec f[#"forall.rs" 6 0 6 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+  let rec f[#"forall.rs" 6 0 6 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:f ensures] [%#sforall] forall _x: UInt32.t. true
       /\ true /\ true /\ true /\ true /\ true /\ true /\ true /\ true}
       (! return' {result}) ]

--- a/tests/should_succeed/specification/logic_call.coma
+++ b/tests/should_succeed/specification/logic_call.coma
@@ -15,7 +15,7 @@ module M_logic_call__dummy [#"logic_call.rs" 11 0 11 21]
   
   let rec dummy[#"logic_call.rs" 11 0 11 21] (return'  (x:UInt32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#slogic_call] (0: UInt32.t) ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32.t = Any.any_l () ] 
+     [ & _0: UInt32.t = Any.any_l () ] )
     [ return''0 (result:UInt32.t)-> {[@expl:dummy ensures] [%#slogic_call'0] reflexive result} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/specification/logic_functions.coma
+++ b/tests/should_succeed/specification/logic_functions.coma
@@ -11,9 +11,9 @@ module M_logic_functions__use_logic [#"logic_functions.rs" 10 0 10 18]
   
   meta "select_lsinst" "all"
   
-  let rec use_logic[#"logic_functions.rs" 10 0 10 18] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec use_logic[#"logic_functions.rs" 10 0 10 18] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> {[@expl:use_logic ensures] [%#slogic_functions] logic} (! return' {result}) ] 
+    ) [ return''0 (result:())-> {[@expl:use_logic ensures] [%#slogic_functions] logic} (! return' {result}) ] 
 end
 module M_logic_functions__use_logic_pearlite [#"logic_functions.rs" 19 0 19 27]
   let%span slogic_functions = "logic_functions.rs" 18 10 18 26
@@ -28,9 +28,9 @@ module M_logic_functions__use_logic_pearlite [#"logic_functions.rs" 19 0 19 27]
   
   meta "select_lsinst" "all"
   
-  let rec use_logic_pearlite[#"logic_functions.rs" 19 0 19 27] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec use_logic_pearlite[#"logic_functions.rs" 19 0 19 27] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:use_logic_pearlite ensures] [%#slogic_functions] logic_pearlite}
       (! return' {result}) ]
 

--- a/tests/should_succeed/specification/loops.coma
+++ b/tests/should_succeed/specification/loops.coma
@@ -9,5 +9,5 @@ module M_loops__while_loop_variant [#"loops.rs" 4 0 4 34]
     [ bb0 = bb1
     | bb1 = bb1'0 [ bb1'0 = (! bb2) [ bb2 = any [ br0 -> {x'0 = false} (! bb4) | br1 -> {x'0} (! bb1'0) ]  ]  ] 
     | bb4 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x'0: bool = x ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & x'0: bool = x ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/specification/model.coma
+++ b/tests/should_succeed/specification/model.coma
@@ -23,7 +23,7 @@ module M_model__test_arc [#"model.rs" 41 0 41 41]
   
   let rec test_arc[#"model.rs" 41 0 41 41] (a:t_Arc) (return'  (x:()))= {[@expl:test_arc requires] [%#smodel] view (view'0 a)
     = 0}
-    (! bb0 [ bb0 = bb1 | bb1 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+    (! bb0 [ bb0 = bb1 | bb1 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -52,7 +52,7 @@ module M_model__test_rc [#"model.rs" 44 0 44 37]
   
   let rec test_rc[#"model.rs" 44 0 44 37] (v:t_Rc) (return'  (x:()))= {[@expl:test_rc requires] [%#smodel] view (view'0 v)
     = 0}
-    (! bb0 [ bb0 = bb1 | bb1 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+    (! bb0 [ bb0 = bb1 | bb1 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/specification/opaque.coma
+++ b/tests/should_succeed/specification/opaque.coma
@@ -22,5 +22,5 @@ module M_opaque__test [#"opaque.rs" 20 0 20 13]
       | s1 = {[@expl:assertion] [%#sopaque'0] transparent_crate} s2
       | s2 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/specification/trusted.coma
+++ b/tests/should_succeed/specification/trusted.coma
@@ -15,7 +15,7 @@ module M_trusted__victim_of_lie [#"trusted.rs" 17 0 17 29]
   
   let rec victim_of_lie[#"trusted.rs" 17 0 17 29] (return'  (x:UInt32.t))= (! bb0
     [ bb0 = s0 [ s0 = lie (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: UInt32.t = Any.any_l () ] 
+     [ & _0: UInt32.t = Any.any_l () ] )
     [ return''0 (result:UInt32.t)-> {[@expl:victim_of_lie ensures] [%#strusted] result = (10: UInt32.t)}
       (! return' {result}) ]
 
@@ -44,7 +44,7 @@ module M_trusted__innocent_victim [#"trusted.rs" 29 0 29 31]
     [ bb0 = s0 [ s0 = my_unverified_code (fun (_ret:UInt32.t) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = im_out_of_control (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: UInt32.t = Any.any_l () | & _2: UInt32.t = Any.any_l () ] 
+     [ & _0: UInt32.t = Any.any_l () | & _2: UInt32.t = Any.any_l () ] )
     [ return''0 (result:UInt32.t)-> {[@expl:innocent_victim ensures] [%#strusted] result = (10: UInt32.t)}
       (! return' {result}) ]
 

--- a/tests/should_succeed/split_borrow.coma
+++ b/tests/should_succeed/split_borrow.coma
@@ -9,7 +9,7 @@ module M_split_borrow__z [#"split_borrow.rs" 5 0 5 14]
   
   let rec z[#"split_borrow.rs" 5 0 5 14] (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#ssplit_borrow] true ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () ]  [ return''0 (result:bool)-> (! return' {result}) ] 
+     [ & _0: bool = Any.any_l () ] ) [ return''0 (result:bool)-> (! return' {result}) ] 
 end
 module M_split_borrow__f [#"split_borrow.rs" 9 0 9 10]
   let%span ssplit_borrow = "split_borrow.rs" 10 23 10 24
@@ -61,7 +61,7 @@ module M_split_borrow__f [#"split_borrow.rs" 9 0 9 10]
       | s2 = bb4 ]
     
     | bb4 = s0 [ s0 = -{resolve'0 y}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: tuple = Any.any_l ()
     | & _2: t_MyInt = Any.any_l ()
@@ -70,7 +70,7 @@ module M_split_borrow__f [#"split_borrow.rs" 9 0 9 10]
     | & _6: bool = Any.any_l ()
     | & _7: t_MyInt = Any.any_l ()
     | & _8: t_MyInt = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_split_borrow__g [#"split_borrow.rs" 23 0 23 10]
   let%span ssplit_borrow = "split_borrow.rs" 24 23 24 24
@@ -121,7 +121,7 @@ module M_split_borrow__g [#"split_borrow.rs" 23 0 23 10]
       | s8 = -{resolve'2 x}- s9
       | s9 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: tuple = Any.any_l ()
     | & _2: t_MyInt = Any.any_l ()
@@ -129,5 +129,5 @@ module M_split_borrow__g [#"split_borrow.rs" 23 0 23 10]
     | & x: MutBorrow.t tuple = Any.any_l ()
     | & _z: MutBorrow.t t_MyInt = Any.any_l ()
     | & _6: t_MyInt = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/std_types.coma
+++ b/tests/should_succeed/std_types.coma
@@ -13,7 +13,7 @@ module M_std_types__x [#"std_types.rs" 5 0 5 20]
   
   meta "select_lsinst" "all"
   
-  let rec x[#"std_types.rs" 5 0 5 20] (_x:t_MyType) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec x[#"std_types.rs" 5 0 5 20] (_x:t_MyType) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/such_that.coma
+++ b/tests/should_succeed/such_that.coma
@@ -52,14 +52,14 @@ module M_such_that__foo [#"such_that.rs" 4 0 4 12]
       | s2 = bb5 ]
     
     | bb5 = s0 [ s0 = {[@expl:assertion] [%#ssuch_that'5] x'0 + Int32.to_int y + 1 = 0} s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: int = Any.any_l ()
     | & y: Int32.t = Any.any_l ()
     | & mapping: Map.map int int = Any.any_l ()
     | & predicate': Map.map int bool = Any.any_l ()
     | & x'0: int = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_such_that__even [#"such_that.rs" 18 0 18 16]
   let%span ssuch_that = "such_that.rs" 19 4 19 5
@@ -75,7 +75,7 @@ module M_such_that__even [#"such_that.rs" 18 0 18 16]
   
   let rec even[#"such_that.rs" 18 0 18 16] (return'  (x:Int32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#ssuch_that] (2: Int32.t) ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int32.t = Any.any_l () ] 
+     [ & _0: Int32.t = Any.any_l () ] )
     [ return''0 (result:Int32.t)-> {[@expl:even ensures] [%#ssuch_that'0] Int.mod (Int32.to_int result) 2 = 0}
       (! return' {result}) ]
 

--- a/tests/should_succeed/sum.coma
+++ b/tests/should_succeed/sum.coma
@@ -168,7 +168,7 @@ module M_sum__sum_first_n [#"sum.rs" 6 0 6 33]
        ]
     
     | bb10 = s0 [ s0 =  [ &_0 <- sum ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & n'0: UInt32.t = n
     | & sum: UInt32.t = Any.any_l ()
@@ -182,7 +182,7 @@ module M_sum__sum_first_n [#"sum.rs" 6 0 6 33]
     | & __creusot_proc_iter_elem: UInt32.t = Any.any_l ()
     | & _24: Seq.seq UInt32.t = Any.any_l ()
     | & i: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:sum_first_n ensures] [%#ssum'7] UInt32.t'int result
       = Int.div (UInt32.t'int n * (UInt32.t'int n + 1)) 2}
       (! return' {result}) ]

--- a/tests/should_succeed/sum_of_odds.coma
+++ b/tests/should_succeed/sum_of_odds.coma
@@ -219,7 +219,7 @@ module M_sum_of_odds__compute_sum_of_odd [#"sum_of_odds.rs" 32 0 32 36]
        ]
     
     | bb9 = s0 [ s0 =  [ &_0 <- s ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt32.t = Any.any_l ()
     | & x'0: UInt32.t = x
     | & s: UInt32.t = Any.any_l ()
@@ -235,7 +235,7 @@ module M_sum_of_odds__compute_sum_of_odd [#"sum_of_odds.rs" 32 0 32 36]
     | & i: UInt32.t = Any.any_l ()
     | & _30: UInt32.t = Any.any_l ()
     | & _31: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt32.t)-> {[@expl:compute_sum_of_odd ensures] [%#ssum_of_odds'10] UInt32.t'int result
       = sum_of_odd (UInt32.t'int x)}
       (! return' {result}) ]
@@ -297,7 +297,7 @@ module M_sum_of_odds__test [#"sum_of_odds.rs" 46 0 46 19]
         s1
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & x'0: UInt32.t = x | & y: UInt32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x'0: UInt32.t = x | & y: UInt32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/swap_borrows.coma
+++ b/tests/should_succeed/swap_borrows.coma
@@ -21,9 +21,9 @@ module M_swap_borrows__swap [#"swap_borrows.rs" 5 0 5 31]
   meta "select_lsinst" "all"
   
   let rec swap[#"swap_borrows.rs" 5 0 5 31] (x:tuple) (return'  (x'0:tuple))= {[@expl:swap 'x' type invariant] [%#sswap_borrows] inv'0 x}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- { _p0 = x'0._p1; _p1 = x'0._p0 } ] s1 | s1 = bb3 ]  | bb3 = return''0 {_0} ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- { _p0 = x'0._p1; _p1 = x'0._p0 } ] s1 | s1 = bb3 ]  | bb3 = return''0 {_0} ] 
     [ & _0: tuple = Any.any_l () | & x'0: tuple = x ]
-    
+    )
     [ return''0 (result:tuple)-> {[@expl:swap result type invariant] [%#sswap_borrows'0] inv'0 result}
       {[@expl:swap ensures] [%#sswap_borrows'1] result = { _p0 = x._p1; _p1 = x._p0 }}
       (! return' {result}) ]
@@ -95,7 +95,7 @@ module M_swap_borrows__f [#"swap_borrows.rs" 10 0 10 10]
       | s5 = {[@expl:assertion] [%#sswap_borrows'3] a = (0: UInt32.t)} s6
       | s6 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: UInt32.t = Any.any_l ()
     | & b: UInt32.t = Any.any_l ()
@@ -105,5 +105,5 @@ module M_swap_borrows__f [#"swap_borrows.rs" 10 0 10 10]
     | & _6: MutBorrow.t UInt32.t = Any.any_l ()
     | & _7: MutBorrow.t UInt32.t = Any.any_l ()
     | & _8: MutBorrow.t UInt32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/switch.coma
+++ b/tests/should_succeed/switch.coma
@@ -27,7 +27,7 @@ module M_switch__test [#"switch.rs" 9 0 9 35]
       | s2 = bb5 ]
     
     | bb5 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & o'0: t_Option = o | & x: UInt32.t = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () | & o'0: t_Option = o | & x: UInt32.t = Any.any_l () ] )
     [ return''0 (result:bool)-> (! return' {result}) ]
 
 end
@@ -56,7 +56,7 @@ module M_switch__test2 [#"switch.rs" 16 0 16 42]
     | bb3 = s0 [ s0 =  [ &_0 <- o'0._p1 ] s1 | s1 = bb5 ] 
     | bb4 = s0 [ s0 = v_Some {o'0._p0} (fun (r0:UInt32.t) ->  [ &x <- r0 ] s1) | s1 =  [ &_0 <- x ] s2 | s2 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: UInt32.t = Any.any_l () | & o'0: tuple = o | & x: UInt32.t = Any.any_l () ] 
+     [ & _0: UInt32.t = Any.any_l () | & o'0: tuple = o | & x: UInt32.t = Any.any_l () ] )
     [ return''0 (result:UInt32.t)-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/switch_struct.coma
+++ b/tests/should_succeed/switch_struct.coma
@@ -36,10 +36,10 @@ module M_switch_struct__test [#"switch_struct.rs" 8 0 8 30]
       | s2 = bb5 ]
     
     | bb5 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & o'0: t_M = o
     | & field1: UInt32.t = Any.any_l ()
     | & field2: UInt32.t = Any.any_l () ]
-     [ return''0 (result:bool)-> (! return' {result}) ] 
+    ) [ return''0 (result:bool)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/syntax/01_idents.coma
+++ b/tests/should_succeed/syntax/01_idents.coma
@@ -5,9 +5,9 @@ module M_01_idents__clone [#"01_idents.rs" 3 0 3 14]
   
   meta "select_lsinst" "all"
   
-  let rec clone'[#"01_idents.rs" 3 0 3 14] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec clone'[#"01_idents.rs" 3 0 3 14] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_idents__function [#"01_idents.rs" 5 0 5 17]
   use creusot.prelude.Any
@@ -16,9 +16,9 @@ module M_01_idents__function [#"01_idents.rs" 5 0 5 17]
   
   meta "select_lsinst" "all"
   
-  let rec function'[#"01_idents.rs" 5 0 5 17] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec function'[#"01_idents.rs" 5 0 5 17] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_idents__import [#"01_idents.rs" 7 0 7 15]
   use creusot.prelude.Any
@@ -27,9 +27,9 @@ module M_01_idents__import [#"01_idents.rs" 7 0 7 15]
   
   meta "select_lsinst" "all"
   
-  let rec import'[#"01_idents.rs" 7 0 7 15] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec import'[#"01_idents.rs" 7 0 7 15] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_idents__export [#"01_idents.rs" 9 0 9 15]
   use creusot.prelude.Any
@@ -38,9 +38,9 @@ module M_01_idents__export [#"01_idents.rs" 9 0 9 15]
   
   meta "select_lsinst" "all"
   
-  let rec export'[#"01_idents.rs" 9 0 9 15] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec export'[#"01_idents.rs" 9 0 9 15] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_idents__result [#"01_idents.rs" 11 0 11 15]
   use creusot.prelude.Any
@@ -49,9 +49,9 @@ module M_01_idents__result [#"01_idents.rs" 11 0 11 15]
   
   meta "select_lsinst" "all"
   
-  let rec result[#"01_idents.rs" 11 0 11 15] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec result[#"01_idents.rs" 11 0 11 15] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result'0:())-> (! return' {result'0}) ] 
+    ) [ return''0 (result'0:())-> (! return' {result'0}) ] 
 end
 module M_01_idents__qy95zaqy95z [#"01_idents.rs" 13 0 13 12]
   use creusot.prelude.Any
@@ -60,9 +60,9 @@ module M_01_idents__qy95zaqy95z [#"01_idents.rs" 13 0 13 12]
   
   meta "select_lsinst" "all"
   
-  let rec qy95zaqy95z[#"01_idents.rs" 13 0 13 12] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec qy95zaqy95z[#"01_idents.rs" 13 0 13 12] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_idents__qy95z_a_qy113zyqy95z_bqy95zqy95zqy95z_cqy95zqy95z [#"01_idents.rs" 16 0 16 25]
   use creusot.prelude.Any
@@ -73,7 +73,7 @@ module M_01_idents__qy95z_a_qy113zyqy95z_bqy95zqy95zqy95z_cqy95zqy95z [#"01_iden
   
   let rec qy95z_a_qy113zyqy95z_bqy95zqy95zqy95z_cqy95zqy95z[#"01_idents.rs" 16 0 16 25] (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_idents__F [#"01_idents.rs" 19 0 19 10]
   use creusot.prelude.Any
@@ -82,9 +82,9 @@ module M_01_idents__F [#"01_idents.rs" 19 0 19 10]
   
   meta "select_lsinst" "all"
   
-  let rec v_F[#"01_idents.rs" 19 0 19 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec v_F[#"01_idents.rs" 19 0 19 10] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_idents__v_F [#"01_idents.rs" 22 0 22 12]
   use creusot.prelude.Any
@@ -93,9 +93,9 @@ module M_01_idents__v_F [#"01_idents.rs" 22 0 22 12]
   
   meta "select_lsinst" "all"
   
-  let rec v_v_F[#"01_idents.rs" 22 0 22 12] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec v_v_F[#"01_idents.rs" 22 0 22 12] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_01_idents__qy95zqy974z [#"01_idents.rs" 34 0 34 11]
   let%span s01_idents = "01_idents.rs" 35 12 35 13
@@ -124,12 +124,12 @@ module M_01_idents__qy95zqy974z [#"01_idents.rs" 34 0 34 11]
       | s4 =  [ &_1 <- [%#s01_idents'1] (3: Int32.t) ] s5
       | s5 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v_A: Int32.t = Any.any_l ()
     | & _937_: t_qy214z = Any.any_l ()
     | & _3: t_qy931z = Any.any_l ()
     | & _0'0: Int32.t = Any.any_l ()
     | & _1: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/syntax/02_operators.coma
+++ b/tests/should_succeed/syntax/02_operators.coma
@@ -20,13 +20,13 @@ module M_02_operators__division [#"02_operators.rs" 8 0 8 40]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt64.div {x'0} {_5} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & x'0: UInt64.t = x
     | & y'0: UInt64.t = y
     | & _5: UInt64.t = Any.any_l ()
     | & _6: bool = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end
 module M_02_operators__modulus [#"02_operators.rs" 23 0 23 39]
   let%span s02_operators = "02_operators.rs" 24 4 24 9
@@ -50,13 +50,13 @@ module M_02_operators__modulus [#"02_operators.rs" 23 0 23 39]
       | s3 = bb1 ]
     
     | bb1 = s0 [ s0 = UInt64.rem {x'0} {_5} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & x'0: UInt64.t = x
     | & y'0: UInt64.t = y
     | & _5: UInt64.t = Any.any_l ()
     | & _6: bool = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end
 module M_02_operators__multiply [#"02_operators.rs" 38 0 38 40]
   let%span s02_operators = "02_operators.rs" 37 11 37 33
@@ -76,7 +76,7 @@ module M_02_operators__multiply [#"02_operators.rs" 38 0 38 40]
     <= UInt64.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64.mul {x'0} {y'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & x'0: UInt64.t = x | & y'0: UInt64.t = y ] 
+     [ & _0: UInt64.t = Any.any_l () | & x'0: UInt64.t = x | & y'0: UInt64.t = y ] )
     [ return''0 (result:UInt64.t)-> (! return' {result}) ]
 
 end
@@ -98,7 +98,7 @@ module M_02_operators__add [#"02_operators.rs" 48 0 48 35]
     <= UInt64.t'int v_MAX}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64.add {x'0} {y'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & x'0: UInt64.t = x | & y'0: UInt64.t = y ] 
+     [ & _0: UInt64.t = Any.any_l () | & x'0: UInt64.t = x | & y'0: UInt64.t = y ] )
     [ return''0 (result:UInt64.t)-> (! return' {result}) ]
 
 end
@@ -118,7 +118,7 @@ module M_02_operators__sub [#"02_operators.rs" 63 0 63 35]
     >= 0}
     (! bb0
     [ bb0 = s0 [ s0 = UInt64.sub {x'0} {y'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt64.t = Any.any_l () | & x'0: UInt64.t = x | & y'0: UInt64.t = y ] 
+     [ & _0: UInt64.t = Any.any_l () | & x'0: UInt64.t = x | & y'0: UInt64.t = y ] )
     [ return''0 (result:UInt64.t)-> (! return' {result}) ]
 
 end
@@ -164,7 +164,7 @@ module M_02_operators__expression [#"02_operators.rs" 77 0 77 51]
       | s2 =  [ &_0 <- _7 = _13 ] s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & x'0: UInt64.t = x
     | & y'0: UInt64.t = y
@@ -177,7 +177,7 @@ module M_02_operators__expression [#"02_operators.rs" 77 0 77 51]
     | & _14: UInt64.t = Any.any_l ()
     | & _16: UInt64.t = Any.any_l ()
     | & _17: bool = Any.any_l () ]
-     [ return''0 (result:bool)-> {[@expl:expression ensures] [%#s02_operators'3] result} (! return' {result}) ] 
+    ) [ return''0 (result:bool)-> {[@expl:expression ensures] [%#s02_operators'3] result} (! return' {result}) ] 
 end
 module M_02_operators__primitive_comparison [#"02_operators.rs" 92 0 92 29]
   let%span s02_operators = "02_operators.rs" 91 10 91 20
@@ -255,7 +255,7 @@ module M_02_operators__primitive_comparison [#"02_operators.rs" 92 0 92 29]
   
   let rec primitive_comparison[#"02_operators.rs" 92 0 92 29] (x:t_X) (return'  (x'0:()))= (! bb0
     [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:primitive_comparison ensures] [%#s02_operators] UInt64.le x.t_X__a x.t_X__a}
       (! return' {result}) ]
 
@@ -271,7 +271,7 @@ module M_02_operators__bool_eq [#"02_operators.rs" 95 0 95 36]
   
   let rec bool_eq[#"02_operators.rs" 95 0 95 36] (a:bool) (b:bool) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- a'0 = b'0 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & a'0: bool = a | & b'0: bool = b ] 
+     [ & _0: bool = Any.any_l () | & a'0: bool = a | & b'0: bool = b ] )
     [ return''0 (result:bool)-> {[@expl:bool_eq ensures] [%#s02_operators] result = (a = b)} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/syntax/04_assoc_prec.coma
+++ b/tests/should_succeed/syntax/04_assoc_prec.coma
@@ -14,9 +14,9 @@ module M_04_assoc_prec__respect_prec [#"04_assoc_prec.rs" 12 0 12 34]
   
   meta "select_lsinst" "all"
   
-  let rec respect_prec[#"04_assoc_prec.rs" 12 0 12 34] (x:tuple) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec respect_prec[#"04_assoc_prec.rs" 12 0 12 34] (x:tuple) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:respect_prec ensures #0] [%#s04_assoc_prec] 5 = 3  -> 2 + 1 = 3}
       {[@expl:respect_prec ensures #1] [%#s04_assoc_prec'0] Int.div (5 * 3) 2 <> 4 * (40 + 1)}
       {[@expl:respect_prec ensures #2] [%#s04_assoc_prec'1] x._p0 = x._p1}
@@ -33,7 +33,7 @@ module M_04_assoc_prec__respect_assoc [#"04_assoc_prec.rs" 15 0 15 22]
   
   meta "select_lsinst" "all"
   
-  let rec respect_assoc[#"04_assoc_prec.rs" 15 0 15 22] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec respect_assoc[#"04_assoc_prec.rs" 15 0 15 22] (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> {[@expl:respect_assoc ensures] [%#s04_assoc_prec] 0 + 1 = 0} (! return' {result}) ] 
+    ) [ return''0 (result:())-> {[@expl:respect_assoc ensures] [%#s04_assoc_prec] 0 + 1 = 0} (! return' {result}) ] 
 end

--- a/tests/should_succeed/syntax/05_annotations.coma
+++ b/tests/should_succeed/syntax/05_annotations.coma
@@ -23,5 +23,5 @@ module M_05_annotations__assertion [#"05_annotations.rs" 5 0 5 25]
       | s3 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_T = x ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & x'0: t_T = x ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/syntax/05_pearlite.coma
+++ b/tests/should_succeed/syntax/05_pearlite.coma
@@ -44,9 +44,9 @@ module M_05_pearlite__struct_in_pearlite [#"05_pearlite.rs" 26 0 26 31]
   
   meta "select_lsinst" "all"
   
-  let rec struct_in_pearlite[#"05_pearlite.rs" 26 0 26 31] (x:t_A) (return'  (x'0:()))= (! bb0
-    [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ] 
+  let rec struct_in_pearlite[#"05_pearlite.rs" 26 0 26 31] (x:t_A) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0} ] 
+    [ & _0: () = Any.any_l () ]
+    )
     [ return''0 (result:())-> {[@expl:struct_in_pearlite ensures] [%#s05_pearlite] x = { t_A__a = false }}
       (! return' {result}) ]
 
@@ -64,9 +64,9 @@ module M_05_pearlite__struct_order [#"05_pearlite.rs" 34 0 34 25]
   
   meta "select_lsinst" "all"
   
-  let rec struct_order[#"05_pearlite.rs" 34 0 34 25] (x:t_B) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec struct_order[#"05_pearlite.rs" 34 0 34 25] (x:t_B) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:struct_order ensures] [%#s05_pearlite] x
       = { t_B__field1 = false; t_B__field2 = (0: UInt32.t) }}
       (! return' {result}) ]
@@ -85,7 +85,7 @@ module M_05_pearlite__ghost_closure [#"05_pearlite.rs" 50 0 50 22]
   
   let rec ghost_closure[#"05_pearlite.rs" 50 0 50 22] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_x <- [%#s05_pearlite] fun (a: UInt32.t) -> a ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _x: Map.map UInt32.t UInt32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & _x: Map.map UInt32.t UInt32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -100,7 +100,7 @@ module M_05_pearlite__pearlite_closure [#"05_pearlite.rs" 54 0 54 57]
   
   let rec pearlite_closure[#"05_pearlite.rs" 54 0 54 57] (_x:Map.map UInt32.t bool) (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_05_pearlite__caller [#"05_pearlite.rs" 56 0 56 15]
   let%span s05_pearlite = "05_pearlite.rs" 57 21 57 44
@@ -121,7 +121,7 @@ module M_05_pearlite__caller [#"05_pearlite.rs" 56 0 56 15]
     [ bb0 = s0 [ s0 =  [ &_2 <- [%#s05_pearlite] fun (_a: UInt32.t) -> true ] s1 | s1 = bb1 ] 
     | bb1 = s0 [ s0 = pearlite_closure {_2} (fun (_ret:()) ->  [ &_1 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _1: () = Any.any_l () | & _2: Map.map UInt32.t bool = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & _1: () = Any.any_l () | & _2: Map.map UInt32.t bool = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/syntax/07_extern_spec.coma
+++ b/tests/should_succeed/syntax/07_extern_spec.coma
@@ -9,7 +9,7 @@ module M_07_extern_spec__qyi17893701863040683958__func [#"07_extern_spec.rs" 11 
   
   let rec func[#"07_extern_spec.rs" 11 4 11 34] (self_:()) (s:()) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#s07_extern_spec] true ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () ]  [ return''0 (result:bool)-> (! return' {result}) ] 
+     [ & _0: bool = Any.any_l () ] ) [ return''0 (result:bool)-> (! return' {result}) ] 
 end
 module M_07_extern_spec__extern_spec_UseSelf_i32_func_body [#"07_extern_spec.rs" 30 8 30 40]
   let%span s07_extern_spec = "07_extern_spec.rs" 31 21 31 22
@@ -24,7 +24,7 @@ module M_07_extern_spec__extern_spec_UseSelf_i32_func_body [#"07_extern_spec.rs"
   
   let rec extern_spec_UseSelf_i32_func_body[#"07_extern_spec.rs" 30 8 30 40] (self_:Int32.t) (s:Int32.t) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- self_'0 = ([%#s07_extern_spec] (1: Int32.t)) ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () | & self_'0: Int32.t = self_ ] 
+     [ & _0: bool = Any.any_l () | & self_'0: Int32.t = self_ ] )
     [ return''0 (result:bool)-> {[@expl:extern_spec_UseSelf_i32_func_body ensures] [%#s07_extern_spec'0] result
       = (self_ = (1: Int32.t))}
       (! return' {result}) ]

--- a/tests/should_succeed/syntax/09_maintains.coma
+++ b/tests/should_succeed/syntax/09_maintains.coma
@@ -13,7 +13,7 @@ module M_09_maintains__test_1 [#"09_maintains.rs" 28 0 28 36]
   meta "select_lsinst" "all"
   
   let rec test_1[#"09_maintains.rs" 28 0 28 36] (a:()) (b:bool) (c:UInt64.t) (return'  (x:()))= {[@expl:test_1 requires] [%#s09_maintains] invariant' a b c}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:test_1 ensures] [%#s09_maintains] invariant' a b c} (! return' {result}) ]
 
 end
@@ -40,9 +40,11 @@ module M_09_maintains__test_2 [#"09_maintains.rs" 31 0 31 41]
   meta "select_lsinst" "all"
   
   let rec test_2[#"09_maintains.rs" 31 0 31 41] (a:MutBorrow.t ()) (b:bool) (c:UInt64.t) (return'  (x:()))= {[@expl:test_2 requires] [%#s09_maintains] invariant' a.current b c}
-    (! bb0 [ bb0 = s0 [ s0 = -{resolve'0 a'0}- s1 | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 = -{resolve'0 a'0}- s1 | s1 = return''0 {_0} ]  ] 
     [ & _0: () = Any.any_l () | & a'0: MutBorrow.t () = a ]
-     [ return''0 (result:())-> {[@expl:test_2 ensures] [%#s09_maintains] invariant' a.final b c} (! return' {result}) ] 
+    )
+    [ return''0 (result:())-> {[@expl:test_2 ensures] [%#s09_maintains] invariant' a.final b c} (! return' {result}) ]
+
 end
 module M_09_maintains__test_3 [#"09_maintains.rs" 34 0 34 46]
   let%span s09_maintains = "09_maintains.rs" 33 0 33 41
@@ -73,9 +75,9 @@ module M_09_maintains__test_3 [#"09_maintains.rs" 34 0 34 46]
   meta "select_lsinst" "all"
   
   let rec test_3[#"09_maintains.rs" 34 0 34 46] (a:MutBorrow.t ()) (b:MutBorrow.t bool) (c:UInt64.t) (return'  (x:()))= {[@expl:test_3 requires] [%#s09_maintains] invariant' a.current b.current c}
-    (! bb0 [ bb0 = s0 [ s0 = -{resolve'0 b'0}- s1 | s1 = -{resolve'2 a'0}- s2 | s2 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 = -{resolve'0 b'0}- s1 | s1 = -{resolve'2 a'0}- s2 | s2 = return''0 {_0} ]  ] 
     [ & _0: () = Any.any_l () | & a'0: MutBorrow.t () = a | & b'0: MutBorrow.t bool = b ]
-    
+    )
     [ return''0 (result:())-> {[@expl:test_3 ensures] [%#s09_maintains] invariant' a.final b.final c}
       (! return' {result}) ]
 
@@ -97,7 +99,7 @@ module M_09_maintains__test_5 [#"09_maintains.rs" 37 0 37 29]
   
   let rec test_5[#"09_maintains.rs" 37 0 37 29] (a:()) (b:UInt64.t) (return'  (x:()))= {[@expl:test_5 requires] [%#s09_maintains] inv2 a (UInt64.t'int b
     + 0)}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:test_5 ensures] [%#s09_maintains] inv2 a (UInt64.t'int b + 0)}
       (! return' {result}) ]
 
@@ -116,7 +118,7 @@ module M_09_maintains__test_6 [#"09_maintains.rs" 40 0 40 28]
   meta "select_lsinst" "all"
   
   let rec test_6[#"09_maintains.rs" 40 0 40 28] (a:()) (b:bool) (return'  (x:()))= {[@expl:test_6 requires] [%#s09_maintains] other_inv a b}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:test_6 ensures] [%#s09_maintains] other_inv a b} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/syntax/10_mutual_rec_types.coma
+++ b/tests/should_succeed/syntax/10_mutual_rec_types.coma
@@ -16,7 +16,7 @@ module M_10_mutual_rec_types__use_tree [#"10_mutual_rec_types.rs" 15 0 15 25]
   
   let rec use_tree[#"10_mutual_rec_types.rs" 15 0 15 25] (_0:t_Tree) (return'  (x:()))= (! bb0
     [ bb0 = return''0 {_0'0} ]
-    ) [ & _0'0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0'0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_10_mutual_rec_types__qyi18211245992252154719__height [#"10_mutual_rec_types.rs" 18 4 18 31] (* Tree *)
   let%span s10_mutual_rec_types = "10_mutual_rec_types.rs" 21 69 21 70
@@ -79,12 +79,12 @@ module M_10_mutual_rec_types__qyi18211245992252154719__height [#"10_mutual_rec_t
     
     | bb4 = s0 [ s0 =  [ &_0 <- [%#s10_mutual_rec_types'0] (0: UInt64.t) ] s1 | s1 = bb8 ] 
     | bb8 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: t_Tree = self
     | & n: t_Node = Any.any_l ()
     | & _4: UInt64.t = Any.any_l ()
     | & _5: UInt64.t = Any.any_l ()
     | & _7: UInt64.t = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/syntax/11_array_types.coma
+++ b/tests/should_succeed/syntax/11_array_types.coma
@@ -41,7 +41,7 @@ module M_11_array_types__omg [#"11_array_types.rs" 8 0 8 28]
       | s1 = {[@expl:assertion] [%#s11_array_types'2] Int64.to_int (index_logic x'0.t_UsesArray__0 0) = 5} s2
       | s2 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_UsesArray = x | & _3: UInt64.t = Any.any_l () | & _4: bool = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x'0: t_UsesArray = x | & _3: UInt64.t = Any.any_l () | & _4: bool = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -83,7 +83,7 @@ module M_11_array_types__call_omg [#"11_array_types.rs" 14 0 14 17]
       | s3 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & arr: Slice64.array Int64.t = Any.any_l () | & _2: t_UsesArray = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & arr: Slice64.array Int64.t = Any.any_l () | & _2: t_UsesArray = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/syntax/12_ghost_code.coma
+++ b/tests/should_succeed/syntax/12_ghost_code.coma
@@ -10,7 +10,7 @@ module M_12_ghost_code__ghost_arg [#"12_ghost_code.rs" 4 0 4 34]
   
   let rec ghost_arg[#"12_ghost_code.rs" 4 0 4 34] (g:UInt32.t) (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_x <- [%#s12_ghost_code] g'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & g'0: UInt32.t = g | & _x: UInt32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & g'0: UInt32.t = g | & _x: UInt32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -62,7 +62,7 @@ module M_12_ghost_code__ghost_vec [#"12_ghost_code.rs" 8 0 8 18]
     [ bb0 = s0 [ s0 = new (fun (_ret:t_Vec) ->  [ &x <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &_s <- [%#s12_ghost_code] x ] s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x: t_Vec = Any.any_l () | & _s: t_Vec = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x: t_Vec = Any.any_l () | & _s: t_Vec = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end
@@ -87,12 +87,12 @@ module M_12_ghost_code__ghost_copy [#"12_ghost_code.rs" 17 0 17 19]
     
     | bb1 = s0 [ s0 =  [ &_4 <- [%#s12_ghost_code'1] Seq.snoc _s a ] s1 | s1 = bb2 ] 
     | bb2 = s0 [ s0 =  [ &_s <- _4 ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a: Int32.t = Any.any_l ()
     | & _s: Seq.seq Int32.t = Any.any_l ()
     | & _4: Seq.seq Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_12_ghost_code__ghost_is_copy [#"12_ghost_code.rs" 23 0 23 22]
   let%span s12_ghost_code = "12_ghost_code.rs" 24 16 24 17
@@ -129,14 +129,14 @@ module M_12_ghost_code__ghost_is_copy [#"12_ghost_code.rs" 23 0 23 22]
       | s2 = {[@expl:assertion] [%#s12_ghost_code'1] g1 = g2} s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: Int32.t = Any.any_l ()
     | & r: MutBorrow.t Int32.t = Any.any_l ()
     | & g: MutBorrow.t Int32.t = Any.any_l ()
     | & g1: MutBorrow.t Int32.t = Any.any_l ()
     | & g2: MutBorrow.t Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_12_ghost_code__ghost_check [#"12_ghost_code.rs" 35 0 35 20]
   let%span s12_ghost_code = "12_ghost_code.rs" 39 4 39 31
@@ -224,7 +224,7 @@ module M_12_ghost_code__ghost_check [#"12_ghost_code.rs" 35 0 35 20]
     
     | bb7 = return''0 {_0}
     | bb6 = {[%#s12_ghost_code'2] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & x: t_Vec = Any.any_l ()
     | & _2: () = Any.any_l ()
@@ -232,7 +232,7 @@ module M_12_ghost_code__ghost_check [#"12_ghost_code.rs" 35 0 35 20]
     | & _5: MutBorrow.t t_Vec = Any.any_l ()
     | & _7: bool = Any.any_l ()
     | & _8: UInt64.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_12_ghost_code__takes_struct [#"12_ghost_code.rs" 52 0 52 36]
   let%span s12_ghost_code = "12_ghost_code.rs" 53 10 53 27
@@ -261,7 +261,7 @@ module M_12_ghost_code__takes_struct [#"12_ghost_code.rs" 52 0 52 36]
     (! bb0
     [ bb0 = s0 [ s0 =  [ &_3 <- [%#s12_ghost_code] x'0.t_MyStruct__f ] s1 | s1 = bb1 ] 
     | bb1 = s0 [ s0 =  [ &x'0 <- { x'0 with t_MyStruct__g = _3 } ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_MyStruct = x | & _3: UInt32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x'0: t_MyStruct = x | & _3: UInt32.t = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/syntax/13_vec_macro.coma
+++ b/tests/should_succeed/syntax/13_vec_macro.coma
@@ -114,11 +114,11 @@ module M_13_vec_macro__x [#"13_vec_macro.rs" 5 0 5 10]
     | bb4 = s0 [ s0 = into_vec {_10} (fun (_ret:t_Vec'0) ->  [ &v2 <- _ret ] s1) | s1 = bb5 ] 
     | bb5 = s0 [ s0 = {[@expl:assertion] [%#s13_vec_macro'6] Seq.length (view'0 v2) = 3} s1 | s1 = bb8 ] 
     | bb8 = return''0 {_0} ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v0: t_Vec = Any.any_l ()
     | & v1: t_Vec'0 = Any.any_l ()
     | & v2: t_Vec'0 = Any.any_l ()
     | & _10: Slice64.array Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/syntax/14_const_fns.coma
+++ b/tests/should_succeed/syntax/14_const_fns.coma
@@ -16,5 +16,5 @@ module M_14_const_fns__omg [#"14_const_fns.rs" 5 0 5 31]
       [ s0 = Int32.sub {x'0} {[%#s14_const_fns] (1: Int32.t)} (fun (_ret:Int32.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: Int32.t = Any.any_l () | & x'0: Int32.t = x ]  [ return''0 (result:Int32.t)-> (! return' {result}) ] 
+     [ & _0: Int32.t = Any.any_l () | & x'0: Int32.t = x ] ) [ return''0 (result:Int32.t)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/syntax/derive_macros/default.coma
+++ b/tests/should_succeed/syntax/derive_macros/default.coma
@@ -9,7 +9,7 @@ module M_default__qyi3915135727482750158__default [#"default.rs" 4 9 4 16] (* <U
   
   let rec default[#"default.rs" 4 9 4 16] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- () ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:default ensures] [%#sdefault] true} (! return' {result}) ]
 
 end
@@ -147,7 +147,7 @@ module M_default__qyi13740418467561183253__default [#"default.rs" 7 9 7 16] (* <
     [ bb0 = s0 [ s0 = default (fun (_ret:Int32.t) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = default'0 (fun (_ret:Int64.t) ->  [ &_3 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- { t_Tuple__0 = _2; t_Tuple__1 = _3 } ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Tuple = Any.any_l () | & _2: Int32.t = Any.any_l () | & _3: Int64.t = Any.any_l () ] 
+     [ & _0: t_Tuple = Any.any_l () | & _2: Int32.t = Any.any_l () | & _3: Int64.t = Any.any_l () ] )
     [ return''0 (result:t_Tuple)-> {[@expl:default ensures] [%#sdefault] true
       /\ postcondition () () result.t_Tuple__0 /\ postcondition'0 () () result.t_Tuple__1}
       (! return' {result}) ]
@@ -308,7 +308,7 @@ module M_default__qyi8078909456326062290__default [#"default.rs" 10 9 10 16] (* 
     | bb1 = s0 [ s0 = default'0 (fun (_ret:t_T) ->  [ &_3 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- { t_Named__x = _2; t_Named__y = _3 } ] s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0: t_Named = Any.any_l () | & _2: Int32.t = Any.any_l () | & _3: t_T = Any.any_l () ] 
+     [ & _0: t_Named = Any.any_l () | & _2: Int32.t = Any.any_l () | & _3: t_T = Any.any_l () ] )
     [ return''0 (result:t_Named)-> {[@expl:default result type invariant] [%#sdefault] inv'0 result}
       {[@expl:default ensures] [%#sdefault] true
       /\ postcondition () () result.t_Named__x /\ postcondition'0 () () result.t_Named__y}
@@ -330,7 +330,7 @@ module M_default__qyi4734115080308954550__default [#"default.rs" 16 9 16 16] (* 
   
   let rec default[#"default.rs" 16 9 16 16] (return'  (x:t_EUnit))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- C_Y ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_EUnit = Any.any_l () ] 
+     [ & _0: t_EUnit = Any.any_l () ] )
     [ return''0 (result:t_EUnit)-> {[@expl:default ensures] [%#sdefault] match result with
         | C_Y -> true
         | _ -> false
@@ -439,7 +439,7 @@ module M_default__qyi14004758275928035824__default [#"default.rs" 23 9 23 16] (*
     [ bb0 = s0 [ s0 = default (fun (_ret:Int32.t) ->  [ &_2 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = default (fun (_ret:Int32.t) ->  [ &_3 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- C_A _2 _3 ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_ETuple = Any.any_l () | & _2: Int32.t = Any.any_l () | & _3: Int32.t = Any.any_l () ] 
+     [ & _0: t_ETuple = Any.any_l () | & _2: Int32.t = Any.any_l () | & _3: Int32.t = Any.any_l () ] )
     [ return''0 (result:t_ETuple)-> {[@expl:default ensures] [%#sdefault] match result with
         | C_A x0 x1 -> true /\ postcondition () () x0 /\ postcondition () () x1
         | _ -> false
@@ -616,7 +616,7 @@ module M_default__qyi4220271428403486757__default [#"default.rs" 32 9 32 16] (* 
     | bb1 = s0 [ s0 = default'0 (fun (_ret:t_U) ->  [ &_3 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = s0 [ s0 =  [ &_0 <- C_A _2 _3 ] s1 | s1 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    ) [ & _0: t_ENamed = Any.any_l () | & _2: t_T = Any.any_l () | & _3: t_U = Any.any_l () ] 
+     [ & _0: t_ENamed = Any.any_l () | & _2: t_T = Any.any_l () | & _3: t_U = Any.any_l () ] )
     [ return''0 (result:t_ENamed)-> {[@expl:default result type invariant] [%#sdefault] inv'1 result}
       {[@expl:default ensures] [%#sdefault] match result with
         | C_A x y -> true /\ postcondition () () x /\ postcondition'0 () () y

--- a/tests/should_succeed/syntax/derive_macros/mixed.coma
+++ b/tests/should_succeed/syntax/derive_macros/mixed.coma
@@ -195,14 +195,14 @@ module M_mixed__qyi2592445413368279263__clone [#"mixed.rs" 8 9 8 14] (* <Product
     
     | bb2 = s0 [ s0 =  [ &_0 <- { t_Product__a = _3; t_Product__b = _6 } ] s1 | s1 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Product = Any.any_l ()
     | & self'0: t_Product = self
     | & _3: t_A = Any.any_l ()
     | & _5: t_A = Any.any_l ()
     | & _6: t_B = Any.any_l ()
     | & _8: t_B = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Product)-> {[@expl:clone result type invariant] [%#smixed] inv'3 result}
       {[@expl:clone ensures] [%#smixed'0] postcondition () self.t_Product__a result.t_Product__a
       /\ postcondition'0 () self.t_Product__b result.t_Product__b}
@@ -332,7 +332,7 @@ module M_mixed__qyi15378480724732772077__eq [#"mixed.rs" 8 16 8 25] (* <Product<
     
     | bb3 = s0 [ s0 =  [ &_0 <- [%#smixed] false ] s1 | s1 = bb5 ] 
     | bb5 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & self'0: t_Product = self | & rhs'0: t_Product = rhs | & _4: bool = Any.any_l () ] 
+     [ & _0: bool = Any.any_l () | & self'0: t_Product = self | & rhs'0: t_Product = rhs | & _4: bool = Any.any_l () ] )
     [ return''0 (result:bool)-> {[@expl:eq ensures] [%#smixed'0] result = (deep_model'4 self = deep_model'4 rhs)}
       (! return' {result}) ]
 
@@ -554,7 +554,7 @@ module M_mixed__qyi1267749258272586863__clone [#"mixed.rs" 28 9 28 14] (* <Sum<A
     
     | bb5 = s0 [ s0 =  [ &_0 <- C_A _5 ] s1 | s1 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Sum = Any.any_l ()
     | & self'0: t_Sum = self
     | & v0_1: t_A = Any.any_l ()
@@ -563,7 +563,7 @@ module M_mixed__qyi1267749258272586863__clone [#"mixed.rs" 28 9 28 14] (* <Sum<A
     | & b_1: t_B = Any.any_l ()
     | & _9: t_B = Any.any_l ()
     | & _11: t_B = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Sum)-> {[@expl:clone result type invariant] [%#smixed] inv'3 result}
       {[@expl:clone ensures] [%#smixed] match { _p0 = self; _p1 = result } with
         | {_p0 = C_A v0_1 ; _p1 = C_A v0_r} -> postcondition () v0_1 v0_r
@@ -734,7 +734,7 @@ module M_mixed__qyi16267973469411556781__eq [#"mixed.rs" 28 16 28 25] (* <Sum<A,
     | bb9 = s0 [ s0 =  [ &_0 <- [%#smixed] true ] s1 | s1 = bb16 ] 
     | bb10 = s0 [ s0 =  [ &_0 <- [%#smixed] false ] s1 | s1 = bb16 ] 
     | bb16 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self'0: t_Sum = self
     | & rhs'0: t_Sum = rhs
@@ -745,7 +745,7 @@ module M_mixed__qyi16267973469411556781__eq [#"mixed.rs" 28 16 28 25] (* <Sum<A,
     | & b_1: t_B = Any.any_l ()
     | & b_2: t_B = Any.any_l ()
     | & _17: bool = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:eq ensures] [%#smixed] result = (deep_model'4 self = deep_model'4 rhs)}
       (! return' {result}) ]
 
@@ -1147,7 +1147,7 @@ module M_mixed__qyi2388806976216935010__clone [#"mixed.rs" 56 18 56 23] (* <Sum2
     
     | bb5 = s0 [ s0 =  [ &_0 <- C_X _5 ] s1 | s1 = bb10 ] 
     | bb10 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Sum2 = Any.any_l ()
     | & self'0: t_Sum2 = self
     | & v0_1: t_A = Any.any_l ()
@@ -1159,7 +1159,7 @@ module M_mixed__qyi2388806976216935010__clone [#"mixed.rs" 56 18 56 23] (* <Sum2
     | & _12: bool = Any.any_l ()
     | & _13: t_B = Any.any_l ()
     | & _15: t_B = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Sum2)-> {[@expl:clone result type invariant] [%#smixed] inv'3 result}
       {[@expl:clone ensures] [%#smixed] match { _p0 = self; _p1 = result } with
         | {_p0 = C_X v0_1 ; _p1 = C_X v0_r} -> postcondition () v0_1 v0_r

--- a/tests/should_succeed/syntax/int_suffix.coma
+++ b/tests/should_succeed/syntax/int_suffix.coma
@@ -29,7 +29,7 @@ module M_int_suffix__foo [#"int_suffix.rs" 5 0 5 26]
     | bb1 = s0 [ s0 = into_inner {_3} (fun (_ret:int) ->  [ &_2 <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = s0 [ s0 = new'0 {_2} (fun (_ret: int) ->  [ &_0 <- _ret ] s1) | s1 = bb3 ] 
     | bb3 = return''0 {_0} ]
-    ) [ & _0:  int = Any.any_l () | & _2: int = Any.any_l () | & _3:  int = Any.any_l () ] 
+     [ & _0:  int = Any.any_l () | & _2: int = Any.any_l () | & _3:  int = Any.any_l () ] )
     [ return''0 (result: int)-> {[@expl:foo ensures] [%#sint_suffix'0] result = 1} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/take_first_mut.coma
+++ b/tests/should_succeed/take_first_mut.coma
@@ -310,7 +310,7 @@ module M_take_first_mut__take_first_mut [#"take_first_mut.rs" 14 0 14 74]
       [ s0 =  [ &_0 <- C_None'0 ] s1 | s1 = {[@expl:type invariant] inv'3 _5} s2 | s2 = -{resolve'1 _5}- s3 | s3 = bb7 ]
     
     | bb7 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'0 = Any.any_l ()
     | & self_'0: MutBorrow.t (MutBorrow.t (Slice64.slice t_T)) = self_
     | & _3: t_Option = Any.any_l ()
@@ -321,7 +321,7 @@ module M_take_first_mut__take_first_mut [#"take_first_mut.rs" 14 0 14 74]
     | & rem: MutBorrow.t (Slice64.slice t_T) = Any.any_l ()
     | & _11: MutBorrow.t (Slice64.slice t_T) = Any.any_l ()
     | & _12: MutBorrow.t t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option'0)-> {[@expl:take_first_mut result type invariant] [%#stake_first_mut'0] inv'8 result}
       {[@expl:take_first_mut ensures] [%#stake_first_mut'1] match result with
         | C_Some'0 r -> r.current = index_logic (self_.current).current 0

--- a/tests/should_succeed/trait.coma
+++ b/tests/should_succeed/trait.coma
@@ -17,7 +17,7 @@ module M_trait__uses_custom [#"trait.rs" 9 0 9 54]
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv _t'0} s1 | s1 = -{resolve _t'0}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _t'0: t_T = _t ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & _t'0: t_T = _t ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_trait__uses_custom2 [#"trait.rs" 13 0 13 61]
   let%span strait = "trait.rs" 13 55 13 57
@@ -38,5 +38,5 @@ module M_trait__uses_custom2 [#"trait.rs" 13 0 13 61]
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv _t'0} s1 | s1 = -{resolve _t'0}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _t'0: t_T = _t ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & _t'0: t_T = _t ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/trait_impl.coma
+++ b/tests/should_succeed/trait_impl.coma
@@ -37,7 +37,7 @@ module M_trait_impl__qyi2836079215804511776__x [#"trait_impl.rs" 25 4 25 14] (* 
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv'1 self'0} s1 | s1 = -{resolve'2 self'0}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & self'0: tuple = self ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & self'0: tuple = self ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_trait_impl__qyi6561549274672949751__x [#"trait_impl.rs" 29 4 29 14] (* <u32 as T<B>> *)
   use creusot.int.UInt32
@@ -47,9 +47,9 @@ module M_trait_impl__qyi6561549274672949751__x [#"trait_impl.rs" 29 4 29 14] (* 
   
   meta "select_lsinst" "all"
   
-  let rec x[#"trait_impl.rs" 29 4 29 14] (self:UInt32.t) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec x[#"trait_impl.rs" 29 4 29 14] (self:UInt32.t) (return'  (x'0:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_trait_impl__qyi2836079215804511776__x__refines [#"trait_impl.rs" 25 4 25 14] (* <(T1, T2) as T<B>> *)
   let%span strait_impl = "trait_impl.rs" 25 4 25 14

--- a/tests/should_succeed/traits/01.coma
+++ b/tests/should_succeed/traits/01.coma
@@ -29,5 +29,5 @@ module M_01__uses_generic [#"01.rs" 8 0 8 38]
   let rec uses_generic[#"01.rs" 8 0 8 38] (b:t_T) (return'  (x:UInt32.t))= {[@expl:uses_generic 'b' type invariant] [%#s01] inv b}
     (! bb0
     [ bb0 = s0 [ s0 = from_b {b'0} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1) | s1 = bb2 ]  | bb2 = return''0 {_0} ]
-    ) [ & _0: UInt32.t = Any.any_l () | & b'0: t_T = b ]  [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
+     [ & _0: UInt32.t = Any.any_l () | & b'0: t_T = b ] ) [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/traits/02.coma
+++ b/tests/should_succeed/traits/02.coma
@@ -41,7 +41,7 @@ module M_02__omg [#"02.rs" 11 0 11 30]
     [ bb0 = s0 [ s0 = is_true {a'0} (fun (_ret:bool) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv a'0} s1 | s1 = -{resolve a'0}- s2 | s2 = bb2 ] 
     | bb2 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & a'0: t_T = a ] 
+     [ & _0: bool = Any.any_l () | & a'0: t_T = a ] )
     [ return''0 (result:bool)-> {[@expl:omg ensures] [%#s02'0] result = true} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/traits/03.coma
+++ b/tests/should_succeed/traits/03.coma
@@ -10,7 +10,7 @@ module M_03__qyi14704115191559214502__f [#"03.rs" 9 4 9 23] (* <i32 as A> *)
   
   let rec f[#"03.rs" 9 4 9 23] (self:Int32.t) (return'  (x:Int32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#s03] (0: Int32.t) ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: Int32.t = Any.any_l () ]  [ return''0 (result:Int32.t)-> (! return' {result}) ] 
+     [ & _0: Int32.t = Any.any_l () ] ) [ return''0 (result:Int32.t)-> (! return' {result}) ] 
 end
 module M_03__qyi2795904175370379619__g [#"03.rs" 20 4 20 23] (* <u32 as B> *)
   let%span s03 = "03.rs" 21 8 21 9
@@ -24,7 +24,7 @@ module M_03__qyi2795904175370379619__g [#"03.rs" 20 4 20 23] (* <u32 as B> *)
   
   let rec g[#"03.rs" 20 4 20 23] (self:UInt32.t) (return'  (x:UInt32.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#s03] (1: UInt32.t) ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32.t = Any.any_l () ]  [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
+     [ & _0: UInt32.t = Any.any_l () ] ) [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
 end
 module M_03__qyi4233438312138697795__h [#"03.rs" 30 4 30 24] (* <u32 as C> *)
   let%span s03 = "03.rs" 30 12 30 13
@@ -49,9 +49,9 @@ module M_03__qyi4233438312138697795__h [#"03.rs" 30 4 30 24] (* <u32 as C> *)
   meta "select_lsinst" "all"
   
   let rec h[#"03.rs" 30 4 30 24] (y:t_G) (return'  (x:t_G))= {[@expl:h 'y' type invariant] [%#s03] inv'0 y}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- y'0 ] s1 | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- y'0 ] s1 | s1 = return''0 {_0} ]  ] 
     [ & _0: t_G = Any.any_l () | & y'0: t_G = y ]
-     [ return''0 (result:t_G)-> {[@expl:h result type invariant] [%#s03'0] inv'0 result} (! return' {result}) ] 
+    ) [ return''0 (result:t_G)-> {[@expl:h result type invariant] [%#s03'0] inv'0 result} (! return' {result}) ] 
 end
 module M_03__qyi2795904175370379619__g__refines [#"03.rs" 20 4 20 23] (* <u32 as B> *)
   let%span s03 = "03.rs" 20 4 20 23

--- a/tests/should_succeed/traits/04.coma
+++ b/tests/should_succeed/traits/04.coma
@@ -79,11 +79,11 @@ module M_04__user [#"04.rs" 14 0 14 39]
     | bb4 = s0 [ s0 = func3 {a'0} {b'0} (fun (_ret:bool) ->  [ &_0 <- _ret ] s1) | s1 = bb9 ] 
     | bb7 = s0 [ s0 =  [ &_0 <- [%#s04] false ] s1 | s1 = bb9 ] 
     | bb9 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & a'0: t_T = a
     | & b'0: t_T = b
     | & _4: bool = Any.any_l ()
     | & _7: bool = Any.any_l () ]
-     [ return''0 (result:bool)-> {[@expl:user ensures] [%#s04'2] result = false} (! return' {result}) ] 
+    ) [ return''0 (result:bool)-> {[@expl:user ensures] [%#s04'2] result = false} (! return' {result}) ] 
 end

--- a/tests/should_succeed/traits/06.coma
+++ b/tests/should_succeed/traits/06.coma
@@ -48,7 +48,7 @@ module M_06__test [#"06.rs" 9 0 11 15]
     (! bb0
     [ bb0 = s0 [ s0 = ix {a'0} {[%#s06] (0: UInt64.t)} (fun (_ret:t_Tgt) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: t_Tgt = Any.any_l () | & a'0: t_T = a ] 
+     [ & _0: t_Tgt = Any.any_l () | & a'0: t_T = a ] )
     [ return''0 (result:t_Tgt)-> {[@expl:test result type invariant] [%#s06'1] inv'1 result} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/traits/07.coma
+++ b/tests/should_succeed/traits/07.coma
@@ -6,9 +6,9 @@ module M_07__qyi5864428518595652275__ix [#"07.rs" 11 4 11 36] (* <i32 as Ix> *)
   
   meta "select_lsinst" "all"
   
-  let rec ix[#"07.rs" 11 4 11 36] (self:Int32.t) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] )
+  let rec ix[#"07.rs" 11 4 11 36] (self:Int32.t) (return'  (x:()))= (! bb0 [ bb0 = return''0 {_0} ] 
     [ & _0: () = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_07__test [#"07.rs" 16 0 16 81]
   let%span s07 = "07.rs" 17 4 17 8
@@ -23,7 +23,7 @@ module M_07__test [#"07.rs" 16 0 16 81]
   
   let rec test[#"07.rs" 16 0 16 81] (_a:UInt32.t) (_b:UInt64.t) (return'  (x:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#s07] true ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () ]  [ return''0 (result:bool)-> (! return' {result}) ] 
+     [ & _0: bool = Any.any_l () ] ) [ return''0 (result:bool)-> (! return' {result}) ] 
 end
 module M_07__test2 [#"07.rs" 20 0 20 21]
   use creusot.int.Int32
@@ -37,5 +37,5 @@ module M_07__test2 [#"07.rs" 20 0 20 21]
   
   let rec test2[#"07.rs" 20 0 20 21] (a:Int32.t) (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 = ix {a'0} (fun (_ret:()) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & a'0: Int32.t = a ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & a'0: Int32.t = a ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/traits/08.coma
+++ b/tests/should_succeed/traits/08.coma
@@ -31,7 +31,7 @@ module M_08__Tr__program [#"08.rs" 10 4 10 21]
   meta "select_lsinst" "all"
   
   let rec program[#"08.rs" 10 4 10 21] (self:t_Self) (return'  (x:()))= {[@expl:program 'self' type invariant] [%#s08] inv'0 self}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_08__test [#"08.rs" 13 0 13 24]
   use creusot.prelude.Any
@@ -50,5 +50,5 @@ module M_08__test [#"08.rs" 13 0 13 24]
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv _1} s1 | s1 = -{resolve _1}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0'0} ]
-    ) [ & _0'0: () = Any.any_l () | & _1: t_T = _0 ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0'0: () = Any.any_l () | & _1: t_T = _0 ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/traits/09.coma
+++ b/tests/should_succeed/traits/09.coma
@@ -13,7 +13,7 @@ module M_09__test [#"09.rs" 7 0 7 43]
       [ s0 = UInt32.add {t'0} {[%#s09] (0: UInt32.t)} (fun (_ret:UInt32.t) ->  [ &_0 <- _ret ] s1)
       | s1 = return''0 {_0} ]
      ]
-    ) [ & _0: UInt32.t = Any.any_l () | & t'0: UInt32.t = t ]  [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
+     [ & _0: UInt32.t = Any.any_l () | & t'0: UInt32.t = t ] ) [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
 end
 module M_09__test2 [#"09.rs" 11 0 11 53]
   let%span s09 = "09.rs" 11 37 11 38
@@ -30,7 +30,7 @@ module M_09__test2 [#"09.rs" 11 0 11 53]
   meta "select_lsinst" "all"
   
   let rec test2[#"09.rs" 11 0 11 53] (t:t_X) (return'  (x:t_X))= {[@expl:test2 't' type invariant] [%#s09] inv t}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- t'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- t'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ] 
     [ & _0: t_X = Any.any_l () | & t'0: t_X = t ]
-     [ return''0 (result:t_X)-> {[@expl:test2 result type invariant] [%#s09'0] inv result} (! return' {result}) ] 
+    ) [ return''0 (result:t_X)-> {[@expl:test2 result type invariant] [%#s09'0] inv result} (! return' {result}) ] 
 end

--- a/tests/should_succeed/traits/11.coma
+++ b/tests/should_succeed/traits/11.coma
@@ -15,5 +15,5 @@ module M_11__test [#"11.rs" 18 0 18 23]
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv _1} s1 | s1 = -{resolve _1}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0'0} ]
-    ) [ & _0'0: () = Any.any_l () | & _1: t_T = _0 ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0'0: () = Any.any_l () | & _1: t_T = _0 ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/traits/12_default_method.coma
+++ b/tests/should_succeed/traits/12_default_method.coma
@@ -33,9 +33,9 @@ module M_12_default_method__T__default [#"12_default_method.rs" 6 4 6 28]
   meta "select_lsinst" "all"
   
   let rec default[#"12_default_method.rs" 6 4 6 28] (self:t_Self) (return'  (x:UInt32.t))= {[@expl:default 'self' type invariant] [%#s12_default_method'0] inv'0 self}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- [%#s12_default_method] (0: UInt32.t) ] s1 | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- [%#s12_default_method] (0: UInt32.t) ] s1 | s1 = return''0 {_0} ]  ] 
     [ & _0: UInt32.t = Any.any_l () ]
-     [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt32.t)-> (! return' {result}) ] 
 end
 module M_12_default_method__should_use_impl [#"12_default_method.rs" 20 0 20 30]
   let%span s12_default_method = "12_default_method.rs" 19 10 19 27
@@ -55,7 +55,7 @@ module M_12_default_method__should_use_impl [#"12_default_method.rs" 20 0 20 30]
   
   let rec should_use_impl[#"12_default_method.rs" 20 0 20 30] (x:UInt32.t) (return'  (x'0:()))= (! bb0
     [ bb0 = s0 [ s0 = default {x'0} (fun (_ret:UInt32.t) ->  [ &_3 <- _ret ] s1) | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x'0: UInt32.t = x | & _3: UInt32.t = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & x'0: UInt32.t = x | & _3: UInt32.t = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:should_use_impl ensures] [%#s12_default_method] logic_default x}
       (! return' {result}) ]
 

--- a/tests/should_succeed/traits/13_assoc_types.coma
+++ b/tests/should_succeed/traits/13_assoc_types.coma
@@ -28,7 +28,7 @@ module M_13_assoc_types__qyi11934247085425626303__model [#"13_assoc_types.rs" 13
     (! bb0
     [ bb0 = s0 [ s0 = model {self'0} (fun (_ret:t_ModelTy) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: t_ModelTy = Any.any_l () | & self'0: t_T = self ] 
+     [ & _0: t_ModelTy = Any.any_l () | & self'0: t_T = self ] )
     [ return''0 (result:t_ModelTy)-> {[@expl:model result type invariant] [%#s13_assoc_types'0] inv'1 result}
       (! return' {result}) ]
 

--- a/tests/should_succeed/traits/15_impl_interfaces.coma
+++ b/tests/should_succeed/traits/15_impl_interfaces.coma
@@ -11,5 +11,5 @@ module M_15_impl_interfaces__calls [#"15_impl_interfaces.rs" 23 0 23 36]
   
   let rec calls[#"15_impl_interfaces.rs" 23 0 23 36] (a:()) (return'  (x'0:()))= {[@expl:calls requires] [%#s15_impl_interfaces] x a
     = ()}
-    (! bb0 [ bb0 = return''0 {_0} ] ) [ & _0: () = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+    (! bb0 [ bb0 = return''0 {_0} ]  [ & _0: () = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/traits/16_impl_cloning.coma
+++ b/tests/should_succeed/traits/16_impl_cloning.coma
@@ -100,7 +100,7 @@ module M_16_impl_cloning__test [#"16_impl_cloning.rs" 16 0 16 30]
   let rec test[#"16_impl_cloning.rs" 16 0 16 30] (x:MutBorrow.t t_Vec'0) (return'  (x'0:()))= {[@expl:test 'x' type invariant] [%#s16_impl_cloning] inv'4 x}
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv'4 x'0} s1 | s1 = -{resolve'0 x'0}- s2 | s2 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & x'0: MutBorrow.t t_Vec'0 = x ] 
+     [ & _0: () = Any.any_l () | & x'0: MutBorrow.t t_Vec'0 = x ] )
     [ return''0 (result:())-> {[@expl:test ensures] [%#s16_impl_cloning'0] view'1 x = view'0 x.current}
       (! return' {result}) ]
 

--- a/tests/should_succeed/traits/19_sealed.coma
+++ b/tests/should_succeed/traits/19_sealed.coma
@@ -25,7 +25,7 @@ module M_19_sealed__p [#"19_sealed.rs" 16 0 16 29]
     (! bb0
     [ bb0 = s0 [ s0 = {[@expl:type invariant] inv x'0} s1 | s1 = -{resolve x'0}- s2 | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_T = x ] 
+     [ & _0: () = Any.any_l () | & x'0: t_T = x ] )
     [ return''0 (result:())-> {[@expl:p ensures] [%#s19_sealed'0] g x y = f x y + 1} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/trigger.coma
+++ b/tests/should_succeed/trigger.coma
@@ -36,7 +36,7 @@ module M_trigger__test [#"trigger.rs" 22 0 22 13]
   
   let rec test[#"trigger.rs" 22 0 22 13] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_2 <- [%#strigger] () ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _2: () = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & _2: () = Any.any_l () ] )
     [ return''0 (result:())-> {[@expl:test ensures] [%#strigger'0] id 5 >= id 2} (! return' {result}) ]
 
 end

--- a/tests/should_succeed/two_modules.coma
+++ b/tests/should_succeed/two_modules.coma
@@ -14,7 +14,7 @@ module M_two_modules__mod2__x [#"two_modules.rs" 15 4 15 33]
   
   let rec x[#"two_modules.rs" 15 4 15 33] (_t:t_T) (return'  (x'0:bool))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#stwo_modules] true ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: bool = Any.any_l () ]  [ return''0 (result:bool)-> (! return' {result}) ] 
+     [ & _0: bool = Any.any_l () ] ) [ return''0 (result:bool)-> (! return' {result}) ] 
 end
 module M_two_modules__f [#"two_modules.rs" 22 0 22 10]
   use creusot.prelude.Any
@@ -33,7 +33,7 @@ module M_two_modules__f [#"two_modules.rs" 22 0 22 10]
   let rec f[#"two_modules.rs" 22 0 22 10] (return'  (x'0:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_2 <- C_B ] s1 | s1 = x {_2} (fun (_ret:bool) ->  [ &_1 <- _ret ] s2) | s2 = bb1 ] 
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & _1: bool = Any.any_l () | & _2: t_T = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & _1: bool = Any.any_l () | & _2: t_T = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/type_constructors.coma
+++ b/tests/should_succeed/type_constructors.coma
@@ -12,5 +12,5 @@ module M_type_constructors__f [#"type_constructors.rs" 17 0 17 10]
   
   let rec f[#"type_constructors.rs" 17 0 17 10] (return'  (x:()))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_3 <- C_B ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: () = Any.any_l () | & _3: t_X = Any.any_l () ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & _3: t_X = Any.any_l () ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/type_invariants/generated.coma
+++ b/tests/should_succeed/type_invariants/generated.coma
@@ -75,5 +75,5 @@ module M_generated__use_foo [#"generated.rs" 18 0 18 61]
       | s1 = {[@expl:assertion] [%#sgenerated] inv'3 x'0} s2
       | s2 = return''0 {_0} ]
      ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_Foo'0 = x ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & x'0: t_Foo'0 = x ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/type_invariants/non_zero.coma
+++ b/tests/should_succeed/type_invariants/non_zero.coma
@@ -27,9 +27,9 @@ module M_non_zero__qyi12916758414494363779__new [#"non_zero.rs" 16 4 16 30] (* N
   
   let rec new[#"non_zero.rs" 16 4 16 30] (n:UInt32.t) (return'  (x:t_NonZeroU32))= {[@expl:new requires] [%#snon_zero] UInt32.t'int n
     > 0}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- { t_NonZeroU32__0 = n'0 } ] s1 | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- { t_NonZeroU32__0 = n'0 } ] s1 | s1 = return''0 {_0} ]  ] 
     [ & _0: t_NonZeroU32 = Any.any_l () | & n'0: UInt32.t = n ]
-    
+    )
     [ return''0 (result:t_NonZeroU32)-> {[@expl:new result type invariant] [%#snon_zero'0] inv result}
       (! return' {result}) ]
 
@@ -75,12 +75,12 @@ module M_non_zero__qyi12916758414494363779__add [#"non_zero.rs" 21 4 21 39] (* N
       | s1 =  [ &_0 <- { t_NonZeroU32__0 = _4 } ] s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_NonZeroU32 = Any.any_l ()
     | & self'0: t_NonZeroU32 = self
     | & rhs'0: t_NonZeroU32 = rhs
     | & _4: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_NonZeroU32)-> {[@expl:add result type invariant] [%#snon_zero'2] inv result}
       (! return' {result}) ]
 
@@ -158,12 +158,12 @@ module M_non_zero__qyi12916758414494363779__sub [#"non_zero.rs" 40 4 40 39] (* N
       | s1 =  [ &_0 <- { t_NonZeroU32__0 = _4 } ] s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_NonZeroU32 = Any.any_l ()
     | & self'0: t_NonZeroU32 = self
     | & rhs'0: t_NonZeroU32 = rhs
     | & _4: UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_NonZeroU32)-> {[@expl:sub result type invariant] [%#snon_zero'2] inv result}
       (! return' {result}) ]
 

--- a/tests/should_succeed/type_invariants/type_invariants.coma
+++ b/tests/should_succeed/type_invariants/type_invariants.coma
@@ -21,9 +21,9 @@ module M_type_invariants__id [#"type_invariants.rs" 14 0 14 44]
   meta "select_lsinst" "all"
   
   let rec id[#"type_invariants.rs" 14 0 14 44] (x:()) (return'  (x'0:()))= {[@expl:id 'x' type invariant] [%#stype_invariants] inv x}
-    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- x'0 ] s1 | s1 = return''0 {_0} ]  ] )
+    (! bb0 [ bb0 = s0 [ s0 =  [ &_0 <- x'0 ] s1 | s1 = return''0 {_0} ]  ] 
     [ & _0: () = Any.any_l () | & x'0: () = x ]
-    
+    )
     [ return''0 (result:())-> {[@expl:id result type invariant] [%#stype_invariants'0] inv result}
       (! return' {result}) ]
 

--- a/tests/should_succeed/type_invariants/vec_inv.coma
+++ b/tests/should_succeed/type_invariants/vec_inv.coma
@@ -118,5 +118,5 @@ module M_vec_inv__vec [#"vec_inv.rs" 18 0 18 32]
       | s3 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & x'0: t_Vec = x ]  [ return''0 (result:())-> (! return' {result}) ] 
+     [ & _0: () = Any.any_l () | & x'0: t_Vec = x ] ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/union_find.coma
+++ b/tests/should_succeed/union_find.coma
@@ -32,7 +32,7 @@ module M_union_find__implementation__qyi17232405883558456141__eq [#"union_find.r
       [ s0 = addr_eq {self'0.t_Element__0} {other'0.t_Element__0} (fun (_ret:bool) ->  [ &_0 <- _ret ] s1) | s1 = bb1 ]
     
     | bb1 = return''0 {_0} ]
-    ) [ & _0: bool = Any.any_l () | & self'0: t_Element = self | & other'0: t_Element = other ] 
+     [ & _0: bool = Any.any_l () | & self'0: t_Element = self | & other'0: t_Element = other ] )
     [ return''0 (result:bool)-> {[@expl:eq ensures] [%#sunion_find] result = (deep_model'0 self = deep_model'0 other)}
       (! return' {result}) ]
 
@@ -60,7 +60,7 @@ module M_union_find__implementation__qyi15934775324707434347__addr [#"union_find
   
   let rec addr[#"union_find.rs" 33 8 33 40] (self:t_Element) (return'  (x:UInt64.t))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- [%#sunion_find] deep_model self'0 ] s1 | s1 = bb1 ]  | bb1 = return''0 {_0} ]
-    ) [ & _0: UInt64.t = Any.any_l () | & self'0: t_Element = self ] 
+     [ & _0: UInt64.t = Any.any_l () | & self'0: t_Element = self ] )
     [ return''0 (result:UInt64.t)-> {[@expl:addr ensures] [%#sunion_find'0] result = deep_model self}
       (! return' {result}) ]
 
@@ -80,7 +80,7 @@ module M_union_find__implementation__qyi10464084137166016688__clone [#"union_fin
   
   let rec clone'[#"union_find.rs" 46 8 46 31] (self:t_Element) (return'  (x:t_Element))= (! bb0
     [ bb0 = s0 [ s0 =  [ &_0 <- { t_Element__0 = self'0.t_Element__0 } ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: t_Element = Any.any_l () | & self'0: t_Element = self ] 
+     [ & _0: t_Element = Any.any_l () | & self'0: t_Element = self ] )
     [ return''0 (result:t_Element)-> {[@expl:clone ensures] [%#sunion_find] self = result} (! return' {result}) ]
 
 end
@@ -376,7 +376,7 @@ module M_union_find__implementation__qyi1944850640244667852__new [#"union_find.r
         s1
       | s1 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_UnionFind = Any.any_l ()
     | & _2: Fset.fset t_Element = Any.any_l ()
     | & _4:  t_FMap = Any.any_l ()
@@ -384,7 +384,7 @@ module M_union_find__implementation__qyi1944850640244667852__new [#"union_find.r
     | & _7: Map.map t_Element int = Any.any_l ()
     | & _9: Map.map t_Element t_Element = Any.any_l ()
     | & _11: int = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_UnionFind)-> {[@expl:new result type invariant] [%#sunion_find'4] inv'6 result}
       {[@expl:new ensures] [%#sunion_find'5] Fset.is_empty result.t_UnionFind__domain}
       (! return' {result}) ]
@@ -1626,7 +1626,7 @@ module M_union_find__implementation__qyi1944850640244667852__make [#"union_find.
     | bb23 = s0 [ s0 = new'1 {_18} (fun (_ret: ()) ->  [ &_17 <- _ret ] s1) | s1 = bb24 ] 
     | bb24 = s0 [ s0 =  [ &_0 <- element ] s1 | s1 = bb25 ] 
     | bb25 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Element = Any.any_l ()
     | & self'0: MutBorrow.t t_UnionFind = self
     | & value'0: t_T = value
@@ -1659,7 +1659,7 @@ module M_union_find__implementation__qyi1944850640244667852__make [#"union_find.
     | & _44: Map.map t_Element t_T = Any.any_l ()
     | & _46: Map.map t_Element int = Any.any_l ()
     | & _48: Map.map t_Element t_Element = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Element)-> {[@expl:make ensures #0] [%#sunion_find'6] not contains'0 (domain self.current) result}
       {[@expl:make ensures #1] [%#sunion_find'7] domain self.final = insert'0 (domain self.current) result}
       {[@expl:make ensures #2] [%#sunion_find'8] root_of self.final = Map.set (root_of self.current) result result}
@@ -2268,7 +2268,7 @@ module M_union_find__implementation__qyi1944850640244667852__find_inner [#"union
       | s3 = bb21 ]
     
     | bb21 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Element = Any.any_l ()
     | & self'0: MutBorrow.t t_UnionFind = self
     | & elem'0: t_Element = elem
@@ -2293,7 +2293,7 @@ module M_union_find__implementation__qyi1944850640244667852__find_inner [#"union
     | & _35: UInt64.t = Any.any_l ()
     | & _38: t_Content = Any.any_l ()
     | & _40: MutBorrow.t t_Content = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Element)-> {[@expl:find_inner ensures #0] [%#sunion_find'1] result
       = index_logic'2 (root_of self.current) elem}
       {[@expl:find_inner ensures #1] [%#sunion_find'2] unchanged self}
@@ -2596,12 +2596,12 @@ module M_union_find__implementation__qyi1944850640244667852__find [#"union_find.
       | s2 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'7 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Element = Any.any_l ()
     | & self'0: MutBorrow.t t_UnionFind = self
     | & elem'0: t_Element = elem
     | & _6: MutBorrow.t t_UnionFind = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Element)-> {[@expl:find ensures #0] [%#sunion_find'1] result
       = index_logic'2 (root_of self.current) elem}
       {[@expl:find ensures #1] [%#sunion_find'2] unchanged self}
@@ -2993,7 +2993,7 @@ module M_union_find__implementation__qyi1944850640244667852__get [#"union_find.r
       | s1 =  [ &_0 <- value ] s2
       | s2 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_T = Any.any_l ()
     | & self'0: t_UnionFind = self
     | & elem'0: t_Element = elem
@@ -3005,7 +3005,7 @@ module M_union_find__implementation__qyi1944850640244667852__get [#"union_find.r
     | & _14: UInt64.t = Any.any_l ()
     | & _16: t_Content = Any.any_l ()
     | & value: t_T = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_T)-> {[@expl:get result type invariant] [%#sunion_find'2] inv'14 result}
       {[@expl:get ensures] [%#sunion_find'3] result = index_logic'1 (values self) elem}
       (! return' {result}) ]
@@ -3322,7 +3322,7 @@ module M_union_find__implementation__qyi1944850640244667852__equiv [#"union_find
       | s3 = bb3 ]
     
     | bb3 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self'0: MutBorrow.t t_UnionFind = self
     | & e1'0: t_Element = e1
@@ -3331,7 +3331,7 @@ module M_union_find__implementation__qyi1944850640244667852__equiv [#"union_find
     | & _9: MutBorrow.t t_UnionFind = Any.any_l ()
     | & r2: t_Element = Any.any_l ()
     | & _12: MutBorrow.t t_UnionFind = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:equiv ensures #0] [%#sunion_find'2] result
       = (index_logic'2 (root_of self.current) e1 = index_logic'2 (root_of self.current) e2)}
       {[@expl:equiv ensures #1] [%#sunion_find'3] unchanged self}
@@ -4236,7 +4236,7 @@ module M_union_find__implementation__qyi1944850640244667852__link [#"union_find.
       | s4 = bb67 ]
     
     | bb67 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Element = Any.any_l ()
     | & self'0: MutBorrow.t t_UnionFind = self
     | & x'0: t_Element = x
@@ -4312,7 +4312,7 @@ module M_union_find__implementation__qyi1944850640244667852__link [#"union_find.
     | & _133: Map.map t_Element t_T = Any.any_l ()
     | & _135: int = Any.any_l ()
     | & _137: Map.map t_Element int = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Element)-> {[@expl:link ensures #0] [%#sunion_find'12] domain self.final
       = domain self.current}
       {[@expl:link ensures #1] [%#sunion_find'13] result = index_logic'2 (root_of self.current) x
@@ -4689,7 +4689,7 @@ module M_union_find__implementation__qyi1944850640244667852__union_aux [#"union_
       | s2 = bb3 ]
     
     | bb3 = s0 [ s0 = {[@expl:type invariant] inv'7 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Element = Any.any_l ()
     | & self'0: MutBorrow.t t_UnionFind = self
     | & x'0: t_Element = x
@@ -4699,7 +4699,7 @@ module M_union_find__implementation__qyi1944850640244667852__union_aux [#"union_
     | & ry: t_Element = Any.any_l ()
     | & _14: MutBorrow.t t_UnionFind = Any.any_l ()
     | & _16: MutBorrow.t t_UnionFind = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Element)-> {[@expl:union_aux ensures #0] [%#sunion_find'2] domain self.final
       = domain self.current}
       {[@expl:union_aux ensures #1] [%#sunion_find'3] result = index_logic'2 (root_of self.current) x
@@ -5028,14 +5028,14 @@ module M_union_find__implementation__qyi1944850640244667852__union [#"union_find
       | s2 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'7 self'0} s1 | s1 = -{resolve'0 self'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_UnionFind = self
     | & x'0: t_Element = x
     | & y'0: t_Element = y
     | & _8: t_Element = Any.any_l ()
     | & _9: MutBorrow.t t_UnionFind = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:union ensures #0] [%#sunion_find'2] domain self.final = domain self.current}
       {[@expl:union ensures #1] [%#sunion_find'3] exists r: t_Element. (r = index_logic'2 (root_of self.current) x
       \/ r = index_logic'2 (root_of self.current) y)
@@ -5403,7 +5403,7 @@ module M_union_find__example [#"union_find.rs" 367 0 367 16]
     | bb13 = {[%#sunion_find'8] false} any
     | bb10 = {[%#sunion_find'9] false} any
     | bb7 = {[%#sunion_find'10] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & uf: t_UnionFind = Any.any_l ()
     | & x: t_Element = Any.any_l ()
@@ -5429,7 +5429,7 @@ module M_union_find__example [#"union_find.rs" 367 0 367 16]
     | & _46: Int32.t = Any.any_l ()
     | & _51: bool = Any.any_l ()
     | & _53: Int32.t = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end
 module M_union_find__example_addrs_eq [#"union_find.rs" 387 0 387 77]
   let%span sunion_find = "union_find.rs" 391 22 391 30
@@ -5622,7 +5622,7 @@ module M_union_find__example_addrs_eq [#"union_find.rs" 387 0 387 77]
     | bb1 = any [ br0 -> {_5 = false} (! bb4) | br1 -> {_5} (! bb2) ] 
     | bb2 = s0 [ s0 = {[@expl:assertion] [%#sunion_find] e1'0 = e2'0} s1 | s1 = bb4 ] 
     | bb4 = return''0 {_0} ]
-    ) [ & _0: () = Any.any_l () | & e1'0: t_Element = e1 | & e2'0: t_Element = e2 | & _5: bool = Any.any_l () ] 
+     [ & _0: () = Any.any_l () | & e1'0: t_Element = e1 | & e2'0: t_Element = e2 | & _5: bool = Any.any_l () ] )
     [ return''0 (result:())-> (! return' {result}) ]
 
 end

--- a/tests/should_succeed/unnest.coma
+++ b/tests/should_succeed/unnest.coma
@@ -37,11 +37,11 @@ module M_unnest__unnest [#"unnest.rs" 8 0 8 64]
       | s3 = -{resolve'2 x'0}- s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: MutBorrow.t UInt32.t = Any.any_l ()
     | & x'0: MutBorrow.t (MutBorrow.t UInt32.t) = x
     | & _2: MutBorrow.t UInt32.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:MutBorrow.t UInt32.t)-> {[@expl:unnest ensures #0] [%#sunnest] result.current
       = (x.current).current}
       {[@expl:unnest ensures #1] [%#sunnest'0] result.final = (x.final).current}

--- a/tests/should_succeed/unused_in_loop.coma
+++ b/tests/should_succeed/unused_in_loop.coma
@@ -17,7 +17,7 @@ module M_unused_in_loop__unused_in_loop [#"unused_in_loop.rs" 5 0 5 37]
         (! s0) [ s0 = bb2 ]  [ bb2 = any [ br0 -> {b'0 = false} (! bb1'0) | br1 -> {b'0} (! bb3) ]  ]  ]
     
     | bb3 = s0 [ s0 =  [ &_0 <- x ] s1 | s1 = return''0 {_0} ]  ]
-    ) [ & _0: UInt32.t = Any.any_l () | & b'0: bool = b | & x: UInt32.t = Any.any_l () ] 
+     [ & _0: UInt32.t = Any.any_l () | & b'0: bool = b | & x: UInt32.t = Any.any_l () ] )
     [ return''0 (result:UInt32.t)-> {[@expl:unused_in_loop ensures] [%#sunused_in_loop'1] result = (10: UInt32.t)}
       (! return' {result}) ]
 

--- a/tests/should_succeed/vecdeque.coma
+++ b/tests/should_succeed/vecdeque.coma
@@ -276,7 +276,7 @@ module M_vecdeque__test_deque [#"vecdeque.rs" 5 0 5 19]
     | bb11 = {[%#svecdeque'11] false} any
     | bb7 = {[%#svecdeque'12] false} any
     | bb4 = {[%#svecdeque'13] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & deque: t_VecDeque = Any.any_l ()
     | & _3: bool = Any.any_l ()
@@ -311,5 +311,5 @@ module M_vecdeque__test_deque [#"vecdeque.rs" 5 0 5 19]
     | & _66: t_Option = Any.any_l ()
     | & _67: t_Option = Any.any_l ()
     | & _68: t_Option = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/vector/01.coma
+++ b/tests/should_succeed/vector/01.coma
@@ -235,7 +235,7 @@ module M_01__all_zero [#"01.rs" 7 0 7 33]
        ]
     
     | bb11 = s0 [ s0 = -{resolve'4 v'0}- s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & old_v: MutBorrow.t t_Vec = Any.any_l ()
@@ -253,7 +253,7 @@ module M_01__all_zero [#"01.rs" 7 0 7 33]
     | & _29: MutBorrow.t UInt32.t = Any.any_l ()
     | & _30: MutBorrow.t t_Vec = Any.any_l ()
     | & old_6_0: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:all_zero ensures #0] [%#s01'8] forall i: int. 0 <= i
       /\ i < Seq.length (view v.final)  -> index_logic v.final i = (0: UInt32.t)}
       {[@expl:all_zero ensures #1] [%#s01'9] Seq.length (view'1 v) = Seq.length (view v.final)}

--- a/tests/should_succeed/vector/02_gnome.coma
+++ b/tests/should_succeed/vector/02_gnome.coma
@@ -385,7 +385,7 @@ module M_02_gnome__gnome_sort [#"02_gnome.rs" 24 0 26 29]
        ]
     
     | bb17 = s0 [ s0 = {[@expl:type invariant] inv'5 v'0} s1 | s1 = -{resolve'2 v'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & old_v: MutBorrow.t t_Vec = Any.any_l ()
@@ -403,7 +403,7 @@ module M_02_gnome__gnome_sort [#"02_gnome.rs" 24 0 26 29]
     | & _30: MutBorrow.t t_Vec = Any.any_l ()
     | & _31: UInt64.t = Any.any_l ()
     | & old_2_0: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:gnome_sort ensures #0] [%#s02_gnome'9] sorted (deep_model'0 v.final)}
       {[@expl:gnome_sort ensures #1] [%#s02_gnome'10] permutation_of (view v.final) (view'0 v)}
       (! return' {result}) ]

--- a/tests/should_succeed/vector/03_knuth_shuffle.coma
+++ b/tests/should_succeed/vector/03_knuth_shuffle.coma
@@ -337,7 +337,7 @@ module M_03_knuth_shuffle__knuth_shuffle [#"03_knuth_shuffle.rs" 13 0 13 39]
        ]
     
     | bb11 = s0 [ s0 = {[@expl:type invariant] inv'6 v'0} s1 | s1 = -{resolve'4 v'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & old_v: MutBorrow.t t_Vec = Any.any_l ()
@@ -361,7 +361,7 @@ module M_03_knuth_shuffle__knuth_shuffle [#"03_knuth_shuffle.rs" 13 0 13 39]
     | & _36: MutBorrow.t t_Vec = Any.any_l ()
     | & _38: UInt64.t = Any.any_l ()
     | & old_6_0: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:knuth_shuffle ensures] [%#s03_knuth_shuffle'9] permutation_of (view v.final) (view'1 v)}
       (! return' {result}) ]
 

--- a/tests/should_succeed/vector/04_binary_search.coma
+++ b/tests/should_succeed/vector/04_binary_search.coma
@@ -274,7 +274,7 @@ module M_04_binary_search__binary_search [#"04_binary_search.rs" 28 0 28 71]
     
     | bb18 = s0 [ s0 =  [ &_0 <- C_Err base ] s1 | s1 = bb21 ] 
     | bb21 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Result = Any.any_l ()
     | & arr'0: t_Vec = arr
     | & elem'0: UInt32.t = elem
@@ -294,7 +294,7 @@ module M_04_binary_search__binary_search [#"04_binary_search.rs" 28 0 28 71]
     | & _43: bool = Any.any_l ()
     | & _47: bool = Any.any_l ()
     | & _50: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Result)-> {[@expl:binary_search ensures #0] [%#s04_binary_search'11] forall x: UInt64.t. result
       = C_Ok x  -> index_logic arr (UInt64.t'int x) = elem}
       {[@expl:binary_search ensures #1] [%#s04_binary_search'12] forall x: UInt64.t. result = C_Err x

--- a/tests/should_succeed/vector/05_binary_search_generic.coma
+++ b/tests/should_succeed/vector/05_binary_search_generic.coma
@@ -403,7 +403,7 @@ module M_05_binary_search_generic__binary_search [#"05_binary_search_generic.rs"
       | s2 = bb24 ]
     
     | bb24 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Result = Any.any_l ()
     | & arr'0: t_Vec = arr
     | & elem'0: t_T = elem
@@ -423,7 +423,7 @@ module M_05_binary_search_generic__binary_search [#"05_binary_search_generic.rs"
     | & _43: t_Ordering = Any.any_l ()
     | & _46: t_T = Any.any_l ()
     | & _49: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Result)-> {[@expl:binary_search ensures #0] [%#s05_binary_search_generic'13] forall x: UInt64.t. result
       = C_Ok x  -> Seq.get (deep_model'1 arr) (UInt64.t'int x) = deep_model elem}
       {[@expl:binary_search ensures #1] [%#s05_binary_search_generic'14] forall x: UInt64.t. result = C_Err x

--- a/tests/should_succeed/vector/06_knights_tour.coma
+++ b/tests/should_succeed/vector/06_knights_tour.coma
@@ -86,14 +86,14 @@ module M_06_knights_tour__qyi50474406909270761__clone [#"06_knights_tour.rs" 4 1
       | s2 = bb2 ]
     
     | bb2 = s0 [ s0 =  [ &_0 <- { t_Point__x = _3; t_Point__y = _6 } ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Point = Any.any_l ()
     | & self'0: t_Point = self
     | & _3: Int64.t = Any.any_l ()
     | & _5: Int64.t = Any.any_l ()
     | & _6: Int64.t = Any.any_l ()
     | & _8: Int64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Point)-> {[@expl:clone ensures] [%#s06_knights_tour] postcondition () self.t_Point__x result.t_Point__x
       /\ postcondition () self.t_Point__y result.t_Point__y}
       (! return' {result}) ]
@@ -135,13 +135,13 @@ module M_06_knights_tour__qyi18370800917002056__mov [#"06_knights_tour.rs" 18 4 
       | s2 =  [ &_0 <- { t_Point__x = _9; t_Point__y = _12 } ] s3
       | s3 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: t_Point = Any.any_l ()
     | & self'0: t_Point = self
     | & p'0: tuple = p
     | & _9: Int64.t = Any.any_l ()
     | & _12: Int64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Point)-> {[@expl:mov ensures #0] [%#s06_knights_tour'3] Int64.to_int result.t_Point__x
       = Int64.to_int self.t_Point__x + Int64.to_int p._p0}
       {[@expl:mov ensures #1] [%#s06_knights_tour'4] Int64.to_int result.t_Point__y
@@ -294,7 +294,7 @@ module M_06_knights_tour__qyi4580598960913230815__new [#"06_knights_tour.rs" 40 
     
     | bb2 = s0 [ s0 =  [ &_0'1 <- res ] s1 | s1 = bb3 ] 
     | bb3 = return''0 {_0'1} ]
-    ) [ & _0'1: t_Vec = Any.any_l () | & _1'0: MutBorrow.t closure3 = self | & res: t_Vec = Any.any_l () ] 
+     [ & _0'1: t_Vec = Any.any_l () | & _1'0: MutBorrow.t closure3 = self | & res: t_Vec = Any.any_l () ] )
     [ return''0 (result:t_Vec)-> {[@expl:closure ensures] [%#s06_knights_tour'4] Seq.length (view result)
       = UInt64.t'int (self.final)._0}
       {[@expl:closure hist_inv post] hist_inv self.current self.final}
@@ -476,14 +476,14 @@ module M_06_knights_tour__qyi4580598960913230815__new [#"06_knights_tour.rs" 40 
     | bb1 = s0 [ s0 = collect {_6} (fun (_ret:t_Vec'0) ->  [ &rows <- _ret ] s1) | s1 = bb2 ] 
     | bb2 = s0 [ s0 =  [ &_0'0 <- { t_Board__size = size'0; t_Board__field = rows } ] s1 | s1 = bb4 ] 
     | bb4 = return''0 {_0'0} ]
-    )
+    
     [ & _0'0: t_Board = Any.any_l ()
     | & size'0: UInt64.t = size
     | & rows: t_Vec'0 = Any.any_l ()
     | & _6: t_MapInv = Any.any_l ()
     | & _7: t_Range = Any.any_l ()
     | & _9: closure3 = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Board)-> {[@expl:new ensures #0] [%#s06_knights_tour'1] result.t_Board__size = size}
       {[@expl:new ensures #1] [%#s06_knights_tour'2] wf result}
       (! return' {result}) ]
@@ -628,7 +628,7 @@ module M_06_knights_tour__qyi4580598960913230815__available [#"06_knights_tour.r
     | bb11 = s0 [ s0 =  [ &_0 <- _18 = ([%#s06_knights_tour'1] (0: UInt64.t)) ] s1 | s1 = bb12 ] 
     | bb9 = s0 [ s0 =  [ &_0 <- [%#s06_knights_tour'2] false ] s1 | s1 = bb12 ] 
     | bb12 = return''0 {_0} ]
-    )
+    
     [ & _0: bool = Any.any_l ()
     | & self'0: t_Board = self
     | & p'0: t_Point = p
@@ -642,7 +642,7 @@ module M_06_knights_tour__qyi4580598960913230815__available [#"06_knights_tour.r
     | & _20: t_Vec'0 = Any.any_l ()
     | & _22: UInt64.t = Any.any_l ()
     | & _24: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:bool)-> {[@expl:available ensures] [%#s06_knights_tour'4] result  -> in_bounds'1 self p}
       (! return' {result}) ]
 
@@ -914,7 +914,7 @@ module M_06_knights_tour__qyi4580598960913230815__count_degree [#"06_knights_tou
        ]
     
     | bb18 = s0 [ s0 =  [ &_0 <- count ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & self'0: t_Board = self
     | & p'0: t_Point = p
@@ -932,7 +932,7 @@ module M_06_knights_tour__qyi4580598960913230815__count_degree [#"06_knights_tou
     | & next'0: t_Point = Any.any_l ()
     | & _30: tuple = Any.any_l ()
     | & _31: bool = Any.any_l () ]
-     [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
+    ) [ return''0 (result:UInt64.t)-> (! return' {result}) ] 
 end
 module M_06_knights_tour__qyi4580598960913230815__set [#"06_knights_tour.rs" 87 4 87 41] (* Board *)
   let%span s06_knights_tour = "06_knights_tour.rs" 83 15 83 24
@@ -1112,7 +1112,7 @@ module M_06_knights_tour__qyi4580598960913230815__set [#"06_knights_tour.rs" 87 
       | s3 = -{resolve'4 self'0}- s4
       | s4 = return''0 {_0} ]
      ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & self'0: MutBorrow.t t_Board = self
     | & p'0: t_Point = p
@@ -1123,7 +1123,7 @@ module M_06_knights_tour__qyi4580598960913230815__set [#"06_knights_tour.rs" 87 
     | & _12: MutBorrow.t t_Vec = Any.any_l ()
     | & _13: UInt64.t = Any.any_l ()
     | & _15: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:set ensures #0] [%#s06_knights_tour'1] wf self.final}
       {[@expl:set ensures #1] [%#s06_knights_tour'2] (self.final).t_Board__size = (self.current).t_Board__size}
       (! return' {result}) ]
@@ -1334,7 +1334,7 @@ module M_06_knights_tour__min [#"06_knights_tour.rs" 110 0 110 58]
        ]
     
     | bb9 = s0 [ s0 =  [ &_0 <- min'0 ] s1 | s1 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: t_Option = Any.any_l ()
     | & v'0: t_Vec = v
     | & min'0: t_Option = Any.any_l ()
@@ -1351,7 +1351,7 @@ module M_06_knights_tour__min [#"06_knights_tour.rs" 110 0 110 58]
     | & m: tuple = Any.any_l ()
     | & _30: bool = Any.any_l ()
     | & _33: t_Option = Any.any_l () ]
-    
+    )
     [ return''0 (result:t_Option)-> {[@expl:min ensures] [%#s06_knights_tour'4] forall r: tuple. result = C_Some r
        -> (exists i: int. 0 <= i /\ i < Seq.length (view'0 v) /\ index_logic v i = r)}
       (! return' {result}) ]
@@ -1958,7 +1958,7 @@ module M_06_knights_tour__knights_tour [#"06_knights_tour.rs" 135 0 135 69]
     | bb39 = s0 [ s0 =  [ &_0 <- C_None'2 ] s1 | s1 = bb47 ] 
     | bb12 = s0 [ s0 =  [ &_0 <- C_Some'2 board ] s1 | s1 = bb47 ] 
     | bb47 = return''0 {_0} ]
-    )
+    
     [ & _0: t_Option'2 = Any.any_l ()
     | & size'0: UInt64.t = size
     | & x'0: UInt64.t = x
@@ -2004,5 +2004,5 @@ module M_06_knights_tour__knights_tour [#"06_knights_tour.rs" 135 0 135 69]
     | & adj'0: t_Point = Any.any_l ()
     | & _92: () = Any.any_l ()
     | & _93: MutBorrow.t t_Board = Any.any_l () ]
-     [ return''0 (result:t_Option'2)-> (! return' {result}) ] 
+    ) [ return''0 (result:t_Option'2)-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/vector/07_read_write.coma
+++ b/tests/should_succeed/vector/07_read_write.coma
@@ -213,7 +213,7 @@ module M_07_read_write__read_write [#"07_read_write.rs" 6 0 6 75]
     
     | bb4 = return''0 {_0}
     | bb5 = {[%#s07_read_write] false} any ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & a'0: MutBorrow.t t_Vec = a
     | & i'0: UInt64.t = i
@@ -222,5 +222,5 @@ module M_07_read_write__read_write [#"07_read_write.rs" 6 0 6 75]
     | & _7: MutBorrow.t t_Vec = Any.any_l ()
     | & _10: bool = Any.any_l ()
     | & _12: t_T = Any.any_l () ]
-     [ return''0 (result:())-> (! return' {result}) ] 
+    ) [ return''0 (result:())-> (! return' {result}) ] 
 end

--- a/tests/should_succeed/vector/08_haystack.coma
+++ b/tests/should_succeed/vector/08_haystack.coma
@@ -341,7 +341,7 @@ module M_08_haystack__search [#"08_haystack.rs" 22 0 22 60]
     | bb24 = s0 [ s0 =  [ &_0 <- i ] s1 | s1 = bb32 ] 
     | bb12 = s0 [ s0 = len {haystack'0} (fun (_ret:UInt64.t) ->  [ &_0 <- _ret ] s1) | s1 = bb32 ] 
     | bb32 = return''0 {_0} ]
-    )
+    
     [ & _0: UInt64.t = Any.any_l ()
     | & needle'0: t_Vec = needle
     | & haystack'0: t_Vec = haystack
@@ -373,7 +373,7 @@ module M_08_haystack__search [#"08_haystack.rs" 22 0 22 60]
     | & _59: UInt8.t = Any.any_l ()
     | & _63: UInt8.t = Any.any_l ()
     | & _65: UInt64.t = Any.any_l () ]
-    
+    )
     [ return''0 (result:UInt64.t)-> {[@expl:search ensures #0] [%#s08_haystack'12] UInt64.t'int result
       = Seq.length (view'0 haystack)
       \/ UInt64.t'int result < Seq.length (view'0 haystack) - Seq.length (view'0 needle) + 1}

--- a/tests/should_succeed/vector/09_capacity.coma
+++ b/tests/should_succeed/vector/09_capacity.coma
@@ -160,7 +160,7 @@ module M_09_capacity__change_capacity [#"09_capacity.rs" 6 0 6 41]
       | s2 = bb4 ]
     
     | bb4 = s0 [ s0 = {[@expl:type invariant] inv'3 v'0} s1 | s1 = -{resolve'0 v'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & _4: () = Any.any_l ()
@@ -171,7 +171,7 @@ module M_09_capacity__change_capacity [#"09_capacity.rs" 6 0 6 41]
     | & _9: MutBorrow.t t_Vec = Any.any_l ()
     | & _10: () = Any.any_l ()
     | & _11: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:change_capacity ensures #0] [%#s09_capacity'3] Seq.length (view v.final)
       = Seq.length (view'0 v)}
       {[@expl:change_capacity ensures #1] [%#s09_capacity'4] forall i: int. 0 <= i /\ i < Seq.length (view'0 v)
@@ -281,12 +281,12 @@ module M_09_capacity__clear_vec [#"09_capacity.rs" 14 0 14 35]
       | s2 = bb1 ]
     
     | bb1 = s0 [ s0 = {[@expl:type invariant] inv'3 v'0} s1 | s1 = -{resolve'0 v'0}- s2 | s2 = return''0 {_0} ]  ]
-    )
+    
     [ & _0: () = Any.any_l ()
     | & v'0: MutBorrow.t t_Vec = v
     | & _3: () = Any.any_l ()
     | & _4: MutBorrow.t t_Vec = Any.any_l () ]
-    
+    )
     [ return''0 (result:())-> {[@expl:clear_vec ensures] [%#s09_capacity'0] Seq.length (view v.final) = 0}
       (! return' {result}) ]
 


### PR DESCRIPTION
This refactor simplifies `to_why` by merging the two `!open_body` checks into one. Also, local variables are supposed to be hidden from callers.