### PR TITLE
Make namespace constructor names more stable

### DIFF
--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -113,11 +113,7 @@ impl<'tcx> Why3Generator<'tcx> {
         self.used_namespaces.set(true);
         *self.namespaces.borrow_mut().entry(namespace_fun).or_insert_with(|| {
             let name = self.ctx.item_name(namespace_fun);
-            why3::Ident::fresh_local(format!(
-                "Namespace_{name}_{}'{}",
-                namespace_fun.krate.index(),
-                namespace_fun.index.index()
-            ))
+            why3::Ident::fresh_local(format!("Namespace_{name}"))
         })
     }
 

--- a/tests/should_succeed/local_invariant_cellinv.coma
+++ b/tests/should_succeed/local_invariant_cellinv.coma
@@ -1,7 +1,7 @@
 module M_local_invariant_cellinv__qyi5959203038510030748__read [#"local_invariant_cellinv.rs" 37 4 37 65] (* CellInv<T> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PCELL_0'31 int | Other namespace_other
+  type t_Namespace = Namespace_PCELL int | Other namespace_other
   
   let%span slocal_invariant_cellinv = "local_invariant_cellinv.rs" 37 24 37 28
   let%span slocal_invariant_cellinv'0 = "local_invariant_cellinv.rs" 36 4 36 41
@@ -182,7 +182,7 @@ module M_local_invariant_cellinv__qyi5959203038510030748__read [#"local_invarian
   function public (self: t_LocalInvariant) : t_Id
   
   predicate invariant''7 [#"local_invariant_cellinv.rs" 20 4 20 30] (self: t_CellInv) =
-    [%#slocal_invariant_cellinv'5] namespace self.t_CellInv__permission = Namespace_PCELL_0'31 0
+    [%#slocal_invariant_cellinv'5] namespace self.t_CellInv__permission = Namespace_PCELL 0
     /\ public self.t_CellInv__permission = id self.t_CellInv__data
   
   predicate inv'10 (_0'0: t_CellInv)
@@ -334,7 +334,7 @@ module M_local_invariant_cellinv__qyi5959203038510030748__read [#"local_invarian
   
   let rec read [#"local_invariant_cellinv.rs" 37 4 37 65] (self: t_CellInv) (tokens: t_Tokens) (return' (x: t_T)) =
     {[@expl:read 'self' type invariant] [%#slocal_invariant_cellinv] inv'11 self}
-    {[@expl:read requires] [%#slocal_invariant_cellinv'0] contains'0 tokens (Namespace_PCELL_0'31 0)}
+    {[@expl:read requires] [%#slocal_invariant_cellinv'0] contains'0 tokens (Namespace_PCELL 0)}
     (! bb0
     [ bb0 = s0
       [ s0 = [ &_7 <- { _0 = self'0 } ] s1
@@ -352,7 +352,7 @@ end
 module M_local_invariant_cellinv__qyi5959203038510030748__write [#"local_invariant_cellinv.rs" 43 4 43 52] (* CellInv<T> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PCELL_0'31 int | Other namespace_other
+  type t_Namespace = Namespace_PCELL int | Other namespace_other
   
   let%span slocal_invariant_cellinv = "local_invariant_cellinv.rs" 43 18 43 22
   let%span slocal_invariant_cellinv'0 = "local_invariant_cellinv.rs" 43 24 43 25
@@ -560,7 +560,7 @@ module M_local_invariant_cellinv__qyi5959203038510030748__write [#"local_invaria
   function public (self: t_LocalInvariant) : t_Id
   
   predicate invariant''8 [#"local_invariant_cellinv.rs" 20 4 20 30] (self: t_CellInv) =
-    [%#slocal_invariant_cellinv'5] namespace self.t_CellInv__permission = Namespace_PCELL_0'31 0
+    [%#slocal_invariant_cellinv'5] namespace self.t_CellInv__permission = Namespace_PCELL 0
     /\ public self.t_CellInv__permission = id self.t_CellInv__data
   
   predicate inv'11 (_0'0: t_CellInv)
@@ -744,7 +744,7 @@ module M_local_invariant_cellinv__qyi5959203038510030748__write [#"local_invaria
   let rec write [#"local_invariant_cellinv.rs" 43 4 43 52] (self: t_CellInv) (x: t_T) (tokens: t_Tokens)
     (return' (x'0: ())) = {[@expl:write 'self' type invariant] [%#slocal_invariant_cellinv] inv'12 self}
     {[@expl:write 'x' type invariant] [%#slocal_invariant_cellinv'0] inv x}
-    {[@expl:write requires] [%#slocal_invariant_cellinv'1] contains'0 tokens (Namespace_PCELL_0'31 0)}
+    {[@expl:write requires] [%#slocal_invariant_cellinv'1] contains'0 tokens (Namespace_PCELL 0)}
     (! bb0
     [ bb0 = s0
       [ s0 = [ &_7 <- { _0 = self'0; _1 = x'0 } ] s1

--- a/tests/should_succeed/persistent_array.coma
+++ b/tests/should_succeed/persistent_array.coma
@@ -1,7 +1,7 @@
 module M_persistent_array__implementation__qyi15164097500274694161__clone [#"persistent_array.rs" 45 8 45 31] (* <implementation::PersistentArray<T> as creusot_contracts::Clone> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PARRAY_0'62 int | Other namespace_other
+  type t_Namespace = Namespace_PARRAY int | Other namespace_other
   
   let%span src = "../../creusot-contracts/src/std/rc.rs" 45 18 45 37
   let%span spersistent_array = "persistent_array.rs" 45 18 45 22
@@ -102,7 +102,7 @@ module M_persistent_array__implementation__qyi15164097500274694161__clone [#"per
     [%#spersistent_array'3] (view'1 (view'3 self.t_PersistentArray__contained_in_inv))._p0
       = id (view self.t_PersistentArray__program_value)
     /\ id'0 (view'3 self.t_PersistentArray__contained_in_inv) = public (view'5 self.t_PersistentArray__map_invariant)
-    /\ namespace (view'5 self.t_PersistentArray__map_invariant) = Namespace_PARRAY_0'62 0
+    /\ namespace (view'5 self.t_PersistentArray__map_invariant) = Namespace_PARRAY 0
   
   predicate inv (_0: t_PersistentArray)
   
@@ -155,7 +155,7 @@ end
 module M_persistent_array__implementation__qyi7256199225841846155__new [#"persistent_array.rs" 125 8 125 37] (* implementation::PersistentArray<T> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PARRAY_0'62 int | Other namespace_other
+  type t_Namespace = Namespace_PARRAY int | Other namespace_other
   
   let%span src = "../../creusot-contracts/src/std/rc.rs" 31 26 31 43
   let%span src'0 = "../../creusot-contracts/src/std/rc.rs" 32 23 32 28
@@ -755,7 +755,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__new [#"persis
     [%#spersistent_array'11] (view'10 (view'11 self.t_PersistentArray__contained_in_inv))._p0'0
       = id (view'7 self.t_PersistentArray__program_value)
     /\ id'2 (view'11 self.t_PersistentArray__contained_in_inv) = public (view'12 self.t_PersistentArray__map_invariant)
-    /\ namespace (view'12 self.t_PersistentArray__map_invariant) = Namespace_PARRAY_0'62 0
+    /\ namespace (view'12 self.t_PersistentArray__map_invariant) = Namespace_PARRAY 0
   
   predicate inv'24 (_0: t_PersistentArray)
   
@@ -834,7 +834,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__new [#"persis
       | s1 = new'3 {_38} (fun (_ret: t_PA) -> [ &_37 <- _ret ] s2)
       | s2 = bb21 ]
     | bb21 = s0 [ s0 = [ &_46 <- [%#spersistent_array'4] gset_id ] s1 | s1 = bb22 ]
-    | bb22 = s0 [ s0 = [ &_48 <- [%#spersistent_array'5] Namespace_PARRAY_0'62 0 ] s1 | s1 = bb23 ]
+    | bb22 = s0 [ s0 = [ &_48 <- [%#spersistent_array'5] Namespace_PARRAY 0 ] s1 | s1 = bb23 ]
     | bb23 = s0 [ s0 = new'4 {_37} {_46} {_48} (fun (_ret: t_LocalInvariant) -> [ &local_inv <- _ret ] s1) | s1 = bb24 ]
     | bb24 = s0 [ s0 = into_inner'3 {local_inv} (fun (_ret: t_LocalInvariant) -> [ &_50 <- _ret ] s1) | s1 = bb25 ]
     | bb25 = s0 [ s0 = new'5 {_50} (fun (_ret: t_Rc'0) -> [ &_25 <- _ret ] s1) | s1 = bb26 ]
@@ -895,7 +895,7 @@ end
 module M_persistent_array__implementation__qyi7256199225841846155__set [#"persistent_array.rs" 161 8 161 80] (* implementation::PersistentArray<T> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PARRAY_0'62 int | Other namespace_other
+  type t_Namespace = Namespace_PARRAY int | Other namespace_other
   
   let%span src = "../../creusot-contracts/src/std/rc.rs" 45 18 45 37
   let%span src'0 = "../../creusot-contracts/src/std/rc.rs" 32 23 32 28
@@ -1545,7 +1545,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__set [#"persis
     [%#spersistent_array'13] (view'0 (view'2 self.t_PersistentArray__contained_in_inv))._p0
       = id (view'5 self.t_PersistentArray__program_value)
     /\ id'2 (view'2 self.t_PersistentArray__contained_in_inv) = public (view'15 self.t_PersistentArray__map_invariant)
-    /\ namespace (view'15 self.t_PersistentArray__map_invariant) = Namespace_PARRAY_0'62 0
+    /\ namespace (view'15 self.t_PersistentArray__map_invariant) = Namespace_PARRAY 0
   
   predicate inv'31 (_0'0: t_PersistentArray)
   
@@ -1926,7 +1926,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__set [#"persis
     {[@expl:set 'self' type invariant] [%#spersistent_array'0] inv'32 self}
     {[@expl:set 'value' type invariant] [%#spersistent_array'1] inv value}
     {[@expl:set requires #0] [%#spersistent_array'2] UInt64.t'int index < Seq.length (view'4 self)}
-    {[@expl:set requires #1] [%#spersistent_array'3] contains'3 tokens (Namespace_PARRAY_0'62 0)}
+    {[@expl:set requires #1] [%#spersistent_array'3] contains'3 tokens (Namespace_PARRAY 0)}
     (! bb0
     [ bb0 = s0
       [ s0 = [ &new_logical_value <- [%#spersistent_array] Seq.set (view'4 self'0) (UInt64.t'int index'0) value'0 ] s1
@@ -1978,7 +1978,7 @@ end
 module M_persistent_array__implementation__qyi7256199225841846155__get_immut [#"persistent_array.rs" 214 8 214 95] (* implementation::PersistentArray<T> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PARRAY_0'62 int | Other namespace_other
+  type t_Namespace = Namespace_PARRAY int | Other namespace_other
   
   let%span src = "../../creusot-contracts/src/std/rc.rs" 37 26 37 46
   let%span src'0 = "../../creusot-contracts/src/std/rc.rs" 51 18 51 38
@@ -2426,7 +2426,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get_immut [#"
     [%#spersistent_array'14] (view'9 (view'10 self.t_PersistentArray__contained_in_inv))._p0
       = id'2 (view'7 self.t_PersistentArray__program_value)
     /\ id'0 (view'10 self.t_PersistentArray__contained_in_inv) = public (view'12 self.t_PersistentArray__map_invariant)
-    /\ namespace (view'12 self.t_PersistentArray__map_invariant) = Namespace_PARRAY_0'62 0
+    /\ namespace (view'12 self.t_PersistentArray__map_invariant) = Namespace_PARRAY 0
   
   predicate inv'20 (_0'0: t_PersistentArray)
   
@@ -2658,7 +2658,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get_immut [#"
   
   let rec get_immut [#"persistent_array.rs" 214 8 214 95] (self: t_PersistentArray) (index: UInt64.t) (tokens: t_Tokens)
     (return' (x: t_T)) = {[@expl:get_immut 'self' type invariant] [%#spersistent_array] inv'21 self}
-    {[@expl:get_immut requires #0] [%#spersistent_array'0] contains'3 tokens (Namespace_PARRAY_0'62 0)}
+    {[@expl:get_immut requires #0] [%#spersistent_array'0] contains'3 tokens (Namespace_PARRAY 0)}
     {[@expl:get_immut requires #1] [%#spersistent_array'1] UInt64.t'int index < Seq.length (view'14 self)}
     (! bb0
     [ bb0 = s0
@@ -2682,7 +2682,7 @@ end
 module M_persistent_array__implementation__qyi7256199225841846155__get_inner_immut [#"persistent_array.rs" 230 8 234 18] (* implementation::PersistentArray<T> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PARRAY_0'62 int | Other namespace_other
+  type t_Namespace = Namespace_PARRAY int | Other namespace_other
   
   let%span src = "../../creusot-contracts/src/std/rc.rs" 51 18 51 38
   let%span src'0 = "../../creusot-contracts/src/std/rc.rs" 37 26 37 46
@@ -3173,7 +3173,7 @@ end
 module M_persistent_array__implementation__qyi7256199225841846155__get [#"persistent_array.rs" 259 8 259 89] (* implementation::PersistentArray<T> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PARRAY_0'62 int | Other namespace_other
+  type t_Namespace = Namespace_PARRAY int | Other namespace_other
   
   let%span src = "../../creusot-contracts/src/std/rc.rs" 37 26 37 46
   let%span src'0 = "../../creusot-contracts/src/std/rc.rs" 51 18 51 38
@@ -3823,7 +3823,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get [#"persis
     [%#spersistent_array'19] (view'16 (view'17 self.t_PersistentArray__contained_in_inv))._p0
       = id'2 (view'9 self.t_PersistentArray__program_value)
     /\ id'0 (view'17 self.t_PersistentArray__contained_in_inv) = public (view'0 self.t_PersistentArray__map_invariant)
-    /\ namespace (view'0 self.t_PersistentArray__map_invariant) = Namespace_PARRAY_0'62 0
+    /\ namespace (view'0 self.t_PersistentArray__map_invariant) = Namespace_PARRAY 0
   
   predicate inv'30 (_0'0: t_PersistentArray)
   
@@ -4127,7 +4127,7 @@ module M_persistent_array__implementation__qyi7256199225841846155__get [#"persis
   
   let rec get'1 [#"persistent_array.rs" 259 8 259 89] (self: t_PersistentArray) (index: UInt64.t) (tokens: t_Tokens)
     (return' (x: t_T)) = {[@expl:get 'self' type invariant] [%#spersistent_array'0] inv'31 self}
-    {[@expl:get requires #0] [%#spersistent_array'1] contains'3 tokens (Namespace_PARRAY_0'62 0)}
+    {[@expl:get requires #0] [%#spersistent_array'1] contains'3 tokens (Namespace_PARRAY 0)}
     {[@expl:get requires #1] [%#spersistent_array'2] UInt64.t'int index < Seq.length (view'19 self)}
     (! bb0
     [ bb0 = s0
@@ -4155,7 +4155,7 @@ end
 module M_persistent_array__implementation__qyi7256199225841846155__reroot [#"persistent_array.rs" 298 8 302 26] (* implementation::PersistentArray<T> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PARRAY_0'62 int | Other namespace_other
+  type t_Namespace = Namespace_PARRAY int | Other namespace_other
   
   let%span src = "../../creusot-contracts/src/std/rc.rs" 45 18 45 37
   let%span src'0 = "../../creusot-contracts/src/std/rc.rs" 51 18 51 38
@@ -5219,7 +5219,7 @@ end
 module M_persistent_array__testing [#"persistent_array.rs" 350 0 350 41]
   type namespace_other
   
-  type t_Namespace = Namespace_PARRAY_0'62 int | Other namespace_other
+  type t_Namespace = Namespace_PARRAY int | Other namespace_other
   
   let%span spersistent_array = "persistent_array.rs" 351 38 351 39
   let%span spersistent_array'0 = "persistent_array.rs" 351 41 351 42
@@ -5361,7 +5361,7 @@ module M_persistent_array__testing [#"persistent_array.rs" 350 0 350 41]
   let rec set (self: t_PersistentArray) (index: UInt64.t) (value: Int32.t) (tokens: t_Tokens)
     (return' (x: t_PersistentArray)) = {[@expl:set 'self' type invariant] [%#spersistent_array'17] inv'0 self}
     {[@expl:set requires #0] [%#spersistent_array'18] UInt64.t'int index < Seq.length (view'2 self)}
-    {[@expl:set requires #1] [%#spersistent_array'19] contains'0 tokens (Namespace_PARRAY_0'62 0)}
+    {[@expl:set requires #1] [%#spersistent_array'19] contains'0 tokens (Namespace_PARRAY 0)}
     any
     [ return''0 (result: t_PersistentArray) -> {[%#spersistent_array'20] inv result}
       {[%#spersistent_array'21] view'1 result = Seq.set (view'2 self) (UInt64.t'int index) value}
@@ -5385,7 +5385,7 @@ module M_persistent_array__testing [#"persistent_array.rs" 350 0 350 41]
   meta "select_lsinst" "all"
   
   let rec testing [#"persistent_array.rs" 350 0 350 41] (tokens: t_Tokens) (return' (x: ())) =
-    {[@expl:testing requires] [%#spersistent_array'14] contains'0 tokens (Namespace_PARRAY_0'62 0)}
+    {[@expl:testing requires] [%#spersistent_array'14] contains'0 tokens (Namespace_PARRAY 0)}
     (! bb0
     [ bb0 = s0
       [ s0 = any
@@ -5480,7 +5480,7 @@ end
 module M_persistent_array__implementation__qyi15164097500274694161__clone__refines [#"persistent_array.rs" 45 8 45 31] (* <implementation::PersistentArray<T> as creusot_contracts::Clone> *)
   type namespace_other
   
-  type t_Namespace = Namespace_PARRAY_0'62 int | Other namespace_other
+  type t_Namespace = Namespace_PARRAY int | Other namespace_other
   
   let%span spersistent_array = "persistent_array.rs" 45 8 45 31
   let%span spersistent_array'0 = "persistent_array.rs" 76 16 76 41
@@ -5567,7 +5567,7 @@ module M_persistent_array__implementation__qyi15164097500274694161__clone__refin
     [%#spersistent_array'1] (view'0 (view'2 self.t_PersistentArray__contained_in_inv))._p0
       = id (view'3 self.t_PersistentArray__program_value)
     /\ id'0 (view'2 self.t_PersistentArray__contained_in_inv) = public (view'5 self.t_PersistentArray__map_invariant)
-    /\ namespace (view'5 self.t_PersistentArray__map_invariant) = Namespace_PARRAY_0'62 0
+    /\ namespace (view'5 self.t_PersistentArray__map_invariant) = Namespace_PARRAY 0
   
   predicate inv (_0: t_PersistentArray)
   


### PR DESCRIPTION
The indices in a `DefId` are prone to change if you shuffle definitions around. They're also not necessary to keep around because `fresh_local` already prevents name collisions.