### PR TITLE
Add impl FromIteratorSpec<()> for ()

### DIFF
--- a/creusot-contracts/src/std/iter.rs
+++ b/creusot-contracts/src/std/iter.rs
@@ -69,6 +69,13 @@ pub trait FromIteratorSpec<A>: FromIterator<A> {
     fn from_iter_post(prod: Seq<A>, res: Self) -> bool;
 }
 
+impl FromIteratorSpec<()> for () {
+    #[logic(open)]
+    fn from_iter_post(_: Seq<()>, _res: Self) -> bool {
+        true
+    }
+}
+
 pub trait DoubleEndedIteratorSpec: DoubleEndedIterator + IteratorSpec {
     #[logic(prophetic)]
     fn produces_back(self, visited: Seq<Self::Item>, o: Self) -> bool;

--- a/tests/creusot-contracts/creusot-contracts.coma
+++ b/tests/creusot-contracts/creusot-contracts.coma
@@ -55088,39 +55088,6 @@ module M_std__iter__zip__impl_IteratorSpec_for_Zip_A_B__produces_trans__refines 
               /\ produces_Zip_A_B b bc c
               /\ (forall result: (). produces_Zip_A_B a (Seq.(++) ab bc) c -> produces_Zip_A_B a (Seq.(++) ab bc) c)
 end
-module M_std__iter__impl_IteratorSpec_for_refmut_I__produces_refl__refines (* <&mut I as std::iter::IteratorSpec> *)
-  type namespace_other
-  
-  type t_Namespace = Other namespace_other
-  
-  use creusot.prelude.MutBorrow
-  use seq.Seq
-  
-  type t_I
-  
-  type t_Item
-  
-  predicate produces_I (self: t_I) (visited: Seq.seq t_Item) (o: t_I)
-  
-  function produces_trans_I (a: t_I) (ab: Seq.seq t_Item) (b: t_I) (bc: Seq.seq t_Item) (c: t_I) : ()
-  
-  axiom produces_trans_I_spec: forall a: t_I, ab: Seq.seq t_Item, b: t_I, bc: Seq.seq t_Item, c: t_I. produces_I a ab b
-      -> produces_I b bc c -> produces_I a (Seq.(++) ab bc) c
-  
-  function produces_refl_I (self: t_I) : ()
-  
-  axiom produces_refl_I_spec: forall self: t_I. produces_I self (Seq.empty: Seq.seq t_Item) self
-  
-  predicate produces_refmut_I (self: MutBorrow.t t_I) (visited: Seq.seq t_Item) (o: MutBorrow.t t_I) =
-    produces_I self.current visited o.current /\ self.final = o.final
-  
-  meta "compute_max_steps" 1000000
-  
-  meta "select_lsinst" "all"
-  
-  goal refines: forall self: MutBorrow.t t_I. forall result: (). produces_refmut_I self (Seq.empty: Seq.seq t_Item) self
-        -> produces_refmut_I self (Seq.empty: Seq.seq t_Item) self
-end
 module M_std__iter__impl_IteratorSpec_for_refmut_I__produces_trans__refines (* <&mut I as std::iter::IteratorSpec> *)
   type namespace_other
   
@@ -55157,6 +55124,39 @@ module M_std__iter__impl_IteratorSpec_for_refmut_I__produces_trans__refines (* <
               -> produces_refmut_I a ab b
               /\ produces_refmut_I b bc c
               /\ (forall result: (). produces_refmut_I a (Seq.(++) ab bc) c -> produces_refmut_I a (Seq.(++) ab bc) c)
+end
+module M_std__iter__impl_IteratorSpec_for_refmut_I__produces_refl__refines (* <&mut I as std::iter::IteratorSpec> *)
+  type namespace_other
+  
+  type t_Namespace = Other namespace_other
+  
+  use creusot.prelude.MutBorrow
+  use seq.Seq
+  
+  type t_I
+  
+  type t_Item
+  
+  predicate produces_I (self: t_I) (visited: Seq.seq t_Item) (o: t_I)
+  
+  function produces_trans_I (a: t_I) (ab: Seq.seq t_Item) (b: t_I) (bc: Seq.seq t_Item) (c: t_I) : ()
+  
+  axiom produces_trans_I_spec: forall a: t_I, ab: Seq.seq t_Item, b: t_I, bc: Seq.seq t_Item, c: t_I. produces_I a ab b
+      -> produces_I b bc c -> produces_I a (Seq.(++) ab bc) c
+  
+  function produces_refl_I (self: t_I) : ()
+  
+  axiom produces_refl_I_spec: forall self: t_I. produces_I self (Seq.empty: Seq.seq t_Item) self
+  
+  predicate produces_refmut_I (self: MutBorrow.t t_I) (visited: Seq.seq t_Item) (o: MutBorrow.t t_I) =
+    produces_I self.current visited o.current /\ self.final = o.final
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  goal refines: forall self: MutBorrow.t t_I. forall result: (). produces_refmut_I self (Seq.empty: Seq.seq t_Item) self
+        -> produces_refmut_I self (Seq.empty: Seq.seq t_Item) self
 end
 module M_std__option__impl_IteratorSpec_for_IntoIter_T__produces_trans__refines (* <std::option::IntoIter<T> as std::iter::IteratorSpec> *)
   type namespace_other

--- a/tests/should_fail/bug/1610-crash.stderr
+++ b/tests/should_fail/bug/1610-crash.stderr
@@ -21,9 +21,9 @@ error[E0277]: the trait bound `B: creusot_contracts::prelude::FromIteratorSpec<(
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `creusot_contracts::prelude::FromIteratorSpec<()>` is not implemented for `B`
 
 error: could not resolve trait instance for creusot_contracts::prelude::FromIteratorSpec::from_iter_post[B, <std::iter::Empty<()> as std::iter::Iterator>::Item]
-   --> ./creusot-contracts/src/std/iter.rs:168:89
+   --> ./creusot-contracts/src/std/iter.rs:175:89
     |
-168 |                     resolve(^done) && done.completed() && self.produces(prod, *done) && B::from_iter_post(prod, result))]
+175 |                     resolve(^done) && done.completed() && self.produces(prod, *done) && B::from_iter_post(prod, result))]
     |                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors; 2 warnings emitted


### PR DESCRIPTION
Like `map_inv` as a generalization of `map`, I wanted a `for_each_inv`. It can be encoded trivially as a combination of `map_inv` and `collect::<()>`.