### PR TITLE
README: fixup example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ If you would like to cite Creusot in academic contexts, we encourage you to use 
 
 To get an idea of what verifying a program with Creusot looks like, we encourage you to take a look at some of our test suite:
 
-- [Zeroing out a vector](tests/should_succeed/vector/01.rs)
-- [Binary search on Vectors](tests/should_succeed/vector/04_binary_search.rs)
-- [Sorting a vector](tests/should_succeed/vector/02_gnome.rs)
-- [IterMut](tests/should_succeed/iterators/02_iter_mut.rs)
-- [Normalizing If-Then-Else Expressions](tests/should_succeed/ite_normalize.rs)
+- [Zeroing out a vector](examples/all_zero.rs)
+- [Binary search on Vectors](examples/binary_search.rs)
+- [Sorting a vector](examples/gnome_sort.rs)
+- [IterMut](examples/iterators/02_iter_mut.rs)
+- [Normalizing If-Then-Else Expressions](examples/ite_normalize.rs)
 
-More examples are found in [tests/should_succeed](tests/should_succeed).
+More examples are found in [examples](examples) and [tests/should_succeed](tests/should_succeed).
 
 ## Projects built with Creusot
 


### PR DESCRIPTION
The links broke after https://github.com/creusot-rs/creusot/pull/1884. This fixes them, and links to both the new `examples` directory as well as the original `should_succeed` directory.