### PR TITLE
Remove redundant (and sometimes crashing) call to `codegen_select_candidate`

### DIFF
--- a/tests/should_fail/bug/1565.rs
+++ b/tests/should_fail/bug/1565.rs
@@ -1,0 +1,22 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+pub trait Tr {
+    #[logic]
+    fn f(self) -> Int;
+}
+
+impl Tr for i32 {
+    #[logic]
+    fn f(self) -> Int {
+        g()
+    }
+}
+
+#[logic]
+pub fn g() -> Int
+where
+    i32: Tr,
+{
+    1i32.f()
+}

--- a/tests/should_fail/bug/1565.stderr
+++ b/tests/should_fail/bug/1565.stderr
@@ -1,0 +1,14 @@
+error: Mutually recursive functions: when calling `<i32 as Tr>::f`...
+  --> 1565.rs:11:5
+   |
+11 |     fn f(self) -> Int {
+   |     ^^^^^^^^^^^^^^^^^
+   |
+note: then `<i32 as Tr>::f` might call `<i32 as Tr>::f` via the call to `g`.
+  --> 1565.rs:12:9
+   |
+12 |         g()
+   |         ^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fix #1524 and #1565

This only fixes the crash. I'm still working on using the new API to the trait solver (via `ProofTreeVisitor`). And I'm hoping that this PR unblocks upgrading the toolchain (#1659).