### PR TITLE
Better errors in `ghost!`

### DIFF
--- a/creusot-contracts-proc/src/creusot/proof.rs
+++ b/creusot-contracts-proc/src/creusot/proof.rs
@@ -41,7 +41,7 @@ pub fn snapshot(assertion: TS1) -> TS1 {
 }
 
 pub fn ghost(body: TS1) -> TS1 {
-    let body = proc_macro2::TokenStream::from(crate::ghost::ghost_preprocess(body));
+    let body = proc_macro2::TokenStream::from(crate::ghost::ghost_preprocess(body.into()));
     TS1::from(quote! {
         {
             #[creusot::ghost_block]
@@ -69,7 +69,7 @@ impl syn::parse::Parse for GhostLet {
 }
 
 pub fn ghost_let(body: TS1) -> TS1 {
-    let body = crate::ghost::ghost_preprocess(body);
+    let body: TS1 = crate::ghost::ghost_preprocess(body.into()).into();
     let GhostLet { mutability, var, body } = parse_macro_input!(body as GhostLet);
     TS1::from(quote! {
         #[creusot::ghost_let]

--- a/creusot-contracts-proc/src/ghost.rs
+++ b/creusot-contracts-proc/src/ghost.rs
@@ -3,8 +3,7 @@
 //! This should be kept to a minimum in order to minimize the mismatch between ghost and
 //! normal code.
 
-use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
-use proc_macro2::Literal;
+use proc_macro2::{Delimiter, Group, Literal, TokenStream, TokenTree};
 use quote::quote_spanned;
 
 /// Change `xxxint` into `*::creusot_contracts::Int::new(xxx)`.


### PR DESCRIPTION
If the ghost block has invalid syntax, it will be processed by rustc's parser anyway, allowing better errors & LSP support.