### PR TITLE
ci: Disable Nightly job on MacOS

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
It's too broken due to solver differences between Linux and MacOS.

Maybe we could make it a Nix-on-MacOS job but it's not clear that we would gain much from it.