### PR TITLE
Rework handling of unsized variables in Pearlite

### DIFF
--- a/creusot-contracts-proc/Cargo.toml
+++ b/creusot-contracts-proc/Cargo.toml
@@ -23,7 +23,7 @@ creusot = ["dep:uuid", "dep:pearlite-syn", "proc-macro2/span-locations"]
 quote = "1.0"
 uuid = { version = "1.12", features = ["v4"], optional = true }
 pearlite-syn = { version = "0.6.0-dev", path = "../pearlite-syn", features = ["full"], optional = true }
-syn = { version = "2.0", features = ["full", "visit-mut"] }
+syn = { version = "2.0", features = ["full", "visit", "visit-mut"] }
 proc-macro2 = { version = "1.0" }
 
 [lints.rust]

--- a/creusot-contracts-proc/src/creusot/pretyping.rs
+++ b/creusot-contracts-proc/src/creusot/pretyping.rs
@@ -7,7 +7,12 @@
 
 use pearlite_syn::Term as RT;
 use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree};
-use syn::{ExprMacro, Pat, PatType, UnOp, spanned::Spanned};
+use std::collections::HashSet;
+use syn::{
+    ExprMacro, Ident, Pat, PatIdent, PatType, UnOp,
+    spanned::Spanned,
+    visit::{Visit, visit_pat},
+};
 
 use pearlite_syn::term::*;
 use quote::{ToTokens, quote, quote_spanned};
@@ -35,8 +40,58 @@ impl EncodeError {
     }
 }
 
-// TODO: Rewrite this as a source to source transform and *then* call ToTokens on the result
+struct Locals {
+    /// "ref-bound" variables: we replaced their binder with `&x` and their occurrences should be expanded as `*x`.
+    /// Other variables are untouched, their occurrences should be expanded as `*&x`.
+    refvars: HashSet<Ident>,
+    /// Variables to toggle when leaving scopes.
+    undo: Vec<Vec<Ident>>,
+}
+
+impl Locals {
+    fn new() -> Self {
+        Locals { refvars: HashSet::new(), undo: vec![vec![]] }
+    }
+
+    fn open(&mut self) {
+        self.undo.push(vec![])
+    }
+
+    fn close(&mut self) {
+        for var in self.undo.pop().unwrap().into_iter().rev() {
+            use std::collections::hash_set::Entry::*;
+            match self.refvars.entry(var) {
+                Occupied(entry) => {
+                    entry.remove();
+                }
+                Vacant(entry) => entry.insert(),
+            }
+        }
+    }
+
+    fn bind_ref(&mut self, ident: Ident) {
+        if self.refvars.insert(ident.clone()) {
+            self.undo.last_mut().unwrap().push(ident)
+        }
+    }
+
+    fn bind_raw(&mut self, ident: &Ident) {
+        if self.refvars.remove(ident) {
+            self.undo.last_mut().unwrap().push(ident.clone())
+        }
+    }
+
+    fn is_ref_bound(&self, ident: &Ident) -> bool {
+        self.refvars.contains(ident)
+    }
+}
+
 pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
+    encode_term_(term, &mut Locals::new())
+}
+
+// TODO: Rewrite this as a source to source transform and *then* call ToTokens on the result
+fn encode_term_(term: &RT, locals: &mut Locals) -> Result<TokenStream, EncodeError> {
     let sp = term.span();
     match term {
         // It's unclear what to do with macros. Either we translate the parameters, but then
@@ -83,8 +138,8 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
                 };
             }
 
