### PR TITLE
scripts: Use absolute library location in ./ide to fix spans

### DIFF
--- a/ide
+++ b/ide
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH=$(dirname "$BASH_SOURCE")
+SCRIPTPATH=$(cd $(dirname "$BASH_SOURCE") && pwd)
 eval $(cargo run --bin dev-env)
 why3 \
   --warn-off=unused_variable --warn-off=clone_not_abstract --warn-off=axiom_abstract \


### PR DESCRIPTION
Follow up of #1835