### PR TITLE
doc: Fix broken link to termination.md in gnome_sort tutorial

### DIFF
--- a/guide/src/tutorial/gnome_sort.md
+++ b/guide/src/tutorial/gnome_sort.md
@@ -139,4 +139,4 @@ where
 We have proved the functional correctness of Gnome sort.
 Then we generalized it to sort elements of arbitrary ordered types.
 
-Bonus challenge (non-trivial!): prove the termination of `gnome_sort`. See the [Termination](./termination.md) chapter for more information.
+Bonus challenge (non-trivial!): prove the termination of `gnome_sort`. See the [Termination](../termination.md) chapter for more information.


### PR DESCRIPTION
The relative link `./termination.md` in `guide/src/tutorial/gnome_sort.md` was incorrect since the file is in the `tutorial/` subdirectory.

Changed the path from `./termination.md` to `../termination.md` to correctly navigate up one directory level to reach `guide/src/termination.md`.