### PR TITLE
Improve translation of dyn

### DIFF
--- a/creusot/src/backend/clone_map.rs
+++ b/creusot/src/backend/clone_map.rs
@@ -114,6 +114,10 @@ pub(crate) trait Namer<'tcx> {
         self.dependency(Dependency::Eliminator(def_id, subst)).ident()
     }
 
+    fn dyn_cast(&self, source: Ty<'tcx>, target: Ty<'tcx>) -> Ident {
+        self.dependency(Dependency::DynCast(source, target)).ident()
+    }
+
     // TODO: get rid of this. It feels like it should be unnecessary
     fn normalize<T: TypeFoldable<TyCtxt<'tcx>>>(&self, ty: T) -> T {
         self.tcx().normalize_erasing_regions(self.typing_env(), ty)

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -553,6 +553,14 @@ impl<'tcx> RValue<'tcx> {
                         .collect(),
                 }
             }
+            RValue::Cast(e, source, target)
+                if let Some(source) = source.builtin_deref(false)
+                    && let Some(target) = target.builtin_deref(false)
+                    && let TyKind::Dynamic(_, _, _) = target.kind() =>
+            {
+                let cast = lower.names.dyn_cast(source, target);
+                Exp::var(cast).app(vec![e.into_why(lower, istmts)])
+            }
             RValue::Cast(e, source, target) => {
                 match source.kind() {
                     TyKind::Bool => {

--- a/creusot/src/backend/ty.rs
+++ b/creusot/src/backend/ty.rs
@@ -70,13 +70,13 @@ pub(crate) fn translate_ty<'tcx, N: Namer<'tcx>>(
         }
         FnDef(_, _) => MlT::unit(), /* FnDef types are effectively singleton types, so it is sound to translate to unit. */
         FnPtr(..) => MlT::qconstructor(names.in_pre(PreMod::Opaque, "ptr")),
-        Dynamic(_, _, _) => MlT::qconstructor(names.in_pre(PreMod::Opaque, "dyn")),
         Foreign(_) => MlT::qconstructor(names.in_pre(PreMod::Opaque, "foreign")),
         Error(_) => MlT::unit(),
         Closure(..)
         | Adt(..)
         | Tuple(_)
         | Param(_)
+        | Dynamic(_, _, _)
         | Alias(AliasTyKind::Opaque | AliasTyKind::Projection, _) => {
             MlT::TConstructor(names.ty(ty))
         }

--- a/prelude-generator/prelude.coma
+++ b/prelude-generator/prelude.coma
@@ -72,6 +72,5 @@ module Opaque
   function thin (p : ptr) : ptr
   function len (p : ptr) : int
 
-  type dyn
   type foreign
 end

--- a/tests/should_fail/unsound_dyn.rs
+++ b/tests/should_fail/unsound_dyn.rs
@@ -1,0 +1,18 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+// - Any `trait Tr` is implemented by `dyn Tr`,
+// - but `trait False` below has no valid implementation.
+// Contradiction.
+//
+// We prevent this by restricting the traits allowed in `dyn`.
+pub trait False {
+    #[logic]
+    #[ensures(false)]
+    fn falso(&self);
+}
+
+#[ensures(false)]
+pub fn unsound() {
+    proof_assert! { forall<x: dyn False> x.falso() == () }
+}

--- a/tests/should_fail/unsound_dyn.stderr
+++ b/tests/should_fail/unsound_dyn.stderr
@@ -1,0 +1,4 @@
+error: forbidden dyn type: dyn False (dyn support is currently minimal, please open an issue to improve this feature)
+
+error: aborting due to 1 previous error
+

--- a/tests/should_succeed/bug/1337.coma
+++ b/tests/should_succeed/bug/1337.coma
@@ -8,7 +8,6 @@ module M_1337__qyi4151255744603461468__fmt [#"1337.rs" 3 9 3 14] (* <T as std::f
   
   use creusot.int.Int8
   use creusot.slice.Slice64
-  use creusot.prelude.Opaque
   use creusot.prelude.MutBorrow
   use creusot.int.UInt32
   use creusot.int.UInt16
@@ -28,16 +27,24 @@ module M_1337__qyi4151255744603461468__fmt [#"1337.rs" 3 9 3 14] (* <T as std::f
       (! {false}
       any) ]
   
+  type dyn_Debug
+  
+  function dyn_Debug_of_i8 (x: Int8.t) : dyn_Debug
+  
+  function dyn_Debug_of_ref_i8 (x: Int8.t) : dyn_Debug
+  
   type t_FormattingOptions = {
     t_FormattingOptions__flags: UInt32.t;
     t_FormattingOptions__width: UInt16.t;
     t_FormattingOptions__precision: UInt16.t }
   
-  type t_Formatter = { t_Formatter__options: t_FormattingOptions; t_Formatter__buf: MutBorrow.t Opaque.dyn }
+  type dyn_Write
+  
+  type t_Formatter = { t_Formatter__options: t_FormattingOptions; t_Formatter__buf: MutBorrow.t dyn_Write }
   
   type t_Result = C_Ok () | C_Err ()
   
-  let rec debug_tuple_fields_finish (self_: MutBorrow.t t_Formatter) (name: string) (values: Slice64.slice Opaque.dyn)
+  let rec debug_tuple_fields_finish (self_: MutBorrow.t t_Formatter) (name: string) (values: Slice64.slice dyn_Debug)
     (return' (x: t_Result)) = {[@expl:debug_tuple_fields_finish requires] [%#sfmt] true}
     any [ return''0 (result: t_Result) -> (! return' {result}) ]
   
@@ -49,8 +56,8 @@ module M_1337__qyi4151255744603461468__fmt [#"1337.rs" 3 9 3 14] (* <T as std::f
     [ good (x: Int8.t) (y: Int8.t) -> {C_A x y = input} (! ret {x} {y})
     | bad -> {forall x: Int8.t, y: Int8.t [C_A x y: t_T]. C_A x y <> input} (! {false} any) ]
   
-  let rec debug_struct_field2_finish (self_: MutBorrow.t t_Formatter) (name: string) (name1: string)
-    (value1: Opaque.dyn) (name2: string) (value2: Opaque.dyn) (return' (x: t_Result)) =
+  let rec debug_struct_field2_finish (self_: MutBorrow.t t_Formatter) (name: string) (name1: string) (value1: dyn_Debug)
+    (name2: string) (value2: dyn_Debug) (return' (x: t_Result)) =
     {[@expl:debug_struct_field2_finish requires] [%#sfmt'0] true}
     any [ return''0 (result: t_Result) -> (! return' {result}) ]
   
@@ -79,34 +86,42 @@ module M_1337__qyi4151255744603461468__fmt [#"1337.rs" 3 9 3 14] (* <T as std::f
           (fun (r0: Int8.t) (r1: Int8.t) (r2: Int8.t) (r3: Int8.t) (r4: Int8.t) (r5: Int8.t) -> [ &__self_4 <- r4 ] s5)
       | s5 = v_B {self'0}
           (fun (r0: Int8.t) (r1: Int8.t) (r2: Int8.t) (r3: Int8.t) (r4: Int8.t) (r5: Int8.t) -> [ &__self_5 <- r5 ] s6)
-      | s6 = [ &_40 <- __self_5 ] s7
-      | s7 = any
-        [ any_ (__arr_temp: Slice64.array Opaque.dyn) -> (! -{Seq.get __arr_temp.Slice64.elts 0 = _28
+      | s6 = [ &_28 <- dyn_Debug_of_i8 __self_0'0 ] s7
+      | s7 = [ &_30 <- dyn_Debug_of_i8 __self_1'0 ] s8
+      | s8 = [ &_32 <- dyn_Debug_of_i8 __self_2 ] s9
+      | s9 = [ &_34 <- dyn_Debug_of_i8 __self_3 ] s10
+      | s10 = [ &_36 <- dyn_Debug_of_i8 __self_4 ] s11
+      | s11 = [ &_40 <- __self_5 ] s12
+      | s12 = [ &_38 <- dyn_Debug_of_ref_i8 _40 ] s13
+      | s13 = any
+        [ any_ (__arr_temp: Slice64.array dyn_Debug) -> (! -{Seq.get __arr_temp.Slice64.elts 0 = _28
           /\ Seq.get __arr_temp.Slice64.elts 1 = _30
           /\ Seq.get __arr_temp.Slice64.elts 2 = _32
           /\ Seq.get __arr_temp.Slice64.elts 3 = _34
           /\ Seq.get __arr_temp.Slice64.elts 4 = _36
           /\ Seq.get __arr_temp.Slice64.elts 5 = _38 /\ Seq.length __arr_temp.Slice64.elts = 6}-
-          [ &_27 <- __arr_temp ] s8) ]
-      | s8 = [ &_26 <- _27 ] s9
-      | s9 = [ &values <- _26 ] s10
-      | s10 = [ &_43 <- [%#s1337] "B" ] s11
-      | s11 = MutBorrow.borrow_final <t_Formatter> {f'0.current} {MutBorrow.get_id f'0}
-          (fun (_ret: MutBorrow.t t_Formatter) -> [ &_41 <- _ret ] [ &f'0 <- { f'0 with current = _ret.final } ] s12)
-      | s12 = debug_tuple_fields_finish {_41} {_43} {values} (fun (_ret: t_Result) -> [ &_0 <- _ret ] s13)
-      | s13 = bb6 ]
+          [ &_27 <- __arr_temp ] s14) ]
+      | s14 = [ &_26 <- _27 ] s15
+      | s15 = [ &values <- _26 ] s16
+      | s16 = [ &_43 <- [%#s1337] "B" ] s17
+      | s17 = MutBorrow.borrow_final <t_Formatter> {f'0.current} {MutBorrow.get_id f'0}
+          (fun (_ret: MutBorrow.t t_Formatter) -> [ &_41 <- _ret ] [ &f'0 <- { f'0 with current = _ret.final } ] s18)
+      | s18 = debug_tuple_fields_finish {_41} {_43} {values} (fun (_ret: t_Result) -> [ &_0 <- _ret ] s19)
+      | s19 = bb6 ]
     | bb6 = s0 [ s0 = -{resolve'0 f'0}- s1 | s1 = bb7 ]
     | bb4 = s0
       [ s0 = v_A {self'0} (fun (rx: Int8.t) (ry: Int8.t) -> [ &__self_0 <- rx ] s1)
       | s1 = v_A {self'0} (fun (rx: Int8.t) (ry: Int8.t) -> [ &__self_1 <- ry ] s2)
       | s2 = [ &_8 <- [%#s1337] "A" ] s3
       | s3 = [ &_10 <- [%#s1337'0] "x" ] s4
-      | s4 = [ &_14 <- [%#s1337'1] "y" ] s5
-      | s5 = [ &_17 <- __self_1 ] s6
-      | s6 = MutBorrow.borrow_final <t_Formatter> {f'0.current} {MutBorrow.get_id f'0}
-          (fun (_ret: MutBorrow.t t_Formatter) -> [ &_6 <- _ret ] [ &f'0 <- { f'0 with current = _ret.final } ] s7)
-      | s7 = debug_struct_field2_finish {_6} {_8} {_10} {_11} {_14} {_15} (fun (_ret: t_Result) -> [ &_0 <- _ret ] s8)
-      | s8 = bb5 ]
+      | s4 = [ &_11 <- dyn_Debug_of_i8 __self_0 ] s5
+      | s5 = [ &_14 <- [%#s1337'1] "y" ] s6
+      | s6 = [ &_17 <- __self_1 ] s7
+      | s7 = [ &_15 <- dyn_Debug_of_ref_i8 _17 ] s8
+      | s8 = MutBorrow.borrow_final <t_Formatter> {f'0.current} {MutBorrow.get_id f'0}
+          (fun (_ret: MutBorrow.t t_Formatter) -> [ &_6 <- _ret ] [ &f'0 <- { f'0 with current = _ret.final } ] s9)
+      | s9 = debug_struct_field2_finish {_6} {_8} {_10} {_11} {_14} {_15} (fun (_ret: t_Result) -> [ &_0 <- _ret ] s10)
+      | s10 = bb5 ]
     | bb5 = s0 [ s0 = -{resolve'0 f'0}- s1 | s1 = bb7 ]
     | bb7 = return''0 {_0} ]
     [ & _0: t_Result = Any.any_l ()
@@ -117,9 +132,9 @@ module M_1337__qyi4151255744603461468__fmt [#"1337.rs" 3 9 3 14] (* <T as std::f
     | & _6: MutBorrow.t t_Formatter = Any.any_l ()
     | & _8: string = Any.any_l ()
     | & _10: string = Any.any_l ()
-    | & _11: Opaque.dyn = Any.any_l ()
+    | & _11: dyn_Debug = Any.any_l ()
     | & _14: string = Any.any_l ()
-    | & _15: Opaque.dyn = Any.any_l ()
+    | & _15: dyn_Debug = Any.any_l ()
     | & _17: Int8.t = Any.any_l ()
     | & __self_0'0: Int8.t = Any.any_l ()
     | & __self_1'0: Int8.t = Any.any_l ()
@@ -127,15 +142,15 @@ module M_1337__qyi4151255744603461468__fmt [#"1337.rs" 3 9 3 14] (* <T as std::f
     | & __self_3: Int8.t = Any.any_l ()
     | & __self_4: Int8.t = Any.any_l ()
     | & __self_5: Int8.t = Any.any_l ()
-    | & values: Slice64.slice Opaque.dyn = Any.any_l ()
-    | & _26: Slice64.array Opaque.dyn = Any.any_l ()
-    | & _27: Slice64.array Opaque.dyn = Any.any_l ()
-    | & _28: Opaque.dyn = Any.any_l ()
-    | & _30: Opaque.dyn = Any.any_l ()
-    | & _32: Opaque.dyn = Any.any_l ()
-    | & _34: Opaque.dyn = Any.any_l ()
-    | & _36: Opaque.dyn = Any.any_l ()
-    | & _38: Opaque.dyn = Any.any_l ()
+    | & values: Slice64.slice dyn_Debug = Any.any_l ()
+    | & _26: Slice64.array dyn_Debug = Any.any_l ()
+    | & _27: Slice64.array dyn_Debug = Any.any_l ()
+    | & _28: dyn_Debug = Any.any_l ()
+    | & _30: dyn_Debug = Any.any_l ()
+    | & _32: dyn_Debug = Any.any_l ()
+    | & _34: dyn_Debug = Any.any_l ()
+    | & _36: dyn_Debug = Any.any_l ()
+    | & _38: dyn_Debug = Any.any_l ()
     | & _40: Int8.t = Any.any_l ()
     | & _41: MutBorrow.t t_Formatter = Any.any_l ()
     | & _43: string = Any.any_l () ]) [ return''0 (result: t_Result) -> (! return' {result}) ]


### PR DESCRIPTION
Plug some soundness holes

- Traits may be unimplementable, in which case `dyn` should be forbidden (see `tests/should_fail/unsound_dyn.rs`). Currently we have a hardcoded whitelist: we allow `dyn std::fmt::Debug` and `dyn std::fmt::Write` in order to not break `derive(Debug)`. (Note: there are also cases where a trait is implementable but `dyn` would still break soundness. For example, a trait with a law that `Self` is a singleton.)
- Each `dyn` type should be translated to a different Why3 type. Previously `Opaque.dyn` could implement contradictory traits.