### PR TITLE
Allow `result` argument name for extern functions

### DIFF
--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -201,10 +201,7 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                 | CastKind::Transmute,
                 _,
                 _,
-            ) => self.ctx.crash_and_error(
-                si.span,
-                format!("Pointer casts are currently unsupported {rvalue:?}"),
-            ),
+            ) => self.ctx.crash_and_error(si.span, format!("Unsupported pointer cast: {rvalue:?}")),
             Rvalue::CopyForDeref(_)
             | Rvalue::ShallowInitBox(_, _)
             | Rvalue::NullaryOp(_, _)

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -418,15 +418,20 @@ pub(crate) fn pre_sig_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pre
         assert!(presig.contract.variant.is_none());
     }
 
-    for (input, _, _) in &presig.inputs {
-        if input.0.name() == why3::Symbol::intern("result")
-            && !is_fn_impl_postcond(ctx.tcx, def_id)
-            && !is_fn_mut_impl_postcond(ctx.tcx, def_id)
-            && !is_fn_once_impl_postcond(ctx.tcx, def_id)
-            && !is_fn_mut_impl_hist_inv(ctx.tcx, def_id)
-            && !is_fn_once_impl_precond(ctx.tcx, def_id)
-        {
-            ctx.crash_and_error(ctx.def_span(def_id), "`result` is not allowed as a parameter name")
+    if !presig.contract.extern_no_spec {
+        for (input, _, _) in &presig.inputs {
+            if input.0.name() == why3::Symbol::intern("result")
+                && !is_fn_impl_postcond(ctx.tcx, def_id)
+                && !is_fn_mut_impl_postcond(ctx.tcx, def_id)
+                && !is_fn_once_impl_postcond(ctx.tcx, def_id)
+                && !is_fn_mut_impl_hist_inv(ctx.tcx, def_id)
+                && !is_fn_once_impl_precond(ctx.tcx, def_id)
+            {
+                ctx.crash_and_error(
+                    ctx.def_span(def_id),
+                    "`result` is not allowed as a parameter name",
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Motivation: compiling with `--test` crashes on [`assert_test_result<T: Termination>(result: T) -> Result<(), String>`](https://doc.rust-lang.org/test/fn.assert_test_result.html)

Also update an error message about unsupported casts