### PR TITLE
Fix error when translating `dyn`

### DIFF
--- a/creusot-contracts/src/std/fmt.rs
+++ b/creusot-contracts/src/std/fmt.rs
@@ -1,17 +1,132 @@
 use crate::*;
 #[cfg(creusot)]
-use ::std::fmt::{Arguments, Debug, Formatter};
+use ::std::fmt::{Arguments, Debug, Error, Formatter};
 
 extern_spec! {
     mod core {
         mod fmt {
             impl<'a> Formatter<'a> {
                 #[requires(true)]
+                fn write_str(&mut self, data: &str) -> Result<(), Error>;
+
+                #[requires(true)]
                 fn debug_struct_field1_finish<'b>(
                     &'b mut self,
                     name: &str,
                     name1: &str,
                     value1: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_struct_field2_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    name1: &str,
+                    value1: &dyn Debug,
+                    name2: &str,
+                    value2: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_struct_field3_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    name1: &str,
+                    value1: &dyn Debug,
+                    name2: &str,
+                    value2: &dyn Debug,
+                    name3: &str,
+                    value3: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_struct_field4_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    name1: &str,
+                    value1: &dyn Debug,
+                    name2: &str,
+                    value2: &dyn Debug,
+                    name3: &str,
+                    value3: &dyn Debug,
+                    name4: &str,
+                    value4: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_struct_field5_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    name1: &str,
+                    value1: &dyn Debug,
+                    name2: &str,
+                    value2: &dyn Debug,
+                    name3: &str,
+                    value3: &dyn Debug,
+                    name4: &str,
+                    value4: &dyn Debug,
+                    name5: &str,
+                    value5: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_struct_fields_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    names: &[&str],
+                    values: &[&dyn Debug],
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_tuple_field1_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    value1: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_tuple_field2_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    value1: &dyn Debug,
+                    value2: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_tuple_field3_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    value1: &dyn Debug,
+                    value2: &dyn Debug,
+                    value3: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_tuple_field4_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    value1: &dyn Debug,
+                    value2: &dyn Debug,
+                    value3: &dyn Debug,
+                    value4: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_tuple_field5_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    value1: &dyn Debug,
+                    value2: &dyn Debug,
+                    value3: &dyn Debug,
+                    value4: &dyn Debug,
+                    value5: &dyn Debug,
+                ) -> ::std::fmt::Result;
+
+                #[requires(true)]
+                fn debug_tuple_fields_finish<'b>(
+                    &'b mut self,
+                    name: &str,
+                    values: &[&dyn Debug],
                 ) -> ::std::fmt::Result;
             }
         }

--- a/creusot/src/backend/ty_inv.rs
+++ b/creusot/src/backend/ty_inv.rs
@@ -74,7 +74,8 @@ pub(crate) fn is_tyinv_trivial<'tcx>(
             | TyKind::Str
             | TyKind::FnDef(_, _)
             | TyKind::FnPtr(..)
-            | TyKind::RawPtr(_, _) => (),
+            | TyKind::RawPtr(_, _)
+            | TyKind::Dynamic(_, _, _) => (),
             _ => tcx.dcx().span_fatal(span, format!("Unsupported type: {ty}")),
         }
     }

--- a/tests/should_fail/bug/1544_0.rs
+++ b/tests/should_fail/bug/1544_0.rs
@@ -1,4 +1,0 @@
-extern crate creusot_contracts;
-
-// Should emit a readable error message, not a crash
-pub fn unsupported_type(_x: &dyn std::fmt::Debug) {}

--- a/tests/should_fail/bug/1544_0.stderr
+++ b/tests/should_fail/bug/1544_0.stderr
@@ -1,8 +1,0 @@
-error: Unsupported type: dyn std::fmt::Debug
- --> 1544_0.rs:4:25
-  |
-4 | pub fn unsupported_type(_x: &dyn std::fmt::Debug) {}
-  |                         ^^
-
-error: aborting due to 1 previous error
-

