### PR TITLE
hack: Disable -Znext-solver when invoking rustdoc

### DIFF
--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -123,6 +123,9 @@ fn invoke_cargo(
     if matches!(&args.subcommand, Some(LegacyCreusotSubCommand::Doc { .. })) {
         let mut rustdocflags = String::new();
         for &arg in CREUSOT_RUSTC_ARGS {
+            if arg == "-Znext-solver=globally" {
+                continue;
+            }
             rustdocflags.push_str(arg);
             rustdocflags.push(' ');
         }


### PR DESCRIPTION
Avoid crash during `cargo creusot doc`

Fix #1683 shoddily