### PR TITLE
Update why3find to 1.2.0

### DIFF
--- a/creusot-deps.opam
+++ b/creusot-deps.opam
@@ -5,9 +5,9 @@ maintainer: "Armaël Guéneau <armael.gueneau@inria.fr>"
 authors: "the creusot authors"
 depends: [
   "ocaml" {= "5.3.0"}
-  "why3" {= "git-f0b5"}
-  "why3-ide" {= "git-f0b5" & !?in-creusot-ci}
-  "why3find" {= "git-d227"}
+  "why3" {= "git-a594d1c33"}
+  "why3-ide" {= "git-a594d1c33" & !?in-creusot-ci}
+  "why3find" {= "1.2.0"} # if these versions changes don't forget to update creusot-setup/src/tools_versions_urls.rs
 # optional dependencies of why3
   "ocamlgraph"
   "camlzip"
@@ -16,7 +16,6 @@ depends: [
 # When updating the hash and git-XXX below, don't forget to update them in the
 # depends: field above!
 pin-depends: [
-  [ "why3.git-f0b5" "git+https://gitlab.inria.fr/why3/why3.git#f0b5206c" ]
-  [ "why3-ide.git-f0b5" "git+https://gitlab.inria.fr/why3/why3.git#f0b5206c" ]
-  [ "why3find.git-d227" "git+https://git.frama-c.com/pub/why3find.git#d227fc5" ]
+  [ "why3.git-a594d1c33" "git+https://gitlab.inria.fr/why3/why3.git#a594d1c33" ]
+  [ "why3-ide.git-a594d1c33" "git+https://gitlab.inria.fr/why3/why3.git#a594d1c33" ]
 ]

--- a/creusot-setup/src/tools_versions_urls.rs
+++ b/creusot-setup/src/tools_versions_urls.rs
@@ -8,7 +8,7 @@
 // tools without binary releases
 pub const WHY3_VERSION: &'static str = "1.8.1";
 pub const WHY3_CONFIG_MAGIC_NUMBER: &'static str = "14";
-pub const WHY3FIND_VERSION: &'static str = "1.1.1";
+pub const WHY3FIND_VERSION: &'static str = "1.2.0";
 // tools with binary releases
 pub const ALTERGO_VERSION: &'static str = "2.6.0";
 pub const Z3_VERSION: &'static str = "4.12.4";


### PR DESCRIPTION
@creusot-rs this upgrade requires manually unpinning why3find, now that we pull it from opam instead of from source.

```
opam pin --switch=~/.local/share/creusot remove why3find -n
```