### PR TITLE
Improve formatting of 'encountered a cycle' error message

### DIFF
--- a/tests/should_fail/bug/436_2.stderr
+++ b/tests/should_fail/bug/436_2.stderr
@@ -1,4 +1,4 @@
-error: encountered a cycle during translation: [Item(DefId(0:7 ~ 436_2[acee]::Bad::None), ['{erased}]), Type(creusot_contracts::snapshot::Snapshot<&'{erased} mut Bad<'{erased}>>), Type(Bad<'{erased}>), Item(DefId(0:9 ~ 436_2[acee]::Bad::Some), ['{erased}])]
+error: encountered a cycle during translation: Bad::None['_]; creusot_contracts::snapshot::Snapshot<&mut Bad<'_>>; Bad<'_>; Bad::Some['_];
  --> 436_2.rs:5:5
   |
 5 |     None,


### PR DESCRIPTION
Make the error message not show the hash of `DefId`s which changes with every toolchain update.