### PR TITLE
doc: Fix URLs for custom CSS and JS

### DIFF
--- a/ci/html/header.html
+++ b/ci/html/header.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" type="text/css" href="/highlight.css">
+<link rel="stylesheet" type="text/css" href="https://creusot-rs.github.io/creusot/doc/highlight.css">

--- a/ci/html/postscript.html
+++ b/ci/html/postscript.html
@@ -1,4 +1,4 @@
-<script src="/highlight.js"></script>
+<script src="https://creusot-rs.github.io/creusot/doc/highlight.js"></script>
 <script>
   hljs.configure({
       tabReplace: '    ',


### PR DESCRIPTION
There doesn't seem to be an option in rustdoc to insert relative paths to our own files so we have to use full URLs.