### PR TITLE
erasure: ignore ghost mut bindings

### DIFF
--- a/creusot/src/validate/erasure.rs
+++ b/creusot/src/validate/erasure.rs
@@ -1122,6 +1122,9 @@ impl<'a, 'tcx> AnfBuilder<'a, 'tcx> {
                 let mut pattern = &**pattern;
                 loop {
                     match &pattern.kind {
+                        PatKind::Binding { .. } if is_ghost_or_snap(self.tcx, pattern.ty) => {
+                            return Ok(());
+                        }
                         PatKind::Binding {
                             var,
                             mode: BindingMode(ByRef::No, Mutability::Not),


### PR DESCRIPTION
This:
```
let mut g = ghost! { ... };
```
should be a noop.