### PR TITLE
Support ranges in IndexLogic

### DIFF
--- a/creusot-contracts/src/logic/seq.rs
+++ b/creusot-contracts/src/logic/seq.rs
@@ -4,8 +4,12 @@ use crate::{
     ghost::Plain,
     logic::{Mapping, ops::IndexLogic},
     prelude::*,
+    std::ops::RangeInclusiveExt as _,
 };
-use std::marker::PhantomData;
+use std::{
+    marker::PhantomData,
+    ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
+};
 
 /// A type of sequence usable in pearlite and `ghost!` blocks.
 ///
@@ -424,6 +428,60 @@ impl<T> IndexLogic<Int> for Seq<T> {
     #[builtin("seq.Seq.get")]
     fn index_logic(self, _: Int) -> Self::Item {
         dead
+    }
+}
+
+impl<T> IndexLogic<Range<Int>> for Seq<T> {
+    type Item = Seq<T>;
+
+    #[logic(open, inline)]
+    fn index_logic(self, range: Range<Int>) -> Self::Item {
+        self.subsequence(range.start, range.end)
+    }
+}
+
+impl<T> IndexLogic<RangeInclusive<Int>> for Seq<T> {
+    type Item = Seq<T>;
+
+    #[logic(open, inline)]
+    fn index_logic(self, range: RangeInclusive<Int>) -> Self::Item {
+        self.subsequence(range.start_log(), range.end_log() + 1)
+    }
+}
+
+impl<T> IndexLogic<RangeFull> for Seq<T> {
+    type Item = Seq<T>;
+
+    #[logic(open, inline)]
+    fn index_logic(self, _: RangeFull) -> Self::Item {
+        self
+    }
+}
+
+impl<T> IndexLogic<RangeFrom<Int>> for Seq<T> {
+    type Item = Seq<T>;
+
+    #[logic(open, inline)]
+    fn index_logic(self, range: RangeFrom<Int>) -> Self::Item {
+        self.subsequence(range.start, self.len())
+    }
+}
+
+impl<T> IndexLogic<RangeTo<Int>> for Seq<T> {
+    type Item = Seq<T>;
+
+    #[logic(open, inline)]
+    fn index_logic(self, range: RangeTo<Int>) -> Self::Item {
+        self.subsequence(0, range.end)
+    }
+}
+
+impl<T> IndexLogic<RangeToInclusive<Int>> for Seq<T> {
+    type Item = Seq<T>;
+
+    #[logic(open, inline)]
+    fn index_logic(self, range: RangeToInclusive<Int>) -> Self::Item {
+        self.subsequence(0, range.end + 1)
     }
 }
 

