### PR TITLE
Fix bugs in BodyLocals::from_body

### DIFF
--- a/tests/creusot-contracts/creusot-contracts.coma
+++ b/tests/creusot-contracts/creusot-contracts.coma
@@ -43067,10 +43067,10 @@ module M_std__option__extern_spec_std_option_T_Option_T_as_slice_body
         [ bb0'0 = s0'0
           [ s0'0 = any
             [ any_ (__arr_temp: Slice64.array t_T) -> (! -{Seq.length __arr_temp.Slice64.elts = 0}-
-              [ &self_ <- __arr_temp ] s1'0) ]
-          | s1'0 = [ &_0'0 <- self_ ] s2'0
+              [ &_1 <- __arr_temp ] s1'0) ]
+          | s1'0 = [ &_0'0 <- _1 ] s2'0
           | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Slice64.array t_T = Any.any_l () | & self_: Slice64.array t_T = Any.any_l () ]
+        [ & _0'0: Slice64.array t_T = Any.any_l () | & _1: Slice64.array t_T = Any.any_l () ]
         [ _const_ret (_const: Slice64.array t_T) -> [ &_11 <- _const ] s1 ]
       | s1 = [ &_6 <- _11 ] s2
       | s2 = [ &_3 <- _6 ] s3
@@ -43252,14 +43252,14 @@ module M_std__option__extern_spec_std_option_T_Option_T_as_mut_slice_body
         [ bb0'0 = s0'0
           [ s0'0 = any
             [ any_ (__arr_temp: Slice64.array t_T) -> (! -{Seq.length __arr_temp.Slice64.elts = 0}-
-              [ &self_ <- __arr_temp ] s1'0) ]
-          | s1'0 = {inv_array_T_0 self_}
-            MutBorrow.borrow_mut <Slice64.array t_T> {self_}
+              [ &_1 <- __arr_temp ] s1'0) ]
+          | s1'0 = {inv_array_T_0 _1}
+            MutBorrow.borrow_mut <Slice64.array t_T> {_1}
               (fun (_ret: MutBorrow.t (Slice64.array t_T)) ->
                 [ &_0'0 <- _ret ] -{inv_array_T_0 _ret.final}-
-                [ &self_ <- _ret.final ] s2'0)
+                [ &_1 <- _ret.final ] s2'0)
           | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: MutBorrow.t (Slice64.array t_T) = Any.any_l () | & self_: Slice64.array t_T = Any.any_l () ]
+        [ & _0'0: MutBorrow.t (Slice64.array t_T) = Any.any_l () | & _1: Slice64.array t_T = Any.any_l () ]
         [ _const_ret (_const: MutBorrow.t (Slice64.array t_T)) -> [ &_12 <- _const ] s1 ]
       | s1 = {inv_array_T_0 _12.current}
         MutBorrow.borrow_final <Slice64.array t_T> {_12.current} {MutBorrow.get_id _12}
@@ -47479,10 +47479,10 @@ module M_std__ptr__extern_spec_T_ptrconst_T_is_aligned_to_body
             [ any_ (__arr_temp: Slice64.array string) -> (! -{Seq.get __arr_temp.Slice64.elts 0
                 = "is_aligned_to: align is not a power-of-two"
               /\ Seq.length __arr_temp.Slice64.elts = 1}-
-              [ &self_ <- __arr_temp ] s1'0) ]
-          | s1'0 = [ &_0'0 <- self_ ] s2'0
+              [ &_1 <- __arr_temp ] s1'0) ]
+          | s1'0 = [ &_0'0 <- _1 ] s2'0
           | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Slice64.array string = Any.any_l () | & self_: Slice64.array string = Any.any_l () ]
+        [ & _0'0: Slice64.array string = Any.any_l () | & _1: Slice64.array string = Any.any_l () ]
         [ _const_ret (_const: Slice64.array string) -> [ &_21 <- _const ] s1 ]
       | s1 = [ &_14 <- _21 ] s2
       | s2 = new_const {_14} (fun (_ret: t_Arguments) -> [ &_12 <- _ret ] s3)
@@ -47696,10 +47696,10 @@ module M_std__ptr__extern_spec_T_ptrmut_T_is_aligned_to_body
             [ any_ (__arr_temp: Slice64.array string) -> (! -{Seq.get __arr_temp.Slice64.elts 0
                 = "is_aligned_to: align is not a power-of-two"
               /\ Seq.length __arr_temp.Slice64.elts = 1}-
-              [ &self_ <- __arr_temp ] s1'0) ]
-          | s1'0 = [ &_0'0 <- self_ ] s2'0
+              [ &_1 <- __arr_temp ] s1'0) ]
+          | s1'0 = [ &_0'0 <- _1 ] s2'0
           | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Slice64.array string = Any.any_l () | & self_: Slice64.array string = Any.any_l () ]
+        [ & _0'0: Slice64.array string = Any.any_l () | & _1: Slice64.array string = Any.any_l () ]
         [ _const_ret (_const: Slice64.array string) -> [ &_21 <- _const ] s1 ]
       | s1 = [ &_14 <- _21 ] s2
       | s2 = new_const {_14} (fun (_ret: t_Arguments) -> [ &_12 <- _ret ] s3)

--- a/tests/should_succeed/bdd.coma
+++ b/tests/should_succeed/bdd.coma
@@ -1509,17 +1509,17 @@ module M_impl_Context__bdd_canonical (* Context<'arena> *)
 end
 module M_impl_Context_0__new (* Context<'arena> *)
   use creusot.int.UInt64
-  use creusot.prelude.Any
   use map.Map
   use map.Const
+  use creusot.prelude.Any
   use mach.int.Int
-  
-  type t_Bdd = { f0: t_Node; f1: UInt64.t }
-  with t_Node = False' | True' | If UInt64.t t_Bdd t_Bdd
   
   type t_MyHashMap_Node_Bdd
   
-  type t_NodeLog = False''0 | True''0 | If'0 UInt64.t UInt64.t UInt64.t
+  type t_NodeLog = False' | True' | If UInt64.t UInt64.t UInt64.t
+  
+  type t_Node = False''0 | True''0 | If'0 UInt64.t t_Bdd t_Bdd
+  with t_Bdd = { f0: t_Node; f1: UInt64.t }
   
   type t_Option_Bdd = None | Some t_Bdd
   
@@ -1562,9 +1562,9 @@ module M_impl_Context_0__new (* Context<'arena> *)
     cnt: t_PeanoInt }
   
   function deep_model_Node (self: t_Node) : t_NodeLog = match self with
-      | False' -> False''0
-      | True' -> True''0
-      | If v childt childf -> If'0 v (childt.f1) (childf.f1)
+      | False''0 -> False'
+      | True''0 -> True'
+      | If'0 v childt childf -> If v (childt.f1) (childf.f1)
       end
   
   function view_Node [@inline:trivial] (self: t_Node) : t_NodeLog = deep_model_Node self
@@ -1577,16 +1577,16 @@ module M_impl_Context_0__new (* Context<'arena> *)
   constant const_MAX: UInt64.t = (18446744073709551615: UInt64.t)
   
   function leastvar (self: t_Bdd) : int = match self with
-      | {f0 = True'; f1 = _} -> UInt64.t'int const_MAX + 1
-      | {f0 = False'; f1 = _} -> UInt64.t'int const_MAX + 1
-      | {f0 = If v _ _; f1 = _} -> UInt64.t'int v
+      | {f0 = True''0; f1 = _} -> UInt64.t'int const_MAX + 1
+      | {f0 = False''0; f1 = _} -> UInt64.t'int const_MAX + 1
+      | {f0 = If'0 v _ _; f1 = _} -> UInt64.t'int v
       end
   
   predicate is_valid_node (self: t_Context) (n: t_Node) =
     match n with
-      | True' -> true
-      | False' -> true
-      | If v childt childf -> childt.f0 <> childf.f0
+      | True''0 -> true
+      | False''0 -> true
+      | If'0 v childt childf -> childt.f0 <> childf.f0
       /\ is_valid_bdd self childt
       /\ is_valid_bdd self childf /\ UInt64.t'int v < leastvar childt /\ UInt64.t'int v < leastvar childf
       end
@@ -1642,9 +1642,9 @@ module M_impl_Context_0__new (* Context<'arena> *)
   
   predicate interp (self: t_Bdd) (vars: Map.map UInt64.t bool) =
     match self with
-      | {f0 = True'; f1 = _} -> true
-      | {f0 = False'; f1 = _} -> false
-      | {f0 = If v childt childf; f1 = _} -> if Map.get vars v then interp childt vars else interp childf vars
+      | {f0 = True''0; f1 = _} -> true
+      | {f0 = False''0; f1 = _} -> false
+      | {f0 = If'0 v childt childf; f1 = _} -> if Map.get vars v then interp childt vars else interp childf vars
       end
   
   predicate invariant_Context [@inline:trivial] (self: t_Context) =
@@ -1682,32 +1682,22 @@ module M_impl_Context_0__new (* Context<'arena> *)
   meta "select_lsinst" "all"
   
   let rec new'0 (alloc'0: t_Bump) (return (x: t_Context)) = (! bb0
-    [ bb0 = s0
-      [ s0 = bb0'0
-        [ bb0'0 = s0'0
-          [ s0'0 = [ &alloc'0 <- True' ] s1'0 | s1'0 = [ &_0'0 <- alloc'0 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: t_Node = Any.any_l () | & alloc'0: t_Node = Any.any_l () ]
-        [ _const_ret (_const: t_Node) -> [ &_11 <- _const ] s1 ]
-      | s1 = [ &t <- _11 ] s2
-      | s2 = new_Node (fun (_ret: t_MyHashMap_Node_Bdd) -> [ &_5 <- _ret ] s3)
-      | s3 = bb1 ]
-    | bb1 = s0 [ s0 = [ &_6 <- Const.const t ] s1 | s1 = bb2 ]
-    | bb2 = s0 [ s0 = new_Bdd (fun (_ret: t_MyHashMap_Bdd_Bdd) -> [ &_8 <- _ret ] s1) | s1 = bb3 ]
-    | bb3 = s0 [ s0 = new_tup2_Bdd_Bdd (fun (_ret: t_MyHashMap_tup2_Bdd_Bdd_Bdd) -> [ &_9 <- _ret ] s1) | s1 = bb4 ]
-    | bb4 = s0 [ s0 = new (fun (_ret: t_PeanoInt) -> [ &_10 <- _ret ] s1) | s1 = bb5 ]
+    [ bb0 = s0 [ s0 = new_Node (fun (_ret: t_MyHashMap_Node_Bdd) -> [ &_3 <- _ret ] s1) | s1 = bb1 ]
+    | bb1 = s0 [ s0 = [ &_4 <- Const.const (True''0) ] s1 | s1 = bb2 ]
+    | bb2 = s0 [ s0 = new_Bdd (fun (_ret: t_MyHashMap_Bdd_Bdd) -> [ &_6 <- _ret ] s1) | s1 = bb3 ]
+    | bb3 = s0 [ s0 = new_tup2_Bdd_Bdd (fun (_ret: t_MyHashMap_tup2_Bdd_Bdd_Bdd) -> [ &_7 <- _ret ] s1) | s1 = bb4 ]
+    | bb4 = s0 [ s0 = new (fun (_ret: t_PeanoInt) -> [ &_8 <- _ret ] s1) | s1 = bb5 ]
     | bb5 = s0
-      [ s0 = [ &_0 <- { alloc = alloc'0; hashcons = _5; hashcons_ghost = _6; not_memo = _8; and_memo = _9; cnt = _10 } ]
+      [ s0 = [ &_0 <- { alloc = alloc'0; hashcons = _3; hashcons_ghost = _4; not_memo = _6; and_memo = _7; cnt = _8 } ]
         s1
       | s1 = return {_0} ] ]
     [ & _0: t_Context = Any.any_l ()
     | & alloc'0: t_Bump = alloc'0
-    | & t: t_Node = Any.any_l ()
-    | & _5: t_MyHashMap_Node_Bdd = Any.any_l ()
-    | & _6: Map.map UInt64.t t_Node = Any.any_l ()
-    | & _8: t_MyHashMap_Bdd_Bdd = Any.any_l ()
-    | & _9: t_MyHashMap_tup2_Bdd_Bdd_Bdd = Any.any_l ()
-    | & _10: t_PeanoInt = Any.any_l ()
-    | & _11: t_Node = Any.any_l () ])
+    | & _3: t_MyHashMap_Node_Bdd = Any.any_l ()
+    | & _4: Map.map UInt64.t t_Node = Any.any_l ()
+    | & _6: t_MyHashMap_Bdd_Bdd = Any.any_l ()
+    | & _7: t_MyHashMap_tup2_Bdd_Bdd_Bdd = Any.any_l ()
+    | & _8: t_PeanoInt = Any.any_l () ])
     [ return (result: t_Context) -> {[@expl:new result type invariant] inv_Context result} (! return {result}) ]
 end
 module M_impl_Context_0__hashcons (* Context<'arena> *)

--- a/tests/should_succeed/bdd.rs
+++ b/tests/should_succeed/bdd.rs
@@ -421,11 +421,10 @@ impl<'arena> Context<'arena> {
 impl<'arena> Context<'arena> {
     #[check(terminates)]
     pub fn new(alloc: &'arena bumpalo::Bump) -> Self {
-        let t = &True; // FIXME: make it possible to write this is pearlite
         Context {
             alloc,
             hashcons: hashmap::MyHashMap::new(),
-            hashcons_ghost: snapshot! { Mapping::cst(t) },
+            hashcons_ghost: snapshot! { Mapping::cst(&True) },
             not_memo: hashmap::MyHashMap::new(),
             and_memo: hashmap::MyHashMap::new(),
             cnt: PeanoInt::new(),

--- a/tests/should_succeed/bdd/proof.json
+++ b/tests/should_succeed/bdd/proof.json
@@ -7,11 +7,11 @@
   ],
   "proofs": {
     "M_hashmap__impl_Hash_for_tup2_U_V__hash": {
-      "vc_hash_U": { "prover": "cvc5@1.3.1", "time": 0.01 },
-      "vc_hash_V": { "prover": "cvc5@1.3.1", "time": 0.013 },
+      "vc_hash_U": { "prover": "cvc5@1.3.1", "time": 0.036 },
+      "vc_hash_V": { "prover": "cvc5@1.3.1", "time": 0.039 },
       "vc_hash_tup2_U_V": { "prover": "z3@4.15.3", "time": 0.021 },
-      "vc_wrapping_add": { "prover": "cvc5@1.3.1", "time": 0.009 },
-      "vc_wrapping_mul": { "prover": "cvc5@1.3.1", "time": 0.009 }
+      "vc_wrapping_add": { "prover": "cvc5@1.3.1", "time": 0.039 },
+      "vc_wrapping_mul": { "prover": "cvc5@1.3.1", "time": 0.039 }
     },
     "M_hashmap__impl_Hash_for_tup2_U_V__hash__refines": {
       "refines": { "prover": "cvc5@1.3.1", "time": 0.025 }
@@ -24,8 +24,8 @@
     },
     "M_impl_Clone_for_Node__clone": {
       "vc_clone_Bdd": { "prover": "cvc5@1.3.1", "time": 0.017 },
-      "vc_clone_Node": { "prover": "cvc5@1.3.1", "time": 0.012 },
-      "vc_clone_u64": { "prover": "cvc5@1.3.1", "time": 0.011 },
+      "vc_clone_Node": { "prover": "cvc5@1.3.1", "time": 0.03 },
+      "vc_clone_u64": { "prover": "cvc5@1.3.1", "time": 0.027 },
       "vc_elim_If": { "prover": "cvc5@1.3.1", "time": 0.014 }
     },
     "M_impl_Context_0__and": {
@@ -47,7 +47,43 @@
               { "prover": "cvc5@1.3.1", "time": 0.172 },
               { "prover": "z3@4.15.3", "time": 0.025 },
               { "prover": "cvc5@1.3.1", "time": 0.062 },
-              { "prover": "alt-ergo@2.6.2", "time": 1.1 },
+              {
+                "tactic": "split_vc",
+                "children": [
+                  { "prover": "cvc5@1.3.1", "time": 0.061 },
+                  { "prover": "cvc5@1.3.1", "time": 0.089 },
+                  { "prover": "cvc5@1.3.1", "time": 0.059 },
+                  { "prover": "cvc5@1.3.1", "time": 0.061 },
+                  { "prover": "z3@4.15.3", "time": 0.02 },
+                  { "prover": "z3@4.15.3", "time": 0.012 },
+                  { "prover": "cvc5@1.3.1", "time": 0.057 },
+                  { "prover": "cvc5@1.3.1", "time": 0.064 },
+                  { "prover": "z3@4.15.3", "time": 0.015 },
+                  { "prover": "z3@4.15.3", "time": 0.018 },
+                  { "prover": "z3@4.15.3", "time": 0.024 },
+                  { "prover": "z3@4.15.3", "time": 0.025 },
+                  { "prover": "cvc5@1.3.1", "time": 0.078 },
+                  { "prover": "cvc5@1.3.1", "time": 0.076 },
+                  { "prover": "cvc5@1.3.1", "time": 0.092 },
+                  { "prover": "z3@4.15.3", "time": 0.027 },
+                  { "prover": "cvc5@1.3.1", "time": 0.059 },
+                  { "prover": "cvc5@1.3.1", "time": 0.071 },
+                  { "prover": "cvc5@1.3.1", "time": 0.059 },
+                  { "prover": "cvc5@1.3.1", "time": 0.059 },
+                  { "prover": "z3@4.15.3", "time": 0.016 },
+                  { "prover": "z3@4.15.3", "time": 0.013 },
+                  { "prover": "cvc5@1.3.1", "time": 0.06 },
+                  { "prover": "cvc5@1.3.1", "time": 0.067 },
+                  { "prover": "z3@4.15.3", "time": 0.016 },
+                  { "prover": "z3@4.15.3", "time": 0.017 },
+                  { "prover": "z3@4.15.3", "time": 0.018 },
+                  { "prover": "z3@4.15.3", "time": 0.015 },
+                  { "prover": "cvc5@1.3.1", "time": 0.068 },
+                  { "prover": "cvc5@1.3.1", "time": 0.058 },
+                  { "prover": "cvc5@1.3.1", "time": 0.07 },
+                  { "prover": "z3@4.15.3", "time": 0.031 }
+                ]
+              },
               { "prover": "cvc5@1.3.1", "time": 0.101 },
               { "prover": "cvc5@1.3.1", "time": 0.106 },
               { "prover": "cvc5@1.3.1", "time": 0.047 },
@@ -236,7 +272,7 @@
       "vc_add_Node": { "prover": "cvc5@1.3.1", "time": 0.024 },
       "vc_alloc_Node": { "prover": "cvc5@1.3.1", "time": 0.023 },
       "vc_elim_Some": { "prover": "cvc5@1.3.1", "time": 0.026 },
-      "vc_get_Node": { "prover": "cvc5@1.3.1", "time": 0.013 },
+      "vc_get_Node": { "prover": "cvc5@1.3.1", "time": 0.034 },
       "vc_hashcons'0": {
         "tactic": "compute_specified",
         "children": [
@@ -315,7 +351,7 @@
                 "tactic": "split_vc",
                 "children": [
                   { "prover": "cvc5@1.3.1", "time": 0.13 },
-                  { "prover": "z3@4.15.3", "time": 0.117 },
+                  { "prover": "z3@4.15.3", "time": 0.056 },
                   { "prover": "cvc5@1.3.1", "time": 0.165 },
                   { "prover": "cvc5@1.3.1", "time": 0.168 },
                   { "prover": "z3@4.15.3", "time": 0.087 },
@@ -387,7 +423,7 @@
       "vc_grows_is_valid_bdd": { "prover": "cvc5@1.3.1", "time": 0.024 }
     },
     "M_impl_Context__grows_trans": {
-      "vc_grows_trans": { "prover": "cvc5@1.3.1", "time": 0.017 }
+      "vc_grows_trans": { "prover": "cvc5@1.3.1", "time": 0.053 }
     },
     "M_impl_Context__set_irrelevent_var": {
       "vc_set_irrelevent_var": { "prover": "cvc5@1.3.1", "time": 0.063 }
@@ -401,33 +437,33 @@
     "M_impl_Eq_for_Node__assert_receiver_is_total_eq": {
       "vc_assert_receiver_is_total_eq_Node": {
         "prover": "cvc5@1.3.1",
-        "time": 0.013
+        "time": 0.044
       }
     },
     "M_impl_Hash_for_Bdd__hash": {
-      "vc_hash_Bdd": { "prover": "cvc5@1.3.1", "time": 0.012 }
+      "vc_hash_Bdd": { "prover": "cvc5@1.3.1", "time": 0.026 }
     },
     "M_impl_Hash_for_Bdd__hash__refines": {
       "refines": { "prover": "cvc5@1.3.1", "time": 0.021 }
     },
     "M_impl_Hash_for_Node__hash": {
-      "vc_elim_If": { "prover": "cvc5@1.3.1", "time": 0.012 },
+      "vc_elim_If": { "prover": "cvc5@1.3.1", "time": 0.027 },
       "vc_hash_Node": { "prover": "z3@4.15.3", "time": 0.029 },
       "vc_wrapping_add": { "prover": "cvc5@1.3.1", "time": 0.014 },
-      "vc_wrapping_mul": { "prover": "cvc5@1.3.1", "time": 0.013 }
+      "vc_wrapping_mul": { "prover": "cvc5@1.3.1", "time": 0.027 }
     },
     "M_impl_Hash_for_Node__hash__refines": {
       "refines": { "prover": "cvc5@1.3.1", "time": 0.025 }
     },
     "M_impl_PartialEq_for_Bdd__eq": {
-      "vc_eq_Bdd": { "prover": "cvc5@1.3.1", "time": 0.007 }
+      "vc_eq_Bdd": { "prover": "cvc5@1.3.1", "time": 0.022 }
     },
     "M_impl_PartialEq_for_Bdd__eq__refines": {
       "refines": { "prover": "cvc5@1.3.1", "time": 0.025 }
     },
     "M_impl_PartialEq_for_Node__eq": {
-      "vc_elim_If": { "prover": "cvc5@1.3.1", "time": 0.011 },
-      "vc_eq_Bdd": { "prover": "cvc5@1.3.1", "time": 0.011 },
+      "vc_elim_If": { "prover": "cvc5@1.3.1", "time": 0.029 },
+      "vc_eq_Bdd": { "prover": "cvc5@1.3.1", "time": 0.043 },
       "vc_eq_Node": { "prover": "cvc5@1.3.1", "time": 0.027 }
     },
     "M_impl_PartialEq_for_Node__eq__refines": {

--- a/tests/should_succeed/bug/1312.coma
+++ b/tests/should_succeed/bug/1312.coma
@@ -21,20 +21,20 @@ module M_foo99
             [ any_ (__arr_temp: Slice64.array string) -> (! -{Seq.get __arr_temp.Slice64.elts 0
                 = "internal error: entered unreachable code: unwrapped None"
               /\ Seq.length __arr_temp.Slice64.elts = 1}-
-              [ &self <- __arr_temp ] s1'0) ]
-          | s1'0 = [ &_0'0 <- self ] s2'0
+              [ &_1 <- __arr_temp ] s1'0) ]
+          | s1'0 = [ &_0'0 <- _1 ] s2'0
           | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Slice64.array string = Any.any_l () | & self: Slice64.array string = Any.any_l () ]
+        [ & _0'0: Slice64.array string = Any.any_l () | & _1: Slice64.array string = Any.any_l () ]
         [ _const_ret (_const: Slice64.array string) -> [ &_15 <- _const ] s1 ]
       | s1 = [ &_9 <- _15 ] s2
       | s2 = bb0'0
         [ bb0'0 = s0'0
           [ s0'0 = any
             [ any_ (__arr_temp: Slice64.array t_Argument) -> (! -{Seq.length __arr_temp.Slice64.elts = 0}-
-              [ &self <- __arr_temp ] s1'0) ]
-          | s1'0 = [ &_0'0 <- self ] s2'0
+              [ &_1 <- __arr_temp ] s1'0) ]
+          | s1'0 = [ &_0'0 <- _1 ] s2'0
           | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Slice64.array t_Argument = Any.any_l () | & self: Slice64.array t_Argument = Any.any_l () ]
+        [ & _0'0: Slice64.array t_Argument = Any.any_l () | & _1: Slice64.array t_Argument = Any.any_l () ]
         [ _const_ret (_const: Slice64.array t_Argument) -> [ &_14 <- _const ] s3 ]
       | s3 = [ &_12 <- _14 ] s4
       | s4 = {false} any ] ]

--- a/tests/should_succeed/integer_ops.coma
+++ b/tests/should_succeed/integer_ops.coma
@@ -2064,8 +2064,8 @@ module M_u8__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt8.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt8.t = Any.any_l () | & b: UInt8.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt8.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt8.t = Any.any_l () | & _1: UInt8.t = Any.any_l () ]
         [ _const_ret (_const: UInt8.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt8.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -2078,8 +2078,8 @@ module M_u8__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt8.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt8.t = Any.any_l () | & b: UInt8.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt8.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt8.t = Any.any_l () | & _1: UInt8.t = Any.any_l () ]
         [ _const_ret (_const: UInt8.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt8.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -2135,8 +2135,8 @@ module M_u8__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt8BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt8BW.t = Any.any_l () | & b: UInt8BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt8BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt8BW.t = Any.any_l () | & _1: UInt8BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt8BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt8BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -2149,8 +2149,8 @@ module M_u8__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt8BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt8BW.t = Any.any_l () | & b: UInt8BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt8BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt8BW.t = Any.any_l () | & _1: UInt8BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt8BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt8BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -2592,8 +2592,8 @@ module M_i8__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int8.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int8.t = Any.any_l () | & b: Int8.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int8.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int8.t = Any.any_l () | & _1: Int8.t = Any.any_l () ]
         [ _const_ret (_const: Int8.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int8.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -2606,8 +2606,8 @@ module M_i8__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int8.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int8.t = Any.any_l () | & b: Int8.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int8.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int8.t = Any.any_l () | & _1: Int8.t = Any.any_l () ]
         [ _const_ret (_const: Int8.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int8.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -2663,8 +2663,8 @@ module M_i8__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int8BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int8BW.t = Any.any_l () | & b: Int8BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int8BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int8BW.t = Any.any_l () | & _1: Int8BW.t = Any.any_l () ]
         [ _const_ret (_const: Int8BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int8BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -2677,8 +2677,8 @@ module M_i8__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int8BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int8BW.t = Any.any_l () | & b: Int8BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int8BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int8BW.t = Any.any_l () | & _1: Int8BW.t = Any.any_l () ]
         [ _const_ret (_const: Int8BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int8BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -3132,8 +3132,8 @@ module M_u16__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt16.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt16.t = Any.any_l () | & b: UInt16.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt16.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt16.t = Any.any_l () | & _1: UInt16.t = Any.any_l () ]
         [ _const_ret (_const: UInt16.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt16.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -3146,8 +3146,8 @@ module M_u16__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt16.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt16.t = Any.any_l () | & b: UInt16.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt16.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt16.t = Any.any_l () | & _1: UInt16.t = Any.any_l () ]
         [ _const_ret (_const: UInt16.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt16.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -3203,8 +3203,8 @@ module M_u16__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt16BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt16BW.t = Any.any_l () | & b: UInt16BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt16BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt16BW.t = Any.any_l () | & _1: UInt16BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt16BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt16BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -3217,8 +3217,8 @@ module M_u16__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt16BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt16BW.t = Any.any_l () | & b: UInt16BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt16BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt16BW.t = Any.any_l () | & _1: UInt16BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt16BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt16BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -3576,8 +3576,8 @@ module M_i16__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int16.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int16.t = Any.any_l () | & b: Int16.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int16.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int16.t = Any.any_l () | & _1: Int16.t = Any.any_l () ]
         [ _const_ret (_const: Int16.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int16.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -3590,8 +3590,8 @@ module M_i16__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int16.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int16.t = Any.any_l () | & b: Int16.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int16.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int16.t = Any.any_l () | & _1: Int16.t = Any.any_l () ]
         [ _const_ret (_const: Int16.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int16.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -3647,8 +3647,8 @@ module M_i16__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int16BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int16BW.t = Any.any_l () | & b: Int16BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int16BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int16BW.t = Any.any_l () | & _1: Int16BW.t = Any.any_l () ]
         [ _const_ret (_const: Int16BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int16BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -3661,8 +3661,8 @@ module M_i16__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int16BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int16BW.t = Any.any_l () | & b: Int16BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int16BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int16BW.t = Any.any_l () | & _1: Int16BW.t = Any.any_l () ]
         [ _const_ret (_const: Int16BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int16BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -3996,8 +3996,8 @@ module M_u32__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt32.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt32.t = Any.any_l () | & b: UInt32.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt32.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt32.t = Any.any_l () | & _1: UInt32.t = Any.any_l () ]
         [ _const_ret (_const: UInt32.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt32.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4010,8 +4010,8 @@ module M_u32__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt32.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt32.t = Any.any_l () | & b: UInt32.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt32.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt32.t = Any.any_l () | & _1: UInt32.t = Any.any_l () ]
         [ _const_ret (_const: UInt32.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt32.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4067,8 +4067,8 @@ module M_u32__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt32BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt32BW.t = Any.any_l () | & b: UInt32BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt32BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt32BW.t = Any.any_l () | & _1: UInt32BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt32BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt32BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4081,8 +4081,8 @@ module M_u32__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt32BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt32BW.t = Any.any_l () | & b: UInt32BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt32BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt32BW.t = Any.any_l () | & _1: UInt32BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt32BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt32BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4440,8 +4440,8 @@ module M_i32__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int32.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int32.t = Any.any_l () | & b: Int32.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int32.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int32.t = Any.any_l () | & _1: Int32.t = Any.any_l () ]
         [ _const_ret (_const: Int32.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int32.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4454,8 +4454,8 @@ module M_i32__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int32.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int32.t = Any.any_l () | & b: Int32.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int32.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int32.t = Any.any_l () | & _1: Int32.t = Any.any_l () ]
         [ _const_ret (_const: Int32.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int32.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4511,8 +4511,8 @@ module M_i32__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int32BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int32BW.t = Any.any_l () | & b: Int32BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int32BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int32BW.t = Any.any_l () | & _1: Int32BW.t = Any.any_l () ]
         [ _const_ret (_const: Int32BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int32BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4525,8 +4525,8 @@ module M_i32__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int32BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int32BW.t = Any.any_l () | & b: Int32BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int32BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int32BW.t = Any.any_l () | & _1: Int32BW.t = Any.any_l () ]
         [ _const_ret (_const: Int32BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int32BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4856,8 +4856,8 @@ module M_u64__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt64.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt64.t = Any.any_l () | & b: UInt64.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt64.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt64.t = Any.any_l () | & _1: UInt64.t = Any.any_l () ]
         [ _const_ret (_const: UInt64.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt64.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4870,8 +4870,8 @@ module M_u64__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt64.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt64.t = Any.any_l () | & b: UInt64.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt64.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt64.t = Any.any_l () | & _1: UInt64.t = Any.any_l () ]
         [ _const_ret (_const: UInt64.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt64.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4927,8 +4927,8 @@ module M_u64__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt64BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt64BW.t = Any.any_l () | & b: UInt64BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt64BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt64BW.t = Any.any_l () | & _1: UInt64BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt64BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt64BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -4941,8 +4941,8 @@ module M_u64__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt64BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt64BW.t = Any.any_l () | & b: UInt64BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt64BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt64BW.t = Any.any_l () | & _1: UInt64BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt64BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt64BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -5300,8 +5300,8 @@ module M_i64__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int64.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int64.t = Any.any_l () | & b: Int64.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int64.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int64.t = Any.any_l () | & _1: Int64.t = Any.any_l () ]
         [ _const_ret (_const: Int64.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int64.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -5314,8 +5314,8 @@ module M_i64__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int64.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int64.t = Any.any_l () | & b: Int64.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int64.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int64.t = Any.any_l () | & _1: Int64.t = Any.any_l () ]
         [ _const_ret (_const: Int64.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int64.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -5371,8 +5371,8 @@ module M_i64__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int64BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int64BW.t = Any.any_l () | & b: Int64BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int64BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int64BW.t = Any.any_l () | & _1: Int64BW.t = Any.any_l () ]
         [ _const_ret (_const: Int64BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int64BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -5385,8 +5385,8 @@ module M_i64__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int64BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int64BW.t = Any.any_l () | & b: Int64BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int64BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int64BW.t = Any.any_l () | & _1: Int64BW.t = Any.any_l () ]
         [ _const_ret (_const: Int64BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int64BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -5720,8 +5720,8 @@ module M_u128__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt128.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt128.t = Any.any_l () | & b: UInt128.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt128.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt128.t = Any.any_l () | & _1: UInt128.t = Any.any_l () ]
         [ _const_ret (_const: UInt128.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt128.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -5734,8 +5734,8 @@ module M_u128__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt128.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt128.t = Any.any_l () | & b: UInt128.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt128.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt128.t = Any.any_l () | & _1: UInt128.t = Any.any_l () ]
         [ _const_ret (_const: UInt128.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt128.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -5791,8 +5791,8 @@ module M_u128__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt128BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt128BW.t = Any.any_l () | & b: UInt128BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt128BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt128BW.t = Any.any_l () | & _1: UInt128BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt128BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt128BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -5805,8 +5805,8 @@ module M_u128__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt128BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt128BW.t = Any.any_l () | & b: UInt128BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt128BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt128BW.t = Any.any_l () | & _1: UInt128BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt128BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt128BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -6165,8 +6165,8 @@ module M_i128__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int128.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int128.t = Any.any_l () | & b: Int128.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int128.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int128.t = Any.any_l () | & _1: Int128.t = Any.any_l () ]
         [ _const_ret (_const: Int128.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int128.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -6179,8 +6179,8 @@ module M_i128__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int128.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int128.t = Any.any_l () | & b: Int128.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int128.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int128.t = Any.any_l () | & _1: Int128.t = Any.any_l () ]
         [ _const_ret (_const: Int128.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int128.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -6236,8 +6236,8 @@ module M_i128__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int128BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int128BW.t = Any.any_l () | & b: Int128BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int128BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int128BW.t = Any.any_l () | & _1: Int128BW.t = Any.any_l () ]
         [ _const_ret (_const: Int128BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int128BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -6250,8 +6250,8 @@ module M_i128__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int128BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int128BW.t = Any.any_l () | & b: Int128BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int128BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int128BW.t = Any.any_l () | & _1: Int128BW.t = Any.any_l () ]
         [ _const_ret (_const: Int128BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int128BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -6586,8 +6586,8 @@ module M_usize__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt64.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt64.t = Any.any_l () | & b: UInt64.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt64.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt64.t = Any.any_l () | & _1: UInt64.t = Any.any_l () ]
         [ _const_ret (_const: UInt64.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt64.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -6600,8 +6600,8 @@ module M_usize__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt64.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt64.t = Any.any_l () | & b: UInt64.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt64.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt64.t = Any.any_l () | & _1: UInt64.t = Any.any_l () ]
         [ _const_ret (_const: UInt64.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt64.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -6657,8 +6657,8 @@ module M_usize__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt64BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt64BW.t = Any.any_l () | & b: UInt64BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt64BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt64BW.t = Any.any_l () | & _1: UInt64BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt64BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: UInt64BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -6671,8 +6671,8 @@ module M_usize__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- UInt64BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: UInt64BW.t = Any.any_l () | & b: UInt64BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- UInt64BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: UInt64BW.t = Any.any_l () | & _1: UInt64BW.t = Any.any_l () ]
         [ _const_ret (_const: UInt64BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: UInt64BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -7030,8 +7030,8 @@ module M_isize__test_from_bool
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int64.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int64.t = Any.any_l () | & b: Int64.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int64.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int64.t = Any.any_l () | & _1: Int64.t = Any.any_l () ]
         [ _const_ret (_const: Int64.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int64.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -7044,8 +7044,8 @@ module M_isize__test_from_bool
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int64.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int64.t = Any.any_l () | & b: Int64.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int64.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int64.t = Any.any_l () | & _1: Int64.t = Any.any_l () ]
         [ _const_ret (_const: Int64.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int64.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -7101,8 +7101,8 @@ module M_isize__test_from_bool_bw
     [ bb0 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int64BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int64BW.t = Any.any_l () | & b: Int64BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int64BW.of_bool true ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int64BW.t = Any.any_l () | & _1: Int64BW.t = Any.any_l () ]
         [ _const_ret (_const: Int64BW.t) -> [ &_47 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (1: Int64BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]
@@ -7115,8 +7115,8 @@ module M_isize__test_from_bool_bw
     | bb1 = s0
       [ s0 = bb0'0
         [ bb0'0 = s0'0
-          [ s0'0 = [ &b <- Int64BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- b ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
-        [ & _0'0: Int64BW.t = Any.any_l () | & b: Int64BW.t = Any.any_l () ]
+          [ s0'0 = [ &_1 <- Int64BW.of_bool false ] s1'0 | s1'0 = [ &_0'0 <- _1 ] s2'0 | s2'0 = _const_ret {_0'0} ] ]
+        [ & _0'0: Int64BW.t = Any.any_l () | & _1: Int64BW.t = Any.any_l () ]
         [ _const_ret (_const: Int64BW.t) -> [ &_45 <- _const ] s1 ]
       | s1 = bb0'0
         [ bb0'0 = s0'0 [ s0'0 = [ &_0'0 <- (0: Int64BW.t) ] s1'0 | s1'0 = _const_ret {_0'0} ] ]


### PR DESCRIPTION
- When the user writes a parallel assignment, Rustc creates temporary variables which have no name, but is_user_variable returns true
- promoted bodies have no parameter, so their temporaries should not be named after temporaries.

Fixes #1813