-            let left = encode_term(left)?;
-            let right = encode_term(right)?;
+            let left = encode_term_(left, locals)?;
+            let right = encode_term_(right, locals)?;
             match op {
                 Eq(_) => {
                     Ok(quote_spanned! {sp=> ::creusot_contracts::__stubs::equal(#left, #right) })
@@ -122,9 +177,10 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
                 _ => Ok(quote_spanned! {sp=> #left #op #right }),
             }
         }
-        RT::Block(TermBlock { block, .. }) => Ok(encode_block(block)),
+        RT::Block(TermBlock { block, .. }) => Ok(encode_block_(block, locals)),
         RT::Call(TermCall { func, args, .. }) => {
-            let args: Vec<_> = args.into_iter().map(encode_term).collect::<Result<_, _>>()?;
+            let args: Vec<_> =
+                args.into_iter().map(|t| encode_term_(t, locals)).collect::<Result<_, _>>()?;
             if let RT::Path(p) = &**func {
                 if p.inner.path.is_ident("old") {
                     return Ok(
@@ -141,15 +197,15 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
             }
         }
         RT::Cast(TermCast { expr, as_token, ty }) => {
-            let expr_token = encode_term(expr)?;
+            let expr_token = encode_term_(expr, locals)?;
             Ok(quote_spanned! {sp=> #expr_token #as_token  #ty})
         }
         RT::Field(TermField { base, member, .. }) => {
-            let base = encode_term(base)?;
+            let base = encode_term_(base, locals)?;
             Ok(quote!({ #base . #member }))
         }
         RT::Group(TermGroup { expr, .. }) => {
-            let term = encode_term(expr)?;
+            let term = encode_term_(expr, locals)?;
             let mut res = TokenStream::new();
             res.extend_one(TokenTree::Group(Group::new(Delimiter::None, term)));
             Ok(res)
@@ -162,12 +218,15 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
             } else {
                 cond
             };
-            let cond = encode_term(cond)?;
-            let then_branch: Vec<_> =
-                then_branch.stmts.iter().map(encode_stmt).collect::<Result<_, _>>()?;
+            let cond = encode_term_(cond, locals)?;
+            let then_branch: Vec<_> = then_branch
+                .stmts
+                .iter()
+                .map(|s| encode_stmt_(s, locals))
+                .collect::<Result<_, _>>()?;
             let else_branch = match else_branch {
                 Some((_, t)) => {
-                    let term = encode_term(t)?;
+                    let term = encode_term_(t, locals)?;
                     Some(quote_spanned! {sp=> else #term })
                 }
                 None => None,
@@ -177,8 +236,8 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
         RT::Index(TermIndex { expr, index, .. }) => {
             let expr = if let RT::Paren(TermParen { expr, .. }) = &**expr { &**expr } else { expr };
 
-            let expr = encode_term(expr)?;
-            let index = encode_term(index)?;
+            let expr = encode_term_(expr, locals)?;
+            let index = encode_term_(index, locals)?;
 
             Ok(quote! {
                 (#expr).index_logic(#index)
@@ -195,36 +254,37 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
         }
         RT::Lit(TermLit { lit }) => Ok(quote_spanned! {sp=> #lit }),
         RT::Match(TermMatch { expr, arms, .. }) => {
-            let arms: Vec<_> = arms.iter().map(encode_arm).collect::<Result<_, _>>()?;
-            let expr = encode_term(expr)?;
+            let arms: Vec<_> =
+                arms.iter().map(|a| encode_arm_(a, locals)).collect::<Result<_, _>>()?;
+            let expr = encode_term_(expr, locals)?;
             Ok(quote_spanned! {sp=> match #expr { #(#arms)* } })
         }
         RT::MethodCall(TermMethodCall { receiver, method, turbofish, args, .. }) => {
-            let receiver = encode_term(receiver)?;
-            let args: Vec<_> = args.into_iter().map(encode_term).collect::<Result<_, _>>()?;
-
+            let receiver = encode_term_(receiver, locals)?;
+            let args: Vec<_> =
+                args.into_iter().map(|t| encode_term_(t, locals)).collect::<Result<_, _>>()?;
             Ok(quote_spanned! {sp=> #receiver . #method #turbofish ( #(#args),*) })
         }
         RT::Paren(TermParen { paren_token, expr }) => {
             let mut tokens = TokenStream::new();
-            let term = encode_term(expr)?;
+            let term = encode_term_(expr, locals)?;
             paren_token.surround(&mut tokens, |tokens| {
                 tokens.extend(term);
             });
             Ok(tokens)
         }
-        RT::Path(_) => {
-            let mut res = TokenStream::new();
-            res.extend_one(TokenTree::Group(Group::new(
-                Delimiter::Parenthesis,
-                quote_spanned! {sp=> *&#term},
-            )));
-            // Trick to avoid capturing unsized arguments in spec closures.
-            Ok(res)
+        RT::Path(path) if let Some(ident) = path.inner.path.get_ident() => {
+            let term = if locals.is_ref_bound(ident) {
+                quote_spanned! { sp=> *#ident }
+            } else {
+                quote_spanned! { sp=> *&#ident }
+            };
+            Ok(TokenStream::from(TokenTree::Group(Group::new(Delimiter::Parenthesis, term))))
         }
+        RT::Path(path) => Ok(quote_spanned! {sp=> #path}),
         RT::Range(_) => Err(EncodeError::Unsupported(term.span(), "Range".into())),
         RT::Reference(TermReference { mutability, expr, .. }) => {
-            let term = encode_term(expr)?;
+            let term = encode_term_(expr, locals)?;
             Ok(quote_spanned! {sp=>
                 & #mutability #term
             })
@@ -242,7 +302,7 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
                 tv.member.to_tokens(&mut inner);
                 if let Some(colon) = tv.colon_token {
                     colon.to_tokens(&mut inner);
-                    inner.extend(encode_term(&tv.expr)?)
+                    inner.extend(encode_term_(&tv.expr, locals)?)
                 }
                 punc.to_tokens(&mut inner);
             }
@@ -264,12 +324,13 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
             if elems.is_empty() {
                 return Ok(quote_spanned! {sp=> () });
             }
-            let elems: Vec<_> = elems.into_iter().map(encode_term).collect::<Result<_, _>>()?;
+            let elems: Vec<_> =
+                elems.into_iter().map(|t| encode_term_(t, locals)).collect::<Result<_, _>>()?;
             Ok(quote_spanned! {sp=> (#(#elems),*,) })
         }
         RT::Type(ty) => Ok(quote_spanned! {sp=> #ty }),
         RT::Unary(TermUnary { op, expr }) => {
-            let term = encode_term(expr)?;
+            let term = encode_term_(expr, locals)?;
             if matches!(op, UnOp::Neg(_)) {
                 Ok(quote_spanned! {sp=> ::creusot_contracts::logic::ops::NegLogic::neg(#term) })
             } else {
@@ -279,7 +340,7 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
             }
         }
         RT::Final(TermFinal { term, .. }) => {
-            let term = encode_term(term)?;
+            let term = encode_term_(term, locals)?;
             Ok(quote_spanned! {sp=>
                 * ::creusot_contracts::__stubs::fin(#term)
             })
@@ -289,14 +350,14 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
                 RT::Paren(TermParen { expr, .. }) => expr,
                 _ => term,
             };
-            let term = encode_term(term)?;
+            let term = encode_term_(term, locals)?;
             Ok(quote_spanned! {sp=>
                 ::creusot_contracts::model::View::view(#term)
             })
         }
         RT::LogEq(TermLogEq { lhs, rhs, .. }) => {
-            let lhs = encode_term(lhs)?;
-            let rhs = encode_term(rhs)?;
+            let lhs = encode_term_(lhs, locals)?;
+            let rhs = encode_term_(rhs, locals)?;
             Ok(quote_spanned! {sp=>
                 ::creusot_contracts::__stubs::equal(#lhs, #rhs)
             })
@@ -309,27 +370,34 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
                 },
                 _ => hyp,
             };
-            let hyp = encode_term(hyp)?;
-            let cons = encode_term(cons)?;
+            let hyp = encode_term_(hyp, locals)?;
+            let cons = encode_term_(cons, locals)?;
             Ok(quote_spanned! {sp=>
                 ::creusot_contracts::__stubs::implication(#hyp, #cons)
             })
         }
         RT::Quant(TermQuant { quant_token, args, trigger, term, .. }) => {
-            let mut ts = encode_term(term)?;
-            let args_ref = args.iter().map(|QuantArg { ident, ty }| match ty {
-                None => quote! { &#ident: &_ },
-                Some((_, ty)) => quote! { &#ident: &#ty },
-            });
-            ts = encode_trigger(trigger, ts)?;
-            ts = quote_spanned! {sp=>
+            locals.open();
+            let args_ref = args
+                .iter()
+                .map(|QuantArg { ident, ty }| {
+                    locals.bind_ref(ident.clone());
+                    match ty {
+                        None => quote! { #ident: &_ },
+                        Some((_, ty)) => quote! { #ident: &#ty },
+                    }
+                })
+                .collect::<Vec<_>>();
+            let mut ts = encode_term_(term, locals)?;
+            ts = encode_trigger_(trigger, ts, locals)?;
+            locals.close();
+            Ok(quote_spanned! {sp=>
                 ::creusot_contracts::__stubs::#quant_token(
                     #[creusot::no_translate]
                     #[creusot::logic_closure]
                     |#(#args_ref,)*| { #ts }
                 )
-            };
-            Ok(ts)
+            })
         }
         RT::Dead(_) => Ok(quote_spanned! {sp=> *::creusot_contracts::__stubs::dead() }),
         RT::Pearlite(term) => Ok(quote_spanned! {sp=> #term }),
@@ -340,17 +408,76 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
                     "logic closures can only have one parameter".into(),
                 ));
             }
-
+            locals.open();
+            // We want to allow mappings of unsized types, like `|x: [usize]| ...`
+            // but we can't bind variables of unsized types.
+            // - in all cases, wrap the argument type in `&` (`&[usize]`),
+            //   because Rust closure arguments must be sized.
+            // - this changes the type of `x` (`|x: &[usize]|`),
+            //   and we compensate by replacing all occurrences of `x` with `*x`
+            //   (this is enabled by calling `locals.bind_ref`).
+            //
+            // Unfortunately, this idea does not quite work because
+            // (1) closure argument binders can be arbitrary patterns, and
+            // (2) proc macros can't distinguish variables from nullary enum constructors,
+            // so we can't know what variables `var` are bound by a pattern
+            // in order to substitute their occurrences in the closure body with `*var`.
+            // The danger is that if we naively treat a constructor `C` as a bound variable,
+            // adding it to `bind_ref`, its occurrences will become `*C` which is nonsense.
+            //
+            // We compromise:
+            // - we only do the `x` to `*x` substitution for a simple binder `|x|` or `|x: ty|`
+            //   (intentionally assuming that `x` is a variable and not a constructor);
+            // - for non-variable patterns `|pat|` or `|pat: [usize]|`,
+            //   we just don't support unsized variables.
+            //   The binder becomes `|&pat: &[usize]|` so the type of `pat` doesn't change
+            //   and no substitution is necessary (actually we will replace `x` with `*&x` instead,
+            //   which doesn't change the type and works even if `x` is a constructor).
+            //
+            // Another solution could be to forbid non-variable patterns in Pearlite closures,
+            // but I think at least pair patterns `|(x, y)|` could be handy...
             let input = match &clos.inputs[0] {
-                Pat::Type(PatType { attrs, pat, ty, .. }) => quote! { #(#attrs)* &#pat : &#ty},
-                _ => {
-                    let pat = &clos.inputs[0];
+                // |x: ty|
+                Pat::Type(PatType {
+                    attrs,
+                    pat:
+                        box Pat::Ident(PatIdent {
+                            by_ref: None,
+                            mutability: None,
+                            ident,
+                            subpat: None,
+                            ..
+                        }),
+                    ty,
+                    ..
+                }) => {
+                    locals.bind_ref(ident.clone());
+                    quote! { #(#attrs)* #ident : &#ty }
+                }
+                // |pat: ty|
+                Pat::Type(PatType { attrs, pat, ty, .. }) => {
+                    pattern_bind(pat, locals);
+                    quote! { #(#attrs)* &#pat : &#ty }
+                }
+                // |x|
+                Pat::Ident(PatIdent {
+                    by_ref: None,
+                    mutability: None,
+                    ident,
+                    subpat: None,
+                    ..
+                }) => {
+                    locals.bind_ref(ident.clone());
+                    quote! { #ident : &_ }
+                }
+                pat => {
+                    pattern_bind(pat, locals);
                     quote! { &#pat }
                 }
             };
-
             let retty = &clos.output;
-            let clos = encode_term(&clos.body)?;
+            let clos = encode_term_(&clos.body, locals)?;
+            locals.close();
             Ok(quote_spanned! {sp=>
                 ::creusot_contracts::__stubs::mapping_from_fn(
                     #[creusot::no_translate] #[creusot::logic_closure] |#input| #retty #clos)
@@ -360,44 +487,56 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
     }
 }
 
-fn encode_trigger(
+fn encode_trigger_(
     mut trigger: &[Trigger],
     mut ts: TokenStream,
+    locals: &mut Locals,
 ) -> Result<TokenStream, EncodeError> {
     while let [rest @ .., last] = trigger {
         trigger = rest;
-        let trigs = last.terms.iter().map(encode_term).collect::<Result<Vec<_>, _>>()?;
+        let trigs =
+            last.terms.iter().map(|t| encode_term_(t, locals)).collect::<Result<Vec<_>, _>>()?;
         ts = quote!(::creusot_contracts::__stubs::trigger((#(#trigs,)*), #ts))
     }
     Ok(ts)
 }
 
 pub fn encode_block(block: &TBlock) -> TokenStream {
-    // If there are errors during encode_stmt, still emit the braces
+    encode_block_(block, &mut Locals::new())
+}
+
+fn encode_block_(block: &TBlock, locals: &mut Locals) -> TokenStream {
+    // If there are errors during encode_stmt_, still emit the braces
     // to allow the parser to skip over the body and discover more errors.
     let mut tokens = TokenStream::new();
+    locals.open();
     block.brace_token.surround(&mut tokens, |tokens| {
         block.stmts.iter().for_each(|stmt| {
-            encode_stmt(stmt).unwrap_or_else(|e| e.into_tokens()).to_tokens(tokens)
+            encode_stmt_(stmt, locals).unwrap_or_else(|e| e.into_tokens()).to_tokens(tokens)
         })
     });
+    locals.close();
     tokens
 }
 
 pub fn encode_stmt(stmt: &TermStmt) -> Result<TokenStream, EncodeError> {
+    encode_stmt_(stmt, &mut Locals::new())
+}
+
+fn encode_stmt_(stmt: &TermStmt, locals: &mut Locals) -> Result<TokenStream, EncodeError> {
     match stmt {
         TermStmt::Local(TLocal { let_token, pat, init, semi_token }) => {
             if let Some((eq_token, init)) = init {
-                let pat = encode_pattern(pat)?;
-                let init = encode_term(init)?;
+                let init = encode_term_(init, locals)?;
+                pattern_bind(pat, locals);
                 Ok(quote! { #let_token #pat #eq_token #init #semi_token })
             } else {
                 Err(EncodeError::LocalLetNoInit(pat.span()))
             }
         }
-        TermStmt::Expr(e) => encode_term(e),
+        TermStmt::Expr(e) => encode_term_(e, locals),
         TermStmt::Semi(t, s) => {
-            let term = encode_term(t)?;
+            let term = encode_term_(t, locals)?;
             Ok(quote! { #term #s })
         }
         TermStmt::Item(i) => Ok(quote! { #i }),
@@ -405,16 +544,32 @@ pub fn encode_stmt(stmt: &TermStmt) -> Result<TokenStream, EncodeError> {
     }
 }
 
-fn encode_pattern(pat: &Pat) -> Result<TokenStream, EncodeError> {
-    Ok(quote! { #pat })
+impl<'a> Visit<'a> for &'a mut Locals {
+    fn visit_pat(&mut self, pat: &'a Pat) {
+        match pat {
+            Pat::Path(path) if let Some(ident) = path.path.get_ident() => self.bind_raw(ident),
+            Pat::Ident(ident) => self.bind_raw(&ident.ident),
+            _ => visit_pat(self, pat),
+        }
+    }
 }
 
-fn encode_arm(arm: &TermArm) -> Result<TokenStream, EncodeError> {
-    let body = encode_term(&arm.body)?;
+/// `bind_raw` on every variable in `pat`
+fn pattern_bind<'a>(pat: &'a Pat, mut locals: &'a mut Locals) {
+    locals.visit_pat(pat)
+}
+
+fn encode_arm_(arm: &TermArm, locals: &mut Locals) -> Result<TokenStream, EncodeError> {
+    if arm.guard.is_some() {
+        return Err(EncodeError::Unsupported(arm.span(), "match guard".to_string()));
+    }
+    let comma = &arm.comma;
     let pat = &arm.pat;
-    // let (if_tok, guard) = arm.guard;
-    let comma = arm.comma;
-    Ok(quote! { #pat  => #body #comma })
+    locals.open();
+    pattern_bind(&pat, locals);
+    let body = encode_term_(&arm.body, locals)?;
+    locals.close();
+    Ok(quote! { #pat => #body #comma })
 }
 
 #[cfg(test)]

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -4,6 +4,8 @@
         box_patterns,
         extract_if,
         extend_one,
+        hash_set_entry,
+        if_let_guard,
         proc_macro_def_site,
         proc_macro_span,
         let_chains

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -26,7 +26,6 @@
     feature = "nightly",
     allow(incomplete_features, internal_features),
     feature(
-        unsized_locals,
         fn_traits,
         slice_take,
         print_internals,

--- a/tests/creusot-contracts/creusot-contracts.coma
+++ b/tests/creusot-contracts/creusot-contracts.coma
@@ -14143,7 +14143,7 @@ module M_creusot_contracts__stdqy35z1__mem__extern_spec_std_mem_take_body [#"../
   let%span smem = "../../creusot-contracts/src/std/mem.rs" 23 32 23 36
   let%span smem'0 = "../../creusot-contracts/src/std/mem.rs" 23 49 23 50
   let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 21 22 21 37
-  let%span smem'2 = "../../creusot-contracts/src/std/mem.rs" 22 12 22 59
+  let%span smem'2 = "../../creusot-contracts/src/std/mem.rs" 22 22 22 57
   let%span smem'3 = "../../creusot-contracts/src/std/mem.rs" 10 26 10 30
   let%span smem'4 = "../../creusot-contracts/src/std/mem.rs" 10 40 10 43
   let%span smem'5 = "../../creusot-contracts/src/std/mem.rs" 8 22 8 34
@@ -20999,7 +20999,7 @@ module M_creusot_contracts__fn_ghost__qyi4984999370661040133__clone [#"../../cre
   let%span sops'8 = "../../creusot-contracts/src/std/ops.rs" 151 14 152 104
   let%span sfn_ghost = "../../creusot-contracts/src/fn_ghost.rs" 31 14 31 18
   let%span sfn_ghost'0 = "../../creusot-contracts/src/fn_ghost.rs" 31 23 31 27
-  let%span sfn_ghost'1 = "../../creusot-contracts/src/fn_ghost.rs" 30 4 30 58
+  let%span sfn_ghost'1 = "../../creusot-contracts/src/fn_ghost.rs" 30 14 30 56
   let%span sfn_ghost'2 = "../../creusot-contracts/src/fn_ghost.rs" 83 4 83 12
   
   use creusot.prelude.Any
@@ -21155,7 +21155,7 @@ module M_creusot_contracts__fn_ghost__qyi6891646202668648470__qy95z_new [#"../..
 end
 module M_creusot_contracts__invariant__qyi11000281680484769800__clone [#"../../creusot-contracts/src/invariant.rs" 286 4 286 27] (* <invariant::Subset<T> as std::clone::Clone> *)
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 287 8 287 36
-  let%span sinvariant'0 = "../../creusot-contracts/src/invariant.rs" 285 4 285 60
+  let%span sinvariant'0 = "../../creusot-contracts/src/invariant.rs" 285 14 285 58
   let%span sinvariant'1 = "../../creusot-contracts/src/invariant.rs" 206 15 206 30
   let%span sinvariant'2 = "../../creusot-contracts/src/invariant.rs" 207 14 207 27
   let%span sinvariant'3 = "../../creusot-contracts/src/invariant.rs" 269 23 269 36
@@ -21439,7 +21439,7 @@ module M_creusot_contracts__local_invariant__qyi11806525195294501830__open [#"..
   let%span sops'8 = "../../creusot-contracts/src/std/ops.rs" 151 14 152 104
   let%span slocal_invariant = "../../creusot-contracts/src/local_invariant.rs" 212 18 212 22
   let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 212 59 212 60
-  let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 204 4 204 48
+  let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 204 15 204 46
   let%span slocal_invariant'2 = "../../creusot-contracts/src/local_invariant.rs" 205 15 206 115
   let%span slocal_invariant'3 = "../../creusot-contracts/src/local_invariant.rs" 212 68 212 69
   let%span slocal_invariant'4 = "../../creusot-contracts/src/local_invariant.rs" 208 14 209 124
@@ -21705,9 +21705,9 @@ module M_creusot_contracts__local_invariant__qyi14562131538618297666__open [#"..
   let%span sops'8 = "../../creusot-contracts/src/std/ops.rs" 151 14 152 104
   let%span slocal_invariant = "../../creusot-contracts/src/local_invariant.rs" 230 18 230 22
   let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 230 59 230 60
-  let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 227 4 227 119
+  let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 227 15 227 117
   let%span slocal_invariant'2 = "../../creusot-contracts/src/local_invariant.rs" 230 68 230 69
-  let%span slocal_invariant'3 = "../../creusot-contracts/src/local_invariant.rs" 228 4 228 127
+  let%span slocal_invariant'3 = "../../creusot-contracts/src/local_invariant.rs" 228 14 228 125
   let%span sghost = "../../creusot-contracts/src/ghost.rs" 123 19 123 23
   let%span sghost'0 = "../../creusot-contracts/src/ghost.rs" 123 28 123 37
   let%span sghost'1 = "../../creusot-contracts/src/ghost.rs" 122 14 122 32
@@ -21863,7 +21863,7 @@ module M_creusot_contracts__logic__fmap__qyi17941324210461407630__ext_eq [#"../.
   
   let%span sfmap = "../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
   let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 190 12 190 52
-  let%span sfmap'1 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'1 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 175 15 175 30
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 176 14 176 27
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 94 4 94 12
@@ -28329,7 +28329,7 @@ module M_creusot_contracts__logic__ra__auth__qyi8462856325058495004__rel_mono [#
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sauth = "../../creusot-contracts/src/logic/ra/auth.rs" 37 15 37 31
   let%span sauth'0 = "../../creusot-contracts/src/logic/ra/auth.rs" 38 4 38 28
@@ -28417,7 +28417,7 @@ module M_creusot_contracts__logic__ra__auth__qyi8462856325058495004__rel_none [#
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sauth = "../../creusot-contracts/src/logic/ra/auth.rs" 43 14 43 32
   let%span sauth'0 = "../../creusot-contracts/src/logic/ra/auth.rs" 44 36 44 38
@@ -28506,7 +28506,7 @@ module M_creusot_contracts__logic__ra__auth__qyi8462856325058495004__rel_unit [#
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 186 14 186 47
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 187 14 187 43
@@ -28618,7 +28618,7 @@ module M_creusot_contracts__logic__ra__auth__qyi1963254905082259216__update [#".
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
@@ -28865,7 +28865,7 @@ module M_creusot_contracts__logic__ra__auth__qyi1963254905082259216__frame_prese
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
@@ -29470,7 +29470,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__factor [#".
   let%span sfmap'4 = "../../creusot-contracts/src/logic/ra/fmap.rs" 30 12 45 13
   let%span sfmap'5 = "../../creusot-contracts/src/logic/ra/fmap.rs" 14 12 18 13
   let%span sfmap'6 = "../../creusot-contracts/src/logic/fmap.rs" 94 4 94 12
-  let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'8 = "../../creusot-contracts/src/logic/ra/fmap.rs" 120 15 120 64
   let%span sfmap'9 = "../../creusot-contracts/src/logic/ra/fmap.rs" 121 14 121 78
   let%span sfmap'10 = "../../creusot-contracts/src/logic/ra/fmap.rs" 119 4 119 12
@@ -29492,7 +29492,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__factor [#".
   let%span sra'3 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 130 14 130 32
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 135 14 135 98
@@ -29741,7 +29741,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__commutative
   let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
   let%span sfmap'1 = "../../creusot-contracts/src/logic/ra/fmap.rs" 52 8 56 10
   let%span sfmap'2 = "../../creusot-contracts/src/logic/ra/fmap.rs" 14 12 18 13
-  let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 94 4 94 12
   let%span sfmap'5 = "../../creusot-contracts/src/logic/ra/fmap.rs" 120 15 120 64
   let%span sfmap'6 = "../../creusot-contracts/src/logic/ra/fmap.rs" 121 14 121 78
@@ -29763,7 +29763,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__commutative
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -29930,7 +29930,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__associative
   let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
   let%span sfmap'1 = "../../creusot-contracts/src/logic/ra/fmap.rs" 62 8 68 9
   let%span sfmap'2 = "../../creusot-contracts/src/logic/ra/fmap.rs" 14 12 18 13
-  let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 94 4 94 12
   let%span sfmap'5 = "../../creusot-contracts/src/logic/ra/fmap.rs" 120 15 120 64
   let%span sfmap'6 = "../../creusot-contracts/src/logic/ra/fmap.rs" 121 14 121 78
@@ -29952,7 +29952,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__associative
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -30158,7 +30158,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__core [#"../
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -30344,7 +30344,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__core_is_max
   let%span sfmap = "../../creusot-contracts/src/logic/ra/fmap.rs" 82 15 82 33
   let%span sfmap'0 = "../../creusot-contracts/src/logic/ra/fmap.rs" 83 15 83 39
   let%span sfmap'1 = "../../creusot-contracts/src/logic/ra/fmap.rs" 84 14 87 5
-  let%span sfmap'2 = "../../creusot-contracts/src/logic/ra/fmap.rs" 81 4 81 12
+  let%span sfmap'2 = "../../creusot-contracts/src/logic/ra/fmap.rs" 89 8 89 41
   let%span sfmap'3 = "../../creusot-contracts/src/logic/ra/fmap.rs" 14 12 18 13
   let%span sfmap'4 = "../../creusot-contracts/src/logic/ra/fmap.rs" 73 14 76 5
   let%span sfmap'5 = "../../creusot-contracts/src/logic/ra/fmap.rs" 78 8 78 31
@@ -30381,7 +30381,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__core_is_max
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 152 14 155 5
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -30639,7 +30639,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4304869425182553974__unit [#"../
   let%span sfmap'4 = "../../creusot-contracts/src/logic/ra/fmap.rs" 98 8 98 83
   let%span sfmap'5 = "../../creusot-contracts/src/logic/ra/fmap.rs" 14 12 18 13
   let%span sfmap'6 = "../../creusot-contracts/src/logic/fmap.rs" 61 14 61 25
-  let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'8 = "../../creusot-contracts/src/logic/ra/fmap.rs" 50 14 50 32
   let%span sfmap'9 = "../../creusot-contracts/src/logic/ra/fmap.rs" 52 8 56 10
   let%span sfmap'10 = "../../creusot-contracts/src/logic/ra/fmap.rs" 60 14 60 98
@@ -30667,7 +30667,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4304869425182553974__unit [#"../
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -30884,7 +30884,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4304869425182553974__core_total 
   let%span sfmap'4 = "../../creusot-contracts/src/logic/ra/fmap.rs" 107 8 107 59
   let%span sfmap'5 = "../../creusot-contracts/src/logic/ra/fmap.rs" 14 12 18 13
   let%span sfmap'6 = "../../creusot-contracts/src/logic/fmap.rs" 94 4 94 12
-  let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'8 = "../../creusot-contracts/src/logic/ra/fmap.rs" 50 14 50 32
   let%span sfmap'9 = "../../creusot-contracts/src/logic/ra/fmap.rs" 52 8 56 10
   let%span sfmap'10 = "../../creusot-contracts/src/logic/ra/fmap.rs" 60 14 60 98
@@ -30912,7 +30912,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4304869425182553974__core_total 
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -31178,7 +31178,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4304869425182553974__core_is_tot
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -31413,7 +31413,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi17941324210461407630__total_op [
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -31584,7 +31584,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi945878506295166927__frame_preser
   let%span sfmap'3 = "../../creusot-contracts/src/logic/ra/fmap.rs" 159 8 159 67
   let%span sfmap'4 = "../../creusot-contracts/src/logic/ra/fmap.rs" 136 8 136 38
   let%span sfmap'5 = "../../creusot-contracts/src/logic/ra/fmap.rs" 142 8 142 80
-  let%span sfmap'6 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'6 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'7 = "../../creusot-contracts/src/logic/fmap.rs" 94 4 94 12
   let%span sfmap'8 = "../../creusot-contracts/src/logic/ra/fmap.rs" 14 12 18 13
   let%span sfmap'9 = "../../creusot-contracts/src/logic/fmap.rs" 69 14 69 46
@@ -31615,7 +31615,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi945878506295166927__frame_preser
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -31883,7 +31883,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__factor [
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   
   use map.Map
@@ -31996,7 +31996,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__commutat
   type t_Namespace = Other namespace_other
   
   let%span soption = "../../creusot-contracts/src/logic/ra/option.rs" 39 14 39 32
-  let%span soption'0 = "../../creusot-contracts/src/logic/ra/option.rs" 37 4 37 10
+  let%span soption'0 = "../../creusot-contracts/src/logic/ra/option.rs" 41 8 41 39
   let%span soption'1 = "../../creusot-contracts/src/logic/ra/option.rs" 7 8 11 9
   let%span soption'2 = "../../creusot-contracts/src/std/option.rs" 771 8 774 9
   let%span soption'3 = "../../creusot-contracts/src/std/option.rs" 762 8 765 9
@@ -32008,7 +32008,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__commutat
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -32104,7 +32104,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__associat
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -32225,7 +32225,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__core [#"
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -32356,7 +32356,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__core_is_
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
   use map.Map
@@ -32513,7 +32513,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__unit [#"
   let%span soption'0 = "../../creusot-contracts/src/logic/ra/option.rs" 90 8 90 12
   let%span soption'1 = "../../creusot-contracts/src/logic/ra/option.rs" 7 8 11 9
   let%span soption'2 = "../../creusot-contracts/src/logic/ra/option.rs" 39 14 39 32
-  let%span soption'3 = "../../creusot-contracts/src/logic/ra/option.rs" 37 4 37 10
+  let%span soption'3 = "../../creusot-contracts/src/logic/ra/option.rs" 41 8 41 39
   let%span soption'4 = "../../creusot-contracts/src/logic/ra/option.rs" 46 14 46 98
   let%span soption'5 = "../../creusot-contracts/src/logic/ra/option.rs" 49 12 56 13
   let%span soption'6 = "../../creusot-contracts/src/std/option.rs" 771 8 774 9
@@ -32526,7 +32526,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__unit [#"
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -32637,7 +32637,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__core_tot
   let%span soption'1 = "../../creusot-contracts/src/logic/ra/option.rs" 98 8 101 9
   let%span soption'2 = "../../creusot-contracts/src/logic/ra/option.rs" 7 8 11 9
   let%span soption'3 = "../../creusot-contracts/src/logic/ra/option.rs" 39 14 39 32
-  let%span soption'4 = "../../creusot-contracts/src/logic/ra/option.rs" 37 4 37 10
+  let%span soption'4 = "../../creusot-contracts/src/logic/ra/option.rs" 41 8 41 39
   let%span soption'5 = "../../creusot-contracts/src/logic/ra/option.rs" 46 14 46 98
   let%span soption'6 = "../../creusot-contracts/src/logic/ra/option.rs" 49 12 56 13
   let%span soption'7 = "../../creusot-contracts/src/std/option.rs" 771 8 774 9
@@ -32651,7 +32651,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__core_tot
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -32782,7 +32782,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__core_is_
   let%span soption'4 = "../../creusot-contracts/src/logic/ra/option.rs" 96 14 96 43
   let%span soption'5 = "../../creusot-contracts/src/logic/ra/option.rs" 98 8 101 9
   let%span soption'6 = "../../creusot-contracts/src/logic/ra/option.rs" 39 14 39 32
-  let%span soption'7 = "../../creusot-contracts/src/logic/ra/option.rs" 37 4 37 10
+  let%span soption'7 = "../../creusot-contracts/src/logic/ra/option.rs" 41 8 41 39
   let%span soption'8 = "../../creusot-contracts/src/logic/ra/option.rs" 46 14 46 98
   let%span soption'9 = "../../creusot-contracts/src/logic/ra/option.rs" 49 12 56 13
   let%span soption'10 = "../../creusot-contracts/src/logic/ra/option.rs" 7 8 11 9
@@ -32797,7 +32797,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__core_is_
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -32989,7 +32989,7 @@ module M_creusot_contracts__logic__ra__option__qyi9919140421117497760__frame_pre
   let%span soption'8 = "../../creusot-contracts/src/logic/ra/option.rs" 127 8 130 9
   let%span soption'9 = "../../creusot-contracts/src/std/option.rs" 753 8 756 9
   let%span soption'10 = "../../creusot-contracts/src/logic/ra/option.rs" 39 14 39 32
-  let%span soption'11 = "../../creusot-contracts/src/logic/ra/option.rs" 37 4 37 10
+  let%span soption'11 = "../../creusot-contracts/src/logic/ra/option.rs" 41 8 41 39
   let%span soption'12 = "../../creusot-contracts/src/logic/ra/option.rs" 46 14 46 98
   let%span soption'13 = "../../creusot-contracts/src/logic/ra/option.rs" 49 12 56 13
   let%span soption'14 = "../../creusot-contracts/src/std/option.rs" 771 8 774 9
@@ -33005,7 +33005,7 @@ module M_creusot_contracts__logic__ra__option__qyi9919140421117497760__frame_pre
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 17 4 17 35
@@ -33194,7 +33194,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__factor [#"
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 18 14 21 5
   let%span sprod'0 = "../../creusot-contracts/src/logic/ra/prod.rs" 23 8 26 9
@@ -33356,7 +33356,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__commutativ
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 31 14 31 32
@@ -33499,7 +33499,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__associativ
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 36 14 36 98
@@ -33652,7 +33652,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__core [#"..
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 41 14 44 5
@@ -33832,7 +33832,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__core_is_ma
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 53 15 53 33
   let%span sprod'0 = "../../creusot-contracts/src/logic/ra/prod.rs" 54 15 54 39
@@ -34062,7 +34062,7 @@ module M_creusot_contracts__logic__ra__prod__qyi848091308440200351__unit [#"../.
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 186 14 186 47
   let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 187 14 187 43
@@ -34273,7 +34273,7 @@ module M_creusot_contracts__logic__ra__prod__qyi848091308440200351__core_total [
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -34490,7 +34490,7 @@ module M_creusot_contracts__logic__ra__prod__qyi848091308440200351__core_is_tota
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'17 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'18 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -34797,7 +34797,7 @@ module M_creusot_contracts__logic__ra__prod__qyi12871785784760244066__frame_pres
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 17 4 17 35
@@ -35028,7 +35028,7 @@ module M_creusot_contracts__logic__ra__prod__qyi5623508861439716845__frame_prese
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 84 4 84 51
@@ -35377,7 +35377,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__factor [#"..
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 31 14 34 5
   let%span ssum'0 = "../../creusot-contracts/src/logic/ra/sum.rs" 37 68 37 85
@@ -35548,7 +35548,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__commutative 
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 45 14 45 32
@@ -35697,7 +35697,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__associative 
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 50 14 50 98
@@ -35856,7 +35856,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__core [#"../.
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 55 14 58 5
@@ -36041,7 +36041,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__core_is_maxi
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 67 15 67 33
   let%span ssum'0 = "../../creusot-contracts/src/logic/ra/sum.rs" 68 15 68 39
@@ -36335,7 +36335,7 @@ module M_creusot_contracts__logic__ra__sum__qyi1847493758823096333__frame_preser
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 17 4 17 35
@@ -36620,7 +36620,7 @@ module M_creusot_contracts__logic__ra__sum__qyi15765748900338894532__frame_prese
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 17 4 17 35
@@ -36857,7 +36857,7 @@ module M_creusot_contracts__logic__ra__sum__qyi3083214512297526849__frame_preser
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 84 4 84 51
@@ -37172,7 +37172,7 @@ module M_creusot_contracts__logic__ra__sum__qyi3543961907530750261__frame_preser
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 84 4 84 51
@@ -37480,7 +37480,7 @@ module M_creusot_contracts__logic__ra__update__qyi11826117606277287715__update [
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 36 4 36 35
@@ -37563,7 +37563,7 @@ module M_creusot_contracts__logic__ra__update__qyi11826117606277287715__frame_pr
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 42 4 42 35
@@ -37656,7 +37656,7 @@ module M_creusot_contracts__logic__ra__update__qyi5477729486377161480__update [#
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 62 4 62 35
@@ -37747,7 +37747,7 @@ module M_creusot_contracts__logic__ra__update__qyi5477729486377161480__frame_pre
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 68 4 68 35
@@ -37864,7 +37864,7 @@ module M_creusot_contracts__logic__ra__update__qyi10922308247021603688__frame_pr
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 112 15 112 63
@@ -37999,7 +37999,7 @@ module M_creusot_contracts__logic__ra__view__qyi3129231301466035151__inhabits [#
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 186 14 186 47
   let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 187 14 187 43
@@ -38129,7 +38129,7 @@ module M_creusot_contracts__logic__ra__view__qyi9160327263184903567__frag [#"../
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
@@ -38278,7 +38278,7 @@ module M_creusot_contracts__logic__ra__view__qyi9160327263184903567__ext_eq [#".
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
@@ -38288,7 +38288,7 @@ module M_creusot_contracts__logic__ra__view__qyi9160327263184903567__ext_eq [#".
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 187 14 187 43
   let%span sview = "../../creusot-contracts/src/logic/ra/view.rs" 85 14 85 39
   let%span sview'0 = "../../creusot-contracts/src/logic/ra/view.rs" 78 14 78 41
-  let%span sview'1 = "../../creusot-contracts/src/logic/ra/view.rs" 83 4 83 12
+  let%span sview'1 = "../../creusot-contracts/src/logic/ra/view.rs" 87 8 87 49
   let%span sview'2 = "../../creusot-contracts/src/logic/ra/view.rs" 74 20 74 32
   let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 80 20 80 32
   let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 21 15 21 31
@@ -38446,7 +38446,7 @@ module M_creusot_contracts__logic__ra__view__qyi9160327263184903567__new [#"../.
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
@@ -38617,7 +38617,7 @@ module M_creusot_contracts__logic__ra__view__qyi9160327263184903567__new_frag [#
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
@@ -38791,7 +38791,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__factor [#"
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
@@ -38806,7 +38806,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__factor [#"
   let%span sview'2 = "../../creusot-contracts/src/logic/ra/view.rs" 94 14 94 35
   let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 95 14 95 35
   let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 110 15 110 33
-  let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 132 4 132 12
+  let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 139 8 139 49
   let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'7 = "../../creusot-contracts/src/logic/ra/view.rs" 80 20 80 32
   let%span sview'8 = "../../creusot-contracts/src/logic/ra/view.rs" 74 20 74 32
@@ -39021,7 +39021,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__commutativ
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -39213,7 +39213,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__associativ
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -39442,7 +39442,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__core [#"..
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 181 14 181 55
@@ -39455,7 +39455,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__core [#"..
   let%span sview'1 = "../../creusot-contracts/src/logic/ra/view.rs" 214 14 214 43
   let%span sview'2 = "../../creusot-contracts/src/logic/ra/view.rs" 187 8 187 31
   let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
-  let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 211 4 211 12
+  let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 216 8 216 39
   let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 78 14 78 41
   let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 80 20 80 32
   let%span sview'7 = "../../creusot-contracts/src/logic/ra/view.rs" 74 20 74 32
@@ -39661,14 +39661,14 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__core_is_ma
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'17 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'18 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'19 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'19 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'20 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'21 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sview = "../../creusot-contracts/src/logic/ra/view.rs" 191 15 191 33
   let%span sview'0 = "../../creusot-contracts/src/logic/ra/view.rs" 192 15 192 39
   let%span sview'1 = "../../creusot-contracts/src/logic/ra/view.rs" 193 14 196 5
   let%span sview'2 = "../../creusot-contracts/src/logic/ra/view.rs" 78 14 78 41
-  let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 190 4 190 12
+  let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 198 8 198 39
   let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 182 14 185 5
   let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 187 8 187 31
@@ -39680,9 +39680,9 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__core_is_ma
   let%span sview'12 = "../../creusot-contracts/src/logic/ra/view.rs" 97 8 97 57
   let%span sview'13 = "../../creusot-contracts/src/logic/ra/view.rs" 213 14 213 47
   let%span sview'14 = "../../creusot-contracts/src/logic/ra/view.rs" 214 14 214 43
-  let%span sview'15 = "../../creusot-contracts/src/logic/ra/view.rs" 211 4 211 12
+  let%span sview'15 = "../../creusot-contracts/src/logic/ra/view.rs" 216 8 216 39
   let%span sview'16 = "../../creusot-contracts/src/logic/ra/view.rs" 134 14 137 5
-  let%span sview'17 = "../../creusot-contracts/src/logic/ra/view.rs" 132 4 132 12
+  let%span sview'17 = "../../creusot-contracts/src/logic/ra/view.rs" 139 8 139 49
   let%span sview'18 = "../../creusot-contracts/src/logic/ra/view.rs" 21 15 21 31
   let%span sview'19 = "../../creusot-contracts/src/logic/ra/view.rs" 22 4 22 28
   let%span sview'20 = "../../creusot-contracts/src/logic/ra/view.rs" 23 14 23 30
@@ -39929,17 +39929,17 @@ module M_creusot_contracts__logic__ra__view__qyi2387369350023652154__unit [#"../
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 186 14 186 47
   let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 187 14 187 43
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sview = "../../creusot-contracts/src/logic/ra/view.rs" 205 14 205 78
   let%span sview'0 = "../../creusot-contracts/src/logic/ra/view.rs" 110 15 110 33
-  let%span sview'1 = "../../creusot-contracts/src/logic/ra/view.rs" 204 4 204 12
+  let%span sview'1 = "../../creusot-contracts/src/logic/ra/view.rs" 207 8 207 29
   let%span sview'2 = "../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 85 14 85 39
-  let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 83 4 83 12
+  let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 87 8 87 49
   let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 112 8 112 29
   let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 157 14 157 32
   let%span sview'7 = "../../creusot-contracts/src/logic/ra/view.rs" 158 37 158 39
@@ -40170,7 +40170,7 @@ module M_creusot_contracts__logic__ra__view__qyi2387369350023652154__core_total 
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'17 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'18 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -40178,10 +40178,10 @@ module M_creusot_contracts__logic__ra__view__qyi2387369350023652154__core_total 
   let%span sview'0 = "../../creusot-contracts/src/logic/ra/view.rs" 214 14 214 43
   let%span sview'1 = "../../creusot-contracts/src/logic/ra/view.rs" 78 14 78 41
   let%span sview'2 = "../../creusot-contracts/src/logic/ra/view.rs" 110 15 110 33
-  let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 211 4 211 12
+  let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 216 8 216 39
   let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 85 14 85 39
-  let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 83 4 83 12
+  let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 87 8 87 49
   let%span sview'7 = "../../creusot-contracts/src/logic/ra/view.rs" 80 20 80 32
   let%span sview'8 = "../../creusot-contracts/src/logic/ra/view.rs" 74 20 74 32
   let%span sview'9 = "../../creusot-contracts/src/logic/ra/view.rs" 112 8 112 29
@@ -40425,7 +40425,7 @@ module M_creusot_contracts__logic__ra__view__qyi2387369350023652154__core_is_tot
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -40435,7 +40435,7 @@ module M_creusot_contracts__logic__ra__view__qyi2387369350023652154__core_is_tot
   let%span sview'2 = "../../creusot-contracts/src/logic/ra/view.rs" 187 8 187 31
   let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 213 14 213 47
   let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 214 14 214 43
-  let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 211 4 211 12
+  let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 216 8 216 39
   let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 157 14 157 32
   let%span sview'7 = "../../creusot-contracts/src/logic/ra/view.rs" 158 37 158 39
   let%span sview'8 = "../../creusot-contracts/src/logic/ra/view.rs" 162 14 162 98
@@ -40671,7 +40671,7 @@ module M_creusot_contracts__logic__ra__view__qyi5759646997670148869__update [#".
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -40874,7 +40874,7 @@ module M_creusot_contracts__logic__ra__view__qyi5759646997670148869__frame_prese
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -41150,7 +41150,7 @@ module M_creusot_contracts__logic__ra__view__qyi7400797033094478444__update [#".
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -41345,7 +41345,7 @@ module M_creusot_contracts__logic__ra__view__qyi7400797033094478444__frame_prese
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -41604,7 +41604,7 @@ module M_creusot_contracts__logic__ra__view__qyi5746217084655472194__update [#".
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 186 14 186 47
   let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 187 14 187 43
@@ -41793,7 +41793,7 @@ module M_creusot_contracts__logic__ra__view__qyi5746217084655472194__frame_prese
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 181 14 181 55
@@ -42081,7 +42081,7 @@ module M_creusot_contracts__logic__ra__RA__incl_transitive [#"../../creusot-cont
   let%span sra = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'0 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'1 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'2 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'2 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'3 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 135 14 135 98
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -42149,7 +42149,7 @@ module M_creusot_contracts__logic__ra__UnitRA__incl_refl [#"../../creusot-contra
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
   use map.Map
@@ -42230,7 +42230,7 @@ module M_creusot_contracts__logic__ra__UnitRA__unit_core [#"../../creusot-contra
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -42326,7 +42326,7 @@ module M_creusot_contracts__logic__ra__UnitRA__core_total [#"../../creusot-contr
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
   use map.Map
@@ -42649,7 +42649,7 @@ module M_creusot_contracts__pcell__qyi14846468513926953542__take [#"../../creuso
   let%span spcell'2 = "../../creusot-contracts/src/pcell.rs" 258 64 258 65
   let%span spcell'3 = "../../creusot-contracts/src/pcell.rs" 255 14 255 40
   let%span spcell'4 = "../../creusot-contracts/src/pcell.rs" 256 14 256 29
-  let%span spcell'5 = "../../creusot-contracts/src/pcell.rs" 257 4 257 55
+  let%span spcell'5 = "../../creusot-contracts/src/pcell.rs" 257 14 257 53
   let%span spcell'6 = "../../creusot-contracts/src/pcell.rs" 137 27 137 31
   let%span spcell'7 = "../../creusot-contracts/src/pcell.rs" 137 33 137 37
   let%span spcell'8 = "../../creusot-contracts/src/pcell.rs" 137 64 137 67
@@ -42852,7 +42852,7 @@ module M_creusot_contracts__peano__qyi18263836234684628832__clone [#"../../creus
   let%span sops'6 = "../../creusot-contracts/src/std/ops.rs" 145 4 145 30
   let%span sops'7 = "../../creusot-contracts/src/std/ops.rs" 146 4 146 32
   let%span sops'8 = "../../creusot-contracts/src/std/ops.rs" 151 14 152 104
-  let%span speano = "../../creusot-contracts/src/peano.rs" 34 9 34 14
+  let%span speano = "../../creusot-contracts/src/peano.rs" 37 20 37 27
   
   use creusot.int.UInt64
   use creusot.prelude.Any
@@ -44817,7 +44817,7 @@ module M_creusot_contracts__resource__fmap_view__qyi505596245403307893__new [#".
   let%span sfmap = "../../creusot-contracts/src/logic/fmap.rs" 52 14 52 31
   let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 53 14 53 43
   let%span sfmap'1 = "../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
-  let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'3 = "../../creusot-contracts/src/logic/ra/fmap.rs" 96 14 96 78
   let%span sfmap'4 = "../../creusot-contracts/src/logic/ra/fmap.rs" 98 8 98 83
   let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 61 14 61 25
@@ -45244,7 +45244,7 @@ module M_creusot_contracts__resource__fmap_view__qyi505596245403307893__insert [
   
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 101 20 101 44
   let%span sfmap = "../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
-  let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'1 = "../../creusot-contracts/src/logic/fmap.rs" 69 14 69 46
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 70 14 70 88
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 116 8 116 27
@@ -45317,7 +45317,7 @@ module M_creusot_contracts__resource__fmap_view__qyi505596245403307893__insert [
   let%span sview'7 = "../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'8 = "../../creusot-contracts/src/logic/ra/view.rs" 213 14 213 47
   let%span sview'9 = "../../creusot-contracts/src/logic/ra/view.rs" 214 14 214 43
-  let%span sview'10 = "../../creusot-contracts/src/logic/ra/view.rs" 211 4 211 12
+  let%span sview'10 = "../../creusot-contracts/src/logic/ra/view.rs" 216 8 216 39
   let%span sview'11 = "../../creusot-contracts/src/logic/ra/view.rs" 110 15 110 33
   let%span sview'12 = "../../creusot-contracts/src/logic/ra/view.rs" 112 8 112 29
   let%span sfmap_view = "../../creusot-contracts/src/resource/fmap_view.rs" 97 16 97 32
@@ -45931,7 +45931,7 @@ module M_creusot_contracts__resource__fmap_view__qyi505596245403307893__contains
   let%span sview'1 = "../../creusot-contracts/src/logic/ra/view.rs" 162 14 162 98
   let%span sview'2 = "../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 134 14 137 5
-  let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 132 4 132 12
+  let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 139 8 139 49
   let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 93 15 93 33
   let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 94 14 94 35
   let%span sview'7 = "../../creusot-contracts/src/logic/ra/view.rs" 95 14 95 35
@@ -46450,7 +46450,7 @@ module M_creusot_contracts__resource__fmap_view__qyi10168537497030408938__clone 
   let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 213 14 213 47
   let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 214 14 214 43
-  let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 211 4 211 12
+  let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 216 8 216 39
   let%span sview'7 = "../../creusot-contracts/src/logic/ra/view.rs" 78 14 78 41
   let%span sview'8 = "../../creusot-contracts/src/logic/ra/view.rs" 93 15 93 33
   let%span sview'9 = "../../creusot-contracts/src/logic/ra/view.rs" 94 14 94 35
@@ -62698,7 +62698,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__factor__ref
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -62873,7 +62873,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__core__refin
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -63060,7 +63060,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__core_is_max
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
   use map.Map
@@ -63322,7 +63322,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__commutative
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -63491,7 +63491,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4212043372435109977__associative
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -63658,7 +63658,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__commutat
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -63748,7 +63748,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__core__re
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -63852,7 +63852,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__core_is_
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 152 14 155 5
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -63996,7 +63996,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__associat
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -64095,7 +64095,7 @@ module M_creusot_contracts__logic__ra__option__qyi16764344068516726211__factor__
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -64190,7 +64190,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__commutativ
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 32 4 32 36
@@ -64327,7 +64327,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__factor__re
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 22 4 22 49
@@ -64472,7 +64472,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__core_is_ma
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 59 4 59 43
   let%span sprod'0 = "../../creusot-contracts/src/logic/ra/prod.rs" 10 4 10 12
@@ -64662,7 +64662,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__core__refi
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 45 4 45 33
@@ -64805,7 +64805,7 @@ module M_creusot_contracts__logic__ra__prod__qyi15150454618874767012__associativ
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 37 4 37 45
@@ -64951,7 +64951,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__associative_
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 51 4 51 45
@@ -65105,7 +65105,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__core_is_maxi
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 73 4 73 43
   let%span ssum'0 = "../../creusot-contracts/src/logic/ra/sum.rs" 22 8 26 9
@@ -65300,7 +65300,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__commutative_
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 46 4 46 36
@@ -65442,7 +65442,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__factor__refi
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 35 4 35 49
@@ -65591,7 +65591,7 @@ module M_creusot_contracts__logic__ra__sum__qyi4205504013086611447__core__refine
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 59 4 59 33
@@ -65742,7 +65742,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__commutativ
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -65927,7 +65927,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__core_is_ma
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 186 14 186 47
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 187 14 187 43
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -65949,9 +65949,9 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__core_is_ma
   let%span sview'9 = "../../creusot-contracts/src/logic/ra/view.rs" 97 8 97 57
   let%span sview'10 = "../../creusot-contracts/src/logic/ra/view.rs" 213 14 213 47
   let%span sview'11 = "../../creusot-contracts/src/logic/ra/view.rs" 214 14 214 43
-  let%span sview'12 = "../../creusot-contracts/src/logic/ra/view.rs" 211 4 211 12
+  let%span sview'12 = "../../creusot-contracts/src/logic/ra/view.rs" 216 8 216 39
   let%span sview'13 = "../../creusot-contracts/src/logic/ra/view.rs" 134 14 137 5
-  let%span sview'14 = "../../creusot-contracts/src/logic/ra/view.rs" 132 4 132 12
+  let%span sview'14 = "../../creusot-contracts/src/logic/ra/view.rs" 139 8 139 49
   let%span sview'15 = "../../creusot-contracts/src/logic/ra/view.rs" 21 15 21 31
   let%span sview'16 = "../../creusot-contracts/src/logic/ra/view.rs" 22 4 22 28
   let%span sview'17 = "../../creusot-contracts/src/logic/ra/view.rs" 23 14 23 30
@@ -66164,7 +66164,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__factor__re
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -66354,7 +66354,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__core__refi
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -66544,7 +66544,7 @@ module M_creusot_contracts__logic__ra__view__qyi11070982736783244845__associativ
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -66735,7 +66735,7 @@ module M_creusot_contracts__logic__ra__auth__qyi8462856325058495004__rel_mono__r
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sauth = "../../creusot-contracts/src/logic/ra/auth.rs" 40 4 40 43
   let%span sauth'0 = "../../creusot-contracts/src/logic/ra/auth.rs" 30 8 33 9
@@ -66818,7 +66818,7 @@ module M_creusot_contracts__logic__ra__auth__qyi8462856325058495004__rel_unit__r
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 186 14 186 47
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 187 14 187 43
@@ -66915,7 +66915,7 @@ module M_creusot_contracts__logic__ra__auth__qyi8462856325058495004__rel_none__r
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sauth = "../../creusot-contracts/src/logic/ra/auth.rs" 44 4 44 35
   let%span sauth'0 = "../../creusot-contracts/src/logic/ra/auth.rs" 30 8 33 9
@@ -66994,7 +66994,7 @@ module M_creusot_contracts__logic__ra__auth__qyi1963254905082259216__update__ref
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
@@ -67147,7 +67147,7 @@ module M_creusot_contracts__logic__ra__auth__qyi1963254905082259216__frame_prese
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -67493,7 +67493,7 @@ module M_creusot_contracts__logic__ra__option__qyi9919140421117497760__frame_pre
   let%span soption'2 = "../../creusot-contracts/src/logic/ra/option.rs" 125 4 125 35
   let%span soption'3 = "../../creusot-contracts/src/logic/ra/option.rs" 127 8 130 9
   let%span soption'4 = "../../creusot-contracts/src/logic/ra/option.rs" 39 14 39 32
-  let%span soption'5 = "../../creusot-contracts/src/logic/ra/option.rs" 37 4 37 10
+  let%span soption'5 = "../../creusot-contracts/src/logic/ra/option.rs" 41 8 41 39
   let%span soption'6 = "../../creusot-contracts/src/logic/ra/option.rs" 46 14 46 98
   let%span soption'7 = "../../creusot-contracts/src/logic/ra/option.rs" 49 12 56 13
   let%span soption'8 = "../../creusot-contracts/src/std/option.rs" 771 8 774 9
@@ -67506,7 +67506,7 @@ module M_creusot_contracts__logic__ra__option__qyi9919140421117497760__frame_pre
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 13 4 13 35
@@ -67687,7 +67687,7 @@ module M_creusot_contracts__logic__ra__prod__qyi12871785784760244066__frame_pres
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 13 4 13 35
@@ -67917,7 +67917,7 @@ module M_creusot_contracts__logic__ra__sum__qyi1847493758823096333__frame_preser
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 13 4 13 35
@@ -68147,7 +68147,7 @@ module M_creusot_contracts__logic__ra__sum__qyi15765748900338894532__frame_prese
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 13 4 13 35
@@ -68340,7 +68340,7 @@ module M_creusot_contracts__logic__ra__update__qyi11826117606277287715__update__
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 37 4 37 40
@@ -68414,7 +68414,7 @@ module M_creusot_contracts__logic__ra__update__qyi11826117606277287715__frame_pr
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 45 4 45 48
@@ -68499,7 +68499,7 @@ module M_creusot_contracts__logic__ra__update__qyi5477729486377161480__update__r
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 63 4 63 45
@@ -68580,7 +68580,7 @@ module M_creusot_contracts__logic__ra__update__qyi5477729486377161480__frame_pre
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 71 4 71 58
@@ -68672,7 +68672,7 @@ module M_creusot_contracts__logic__ra__view__qyi5759646997670148869__update__ref
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -68846,7 +68846,7 @@ module M_creusot_contracts__logic__ra__view__qyi5759646997670148869__frame_prese
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -69098,7 +69098,7 @@ module M_creusot_contracts__logic__ra__view__qyi7400797033094478444__update__ref
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -69253,7 +69253,7 @@ module M_creusot_contracts__logic__ra__view__qyi7400797033094478444__frame_prese
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -69497,7 +69497,7 @@ module M_creusot_contracts__logic__ra__view__qyi5746217084655472194__update__ref
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -69659,7 +69659,7 @@ module M_creusot_contracts__logic__ra__view__qyi5746217084655472194__frame_prese
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 181 14 181 55
@@ -69929,7 +69929,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4304869425182553974__core_is_tot
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -70165,7 +70165,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4304869425182553974__unit__refin
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -70364,7 +70364,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi4304869425182553974__core_total_
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -70543,7 +70543,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__core_is_
   let%span soption'3 = "../../creusot-contracts/src/logic/ra/option.rs" 96 14 96 43
   let%span soption'4 = "../../creusot-contracts/src/logic/ra/option.rs" 98 8 101 9
   let%span soption'5 = "../../creusot-contracts/src/logic/ra/option.rs" 39 14 39 32
-  let%span soption'6 = "../../creusot-contracts/src/logic/ra/option.rs" 37 4 37 10
+  let%span soption'6 = "../../creusot-contracts/src/logic/ra/option.rs" 41 8 41 39
   let%span soption'7 = "../../creusot-contracts/src/logic/ra/option.rs" 46 14 46 98
   let%span soption'8 = "../../creusot-contracts/src/logic/ra/option.rs" 49 12 56 13
   let%span soption'9 = "../../creusot-contracts/src/logic/ra/option.rs" 7 8 11 9
@@ -70558,7 +70558,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__core_is_
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -70690,7 +70690,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__core_tot
   let%span soption = "../../creusot-contracts/src/logic/ra/option.rs" 97 4 97 31
   let%span soption'0 = "../../creusot-contracts/src/logic/ra/option.rs" 7 8 11 9
   let%span soption'1 = "../../creusot-contracts/src/logic/ra/option.rs" 39 14 39 32
-  let%span soption'2 = "../../creusot-contracts/src/logic/ra/option.rs" 37 4 37 10
+  let%span soption'2 = "../../creusot-contracts/src/logic/ra/option.rs" 41 8 41 39
   let%span soption'3 = "../../creusot-contracts/src/logic/ra/option.rs" 46 14 46 98
   let%span soption'4 = "../../creusot-contracts/src/logic/ra/option.rs" 49 12 56 13
   let%span soption'5 = "../../creusot-contracts/src/std/option.rs" 771 8 774 9
@@ -70703,7 +70703,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__core_tot
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -70810,7 +70810,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__unit__re
   let%span soption = "../../creusot-contracts/src/logic/ra/option.rs" 89 4 89 21
   let%span soption'0 = "../../creusot-contracts/src/logic/ra/option.rs" 7 8 11 9
   let%span soption'1 = "../../creusot-contracts/src/logic/ra/option.rs" 39 14 39 32
-  let%span soption'2 = "../../creusot-contracts/src/logic/ra/option.rs" 37 4 37 10
+  let%span soption'2 = "../../creusot-contracts/src/logic/ra/option.rs" 41 8 41 39
   let%span soption'3 = "../../creusot-contracts/src/logic/ra/option.rs" 46 14 46 98
   let%span soption'4 = "../../creusot-contracts/src/logic/ra/option.rs" 49 12 56 13
   let%span soption'5 = "../../creusot-contracts/src/std/option.rs" 771 8 774 9
@@ -70823,7 +70823,7 @@ module M_creusot_contracts__logic__ra__option__qyi18145756475453833322__unit__re
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -70936,7 +70936,7 @@ module M_creusot_contracts__logic__ra__prod__qyi848091308440200351__unit__refine
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 68 4 68 21
@@ -71095,7 +71095,7 @@ module M_creusot_contracts__logic__ra__prod__qyi848091308440200351__core_total__
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 76 4 76 31
@@ -71257,7 +71257,7 @@ module M_creusot_contracts__logic__ra__prod__qyi848091308440200351__core_is_tota
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29
   let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 181 14 181 55
@@ -71500,7 +71500,7 @@ module M_creusot_contracts__logic__ra__view__qyi2387369350023652154__core_total_
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -71721,7 +71721,7 @@ module M_creusot_contracts__logic__ra__view__qyi2387369350023652154__unit__refin
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -71948,7 +71948,7 @@ module M_creusot_contracts__logic__ra__view__qyi2387369350023652154__core_is_tot
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'13 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'14 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'15 = "../../creusot-contracts/src/logic/ra.rs" 171 14 171 78
   let%span sra'16 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
@@ -71957,7 +71957,7 @@ module M_creusot_contracts__logic__ra__view__qyi2387369350023652154__core_is_tot
   let%span sview'1 = "../../creusot-contracts/src/logic/ra/view.rs" 187 8 187 31
   let%span sview'2 = "../../creusot-contracts/src/logic/ra/view.rs" 213 14 213 47
   let%span sview'3 = "../../creusot-contracts/src/logic/ra/view.rs" 214 14 214 43
-  let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 211 4 211 12
+  let%span sview'4 = "../../creusot-contracts/src/logic/ra/view.rs" 216 8 216 39
   let%span sview'5 = "../../creusot-contracts/src/logic/ra/view.rs" 157 14 157 32
   let%span sview'6 = "../../creusot-contracts/src/logic/ra/view.rs" 158 37 158 39
   let%span sview'7 = "../../creusot-contracts/src/logic/ra/view.rs" 162 14 162 98
@@ -72210,7 +72210,7 @@ module M_creusot_contracts__logic__ra__fmap__qyi945878506295166927__frame_preser
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   
@@ -72461,7 +72461,7 @@ module M_creusot_contracts__logic__ra__prod__qyi5623508861439716845__frame_prese
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sprod = "../../creusot-contracts/src/logic/ra/prod.rs" 141 4 141 96
@@ -72701,7 +72701,7 @@ module M_creusot_contracts__logic__ra__sum__qyi3083214512297526849__frame_preser
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 186 4 191 5
@@ -72947,7 +72947,7 @@ module M_creusot_contracts__logic__ra__sum__qyi3543961907530750261__frame_preser
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span ssum = "../../creusot-contracts/src/logic/ra/sum.rs" 236 4 241 5
@@ -73190,7 +73190,7 @@ module M_creusot_contracts__logic__ra__update__qyi10922308247021603688__frame_pr
   let%span sra'4 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'5 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 82 8 82 34
   let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span supdate = "../../creusot-contracts/src/logic/ra/update.rs" 118 4 118 75
@@ -73315,7 +73315,7 @@ module M_creusot_contracts__logic__ra__view__qyi3129231301466035151__inhabits__r
   let%span sra'6 = "../../creusot-contracts/src/logic/ra.rs" 141 4 141 26
   let%span sra'7 = "../../creusot-contracts/src/logic/ra.rs" 142 4 142 26
   let%span sra'8 = "../../creusot-contracts/src/logic/ra.rs" 143 4 143 25
-  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 139 4 139 18
+  let%span sra'9 = "../../creusot-contracts/src/logic/ra.rs" 145 8 145 34
   let%span sra'10 = "../../creusot-contracts/src/logic/ra.rs" 47 14 50 5
   let%span sra'11 = "../../creusot-contracts/src/logic/ra.rs" 175 14 175 39
   let%span sra'12 = "../../creusot-contracts/src/logic/ra.rs" 177 8 177 29

--- a/tests/should_fail/generic_deref_ghost.coma
+++ b/tests/should_fail/generic_deref_ghost.coma
@@ -1,8 +1,8 @@
 module M_generic_deref_ghost__deref_wrap [#"generic_deref_ghost.rs" 8 0 8 48]
   let%span sgeneric_deref_ghost = "generic_deref_ghost.rs" 8 28 8 29
-  let%span sgeneric_deref_ghost'0 = "generic_deref_ghost.rs" 6 0 6 40
+  let%span sgeneric_deref_ghost'0 = "generic_deref_ghost.rs" 6 11 6 38
   let%span sgeneric_deref_ghost'1 = "generic_deref_ghost.rs" 8 38 8 48
-  let%span sgeneric_deref_ghost'2 = "generic_deref_ghost.rs" 7 0 7 48
+  let%span sgeneric_deref_ghost'2 = "generic_deref_ghost.rs" 7 10 7 46
   let%span sgeneric_deref_ghost'3 = "generic_deref_ghost.rs" 1 0 149 4
   let%span sops = "../../creusot-contracts/src/std/ops.rs" 169 14 169 114
   let%span sops'0 = "../../creusot-contracts/src/std/ops.rs" 174 14 174 100
@@ -120,8 +120,8 @@ module M_generic_deref_ghost__deref_wrap [#"generic_deref_ghost.rs" 8 0 8 48]
       (! return' {result}) ]
 end
 module M_generic_deref_ghost__bad [#"generic_deref_ghost.rs" 12 0 12 32]
-  let%span sgeneric_deref_ghost = "generic_deref_ghost.rs" 6 0 6 40
-  let%span sgeneric_deref_ghost'0 = "generic_deref_ghost.rs" 7 0 7 48
+  let%span sgeneric_deref_ghost = "generic_deref_ghost.rs" 6 11 6 38
+  let%span sgeneric_deref_ghost'0 = "generic_deref_ghost.rs" 7 10 7 46
   let%span sops = "../../creusot-contracts/src/std/ops.rs" 169 14 169 114
   let%span sops'0 = "../../creusot-contracts/src/std/ops.rs" 174 14 174 100
   let%span sops'1 = "../../creusot-contracts/src/std/ops.rs" 179 14 179 61

--- a/tests/should_fail/generic_deref_snap.coma
+++ b/tests/should_fail/generic_deref_snap.coma
@@ -1,8 +1,8 @@
 module M_generic_deref_snap__deref_wrap [#"generic_deref_snap.rs" 8 0 8 48]
   let%span sgeneric_deref_snap = "generic_deref_snap.rs" 8 28 8 29
-  let%span sgeneric_deref_snap'0 = "generic_deref_snap.rs" 6 0 6 40
+  let%span sgeneric_deref_snap'0 = "generic_deref_snap.rs" 6 11 6 38
   let%span sgeneric_deref_snap'1 = "generic_deref_snap.rs" 8 38 8 48
-  let%span sgeneric_deref_snap'2 = "generic_deref_snap.rs" 7 0 7 48
+  let%span sgeneric_deref_snap'2 = "generic_deref_snap.rs" 7 10 7 46
   let%span sgeneric_deref_snap'3 = "generic_deref_snap.rs" 1 0 149 4
   let%span sops = "../../creusot-contracts/src/std/ops.rs" 169 14 169 114
   let%span sops'0 = "../../creusot-contracts/src/std/ops.rs" 174 14 174 100
@@ -120,8 +120,8 @@ module M_generic_deref_snap__deref_wrap [#"generic_deref_snap.rs" 8 0 8 48]
       (! return' {result}) ]
 end
 module M_generic_deref_snap__bad [#"generic_deref_snap.rs" 12 0 12 35]
-  let%span sgeneric_deref_snap = "generic_deref_snap.rs" 6 0 6 40
-  let%span sgeneric_deref_snap'0 = "generic_deref_snap.rs" 7 0 7 48
+  let%span sgeneric_deref_snap = "generic_deref_snap.rs" 6 11 6 38
+  let%span sgeneric_deref_snap'0 = "generic_deref_snap.rs" 7 10 7 46
   let%span sgeneric_deref_snap'1 = "generic_deref_snap.rs" 1 0 149 4
   let%span sops = "../../creusot-contracts/src/std/ops.rs" 169 14 169 114
   let%span sops'0 = "../../creusot-contracts/src/std/ops.rs" 174 14 174 100

--- a/tests/should_succeed/bdd.coma
+++ b/tests/should_succeed/bdd.coma
@@ -1120,7 +1120,7 @@ module M_bdd__qyi11078426090797403070__discr_valuation [#"bdd.rs" 364 4 364 82] 
   let%span sbdd'2 = "bdd.rs" 360 15 360 21
   let%span sbdd'3 = "bdd.rs" 361 14 361 50
   let%span sbdd'4 = "bdd.rs" 362 14 362 33
-  let%span sbdd'5 = "bdd.rs" 365 8 402 9
+  let%span sbdd'5 = "bdd.rs" 366 12 366 45
   let%span sbdd'6 = "bdd.rs" 305 12 305 47
   let%span sbdd'7 = "bdd.rs" 208 12 215 13
   let%span sbdd'8 = "bdd.rs" 220 14 220 25
@@ -1439,7 +1439,7 @@ module M_bdd__qyi11078426090797403070__bdd_canonical [#"bdd.rs" 412 4 412 62] (*
   let%span sbdd'1 = "bdd.rs" 408 4 408 37
   let%span sbdd'2 = "bdd.rs" 409 15 409 51
   let%span sbdd'3 = "bdd.rs" 410 14 410 20
-  let%span sbdd'4 = "bdd.rs" 405 4 405 12
+  let%span sbdd'4 = "bdd.rs" 413 8 413 38
   let%span sbdd'5 = "bdd.rs" 305 12 305 47
   let%span sbdd'6 = "bdd.rs" 208 12 215 13
   let%span sbdd'7 = "bdd.rs" 357 15 357 24
@@ -1448,7 +1448,7 @@ module M_bdd__qyi11078426090797403070__bdd_canonical [#"bdd.rs" 412 4 412 62] (*
   let%span sbdd'10 = "bdd.rs" 360 15 360 21
   let%span sbdd'11 = "bdd.rs" 361 14 361 50
   let%span sbdd'12 = "bdd.rs" 362 14 362 33
-  let%span sbdd'13 = "bdd.rs" 365 8 402 9
+  let%span sbdd'13 = "bdd.rs" 366 12 366 45
   let%span sbdd'14 = "bdd.rs" 220 14 220 25
   let%span sbdd'15 = "bdd.rs" 223 12 231 13
   let%span sbdd'16 = "bdd.rs" 238 12 242 13

--- a/tests/should_succeed/bug/874.coma
+++ b/tests/should_succeed/bug/874.coma
@@ -15,7 +15,7 @@ module M_874__can_extend [#"874.rs" 4 0 4 19]
   let%span sslice = "../../../creusot-contracts/src/std/slice.rs" 356 18 356 35
   let%span sslice'0 = "../../../creusot-contracts/src/std/slice.rs" 30 14 30 41
   let%span sslice'1 = "../../../creusot-contracts/src/std/slice.rs" 31 14 31 42
-  let%span svec = "../../../creusot-contracts/src/std/vec.rs" 137 16 137 63
+  let%span svec = "../../../creusot-contracts/src/std/vec.rs" 137 27 137 61
   let%span svec'0 = "../../../creusot-contracts/src/std/vec.rs" 138 26 141 102
   let%span svec'1 = "../../../creusot-contracts/src/std/vec.rs" 21 14 21 41
   let%span svec'2 = "../../../creusot-contracts/src/std/vec.rs" 185 18 185 34

--- a/tests/should_succeed/cc/collections.coma
+++ b/tests/should_succeed/cc/collections.coma
@@ -21,7 +21,7 @@ module M_collections__roundtrip_hashmap_into_iter [#"collections.rs" 15 0 17 18]
   let%span sfmap'0 = "../../../creusot-contracts/src/logic/fmap.rs" 116 8 116 27
   let%span sfmap'1 = "../../../creusot-contracts/src/logic/fmap.rs" 261 4 261 12
   let%span sfmap'2 = "../../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
-  let%span sfmap'3 = "../../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'3 = "../../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'4 = "../../../creusot-contracts/src/logic/fmap.rs" 120 4 120 12
   let%span sfmap'5 = "../../../creusot-contracts/src/logic/fmap.rs" 61 14 61 25
   let%span sfmap'6 = "../../../creusot-contracts/src/logic/fmap.rs" 104 4 104 12
@@ -335,7 +335,7 @@ module M_collections__roundtrip_hashmap_iter [#"collections.rs" 35 0 35 97]
   let%span sfmap'0 = "../../../creusot-contracts/src/logic/fmap.rs" 120 4 120 12
   let%span sfmap'1 = "../../../creusot-contracts/src/logic/fmap.rs" 61 14 61 25
   let%span sfmap'2 = "../../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
-  let%span sfmap'3 = "../../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'3 = "../../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'4 = "../../../creusot-contracts/src/logic/fmap.rs" 52 14 52 31
   let%span sfmap'5 = "../../../creusot-contracts/src/logic/fmap.rs" 53 14 53 43
   let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 352 20 352 71
@@ -558,7 +558,7 @@ module M_collections__roundtrip_hashmap_iter_mut [#"collections.rs" 51 0 53 24]
   let%span sfmap'3 = "../../../creusot-contracts/src/logic/fmap.rs" 61 14 61 25
   let%span sfmap'4 = "../../../creusot-contracts/src/logic/fmap.rs" 104 4 104 12
   let%span sfmap'5 = "../../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
-  let%span sfmap'6 = "../../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'6 = "../../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'7 = "../../../creusot-contracts/src/logic/fmap.rs" 52 14 52 31
   let%span sfmap'8 = "../../../creusot-contracts/src/logic/fmap.rs" 53 14 53 43
   let%span sseq = "../../../creusot-contracts/src/logic/seq.rs" 352 20 352 71

--- a/tests/should_succeed/generic_deref.coma
+++ b/tests/should_succeed/generic_deref.coma
@@ -1,8 +1,8 @@
 module M_generic_deref__deref_wrap [#"generic_deref.rs" 7 0 7 48]
   let%span sgeneric_deref = "generic_deref.rs" 7 28 7 29
-  let%span sgeneric_deref'0 = "generic_deref.rs" 5 0 5 40
+  let%span sgeneric_deref'0 = "generic_deref.rs" 5 11 5 38
   let%span sgeneric_deref'1 = "generic_deref.rs" 7 38 7 48
-  let%span sgeneric_deref'2 = "generic_deref.rs" 6 0 6 48
+  let%span sgeneric_deref'2 = "generic_deref.rs" 6 10 6 46
   let%span sgeneric_deref'3 = "generic_deref.rs" 1 0 149 4
   let%span sops = "../../creusot-contracts/src/std/ops.rs" 169 14 169 114
   let%span sops'0 = "../../creusot-contracts/src/std/ops.rs" 174 14 174 100
@@ -122,7 +122,7 @@ module M_generic_deref__deref_mut_wrap [#"generic_deref.rs" 17 0 17 63]
   let%span sgeneric_deref = "generic_deref.rs" 17 35 17 36
   let%span sgeneric_deref'0 = "generic_deref.rs" 15 11 15 73
   let%span sgeneric_deref'1 = "generic_deref.rs" 17 49 17 63
-  let%span sgeneric_deref'2 = "generic_deref.rs" 16 0 16 52
+  let%span sgeneric_deref'2 = "generic_deref.rs" 16 10 16 50
   let%span sgeneric_deref'3 = "generic_deref.rs" 1 0 272 4
   let%span sops = "../../creusot-contracts/src/std/ops.rs" 169 14 169 114
   let%span sops'0 = "../../creusot-contracts/src/std/ops.rs" 174 14 174 100

--- a/tests/should_succeed/ghost/ghost_map.coma
+++ b/tests/should_succeed/ghost/ghost_map.coma
@@ -66,7 +66,7 @@ module M_ghost_map__ghost_map [#"ghost_map.rs" 4 0 4 18]
   let%span sfmap'19 = "../../../creusot-contracts/src/logic/fmap.rs" 85 14 85 43
   let%span sfmap'20 = "../../../creusot-contracts/src/logic/fmap.rs" 86 14 86 84
   let%span sfmap'21 = "../../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
-  let%span sfmap'22 = "../../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'22 = "../../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'23 = "../../../creusot-contracts/src/logic/fmap.rs" 52 14 52 31
   let%span sfmap'24 = "../../../creusot-contracts/src/logic/fmap.rs" 53 14 53 43
   let%span sghost = "../../../creusot-contracts/src/ghost.rs" 79 14 79 35

--- a/tests/should_succeed/iterators/03_std_iterators.coma
+++ b/tests/should_succeed/iterators/03_std_iterators.coma
@@ -1756,9 +1756,9 @@ module M_03_std_iterators__my_reverse [#"03_std_iterators.rs" 92 0 92 37]
   let%span sslice'5 = "../../../creusot-contracts/src/std/slice.rs" 30 14 30 41
   let%span sslice'6 = "../../../creusot-contracts/src/std/slice.rs" 31 14 31 42
   let%span sslice'7 = "../../../creusot-contracts/src/std/slice.rs" 20 20 20 30
-  let%span siter = "../../../creusot-contracts/src/std/iter.rs" 159 16 159 64
+  let%span siter = "../../../creusot-contracts/src/std/iter.rs" 159 27 159 62
   let%span siter'0 = "../../../creusot-contracts/src/std/iter.rs" 160 26 160 48
-  let%span siter'1 = "../../../creusot-contracts/src/std/iter.rs" 161 16 161 80
+  let%span siter'1 = "../../../creusot-contracts/src/std/iter.rs" 161 26 161 78
   let%span siter'2 = "../../../creusot-contracts/src/std/iter.rs" 212 18 212 32
   let%span siter'3 = "../../../creusot-contracts/src/std/iter.rs" 92 26 95 17
   let%span smodel = "../../../creusot-contracts/src/model.rs" 62 8 62 22

--- a/tests/should_succeed/iterators/04_skip.coma
+++ b/tests/should_succeed/iterators/04_skip.coma
@@ -168,7 +168,7 @@ module M_04_skip__qyi11393468722733824414__next [#"04_skip.rs" 65 4 65 41] (* <S
   let%span scommon'1 = "common.rs" 19 4 19 34
   let%span scommon'2 = "common.rs" 20 4 20 44
   let%span smem = "../../../creusot-contracts/src/std/mem.rs" 21 22 21 37
-  let%span smem'0 = "../../../creusot-contracts/src/std/mem.rs" 22 12 22 59
+  let%span smem'0 = "../../../creusot-contracts/src/std/mem.rs" 22 22 22 57
   let%span sindex = "../../../creusot-contracts/src/logic/ops/index.rs" 96 8 96 33
   let%span snum = "../../../creusot-contracts/src/std/num.rs" 30 26 30 41
   let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 49 20 49 34

--- a/tests/should_succeed/lang/unsized_quant.coma
+++ b/tests/should_succeed/lang/unsized_quant.coma
@@ -1,7 +1,7 @@
-module M_unsized_quant__l [#"unsized_quant.rs" 19 0 19 10]
-  let%span sunsized_quant = "unsized_quant.rs" 18 10 18 13
-  let%span sunsized_quant'0 = "unsized_quant.rs" 19 11 19 13
-  let%span sunsized_quant'1 = "unsized_quant.rs" 10 8 10 38
+module M_unsized_quant__l [#"unsized_quant.rs" 16 0 16 10]
+  let%span sunsized_quant = "unsized_quant.rs" 15 10 15 13
+  let%span sunsized_quant'0 = "unsized_quant.rs" 16 11 16 13
+  let%span sunsized_quant'1 = "unsized_quant.rs" 7 8 7 38
   let%span sslice = "../../../creusot-contracts/src/std/slice.rs" 30 14 30 41
   let%span sslice'0 = "../../../creusot-contracts/src/std/slice.rs" 31 14 31 42
   let%span smapping = "../../../creusot-contracts/src/logic/mapping.rs" 67 4 67 12
@@ -24,7 +24,7 @@ module M_unsized_quant__l [#"unsized_quant.rs" 19 0 19 10]
   function index_logic (self: Map.map (Slice64.slice Int32.t) int) (a: Slice64.slice Int32.t) : int =
     [%#smapping] Map.get self a
   
-  predicate f [#"unsized_quant.rs" 8 0 8 18] =
+  predicate f [#"unsized_quant.rs" 5 0 5 18] =
     [%#sunsized_quant'1] let len = fun (x: Slice64.slice Int32.t) -> Seq.length (view x) in forall x: Slice64.slice Int32.t, y: Slice64.slice Int32.t. index_logic len x
         + index_logic len y
       >= 0
@@ -33,7 +33,7 @@ module M_unsized_quant__l [#"unsized_quant.rs" 19 0 19 10]
   
   meta "select_lsinst" "all"
   
-  function l [#"unsized_quant.rs" 19 0 19 10] : ()
+  function l [#"unsized_quant.rs" 16 0 16 10] : ()
   
   goal vc_l: [@expl:l ensures] [%#sunsized_quant] f
 end

--- a/tests/should_succeed/lang/unsized_quant.rs
+++ b/tests/should_succeed/lang/unsized_quant.rs
@@ -1,6 +1,3 @@
-#![allow(incomplete_features)]
-#![feature(unsized_locals)]
-
 extern crate creusot_contracts;
 use creusot_contracts::*;
 

--- a/tests/should_succeed/local_invariant_cellinv.coma
+++ b/tests/should_succeed/local_invariant_cellinv.coma
@@ -11,9 +11,9 @@ module M_local_invariant_cellinv__qyi5959203038510030748__read [#"local_invarian
   let%span slocal_invariant_cellinv'4 = "local_invariant_cellinv.rs" 31 8 31 25
   let%span slocal_invariant_cellinv'5 = "local_invariant_cellinv.rs" 21 8 21 92
   let%span slocal_invariant = "../../creusot-contracts/src/local_invariant.rs" 230 59 230 60
-  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 227 4 227 119
+  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 227 15 227 117
   let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 230 4 232 51
-  let%span slocal_invariant'2 = "../../creusot-contracts/src/local_invariant.rs" 228 4 228 127
+  let%span slocal_invariant'2 = "../../creusot-contracts/src/local_invariant.rs" 228 14 228 125
   let%span slocal_invariant'3 = "../../creusot-contracts/src/local_invariant.rs" 133 4 133 12
   let%span slocal_invariant'4 = "../../creusot-contracts/src/local_invariant.rs" 189 4 191 51
   let%span slocal_invariant'5 = "../../creusot-contracts/src/local_invariant.rs" 189 59 189 60
@@ -364,8 +364,8 @@ module M_local_invariant_cellinv__qyi5959203038510030748__write [#"local_invaria
   let%span slocal_invariant_cellinv'4 = "local_invariant_cellinv.rs" 31 8 31 25
   let%span slocal_invariant_cellinv'5 = "local_invariant_cellinv.rs" 21 8 21 92
   let%span slocal_invariant = "../../creusot-contracts/src/local_invariant.rs" 230 59 230 60
-  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 227 4 227 119
-  let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 228 4 228 127
+  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 227 15 227 117
+  let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 228 14 228 125
   let%span slocal_invariant'2 = "../../creusot-contracts/src/local_invariant.rs" 133 4 133 12
   let%span slocal_invariant'3 = "../../creusot-contracts/src/local_invariant.rs" 189 4 191 51
   let%span slocal_invariant'4 = "../../creusot-contracts/src/local_invariant.rs" 189 59 189 60

--- a/tests/should_succeed/persistent_array.coma
+++ b/tests/should_succeed/persistent_array.coma
@@ -222,7 +222,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__new [#"persis
   let%span sfmap'12 = "../../creusot-contracts/src/logic/fmap.rs" 94 4 94 12
   let%span sfmap'13 = "../../creusot-contracts/src/logic/fmap.rs" 61 14 61 25
   let%span sfmap'14 = "../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
-  let%span sfmap'15 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'15 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'16 = "../../creusot-contracts/src/logic/fmap.rs" 511 20 511 76
   let%span sfmap'17 = "../../creusot-contracts/src/logic/fmap.rs" 261 4 261 12
   let%span sfmap'18 = "../../creusot-contracts/src/logic/fmap.rs" 104 4 104 12
@@ -993,7 +993,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__set [#"persis
   let%span sfmap'15 = "../../creusot-contracts/src/logic/fmap.rs" 511 20 511 76
   let%span sfmap'16 = "../../creusot-contracts/src/logic/fmap.rs" 104 4 104 12
   let%span slocal_invariant = "../../creusot-contracts/src/local_invariant.rs" 212 59 212 60
-  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 204 4 204 48
+  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 204 15 204 46
   let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 205 15 206 115
   let%span slocal_invariant'2 = "../../creusot-contracts/src/local_invariant.rs" 208 14 209 124
   let%span slocal_invariant'3 = "../../creusot-contracts/src/local_invariant.rs" 133 4 133 12
@@ -2048,7 +2048,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get_immut [#"
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 104 4 104 12
   let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 511 20 511 76
   let%span slocal_invariant = "../../creusot-contracts/src/local_invariant.rs" 212 59 212 60
-  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 204 4 204 48
+  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 204 15 204 46
   let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 205 15 206 115
   let%span slocal_invariant'2 = "../../creusot-contracts/src/local_invariant.rs" 212 4 214 51
   let%span slocal_invariant'3 = "../../creusot-contracts/src/local_invariant.rs" 208 14 209 124
@@ -3363,7 +3363,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get [#"persis
   let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 104 4 104 12
   let%span sfmap'6 = "../../creusot-contracts/src/logic/fmap.rs" 511 20 511 76
   let%span slocal_invariant = "../../creusot-contracts/src/local_invariant.rs" 212 59 212 60
-  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 204 4 204 48
+  let%span slocal_invariant'0 = "../../creusot-contracts/src/local_invariant.rs" 204 15 204 46
   let%span slocal_invariant'1 = "../../creusot-contracts/src/local_invariant.rs" 205 15 206 115
   let%span slocal_invariant'2 = "../../creusot-contracts/src/local_invariant.rs" 212 4 214 51
   let%span slocal_invariant'3 = "../../creusot-contracts/src/local_invariant.rs" 208 14 209 124

--- a/tests/should_succeed/red_black_tree.coma
+++ b/tests/should_succeed/red_black_tree.coma
@@ -1056,7 +1056,7 @@ module M_red_black_tree__qyi3665871523867809084__rotate_right [#"red_black_tree.
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span smem = "../../creusot-contracts/src/std/mem.rs" 23 32 23 36
   let%span smem'0 = "../../creusot-contracts/src/std/mem.rs" 21 22 21 37
-  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 12 22 59
+  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 22 22 57
   let%span smem'2 = "../../creusot-contracts/src/std/mem.rs" 19 23 19 24
   let%span smem'3 = "../../creusot-contracts/src/std/mem.rs" 19 34 19 35
   let%span smem'4 = "../../creusot-contracts/src/std/mem.rs" 17 22 17 30
@@ -1589,7 +1589,7 @@ module M_red_black_tree__qyi3665871523867809084__rotate_left [#"red_black_tree.r
   let%span sboxed = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span smem = "../../creusot-contracts/src/std/mem.rs" 23 32 23 36
   let%span smem'0 = "../../creusot-contracts/src/std/mem.rs" 21 22 21 37
-  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 12 22 59
+  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 22 22 57
   let%span smem'2 = "../../creusot-contracts/src/std/mem.rs" 19 23 19 24
   let%span smem'3 = "../../creusot-contracts/src/std/mem.rs" 19 34 19 35
   let%span smem'4 = "../../creusot-contracts/src/std/mem.rs" 17 22 17 30
@@ -4723,7 +4723,7 @@ module M_red_black_tree__qyi3529752165842986389__delete_max_rec [#"red_black_tre
   let%span sboxed'2 = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span smem = "../../creusot-contracts/src/std/mem.rs" 23 32 23 36
   let%span smem'0 = "../../creusot-contracts/src/std/mem.rs" 21 22 21 37
-  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 12 22 59
+  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 22 22 57
   let%span soption = "../../creusot-contracts/src/std/option.rs" 102 16 102 17
   let%span soption'0 = "../../creusot-contracts/src/std/option.rs" 103 26 103 75
   let%span soption'1 = "../../creusot-contracts/src/std/option.rs" 105 20 106 100
@@ -5501,7 +5501,7 @@ module M_red_black_tree__qyi3529752165842986389__delete_min_rec [#"red_black_tre
   let%span sboxed'2 = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span smem = "../../creusot-contracts/src/std/mem.rs" 23 32 23 36
   let%span smem'0 = "../../creusot-contracts/src/std/mem.rs" 21 22 21 37
-  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 12 22 59
+  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 22 22 57
   let%span soption = "../../creusot-contracts/src/std/option.rs" 102 16 102 17
   let%span soption'0 = "../../creusot-contracts/src/std/option.rs" 103 26 103 75
   let%span soption'1 = "../../creusot-contracts/src/std/option.rs" 105 20 106 100
@@ -6297,7 +6297,7 @@ module M_red_black_tree__qyi3529752165842986389__delete_rec [#"red_black_tree.rs
   let%span sboxed'2 = "../../creusot-contracts/src/std/boxed.rs" 33 8 33 18
   let%span smem = "../../creusot-contracts/src/std/mem.rs" 23 32 23 36
   let%span smem'0 = "../../creusot-contracts/src/std/mem.rs" 21 22 21 37
-  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 12 22 59
+  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 22 22 57
   let%span smem'2 = "../../creusot-contracts/src/std/mem.rs" 19 23 19 24
   let%span smem'3 = "../../creusot-contracts/src/std/mem.rs" 19 34 19 35
   let%span smem'4 = "../../creusot-contracts/src/std/mem.rs" 17 22 17 30
@@ -7340,7 +7340,7 @@ end
 module M_red_black_tree__qyi7670249875066633436__resolve_coherence [#"red_black_tree.rs" 782 4 782 30] (* <Map<K, V> as creusot_contracts::Resolve> *)
   let%span sred_black_tree = "red_black_tree.rs" 780 15 780 39
   let%span sred_black_tree'0 = "red_black_tree.rs" 781 4 781 30
-  let%span sred_black_tree'1 = "red_black_tree.rs" 779 4 779 23
+  let%span sred_black_tree'1 = "red_black_tree.rs" 783 8 783 48
   let%span sred_black_tree'2 = "red_black_tree.rs" 776 20 776 67
   let%span sred_black_tree'3 = "red_black_tree.rs" 106 4 106 37
   let%span sred_black_tree'4 = "red_black_tree.rs" 107 14 107 78

--- a/tests/should_succeed/resource_algebras/fmap_view_view.coma
+++ b/tests/should_succeed/resource_algebras/fmap_view_view.coma
@@ -946,7 +946,7 @@ module M_fmap_view_view__qyi16747555808275470465__insert [#"fmap_view_view.rs" 1
   let%span sview'11 = "../../../creusot-contracts/src/logic/ra/view.rs" 162 14 162 98
   let%span sview'12 = "../../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'13 = "../../../creusot-contracts/src/logic/ra/view.rs" 134 14 137 5
-  let%span sview'14 = "../../../creusot-contracts/src/logic/ra/view.rs" 132 4 132 12
+  let%span sview'14 = "../../../creusot-contracts/src/logic/ra/view.rs" 139 8 139 49
   let%span sresource = "../../../creusot-contracts/src/resource.rs" 236 8 236 39
   let%span sresource'0 = "../../../creusot-contracts/src/resource.rs" 237 18 237 43
   let%span sresource'1 = "../../../creusot-contracts/src/resource.rs" 238 18 238 56
@@ -1529,7 +1529,7 @@ module M_fmap_view_view__qyi16747555808275470465__contains [#"fmap_view_view.rs"
   let%span sview'1 = "../../../creusot-contracts/src/logic/ra/view.rs" 162 14 162 98
   let%span sview'2 = "../../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'3 = "../../../creusot-contracts/src/logic/ra/view.rs" 134 14 137 5
-  let%span sview'4 = "../../../creusot-contracts/src/logic/ra/view.rs" 132 4 132 12
+  let%span sview'4 = "../../../creusot-contracts/src/logic/ra/view.rs" 139 8 139 49
   let%span sview'5 = "../../../creusot-contracts/src/logic/ra/view.rs" 93 15 93 33
   let%span sview'6 = "../../../creusot-contracts/src/logic/ra/view.rs" 94 14 94 35
   let%span sview'7 = "../../../creusot-contracts/src/logic/ra/view.rs" 95 14 95 35
@@ -2037,7 +2037,7 @@ module M_fmap_view_view__qyi9127813262067876198__clone [#"fmap_view_view.rs" 159
   let%span sview'3 = "../../../creusot-contracts/src/logic/ra/view.rs" 121 12 128 13
   let%span sview'4 = "../../../creusot-contracts/src/logic/ra/view.rs" 213 14 213 47
   let%span sview'5 = "../../../creusot-contracts/src/logic/ra/view.rs" 214 14 214 43
-  let%span sview'6 = "../../../creusot-contracts/src/logic/ra/view.rs" 211 4 211 12
+  let%span sview'6 = "../../../creusot-contracts/src/logic/ra/view.rs" 216 8 216 39
   let%span sview'7 = "../../../creusot-contracts/src/logic/ra/view.rs" 78 14 78 41
   let%span sview'8 = "../../../creusot-contracts/src/logic/ra/view.rs" 93 15 93 33
   let%span sview'9 = "../../../creusot-contracts/src/logic/ra/view.rs" 94 14 94 35
@@ -2045,7 +2045,7 @@ module M_fmap_view_view__qyi9127813262067876198__clone [#"fmap_view_view.rs" 159
   let%span sview'11 = "../../../creusot-contracts/src/logic/ra/view.rs" 110 15 110 33
   let%span sview'12 = "../../../creusot-contracts/src/logic/ra/view.rs" 112 8 112 29
   let%span sview'13 = "../../../creusot-contracts/src/logic/ra/view.rs" 134 14 137 5
-  let%span sview'14 = "../../../creusot-contracts/src/logic/ra/view.rs" 132 4 132 12
+  let%span sview'14 = "../../../creusot-contracts/src/logic/ra/view.rs" 139 8 139 49
   let%span sresource = "../../../creusot-contracts/src/resource.rs" 108 19 108 39
   let%span sresource'0 = "../../../creusot-contracts/src/resource.rs" 109 18 109 42
   let%span sresource'1 = "../../../creusot-contracts/src/resource.rs" 110 18 110 47
@@ -2953,7 +2953,7 @@ module M_fmap_view_view__qyi9127813262067876198__clone__refines [#"fmap_view_vie
   let%span sview'1 = "../../../creusot-contracts/src/logic/ra/view.rs" 157 14 157 32
   let%span sview'2 = "../../../creusot-contracts/src/logic/ra/view.rs" 162 14 162 98
   let%span sview'3 = "../../../creusot-contracts/src/logic/ra/view.rs" 134 14 137 5
-  let%span sview'4 = "../../../creusot-contracts/src/logic/ra/view.rs" 132 4 132 12
+  let%span sview'4 = "../../../creusot-contracts/src/logic/ra/view.rs" 139 8 139 49
   let%span sview'5 = "../../../creusot-contracts/src/logic/ra/view.rs" 93 15 93 33
   let%span sview'6 = "../../../creusot-contracts/src/logic/ra/view.rs" 94 14 94 35
   let%span sview'7 = "../../../creusot-contracts/src/logic/ra/view.rs" 95 14 95 35

--- a/tests/should_succeed/syntax/derive_macros/mixed.coma
+++ b/tests/should_succeed/syntax/derive_macros/mixed.coma
@@ -1,6 +1,6 @@
 module M_mixed__qyi2592445413368279263__clone [#"mixed.rs" 8 9 8 14] (* <Product<A, B> as creusot_contracts::Clone> *)
   let%span smixed = "mixed.rs" 8 9 8 14
-  let%span smixed'0 = "mixed.rs" 8 9 8 14
+  let%span smixed'0 = "mixed.rs" 10 4 11 12
   let%span smixed'1 = "mixed.rs" 1 0 165 4
   let%span sops = "../../../../creusot-contracts/src/std/ops.rs" 169 14 169 114
   let%span sops'0 = "../../../../creusot-contracts/src/std/ops.rs" 174 14 174 100

--- a/tests/should_succeed/take_first_mut.coma
+++ b/tests/should_succeed/take_first_mut.coma
@@ -4,7 +4,7 @@ module M_take_first_mut__take_first_mut [#"take_first_mut.rs" 14 0 14 74]
   let%span stake_first_mut'1 = "take_first_mut.rs" 6 10 13 1
   let%span smem = "../../creusot-contracts/src/std/mem.rs" 23 32 23 36
   let%span smem'0 = "../../creusot-contracts/src/std/mem.rs" 21 22 21 37
-  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 12 22 59
+  let%span smem'1 = "../../creusot-contracts/src/std/mem.rs" 22 22 22 57
   let%span sslice = "../../creusot-contracts/src/std/slice.rs" 301 8 301 9
   let%span sslice'0 = "../../creusot-contracts/src/std/slice.rs" 302 18 310 9
   let%span sslice'1 = "../../creusot-contracts/src/std/slice.rs" 30 14 30 41

--- a/tests/should_succeed/union_find.coma
+++ b/tests/should_succeed/union_find.coma
@@ -91,7 +91,7 @@ module M_union_find__implementation__qyi1944850640244667852__new [#"union_find.r
   let%span sfmap'0 = "../../creusot-contracts/src/logic/fmap.rs" 274 4 274 33
   let%span sfmap'1 = "../../creusot-contracts/src/logic/fmap.rs" 120 4 120 12
   let%span sfmap'2 = "../../creusot-contracts/src/logic/fmap.rs" 186 14 186 39
-  let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 188 8 191 9
+  let%span sfmap'3 = "../../creusot-contracts/src/logic/fmap.rs" 189 12 189 35
   let%span sfmap'4 = "../../creusot-contracts/src/logic/fmap.rs" 52 14 52 31
   let%span sfmap'5 = "../../creusot-contracts/src/logic/fmap.rs" 53 14 53 43
   let%span sfmap'6 = "../../creusot-contracts/src/logic/fmap.rs" 94 4 94 12

--- a/tests/should_succeed/vector/06_knights_tour.coma
+++ b/tests/should_succeed/vector/06_knights_tour.coma
@@ -1,5 +1,5 @@
 module M_06_knights_tour__qyi50474406909270761__clone [#"06_knights_tour.rs" 4 15 4 20] (* <Point as creusot_contracts::Clone> *)
-  let%span s06_knights_tour = "06_knights_tour.rs" 4 15 4 20
+  let%span s06_knights_tour = "06_knights_tour.rs" 6 4 7 16
   let%span snum = "../../../creusot-contracts/src/std/num.rs" 35 26 35 41
   let%span sops = "../../../creusot-contracts/src/std/ops.rs" 169 14 169 114
   let%span sops'0 = "../../../creusot-contracts/src/std/ops.rs" 174 14 174 100


### PR DESCRIPTION
To not rely on deprecated feature `unsized_locals`.

Implement https://github.com/creusot-rs/creusot/pull/1659#issuecomment-3228473959 with one key difference: we can't rewrite arbitrary patterns to wrap variables under `ref` because proc macros can't distinguish variables from unqualified constructors (you want to avoid "`ref None`"). This affects `Mapping` arguments, `match` patterns, and logic function arguments. I compromise by only rewriting `Mapping`s whose argument pattern is a single identifier (`|x|` or `|x: ty|`), which is the vastly most common use case. `Mapping` with non-identifier patterns are not modified. Nor are `match` patterns and logic function arguments (but note that `#[logic] fn f(x: unsizedTy)` already works without doing anything; it's non-variable patterns that are trickier).
