### PR TITLE
Document issue about vec!

### DIFF
--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -126,7 +126,7 @@ pub mod macros {
     /// they carry no ownership. This means that code like this is perfectly fine:
     ///
     /// ```
-    /// # use creusot_contracts::prelude::*;
+    /// # use creusot_contracts::prelude::{vec, *};
     /// let v: Vec<i32> = vec![1, 2];
     /// let s = snapshot!(v);
     /// assert!(v[0] == 1); // ok, `s` does not have ownership of `v`
@@ -329,7 +329,7 @@ pub mod macros {
     /// # Example
     ///
     /// ```
-    /// # use creusot_contracts::prelude::*;
+    /// # use creusot_contracts::prelude::{vec, *};
     /// let x = 1;
     /// let v = vec![x, 2];
     /// let s = snapshot!(v);
@@ -528,7 +528,7 @@ mod base_prelude {
     };
 
     pub use crate::std::{
-        // Shadow std::prelude by our version of derive macros.
+        // Shadow std::prelude by our version of derive macros and of vec!.
         // If the user write the glob pattern "use creusot_contracts::prelude::*",
         // then rustc will either shadow the old identifier or complain about
         // the ambiguity (ex: for the derive macros Clone and PartialEq, a glob
@@ -537,6 +537,7 @@ mod base_prelude {
         clone::Clone,
         cmp::PartialEq,
         default::Default,
+        vec::vec,
     };
 
     // Export extension traits anonymously
@@ -555,23 +556,4 @@ mod base_prelude {
 /// Re-exports available under the `creusot_contracts` namespace
 pub mod prelude {
     pub use crate::{base_prelude::*, macros::*};
-}
-
-/// Creusot-friendly replacement of `vec!`
-///
-/// The std vec macro uses special magic to construct the array argument
-/// to `Box::new` directly on the heap. Because the generated MIR is hard
-/// to translate, we provide a custom `vec!` macro which does not do this.
-#[macro_export]
-macro_rules! vec {
-    () => (
-        ::std::vec::Vec::new()
-    );
-    ($elem:expr; $n:expr) => (
-        ::std::vec::from_elem($elem, $n)
-    );
-    ($($x:expr),*) => (
-        <[_]>::into_vec(::std::boxed::Box::new([$($x),*]))
-    );
-    ($($x:expr,)*) => (vec![$($x),*])
 }

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -314,3 +314,23 @@ mod impls {
     impl<T> Resolve for IntoIter<T> {}
     impl<T> IteratorSpec for IntoIter<T> {}
 }
+
+/// Creusot-friendly replacement of `vec!`
+///
+/// The std vec macro uses special magic to construct the array argument
+/// to `Box::new` directly on the heap. Because the generated MIR is hard
+/// to translate, we provide a custom `vec!` macro which does not do this.
+#[macro_export]
+macro_rules! vec {
+    () => (
+        ::std::vec::Vec::new()
+    );
+    ($elem:expr; $n:expr) => (
+        ::std::vec::from_elem($elem, $n)
+    );
+    ($($x:expr),*) => (
+        <[_]>::into_vec(::std::boxed::Box::new([$($x),*]))
+    );
+    ($($x:expr,)*) => (vec![$($x),*])
+}
+pub use vec;

--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -13,8 +13,8 @@ use crate::{
 use rustc_ast::Mutability;
 use rustc_middle::{
     mir::{
-        BorrowKind::*, CastKind, Location, Operand::*, Place, Rvalue, SourceInfo, Statement,
-        StatementKind,
+        BorrowKind::*, CastKind, Location, NullOp, Operand::*, Place, Rvalue, SourceInfo,
+        Statement, StatementKind,
     },
     ty::{ConstKind, Ty, TyKind, UintTy, adjustment::PointerCoercion},
 };
@@ -200,13 +200,17 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                 _,
                 _,
             ) => self.ctx.crash_and_error(si.span, format!("Unsupported pointer cast: {rvalue:?}")),
+            Rvalue::NullaryOp(NullOp::SizeOf, _) => self
+                .ctx
+                .fatal_error(si.span, format!("MIR code used Rvalue SizeOf: {rvalue:?}"))
+                .with_note("If you are trying to use the vec! macro, you should use the version provided by creusot-contracts.").emit(),
             Rvalue::CopyForDeref(_)
             | Rvalue::ShallowInitBox(_, _)
             | Rvalue::NullaryOp(_, _)
             | Rvalue::ThreadLocalRef(_)
             | Rvalue::WrapUnsafeBinder(_, _) => self.ctx.crash_and_error(
                 si.span,
-                format!("MIR code used an unsupported Rvalue {:?}", rvalue),
+                format!("MIR code used an unsupported Rvalue {rvalue:?}"),
             ),
         };
 

--- a/guide/src/limitations.md
+++ b/guide/src/limitations.md
@@ -28,3 +28,15 @@ In particular, this affects the value of `usize::MAX` and the sizes of
 [The Rust Reference: Type Layout][rust-layout].
 
 [rust-layout]: https://doc.rust-lang.org/reference/type-layout.html
+
+## vec! macro
+
+The vec! macro of Rust's standard library uses special magic to initialize memory slightly more
+efficiently. Creusot does not support this magic, hence the version provided by the standard library
+is not supported in Creusot.
+
+Instead, we provide the replacement macro `creusot_contracts::std::vec::vec`, which has the same
+semantics and can be used in Creusot, albeit being slightly less efficient (the content of the
+vector is first allocated in the stack, and then moved to the newly allocated vector, instead of
+being directly initialized in the heap). It needs to be explicitly imported in order to not conflict
+with Rust's default implementation.

--- a/tests/should_fail/bug/878.rs
+++ b/tests/should_fail/bug/878.rs
@@ -1,6 +1,6 @@
 // WHY3PROVE
 extern crate creusot_contracts;
-use creusot_contracts::{prelude::*, vec};
+use creusot_contracts::prelude::{vec, *};
 
 pub fn test() {
     let mut v = vec![1, 2, 2, 3];

--- a/tests/should_fail/zst.rs
+++ b/tests/should_fail/zst.rs
@@ -1,6 +1,9 @@
 // WHY3PROVE
 extern crate creusot_contracts;
-use creusot_contracts::{ghost::PtrOwn, prelude::*, vec};
+use creusot_contracts::{
+    ghost::PtrOwn,
+    prelude::{vec, *},
+};
 
 pub fn zst_pointers_may_be_equal() {
     let mut v0: Vec<()> = vec![()];

--- a/tests/should_succeed/100doors.rs
+++ b/tests/should_succeed/100doors.rs
@@ -13,7 +13,7 @@
 //! +   Absence of array access out of bounds
 
 extern crate creusot_contracts;
-use creusot_contracts::{prelude::*, vec};
+use creusot_contracts::prelude::{vec, *};
 
 pub fn f() {
     let mut door_open: Vec<bool> = vec![false; 100];

--- a/tests/should_succeed/bug/874.rs
+++ b/tests/should_succeed/bug/874.rs
@@ -1,5 +1,5 @@
 extern crate creusot_contracts;
-use creusot_contracts::{prelude::*, vec};
+use creusot_contracts::prelude::{vec, *};
 
 pub fn can_extend() {
     let mut v = vec![1, 2, 3];

--- a/tests/should_succeed/filter_positive.rs
+++ b/tests/should_succeed/filter_positive.rs
@@ -25,7 +25,7 @@
 // free.
 
 extern crate creusot_contracts;
-use creusot_contracts::{prelude::*, vec};
+use creusot_contracts::prelude::{vec, *};
 
 // number of positive elements of `t` between `i` (included) and `j`
 // (excluded)

--- a/tests/should_succeed/hashmap.rs
+++ b/tests/should_succeed/hashmap.rs
@@ -1,7 +1,7 @@
 extern crate creusot_contracts;
 use creusot_contracts::{
     logic::{Int, Mapping},
-    prelude::*,
+    prelude::{vec, *},
     resolve::structural_resolve,
 };
 

--- a/tests/should_succeed/knapsack.rs
+++ b/tests/should_succeed/knapsack.rs
@@ -1,5 +1,5 @@
 extern crate creusot_contracts;
-use creusot_contracts::{prelude::*, vec};
+use creusot_contracts::prelude::{vec, *};
 
 pub struct Item<Name> {
     pub name: Name,

--- a/tests/should_succeed/knapsack_full.rs
+++ b/tests/should_succeed/knapsack_full.rs
@@ -1,5 +1,5 @@
 extern crate creusot_contracts;
-use creusot_contracts::{prelude::*, vec};
+use creusot_contracts::prelude::{vec, *};
 
 pub struct Item<Name> {
     pub name: Name,

--- a/tests/should_succeed/persistent_array.rs
+++ b/tests/should_succeed/persistent_array.rs
@@ -295,7 +295,10 @@ pub mod implementation {
     }
 }
 
-use creusot_contracts::{ghost::local_invariant::Tokens, prelude::*, vec};
+use creusot_contracts::{
+    ghost::local_invariant::Tokens,
+    prelude::{vec, *},
+};
 use implementation::PersistentArray;
 
 #[requires(tokens.contains(implementation::PARRAY()))]

--- a/tests/should_succeed/syntax/13_vec_macro.rs
+++ b/tests/should_succeed/syntax/13_vec_macro.rs
@@ -1,6 +1,6 @@
 extern crate creusot_contracts;
 
-use creusot_contracts::{prelude::*, vec};
+use creusot_contracts::prelude::{vec, *};
 
 pub fn x() {
     let v0: Vec<u32> = vec![];

--- a/tests/should_succeed/vector/06_knights_tour.rs
+++ b/tests/should_succeed/vector/06_knights_tour.rs
@@ -1,5 +1,8 @@
 extern crate creusot_contracts;
-use creusot_contracts::{prelude::*, std::clone::Clone, vec};
+use creusot_contracts::{
+    prelude::{vec, *},
+    std::clone::Clone,
+};
 
 #[derive(Copy, Clone)]
 struct Point {


### PR DESCRIPTION
vec! macro:

- move it to the vec module,
- document the fact that it should be used instead of std::vec,
- refer to it in the error message, and
- re-export it to the prelude so that an error message is emited if the user tries to use vec! without importing it explicitly.

Fixes https://github.com/creusot-rs/creusot/issues/1804.