--- a/creusot-contracts/src/std/ops.rs
+++ b/creusot-contracts/src/std/ops.rs
@@ -535,6 +535,9 @@ impl<T: DeepModel<DeepModelTy: OrdLogic>> RangeBounds<T> for std::range::RangeIn
 
 pub trait RangeInclusiveExt<Idx> {
     #[logic]
+    fn new_log(start: Idx, end: Idx) -> Self;
+
+    #[logic]
     fn start_log(self) -> Idx;
 
     #[logic]
@@ -548,6 +551,13 @@ pub trait RangeInclusiveExt<Idx> {
 }
 
 impl<Idx> RangeInclusiveExt<Idx> for RangeInclusive<Idx> {
+    #[logic(opaque)]
+    #[trusted]
+    #[ensures(start == result.start_log() && end == result.end_log())]
+    fn new_log(start: Idx, end: Idx) -> Self {
+        dead
+    }
+
     #[logic(opaque)]
     fn start_log(self) -> Idx {
         dead

--- a/tests/creusot-contracts/creusot-contracts.coma
+++ b/tests/creusot-contracts/creusot-contracts.coma
@@ -51927,6 +51927,30 @@ module M_logic__seq__impl_IteratorSpec_for_SeqIter_T__produces_refl__refines (* 
   goal refines: forall self: t_SeqIter_T. forall result: (). produces_SeqIter_T self (Seq.empty: Seq.seq t_T) self
         -> produces_SeqIter_T self (Seq.empty: Seq.seq t_T) self
 end
+module M_logic__seq__impl_IteratorSpec_for_SeqIterRef_T__produces_refl__refines (* <logic::seq::SeqIterRef<'a, T> as std::iter::IteratorSpec> *)
+  type namespace_other
+  
+  type t_Namespace = Other namespace_other
+  
+  use seq.Seq
+  
+  type t_T
+  
+  type t_SeqIterRef_T = { inner: Seq.seq t_T; index: int }
+  
+  function view_SeqIterRef_T (self: t_SeqIterRef_T) : Seq.seq t_T =
+    Seq.([..]) self.inner self.index (Seq.length self.inner)
+  
+  predicate produces_SeqIterRef_T (self: t_SeqIterRef_T) (visited: Seq.seq t_T) (o: t_SeqIterRef_T) =
+    let visited'0 = visited in view_SeqIterRef_T self = Seq.(++) visited'0 (view_SeqIterRef_T o)
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  goal refines: forall self: t_SeqIterRef_T. forall result: (). produces_SeqIterRef_T self (Seq.empty: Seq.seq t_T) self
+        -> produces_SeqIterRef_T self (Seq.empty: Seq.seq t_T) self
+end
 module M_logic__seq__impl_IteratorSpec_for_SeqIterRef_T__produces_trans__refines (* <logic::seq::SeqIterRef<'a, T> as std::iter::IteratorSpec> *)
   type namespace_other
   
@@ -51955,30 +51979,6 @@ module M_logic__seq__impl_IteratorSpec_for_SeqIterRef_T__produces_trans__refines
               /\ produces_SeqIterRef_T b bc c
               /\ (forall result: (). produces_SeqIterRef_T a (Seq.(++) ab bc) c
                 -> produces_SeqIterRef_T a (Seq.(++) ab bc) c)
-end
-module M_logic__seq__impl_IteratorSpec_for_SeqIterRef_T__produces_refl__refines (* <logic::seq::SeqIterRef<'a, T> as std::iter::IteratorSpec> *)
-  type namespace_other
-  
-  type t_Namespace = Other namespace_other
-  
-  use seq.Seq
-  
-  type t_T
-  
-  type t_SeqIterRef_T = { inner: Seq.seq t_T; index: int }
-  
-  function view_SeqIterRef_T (self: t_SeqIterRef_T) : Seq.seq t_T =
-    Seq.([..]) self.inner self.index (Seq.length self.inner)
-  
-  predicate produces_SeqIterRef_T (self: t_SeqIterRef_T) (visited: Seq.seq t_T) (o: t_SeqIterRef_T) =
-    let visited'0 = visited in view_SeqIterRef_T self = Seq.(++) visited'0 (view_SeqIterRef_T o)
-  
-  meta "compute_max_steps" 1000000
-  
-  meta "select_lsinst" "all"
-  
-  goal refines: forall self: t_SeqIterRef_T. forall result: (). produces_SeqIterRef_T self (Seq.empty: Seq.seq t_T) self
-        -> produces_SeqIterRef_T self (Seq.empty: Seq.seq t_T) self
 end
 module M_std__array__impl_IteratorSpec_for_IntoIter_T__produces_refl__refines (* <std::array::IntoIter<T, N> as std::iter::IteratorSpec> *)
   type namespace_other

--- a/tests/should_succeed/cc/seq.coma
+++ b/tests/should_succeed/cc/seq.coma
@@ -123,3 +123,72 @@ module M_f
     | & _15: int = Any.any_l () ])
     [ return (result: UInt64.t) -> {[@expl:f ensures] result = (1: UInt64.t)} (! return {result}) ]
 end
+module M_g
+  use creusot.prelude.Any
+  use seq.Seq
+  use mach.int.Int
+  
+  type t_Range_Int = { start: int; end': int }
+  
+  function index_Seq_Int [@inline:trivial] (self: Seq.seq int) (range: t_Range_Int) : Seq.seq int =
+    Seq.([..]) self range.start range.end'
+  
+  meta "rewrite_def" function index_Seq_Int
+  
+  type t_RangeInclusive_Int
+  
+  function start_log_RangeInclusive_Int (self: t_RangeInclusive_Int) : int
+  
+  function end_log_RangeInclusive_Int (self: t_RangeInclusive_Int) : int
+  
+  function index_Seq_Int'0 [@inline:trivial] (self: Seq.seq int) (range: t_RangeInclusive_Int) : Seq.seq int =
+    Seq.([..]) self (start_log_RangeInclusive_Int range) (end_log_RangeInclusive_Int range + 1)
+  
+  meta "rewrite_def" function index_Seq_Int'0
+  
+  function new_log_RangeInclusive_Int (start'0: int) (end''0: int) : t_RangeInclusive_Int
+  
+  axiom new_log_RangeInclusive_Int_spec: forall start'0: int, end''0: int. start'0
+        = start_log_RangeInclusive_Int (new_log_RangeInclusive_Int start'0 end''0)
+      /\ end''0 = end_log_RangeInclusive_Int (new_log_RangeInclusive_Int start'0 end''0)
+  
+  type t_RangeFrom_Int = { start'0: int }
+  
+  function index_Seq_Int'1 [@inline:trivial] (self: Seq.seq int) (range: t_RangeFrom_Int) : Seq.seq int =
+    Seq.([..]) self range.start'0 (Seq.length self)
+  
+  meta "rewrite_def" function index_Seq_Int'1
+  
+  type t_RangeTo_Int = { end''0: int }
+  
+  function index_Seq_Int'2 [@inline:trivial] (self: Seq.seq int) (range: t_RangeTo_Int) : Seq.seq int =
+    Seq.([..]) self 0 range.end''0
+  
+  meta "rewrite_def" function index_Seq_Int'2
+  
+  type t_RangeToInclusive_Int = { end''1: int }
+  
+  function index_Seq_Int'3 [@inline:trivial] (self: Seq.seq int) (range: t_RangeToInclusive_Int) : Seq.seq int =
+    Seq.([..]) self 0 (range.end''1 + 1)
+  
+  meta "rewrite_def" function index_Seq_Int'3
+  
+  function index_Seq_Int'4 [@inline:trivial] (self: Seq.seq int) (_2: ()) : Seq.seq int = self
+  
+  meta "rewrite_def" function index_Seq_Int'4
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec g (s: Seq.seq int) (return (x: ())) = {[@expl:g requires] Seq.length s >= 1}
+    (! bb0
+    [ bb0 = return {_ret} ] [ & _ret: () = Any.any_l () ])
+    [ return (result: ()) -> {[@expl:g ensures #0] Seq.length (index_Seq_Int s { start = 0; end' = 1 }) = 1}
+      {[@expl:g ensures #1] Seq.length (index_Seq_Int'0 s (new_log_RangeInclusive_Int 0 0)) = 1}
+      {[@expl:g ensures #2] index_Seq_Int'1 s { start'0 = 0 } = s}
+      {[@expl:g ensures #3] Seq.length (index_Seq_Int'2 s { end''0 = 0 }) = 0}
+      {[@expl:g ensures #4] Seq.length (index_Seq_Int'3 s { end''1 = 0 }) = 1}
+      {[@expl:g ensures #5] index_Seq_Int'4 s () = s}
+      (! return {result}) ]
+end

--- a/tests/should_succeed/cc/seq.rs
+++ b/tests/should_succeed/cc/seq.rs
@@ -11,3 +11,12 @@ pub fn f() -> Ghost<usize> {
         x
     }
 }
+
+#[requires(s.len() >= 1)]
+#[ensures(s[0..1].len() == 1)]
+#[ensures(s[0..=0].len() == 1)]
+#[ensures(s[0..] == s)]
+#[ensures(s[..0].len() == 0)]
+#[ensures(s[..=0].len() == 1)]
+#[ensures(s[..] == s)]
+pub fn g(s: Seq<Int>) {}

--- a/tests/should_succeed/cc/seq/proof.json
+++ b/tests/should_succeed/cc/seq/proof.json
@@ -11,14 +11,14 @@
       "vc_f": { "prover": "cvc5@1.3.1", "time": 0.041 },
       "vc_get_mut_ghost_refmut_usize": {
         "prover": "cvc5@1.3.1",
-        "time": 0.033
+        "time": 0.015
       },
       "vc_into_inner_Seq_refmut_usize": {
         "prover": "cvc5@1.3.1",
-        "time": 0.039
+        "time": 0.018
       },
       "vc_new": { "prover": "cvc5@1.3.1", "time": 0.018 },
-      "vc_new_refmut_usize": { "prover": "cvc5@1.3.1", "time": 0.039 },
+      "vc_new_refmut_usize": { "prover": "cvc5@1.3.1", "time": 0.017 },
       "vc_new_usize": { "prover": "cvc5@1.3.1", "time": 0.018 },
       "vc_push_front_ghost_refmut_usize": {
         "prover": "cvc5@1.3.1",
@@ -26,8 +26,9 @@
       },
       "vc_unwrap_refmut_refmut_usize": {
         "prover": "cvc5@1.3.1",
-        "time": 0.033
+        "time": 0.015
       }
-    }
+    },
+    "M_g": { "vc_g": { "prover": "cvc5@1.3.1", "time": 0.016 } }
   }
 }


### PR DESCRIPTION
Provides a shorthand `s[start..end]` for `s.subsequence(start, end)`, including all the other variants of ranges.