### PR TITLE
Add support for #[erasure] with private functions

### DIFF
--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -424,6 +424,9 @@ pub mod macros {
     /// # use creusot_contracts::*;
     /// #[erasure(f)]
     /// fn g(x: usize, i: Ghost<Int>) { /* ... */ }
+    ///
+    /// #[erasure(private crate_name::full::path::to::f2)]
+    /// fn g2(y: bool) { /* ... */ }
     /// ```
     ///
     /// # Inside `extern_spec!`

--- a/creusot/src/contracts_items/attributes.rs
+++ b/creusot/src/contracts_items/attributes.rs
@@ -1,6 +1,10 @@
 //! Defines all the internal creusot attributes.
 
-use rustc_ast::{LitKind, MetaItemInner, Param};
+use rustc_ast::{
+    LitKind, MetaItemInner, Param,
+    token::TokenKind,
+    tokenstream::{TokenStream, TokenTree},
+};
 use rustc_hir::{AttrArgs, Attribute, def::DefKind, def_id::DefId};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{Span, Symbol};
@@ -163,6 +167,34 @@ fn tokenstream_to_meta<'a>(
     }
     let args = args.into();
     Meta { name, args }
+}
+
+/// - `Some(Some(path))` if `#[creusot::spec::erasure(path)]`
+/// - `Some(None)` if `#[creusot::spec::erasure]`
+/// - `None` if no matching attribute
+pub(crate) fn get_erasure(tcx: TyCtxt, def_id: DefId) -> Option<Option<Vec<Symbol>>> {
+    let attr = get_attrs(tcx.get_all_attrs(def_id), &["creusot", "spec", "erasure"]).pop()?;
+    let Attribute::Unparsed(attr) = attr else { unreachable!() };
+    match &attr.args {
+        AttrArgs::Delimited(args) => Some(Some(tokenstream_to_path(tcx, def_id, &args.tokens))),
+        AttrArgs::Empty => Some(None),
+        _ => tcx.crash_and_error(tcx.def_span(def_id), "Bad #[erasure] attribute"),
+    }
+}
+
+fn tokenstream_to_path(tcx: TyCtxt, def_id: DefId, tokens: &TokenStream) -> Vec<Symbol> {
+    let crash = || tcx.crash_and_error(tcx.def_span(def_id), "Bad #[erasure] attribute");
+    tokens
+        .iter()
+        .filter_map(|token| {
+            let TokenTree::Token(token, _) = token else { crash() };
+            match token.kind {
+                TokenKind::PathSep => None,
+                TokenKind::Ident(name, _) => Some(name),
+                _ => crash(),
+            }
+        })
+        .collect()
 }
 
 pub(crate) fn creusot_clause_attrs<'tcx>(

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -2,14 +2,17 @@ use crate::{
     backend::ty_inv::is_tyinv_trivial,
     callbacks,
     contracts_items::{
-        get_creusot_item, get_inv_function, get_resolve_function, get_resolve_method, is_erasure,
+        get_creusot_item, get_inv_function, get_resolve_function, get_resolve_method,
         is_extern_spec, is_logic, is_open_inv_param, is_prophetic, opacity_witness_name,
     },
     metadata::{BinaryMetadata, Metadata, encode_def_ids, get_erasure_required},
     naming::variable_name,
     translation::{
         self,
-        external::{ExternSpec, extract_erasure_from_item, extract_extern_specs_from_item},
+        external::{
+            ExternSpec, extract_erasure_from_child, extract_erasure_from_item,
+            extract_extern_specs_from_item,
+        },
         fmir,
         pearlite::{self, ScopedTerm},
         specification::{ContractClauses, PreSignature, inherited_extern_spec, pre_sig_of},
@@ -179,8 +182,8 @@ pub struct TranslationCtx<'tcx> {
     erasure_required: RefCell<IndexSet<DefId>>,
     extern_specs: HashMap<DefId, ExternSpec<'tcx>>,
     extern_spec_items: HashMap<LocalDefId, DefId>,
-    erased_local_defid: HashMap<LocalDefId, Erased<'tcx>>,
-    erasures_to_check: Vec<(LocalDefId, (DefId, GenericArgsRef<'tcx>))>,
+    erased_local_defid: HashMap<LocalDefId, Erasure<'tcx>>,
+    erasures_to_check: Vec<(LocalDefId, Erasure<'tcx>)>,
     params_open_inv: HashMap<DefId, Vec<usize>>,
     laws: OnceMap<DefId, Box<Vec<DefId>>>,
     fmir_body: OnceMap<BodyId, Box<fmir::Body<'tcx>>>,
@@ -555,17 +558,29 @@ impl<'tcx> TranslationCtx<'tcx> {
 
     pub(crate) fn load_erasures(&mut self) {
         for (&def_id, thir) in self.local_thir.iter() {
-            if is_erasure(self.tcx, def_id.to_def_id()) {
-                let (eraser, erasure, to_check) = extract_erasure_from_item(self, def_id, thir);
-                self.erased_local_defid.insert(eraser, erasure);
+            let Some((eraser, erasure, to_check)) = extract_erasure_from_item(self, def_id, thir)
+            else {
+                continue;
+            };
+            self.erased_local_defid.insert(eraser, erasure);
+            if let Some(to_check) = to_check {
                 self.erasures_to_check.push((eraser, to_check));
+            }
+        }
+        if self.erasures_to_check.is_empty() {
+            return;
+        }
+        for (&def_id, _) in self.local_thir.iter() {
+            if let Some(erasure) = extract_erasure_from_child(self, def_id) {
+                self.erased_local_defid.insert(def_id, erasure.clone());
+                self.erasures_to_check.push((def_id, erasure));
             }
         }
     }
 
     pub(crate) fn iter_erasures_to_check(
         &self,
-    ) -> impl Iterator<Item = &(LocalDefId, (DefId, GenericArgsRef<'tcx>))> {
+    ) -> impl Iterator<Item = &(LocalDefId, Erasure<'tcx>)> {
         self.erasures_to_check.iter()
     }
 
@@ -625,7 +640,7 @@ impl<'tcx> TranslationCtx<'tcx> {
         *self.crate_name.get_or_init(|| crate_name(self.tcx))
     }
 
-    pub(crate) fn erasure(&self, def_id: DefId) -> Option<&Erased<'tcx>> {
+    pub(crate) fn erasure(&self, def_id: DefId) -> Option<&Erasure<'tcx>> {
         match def_id.as_local() {
             Some(local) => self.erased_local_defid.get(&local),
             None => self.externs.erasure(def_id),
@@ -644,7 +659,7 @@ pub fn crate_name(tcx: TyCtxt) -> why3::Symbol {
 }
 
 #[derive(Clone, Debug, TyDecodable, TyEncodable)]
-pub struct Erased<'tcx> {
+pub struct Erasure<'tcx> {
     /// `DefId` of the trait method or standalone `fn` item
     /// For `#[erasure]` checking of calling functions.
     pub def: (DefId, GenericArgsRef<'tcx>),

--- a/creusot/src/metadata.rs
+++ b/creusot/src/metadata.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ctx::Erased,
+    ctx::Erasure,
     translation::{external::ExternSpec, pearlite::ScopedTerm},
     validate::AnfBlock,
 };
@@ -26,7 +26,7 @@ pub struct Metadata<'tcx> {
     crates: HashMap<CrateNum, CrateMetadata<'tcx>>,
     extern_specs: ExternSpecs<'tcx>,
     erased_thir: HashMap<DefId, AnfBlock<'tcx>>,
-    erased_defid: HashMap<DefId, Erased<'tcx>>,
+    erased_defid: HashMap<DefId, Erasure<'tcx>>,
 }
 
 impl<'tcx> Metadata<'tcx> {
@@ -61,7 +61,7 @@ impl<'tcx> Metadata<'tcx> {
         self.erased_thir.get(&id)
     }
 
-    pub(crate) fn erasure(&self, id: DefId) -> Option<&Erased<'tcx>> {
+    pub(crate) fn erasure(&self, id: DefId) -> Option<&Erasure<'tcx>> {
         self.erased_defid.get(&id)
     }
 
@@ -121,7 +121,7 @@ impl<'tcx> CrateMetadata<'tcx> {
         tcx: TyCtxt<'tcx>,
         overrides: &HashMap<String, PathBuf>,
         cnum: CrateNum,
-    ) -> Option<(Self, ExternSpecs<'tcx>, Vec<(DefId, AnfBlock<'tcx>)>, Vec<(DefId, Erased<'tcx>)>)>
+    ) -> Option<(Self, ExternSpecs<'tcx>, Vec<(DefId, AnfBlock<'tcx>)>, Vec<(DefId, Erasure<'tcx>)>)>
     {
         let binary_path = creusot_metadata_path(tcx, overrides, cnum);
         let metadata = load_binary_metadata(tcx, cnum, &binary_path)?;
@@ -150,7 +150,7 @@ pub(crate) struct BinaryMetadata<'tcx> {
     extern_specs: HashMap<DefId, ExternSpec<'tcx>>,
     params_open_inv: HashMap<DefId, Vec<usize>>,
     erased_thir: Vec<(DefId, AnfBlock<'tcx>)>,
-    erased_defid: Vec<(DefId, Erased<'tcx>)>,
+    erased_defid: Vec<(DefId, Erasure<'tcx>)>,
 }
 
 impl<'tcx> BinaryMetadata<'tcx> {
@@ -160,7 +160,7 @@ impl<'tcx> BinaryMetadata<'tcx> {
         extern_specs: HashMap<DefId, ExternSpec<'tcx>>,
         params_open_inv: HashMap<DefId, Vec<usize>>,
         erased_thir: Vec<(DefId, AnfBlock<'tcx>)>,
-        erased_defid: Vec<(DefId, Erased<'tcx>)>,
+        erased_defid: Vec<(DefId, Erasure<'tcx>)>,
     ) -> Self {
         let terms = terms
             .iter_mut()

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -1,14 +1,19 @@
-use std::path::Path;
+use std::{hash::Hash as _, path::Path};
 
-use rustc_hir::{def::DefKind, def_id::DefId};
+use rustc_hir::{
+    def::DefKind,
+    def_id::{DefId, DefPathHash, LOCAL_CRATE},
+    definitions::{DefKey, DefPathData, DisambiguatedDefPathData},
+};
 use rustc_index::IndexVec;
+use rustc_macros::{TyDecodable, TyEncodable, TypeFoldable, TypeVisitable};
 use rustc_middle::{
     mir::Location,
     thir,
-    ty::{GenericArgs, GenericArgsRef, TyCtxt},
+    ty::{self, GenericArgs, GenericArgsRef, TyCtxt},
 };
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
-use rustc_span::Span;
+use rustc_span::{Span, Symbol};
 
 use creusot_args::options::SpanMode;
 
@@ -41,6 +46,167 @@ pub(crate) fn path_of_span(tcx: TyCtxt, span: Span, span_mode: &SpanMode) -> Opt
     }
 
     Some(path.into())
+}
+
+/// Get the `DefId` of an item given its path as a `String`. It may be a private item.
+pub fn forge_def_id<'tcx>(tcx: TyCtxt, path: &[Symbol]) -> Result<DefId, String> {
+    let krate_name = path[0];
+    let cratenum = if krate_name.as_str() == "crate" {
+        LOCAL_CRATE
+    } else {
+        *tcx.crates(())
+            .into_iter()
+            .find(|num| krate_name == tcx.crate_name(**num))
+            .ok_or_else(|| format!("crate not found: {:?}", krate_name.as_str()))?
+    };
+    let stable_crate_id = tcx.stable_crate_id(cratenum);
+    // Code for hashing `stable_crate_id` from rustc_hir::definitions::Definitions::new
+    let hash =
+        DefPathHash::new(stable_crate_id, rustc_hashes::Hash64::new(stable_crate_id.as_u64()));
+    let len = path.len();
+    debug!("forge_def_id: {stable_crate_id:?}");
+    forge_def_id_from(
+        tcx,
+        hash,
+        path.into_iter().enumerate().skip(1).map(|(i, &segment)| {
+            let data = if i == len - 1 {
+                DefPathData::ValueNs(segment)
+            } else {
+                DefPathData::TypeNs(segment)
+            };
+            DisambiguatedDefPathData { data, disambiguator: 0 }
+        }),
+    )
+    .ok_or_else(|| format!("item not found: {path:?}"))
+}
+
+// Code for hashing `DefPathData` from `Definitions::create_def`
+pub fn forge_def_id_from(
+    tcx: TyCtxt,
+    mut hash: DefPathHash,
+    path: impl IntoIterator<Item = DisambiguatedDefPathData>,
+) -> Option<DefId> {
+    for disambiguated_data in path {
+        let parent = tcx.def_path_hash_to_def_id(hash)?;
+        debug!("forge_def_id_from: {parent:?}");
+        let key = DefKey { parent: Some(parent.index), disambiguated_data };
+        hash = compute_stable_hash(key, hash);
+    }
+    tcx.def_path_hash_to_def_id(hash)
+}
+
+fn compute_stable_hash(key: DefKey, parent: DefPathHash) -> DefPathHash {
+    let mut hasher = rustc_data_structures::stable_hasher::StableHasher::new();
+
+    // The new path is in the same crate as `parent`, and will contain the stable_crate_id.
+    // Therefore, we only need to include information of the parent's local hash.
+    parent.local_hash().hash(&mut hasher);
+
+    let DisambiguatedDefPathData { ref data, disambiguator } = key.disambiguated_data;
+
+    std::mem::discriminant(data).hash(&mut hasher);
+    if let Some(name) = hashed_symbol(*data) {
+        // Get a stable hash by considering the symbol chars rather than
+        // the symbol index.
+        name.as_str().hash(&mut hasher);
+    }
+
+    disambiguator.hash(&mut hasher);
+
+    let local_hash = hasher.finish();
+
+    // Construct the new DefPathHash, making sure that the `crate_id`
+    // portion of the hash is properly copied from the parent. This way the
+    // `crate_id` part will be recursively propagated from the root to all
+    // DefPathHashes in this DefPathTable.
+    DefPathHash::new(parent.stable_crate_id(), local_hash)
+}
+
+fn hashed_symbol(data: DefPathData) -> Option<Symbol> {
+    use DefPathData::*;
+    match data {
+        TypeNs(name) | ValueNs(name) | MacroNs(name) | LifetimeNs(name) | AnonAssocTy(name)
+        | OpaqueLifetime(name) => Some(name),
+
+        Impl
+        | ForeignMod
+        | CrateRoot
+        | Use
+        | GlobalAsm
+        | Closure
+        | Ctor
+        | AnonConst
+        | OpaqueTy
+        | SyntheticCoroutineBody
+        | NestedStatic => None,
+    }
+}
+
+pub fn eq_nameless_generic_args<'tcx>(
+    args1: ty::GenericArgsRef<'tcx>,
+    args2: ty::GenericArgsRef<'tcx>,
+) -> bool {
+    NamelessGenericArgs(args1) == NamelessGenericArgs(args2)
+}
+
+/// Custom equality on `GenericArgsRef` to ignore the `name` symbol in `Param`.
+#[derive(Clone, Copy, Debug, Eq, TypeVisitable, TypeFoldable, TyEncodable, TyDecodable)]
+pub struct NamelessGenericArgs<'tcx>(pub ty::GenericArgsRef<'tcx>);
+
+impl<'tcx> From<ty::GenericArgsRef<'tcx>> for NamelessGenericArgs<'tcx> {
+    fn from(args: ty::GenericArgsRef<'tcx>) -> Self {
+        NamelessGenericArgs(args)
+    }
+}
+
+impl<'tcx> PartialEq<NamelessGenericArgs<'tcx>> for NamelessGenericArgs<'tcx> {
+    fn eq(&self, rhs: &Self) -> bool {
+        use rustc_type_ir::GenericArgKind::*;
+        self.0.len() == rhs.0.len()
+            && self.0.iter().zip(rhs.0).all(|(a, b)| match (a.kind(), b.kind()) {
+                (Type(t1), Type(t2)) => equal_types(&t1, &t2),
+                (Const(c1), Const(c2)) => equal_const_kinds(c1.kind(), c2.kind()),
+                (Lifetime(r1), Lifetime(r2)) => r1 == r2,
+                _ => false,
+            })
+    }
+}
+
+fn equal_types<'tcx>(t1: &ty::Ty<'tcx>, t2: &ty::Ty<'tcx>) -> bool {
+    use rustc_type_ir::TyKind::*;
+    match (t1.kind(), t2.kind()) {
+        (Ref(_, ty1, mutable1), Ref(_, ty2, mutable2)) => {
+            mutable1 == mutable2 && equal_types(ty1, ty2)
+        }
+        (Adt(adt1, subst1), Adt(adt2, subst2)) => {
+            adt1 == adt2 && NamelessGenericArgs(*subst1).eq(&NamelessGenericArgs(*subst2))
+        }
+        (Tuple(tys1), Tuple(tys2)) => {
+            tys1.len() == tys2.len()
+                && tys1.iter().zip(tys2.iter()).all(|(ty1, ty2)| equal_types(&ty1, &ty2))
+        }
+        (Array(ty1, c1), Array(ty2, c2)) => {
+            equal_types(ty1, ty2) && equal_const_kinds(c1.kind(), c2.kind())
+        }
+        (Slice(ty1), Slice(ty2)) => equal_types(ty1, ty2),
+        (RawPtr(ty1, mutable1), RawPtr(ty2, mutable2)) => {
+            mutable1 == mutable2 && equal_types(ty1, ty2)
+        }
+        (FnDef(def_id1, subst1), FnDef(def_id2, subst2)) => {
+            def_id1 == def_id2 && NamelessGenericArgs(*subst1) == NamelessGenericArgs(*subst2)
+        }
+        (Param(p1), Param(p2)) => p1.index == p2.index, // Ignore `name`
+        _ => t1 == t2,
+    }
+}
+
+/// Ignore `name` of `Param`
+fn equal_const_kinds<'tcx>(c1: ty::ConstKind<'tcx>, c2: ty::ConstKind<'tcx>) -> bool {
+    use rustc_type_ir::ConstKind::Param;
+    match (c1, c2) {
+        (Param(p1), Param(p2)) => p1.index == p2.index,
+        _ => c1 == c2,
+    }
 }
 
 /// A newtype to carry orphan trait impls.

--- a/guide/highlight.js/src/languages/rust.js
+++ b/guide/highlight.js/src/languages/rust.js
@@ -307,7 +307,7 @@ export default function(hljs) {
         begin: '#!?\\[',
         end: '\\]',
         keywords: {
-          'keyword.creusot': ["law", "logic", "check", "open", "prophetic", "terminates", "trusted", "ghost", "erasure"]
+          'keyword.creusot': ["law", "logic", "check", "open", "prophetic", "terminates", "trusted", "ghost", "erasure", "private"]
         },
         contains: [
           {

--- a/guide/src/erasure.md
+++ b/guide/src/erasure.md
@@ -159,3 +159,32 @@ When `#[erasure(f)]` mentions a function `f` from `core` or `std`, you must use
 ```
 rustup component add rust-src --toolchain $MY_TOOLCHAIN
 ```
+
+### Private functions
+
+It is also possible to name a private function using the `private` keyword
+followed by the full path to the private function:
+
+```rust
+#[erasure(private crate_name::path::to::f)]
+```
+
+### Nested functions
+
+`#[erasure]` automatically takes nested functions into account.
+
+```rust
+fn f() {
+  fn inside_f() {}
+  inside_f()
+}
+
+#[erasure(f)]
+fn g() {
+  fn inside_f() {}
+  inside_f()
+}
+```
+
+The inner function of `g` does not need an `#[erasure]` attribute,
+but it must have the same name as its counterpart in `f`.

--- a/guide/theme/highlight.js
+++ b/guide/theme/highlight.js
@@ -332,7 +332,7 @@ begin:"\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)"+ne}],relevance:0},{
 begin:[/fn/,/\s+/,s],className:{1:"keyword",3:"title.function"}},{
 scope:"keyword.creusot",match:/\bghost\s*!/},{className:"meta",begin:"#!?\\[",
 end:"\\]",keywords:{
-"keyword.creusot":["law","logic","check","open","prophetic","terminates","trusted","ghost","erasure"]
+"keyword.creusot":["law","logic","check","open","prophetic","terminates","trusted","ghost","erasure","private"]
 },contains:[{scope:"creusot",begin:/(?:requires|ensures|invariant|variant)\(/,
 beginScope:"keyword.creusot",endScope:"keyword.creusot",end:/[()]/,
 "on:begin":(e,t)=>{t.data.nesting=0},"on:end":(e,t)=>{

--- a/tests/should_fail/bad_erasure.stderr
+++ b/tests/should_fail/bad_erasure.stderr
@@ -1,4 +1,4 @@
-error: failed #[erasure] check
+error: failed #[erasure] check for bar2
   --> bad_erasure.rs:19:5
    |
 14 |     baz::<42>()
@@ -7,7 +7,7 @@ error: failed #[erasure] check
 19 |     baz::<0>()
    |     ^^^^^^^^^^ #[erasure] expression (baz[0])
 
-error: failed #[erasure] check
+error: failed #[erasure] check for bar3
   --> bad_erasure.rs:24:5
    |
 14 |     baz::<42>()
@@ -16,7 +16,7 @@ error: failed #[erasure] check
 24 |     baz2::<0>()
    |     ^^^^^^^^^^^ #[erasure] expression (baz[0])
 
-error: failed #[erasure] check
+error: failed #[erasure] check for add2
   --> bad_erasure.rs:33:9
    |
 28 |     x + y

--- a/tests/should_succeed/specification/erasure.coma
+++ b/tests/should_succeed/specification/erasure.coma
@@ -577,3 +577,72 @@ module M_erasure__specs [#"erasure.rs" 128 0 128 30]
     [ & _0: () = Any.any_l () | & x'0: int = x | & _7: Int32.t = Any.any_l () | & _8: int = Any.any_l () ])
     [ return''0 (result: ()) -> {[@expl:specs ensures] [%#serasure'5] false} (! return' {result}) ]
 end
+module M_erasure__nested [#"erasure.rs" 136 0 136 15]
+  use creusot.prelude.Any
+  
+  let rec hidden (return' (x: ())) = any [ return''0 (result: ()) -> (! return' {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec nested [#"erasure.rs" 136 0 136 15] (return' (x: ())) = (! bb0
+    [ bb0 = s0 [ s0 = hidden (fun (_ret: ()) -> [ &_0 <- _ret ] s1) | s1 = bb1 ] | bb1 = return''0 {_0} ]
+    [ & _0: () = Any.any_l () ]) [ return''0 (result: ()) -> (! return' {result}) ]
+end
+module M_erasure__nested__hidden [#"erasure.rs" 137 4 137 15]
+  use creusot.prelude.Any
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec hidden [#"erasure.rs" 137 4 137 15] (return' (x: ())) = (! bb0
+    [ bb0 = return''0 {_0} ] [ & _0: () = Any.any_l () ]) [ return''0 (result: ()) -> (! return' {result}) ]
+end
+module M_erasure__nested2 [#"erasure.rs" 142 0 142 16]
+  use creusot.prelude.Any
+  
+  let rec hidden (return' (x: ())) = any [ return''0 (result: ()) -> (! return' {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec nested2 [#"erasure.rs" 142 0 142 16] (return' (x: ())) = (! bb0
+    [ bb0 = s0 [ s0 = hidden (fun (_ret: ()) -> [ &_0 <- _ret ] s1) | s1 = bb1 ] | bb1 = return''0 {_0} ]
+    [ & _0: () = Any.any_l () ]) [ return''0 (result: ()) -> (! return' {result}) ]
+end
+module M_erasure__nested2__hidden [#"erasure.rs" 143 4 143 15]
+  use creusot.prelude.Any
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec hidden [#"erasure.rs" 143 4 143 15] (return' (x: ())) = (! bb0
+    [ bb0 = return''0 {_0} ] [ & _0: () = Any.any_l () ]) [ return''0 (result: ()) -> (! return' {result}) ]
+end
+module M_erasure__nested3 [#"erasure.rs" 148 0 148 16]
+  use creusot.prelude.Any
+  
+  let rec hidden (return' (x: ())) = any [ return''0 (result: ()) -> (! return' {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec nested3 [#"erasure.rs" 148 0 148 16] (return' (x: ())) = (! bb0
+    [ bb0 = s0 [ s0 = hidden (fun (_ret: ()) -> [ &_0 <- _ret ] s1) | s1 = bb1 ] | bb1 = return''0 {_0} ]
+    [ & _0: () = Any.any_l () ]) [ return''0 (result: ()) -> (! return' {result}) ]
+end
+module M_erasure__nested3__hidden [#"erasure.rs" 149 4 149 15]
+  use creusot.prelude.Any
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec hidden [#"erasure.rs" 149 4 149 15] (return' (x: ())) = (! bb0
+    [ bb0 = return''0 {_0} ] [ & _0: () = Any.any_l () ]) [ return''0 (result: ()) -> (! return' {result}) ]
+end

--- a/tests/should_succeed/specification/erasure.rs
+++ b/tests/should_succeed/specification/erasure.rs
@@ -132,3 +132,20 @@ pub fn specs(x: Snapshot<Int>) {
     #[invariant(false)]
     while false {}
 }
+
+pub fn nested() {
+    fn hidden() {}
+    hidden()
+}
+
+#[erasure(nested)]
+pub fn nested2() {
+    fn hidden() {}
+    hidden()
+}
+
+#[erasure(private crate::nested)]
+pub fn nested3() {
+    fn hidden() {}
+    hidden()
+}

--- a/tests/should_succeed/specification/erasure/proof.json
+++ b/tests/should_succeed/specification/erasure/proof.json
@@ -15,6 +15,27 @@
       "vc_foog": { "prover": "cvc5@1.0.5", "time": 0.021 },
       "vc_new": { "prover": "cvc5@1.0.5", "time": 0.027 }
     },
+    "M_erasure__nested": {
+      "vc_hidden": { "prover": "cvc5@1.0.5", "time": 0.009 },
+      "vc_nested": { "prover": "cvc5@1.0.5", "time": 0.01 }
+    },
+    "M_erasure__nested2": {
+      "vc_hidden": { "prover": "cvc5@1.0.5", "time": 0.013 },
+      "vc_nested2": { "prover": "cvc5@1.0.5", "time": 0.011 }
+    },
+    "M_erasure__nested2__hidden": {
+      "vc_hidden": { "prover": "cvc5@1.0.5", "time": 0.01 }
+    },
+    "M_erasure__nested3": {
+      "vc_hidden": { "prover": "cvc5@1.0.5", "time": 0.01 },
+      "vc_nested3": { "prover": "cvc5@1.0.5", "time": 0.01 }
+    },
+    "M_erasure__nested3__hidden": {
+      "vc_hidden": { "prover": "cvc5@1.0.5", "time": 0.013 }
+    },
+    "M_erasure__nested__hidden": {
+      "vc_hidden": { "prover": "cvc5@1.0.5", "time": 0.009 }
+    },
     "M_erasure__no_specs": {
       "vc_foo": { "prover": "cvc5@1.0.5", "time": 0.024 },
       "vc_no_specs": { "prover": "cvc5@1.0.5", "time": 0.019 }
@@ -70,7 +91,7 @@
       "vc_as_ref": { "prover": "cvc5@1.0.5", "time": 0.02 },
       "vc_test_ptr2": {
         "tactic": "split_vc",
-        "children": [ { "prover": "cvc5@1.0.5", "time": 0.02 } ]
+        "children": [ { "prover": "cvc5@1.0.5", "time": 0.01 } ]
       }
     },
     "M_erasure__test_ptr_mut2": {


### PR DESCRIPTION
And more:

- Automatically handle erasure of nested `fn` items
- Add missing check for function argument types
- Support erasure of various casts
- Fix pretty-printer for erasures
- Improve error messages