### PR TITLE
Add Seq::split_off_ghost

### DIFF
--- a/creusot-contracts/src/logic/seq.rs
+++ b/creusot-contracts/src/logic/seq.rs
@@ -669,6 +669,17 @@ impl<T> Seq<T> {
     #[check(ghost)]
     #[ensures(^self == Self::empty())]
     pub fn clear_ghost(&mut self) {}
+
+    /// Split a sequence in two at the given index.
+    #[trusted]
+    #[check(ghost)]
+    #[requires(0 <= mid && mid <= self.len())]
+    #[ensures((^self).len() == mid)]
+    #[ensures((^self).concat(result) == *self)]
+    pub fn split_off_ghost(&mut self, mid: Int) -> Self {
+        let _ = mid;
+        panic!("ghost code")
+    }
 }
 
 impl<T> ::std::ops::Index<Int> for Seq<T> {


### PR DESCRIPTION
Similar to `Vec::split_off`.

Sadly, this precise signature is unimplementable at the moment from the other primitives. The one we can implement involves wrapping the argument and result in `Ghost`.