### PR TITLE
Replace panic with proper error when trait resolution fails in normalize

### DIFF
--- a/tests/should_fail/bug/1610-crash.rs
+++ b/tests/should_fail/bug/1610-crash.rs
@@ -1,0 +1,17 @@
+// Test a crash when trying to implement collect
+// This test may become should_succeed in the future.
+extern crate creusot_contracts;
+use creusot_contracts::prelude::*;
+
+struct P();
+
+impl ::std::iter::Iterator for P {
+    type Item = ();
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+
+    fn collect<B: FromIterator<Self::Item>>(self) -> B {
+        std::iter::empty().collect()
+    }
+}

--- a/tests/should_fail/bug/1610-crash.stderr
+++ b/tests/should_fail/bug/1610-crash.stderr
@@ -1,0 +1,31 @@
+warning: unused import: `creusot_contracts::prelude::*`
+ --> 1610-crash.rs:4:5
+  |
+4 | use creusot_contracts::prelude::*;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+warning: struct `P` is never constructed
+ --> 1610-crash.rs:6:8
+  |
+6 | struct P();
+  |        ^
+  |
+  = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+
+error[E0277]: the trait bound `B: creusot_contracts::prelude::FromIteratorSpec<()>` is not satisfied
+  --> 1610-crash.rs:15:9
+   |
+15 |         std::iter::empty().collect()
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `creusot_contracts::prelude::FromIteratorSpec<()>` is not implemented for `B`
+
+error: could not resolve trait instance for creusot_contracts::prelude::FromIteratorSpec::from_iter_post[B, <std::iter::Empty<()> as std::iter::Iterator>::Item]
+   --> ./creusot-contracts/src/std/iter.rs:168:89
+    |
+168 |                     resolve(^done) && done.completed() && self.produces(prod, *done) && B::from_iter_post(prod, result))]
+    |                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 2 warnings emitted
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes the crash in the test case from #1610 (but the real issue remains).