### PR TITLE
Fix `ide` script

### DIFF
--- a/ide
+++ b/ide
@@ -5,4 +5,4 @@ eval $(cargo run --bin dev-env)
 why3 \
   --warn-off=unused_variable --warn-off=clone_not_abstract --warn-off=axiom_abstract \
   --debug=coma_no_trivial \
-  ide -L "$SCRIPTPATH"/target . $@
+  ide -L "$SCRIPTPATH"/target $@


### PR DESCRIPTION
There are no spans in the tests suite anyways. This broke the scripts by putting the sessions files at the root of creusot's directory (rather than next to the `.coma` file).
@Lysxia is that ok?