--- a/tests/should_succeed/bug/1337.coma
+++ b/tests/should_succeed/bug/1337.coma
@@ -1,0 +1,142 @@
+module M_1337__qyi4151255744603461468__fmt [#"1337.rs" 3 9 3 14] (* <T as std::fmt::Debug> *)
+  let%span s1337 = "1337.rs" 3 9 3 14
+  let%span s1337'0 = "1337.rs" 5 8 5 13
+  let%span s1337'1 = "1337.rs" 5 15 5 20
+  let%span sfmt = "../../../creusot-contracts/src/std/fmt.rs" 125 27 125 31
+  let%span sfmt'0 = "../../../creusot-contracts/src/std/fmt.rs" 20 27 20 31
+  let%span sresolve = "../../../creusot-contracts/src/resolve.rs" 50 20 50 34
+  
+  use creusot.int.Int8
+  use creusot.slice.Slice64
+  use creusot.prelude.Opaque
+  use creusot.prelude.MutBorrow
+  use creusot.int.UInt32
+  use creusot.int.UInt16
+  use creusot.prelude.Any
+  
+  type t_T = C_A Int8.t Int8.t | C_B Int8.t Int8.t Int8.t Int8.t Int8.t Int8.t
+  
+  let rec v_B (input: t_T)
+    (ret (field_0: Int8.t) (field_1: Int8.t) (field_2: Int8.t) (field_3: Int8.t) (field_4: Int8.t) (field_5: Int8.t)) =
+    any
+    [ good (field_0: Int8.t) (field_1: Int8.t) (field_2: Int8.t) (field_3: Int8.t) (field_4: Int8.t)
+      (field_5: Int8.t) -> {C_B field_0 field_1 field_2 field_3 field_4 field_5 = input}
+      (! ret {field_0} {field_1} {field_2} {field_3} {field_4} {field_5})
+    | bad ->
+    {forall field_0: Int8.t, field_1: Int8.t, field_2: Int8.t, field_3: Int8.t, field_4: Int8.t, field_5: Int8.t [C_B field_0 field_1 field_2 field_3 field_4 field_5: t_T]. C_B field_0 field_1 field_2 field_3 field_4 field_5
+        <> input}
+      (! {false}
+      any) ]
+  
+  type t_FormattingOptions = {
+    t_FormattingOptions__flags: UInt32.t;
+    t_FormattingOptions__width: UInt16.t;
+    t_FormattingOptions__precision: UInt16.t }
+  
+  type t_Formatter = { t_Formatter__options: t_FormattingOptions; t_Formatter__buf: MutBorrow.t Opaque.dyn }
+  
+  type t_Result = C_Ok () | C_Err ()
+  
+  let rec debug_tuple_fields_finish (self_: MutBorrow.t t_Formatter) (name: string) (values: Slice64.slice Opaque.dyn)
+    (return' (x: t_Result)) = {[@expl:debug_tuple_fields_finish requires] [%#sfmt] true}
+    any [ return''0 (result: t_Result) -> (! return' {result}) ]
+  
+  predicate resolve (self: MutBorrow.t t_Formatter) = [%#sresolve] self.final = self.current
+  
+  predicate resolve'0 (_0: MutBorrow.t t_Formatter) = resolve _0
+  
+  let rec v_A (input: t_T) (ret (x: Int8.t) (y: Int8.t)) = any
+    [ good (x: Int8.t) (y: Int8.t) -> {C_A x y = input} (! ret {x} {y})
+    | bad -> {forall x: Int8.t, y: Int8.t [C_A x y: t_T]. C_A x y <> input} (! {false} any) ]
+  
+  let rec debug_struct_field2_finish (self_: MutBorrow.t t_Formatter) (name: string) (name1: string)
+    (value1: Opaque.dyn) (name2: string) (value2: Opaque.dyn) (return' (x: t_Result)) =
+    {[@expl:debug_struct_field2_finish requires] [%#sfmt'0] true}
+    any [ return''0 (result: t_Result) -> (! return' {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec fmt [#"1337.rs" 3 9 3 14] (self: t_T) (f: MutBorrow.t t_Formatter) (return' (x: t_Result)) = (! bb0
+    [ bb0 = any
+      [ br0 (x0: Int8.t) (x1: Int8.t) -> {self'0 = C_A x0 x1} (! bb4)
+      | br1 (x0: Int8.t) (x1: Int8.t) (x2: Int8.t) (x3: Int8.t) (x4: Int8.t) (x5: Int8.t) -> {self'0
+        = C_B x0 x1 x2 x3 x4 x5}
+        (! bb3) ]
+    | bb3 = s0
+      [ s0 = v_B {self'0}
+          (fun (r0: Int8.t) (r1: Int8.t) (r2: Int8.t) (r3: Int8.t) (r4: Int8.t) (r5: Int8.t) ->
+            [ &__self_0'0 <- r0 ] s1)
+      | s1 = v_B {self'0}
+          (fun (r0: Int8.t) (r1: Int8.t) (r2: Int8.t) (r3: Int8.t) (r4: Int8.t) (r5: Int8.t) ->
+            [ &__self_1'0 <- r1 ] s2)
+      | s2 = v_B {self'0}
+          (fun (r0: Int8.t) (r1: Int8.t) (r2: Int8.t) (r3: Int8.t) (r4: Int8.t) (r5: Int8.t) -> [ &__self_2 <- r2 ] s3)
+      | s3 = v_B {self'0}
+          (fun (r0: Int8.t) (r1: Int8.t) (r2: Int8.t) (r3: Int8.t) (r4: Int8.t) (r5: Int8.t) -> [ &__self_3 <- r3 ] s4)
+      | s4 = v_B {self'0}
+          (fun (r0: Int8.t) (r1: Int8.t) (r2: Int8.t) (r3: Int8.t) (r4: Int8.t) (r5: Int8.t) -> [ &__self_4 <- r4 ] s5)
+      | s5 = v_B {self'0}
+          (fun (r0: Int8.t) (r1: Int8.t) (r2: Int8.t) (r3: Int8.t) (r4: Int8.t) (r5: Int8.t) -> [ &__self_5 <- r5 ] s6)
+      | s6 = [ &_40 <- __self_5 ] s7
+      | s7 = any
+        [ any_ (__arr_temp: Slice64.array Opaque.dyn) -> (! -{Seq.get __arr_temp.Slice64.elts 0 = _28
+          /\ Seq.get __arr_temp.Slice64.elts 1 = _30
+          /\ Seq.get __arr_temp.Slice64.elts 2 = _32
+          /\ Seq.get __arr_temp.Slice64.elts 3 = _34
+          /\ Seq.get __arr_temp.Slice64.elts 4 = _36
+          /\ Seq.get __arr_temp.Slice64.elts 5 = _38 /\ Seq.length __arr_temp.Slice64.elts = 6}-
+          [ &_27 <- __arr_temp ] s8) ]
+      | s8 = [ &_26 <- _27 ] s9
+      | s9 = [ &values <- _26 ] s10
+      | s10 = [ &_43 <- [%#s1337] "B" ] s11
+      | s11 = MutBorrow.borrow_final <t_Formatter> {f'0.current} {MutBorrow.get_id f'0}
+          (fun (_ret: MutBorrow.t t_Formatter) -> [ &_41 <- _ret ] [ &f'0 <- { f'0 with current = _ret.final } ] s12)
+      | s12 = debug_tuple_fields_finish {_41} {_43} {values} (fun (_ret: t_Result) -> [ &_0 <- _ret ] s13)
+      | s13 = bb6 ]
+    | bb6 = s0 [ s0 = -{resolve'0 f'0}- s1 | s1 = bb7 ]
+    | bb4 = s0
+      [ s0 = v_A {self'0} (fun (rx: Int8.t) (ry: Int8.t) -> [ &__self_0 <- rx ] s1)
+      | s1 = v_A {self'0} (fun (rx: Int8.t) (ry: Int8.t) -> [ &__self_1 <- ry ] s2)
+      | s2 = [ &_8 <- [%#s1337] "A" ] s3
+      | s3 = [ &_10 <- [%#s1337'0] "x" ] s4
+      | s4 = [ &_14 <- [%#s1337'1] "y" ] s5
+      | s5 = [ &_17 <- __self_1 ] s6
+      | s6 = MutBorrow.borrow_final <t_Formatter> {f'0.current} {MutBorrow.get_id f'0}
+          (fun (_ret: MutBorrow.t t_Formatter) -> [ &_6 <- _ret ] [ &f'0 <- { f'0 with current = _ret.final } ] s7)
+      | s7 = debug_struct_field2_finish {_6} {_8} {_10} {_11} {_14} {_15} (fun (_ret: t_Result) -> [ &_0 <- _ret ] s8)
+      | s8 = bb5 ]
+    | bb5 = s0 [ s0 = -{resolve'0 f'0}- s1 | s1 = bb7 ]
+    | bb7 = return''0 {_0} ]
+    [ & _0: t_Result = Any.any_l ()
+    | & self'0: t_T = self
+    | & f'0: MutBorrow.t t_Formatter = f
+    | & __self_0: Int8.t = Any.any_l ()
+    | & __self_1: Int8.t = Any.any_l ()
+    | & _6: MutBorrow.t t_Formatter = Any.any_l ()
+    | & _8: string = Any.any_l ()
+    | & _10: string = Any.any_l ()
+    | & _11: Opaque.dyn = Any.any_l ()
+    | & _14: string = Any.any_l ()
+    | & _15: Opaque.dyn = Any.any_l ()
+    | & _17: Int8.t = Any.any_l ()
+    | & __self_0'0: Int8.t = Any.any_l ()
+    | & __self_1'0: Int8.t = Any.any_l ()
+    | & __self_2: Int8.t = Any.any_l ()
+    | & __self_3: Int8.t = Any.any_l ()
+    | & __self_4: Int8.t = Any.any_l ()
+    | & __self_5: Int8.t = Any.any_l ()
+    | & values: Slice64.slice Opaque.dyn = Any.any_l ()
+    | & _26: Slice64.array Opaque.dyn = Any.any_l ()
+    | & _27: Slice64.array Opaque.dyn = Any.any_l ()
+    | & _28: Opaque.dyn = Any.any_l ()
+    | & _30: Opaque.dyn = Any.any_l ()
+    | & _32: Opaque.dyn = Any.any_l ()
+    | & _34: Opaque.dyn = Any.any_l ()
+    | & _36: Opaque.dyn = Any.any_l ()
+    | & _38: Opaque.dyn = Any.any_l ()
+    | & _40: Int8.t = Any.any_l ()
+    | & _41: MutBorrow.t t_Formatter = Any.any_l ()
+    | & _43: string = Any.any_l () ]) [ return''0 (result: t_Result) -> (! return' {result}) ]
+end

--- a/tests/should_succeed/bug/1337.rs
+++ b/tests/should_succeed/bug/1337.rs
@@ -1,0 +1,7 @@
+extern crate creusot_contracts;
+
+#[derive(Debug)]
+pub enum T {
+    A { x: i8, y: i8 },
+    B(i8, i8, i8, i8, i8, i8),
+}

--- a/tests/should_succeed/bug/1337/proof.json
+++ b/tests/should_succeed/bug/1337/proof.json
@@ -1,0 +1,23 @@
+{
+  "profile": [
+    { "prover": "z3@4.12.4", "size": 33, "time": 0.623 },
+    { "prover": "cvc5@1.0.5", "size": 46, "time": 0.533 },
+    { "prover": "alt-ergo@2.6.0", "size": 17, "time": 0.61 },
+    { "prover": "cvc4@1.8", "size": 45, "time": 0.426 }
+  ],
+  "proofs": {
+    "M_1337__qyi4151255744603461468__fmt": {
+      "vc_debug_struct_field2_finish": {
+        "prover": "cvc5@1.0.5",
+        "time": 0.024
+      },
+      "vc_debug_tuple_fields_finish": {
+        "prover": "cvc5@1.0.5",
+        "time": 0.026
+      },
+      "vc_fmt": { "prover": "cvc5@1.0.5", "time": 0.032 },
+      "vc_v_A": { "prover": "cvc5@1.0.5", "time": 0.026 },
+      "vc_v_B": { "prover": "cvc5@1.0.5", "time": 0.03 }
+    }
+  }
+}

--- a/tests/should_succeed/printing.coma
+++ b/tests/should_succeed/printing.coma
@@ -4,8 +4,8 @@ module M_printing__f [#"printing.rs" 4 0 4 10]
   let%span sprinting'1 = "printing.rs" 7 12 7 20
   let%span sprinting'2 = "printing.rs" 8 14 8 23
   let%span sprinting'3 = "printing.rs" 10 18 10 28
-  let%span sfmt = "../../creusot-contracts/src/std/fmt.rs" 26 45 26 51
-  let%span sfmt'0 = "../../creusot-contracts/src/std/fmt.rs" 25 27 25 31
+  let%span sfmt = "../../creusot-contracts/src/std/fmt.rs" 141 45 141 51
+  let%span sfmt'0 = "../../creusot-contracts/src/std/fmt.rs" 140 27 140 31
   let%span sio = "../../creusot-contracts/src/std/io.rs" 9 22 9 26
   let%span sio'0 = "../../creusot-contracts/src/std/io.rs" 14 22 14 26
   let%span sinvariant = "../../creusot-contracts/src/invariant.rs" 91 8 91 18


### PR DESCRIPTION
Fix #1337

Fix a check to allow `dyn` to be translated to an opaque type

This allows translating `derive(Debug)`: `Debug::fmt` uses the type `std::fmt::Formatter` which contains a field of type `&dyn Write`.