### PR TITLE
Error on incorrect attributes

### DIFF
--- a/creusot/src/validate.rs
+++ b/creusot/src/validate.rs
@@ -2,6 +2,7 @@
 
 mod erasure;
 mod ghost;
+mod incorrect_attributes;
 mod opacity;
 mod purity;
 mod terminates;
@@ -14,6 +15,7 @@ pub(crate) use self::{
 };
 
 use self::{
+    incorrect_attributes::validate_incorrect_attributes,
     opacity::validate_opacity,
     purity::validate_purity,
     terminates::validate_terminates,
@@ -55,6 +57,7 @@ pub(crate) fn validate(ctx: &TranslationCtx) {
         if is_spec(ctx.tcx, def_id) || !is_no_translate(ctx.tcx, def_id) {
             validate_purity(ctx, def_id, thir);
             validate_tokens_new(ctx, def_id, thir);
+            validate_incorrect_attributes(ctx.tcx, def_id);
         }
         if is_extern_spec(ctx.tcx, def_id) || !is_no_translate(ctx.tcx, def_id) {
             validate_opacity(ctx, def_id);

--- a/creusot/src/validate/incorrect_attributes.rs
+++ b/creusot/src/validate/incorrect_attributes.rs
@@ -1,0 +1,22 @@
+use crate::contracts_items::{is_check_ghost, is_check_terminates, is_logic};
+use rustc_hir::def_id::DefId;
+use rustc_middle::ty::TyCtxt;
+
+type AttributeFn = fn(TyCtxt, DefId) -> bool;
+
+const INCOMPATIBLE_ATTRIBUTES: &[(AttributeFn, AttributeFn, &str)] = &[
+    (is_logic, is_check_ghost, "logical function cannot use the `check(ghost)` attribute"),
+    (
+        is_logic,
+        is_check_terminates,
+        "logical function cannot use the `check(terminates)` attribute",
+    ),
+];
+
+pub(super) fn validate_incorrect_attributes(tcx: TyCtxt, def_id: DefId) {
+    for &(attr1, attr2, reason) in INCOMPATIBLE_ATTRIBUTES {
+        if attr1(tcx, def_id) && attr2(tcx, def_id) {
+            tcx.dcx().span_err(tcx.def_span(def_id), reason);
+        }
+    }
+}

--- a/creusot/src/validate/incorrect_attributes.rs
+++ b/creusot/src/validate/incorrect_attributes.rs
@@ -1,4 +1,4 @@
-use crate::contracts_items::{is_check_ghost, is_check_terminates, is_logic};
+use crate::contracts_items::{is_check_ghost, is_check_terminates, is_law, is_logic};
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
 
@@ -14,6 +14,14 @@ const INCOMPATIBLE_ATTRIBUTES: &[(AttributeFn, AttributeFn, &str)] = &[
 ];
 
 pub(super) fn validate_incorrect_attributes(tcx: TyCtxt, def_id: DefId) {
+    if is_law(tcx, def_id)
+        && !(tcx.trait_of_assoc(def_id).is_some() || tcx.trait_impl_of_assoc(def_id).is_some())
+    {
+        tcx.dcx().span_err(
+            tcx.def_span(def_id),
+            "Laws can only be declared in trait definitions or implementations",
+        );
+    }
     for &(attr1, attr2, reason) in INCOMPATIBLE_ATTRIBUTES {
         if attr1(tcx, def_id) && attr2(tcx, def_id) {
             tcx.dcx().span_err(tcx.def_span(def_id), reason);

--- a/tests/should_succeed/bug/641.rs
+++ b/tests/should_succeed/bug/641.rs
@@ -1,7 +1,7 @@
 extern crate creusot_contracts;
 use creusot_contracts::{logic, maintains};
 
-#[logic(open, law)]
+#[logic(open)]
 pub fn test_law() {}
 
 #[logic(open)]

--- a/tests/should_succeed/trigger.rs
+++ b/tests/should_succeed/trigger.rs
@@ -10,7 +10,7 @@ mod inner {
         i
     }
 
-    #[logic(open(self), law)]
+    #[logic(open(self))]
     #[ensures(forall<i, j> #[trigger(id(i), id(j))] i <= j ==> id(i) <= id(j))]
     pub fn id_mono() {}
 }

--- a/tests/should_succeed/type_invariants/quant.rs
+++ b/tests/should_succeed/type_invariants/quant.rs
@@ -10,10 +10,10 @@ impl Invariant for WithInvariant {
     }
 }
 
-#[logic(open, law)]
+#[logic(open)]
 #[ensures(forall<x: WithInvariant> x.invariant())]
 pub fn forall() {}
 
-#[logic(open, law)]
+#[logic(open)]
 #[ensures(exists<_x: WithInvariant> true)]
 pub fn exists() {}


### PR DESCRIPTION
Forbids:
- `#[check(...)]` on logical functions
- Usage of `#[logic(law)]` outside traits