### PR TITLE
Add more descriptions to published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,12 @@ members = [
 
 [workspace.package]
 version = "0.9.0"
+documentation = "https://creusot-rs.github.io/creusot/doc/creusot_std/"
+readme = "README.md"
+keywords = ["verification"]
+repository = "https://github.com/creusot-rs/creusot"
+homepage = "https://github.com/creusot-rs/creusot"
+categories = ["development-tools"]
 
 [profile.dev]
 split-debuginfo = "off"

--- a/creusot-std-proc/Cargo.toml
+++ b/creusot-std-proc/Cargo.toml
@@ -3,9 +3,14 @@ name = "creusot-std-proc"
 version.workspace = true
 authors = ["Xavier Denis <xldenis@gmail.com>"]
 edition = "2024"
-repository = "https://github.com/creusot-rs/creusot"
 license = "LGPL-2.1-or-later"
 description = "Proc macro crate for creusot-std"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 proc-macro = true

--- a/creusot-std/Cargo.toml
+++ b/creusot-std/Cargo.toml
@@ -3,9 +3,14 @@ name = "creusot-std"
 version.workspace = true
 authors = ["Xavier Denis <xldenis@gmail.com>"]
 edition = "2024"
-homepage = "https://github.com/creusot-rs/creusot"
 license = "LGPL-2.1-or-later"
 description = "Standard library of Creusot: provides specification macros, contracts for Rust standard library and logic helpers"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/pearlite-syn/Cargo.toml
+++ b/pearlite-syn/Cargo.toml
@@ -3,8 +3,12 @@ name = "pearlite-syn"
 version.workspace = true
 edition = "2024"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/creusot-rs/creusot"
 description = "A syn parser for the Pearlite specification language in Creusot"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/why3/Cargo.toml
+++ b/why3/Cargo.toml
@@ -3,9 +3,12 @@ name = "why3"
 version.workspace = true
 authors = ["Xavier Denis <xldenis@gmail.com>"]
 edition = "2024"
-repository = "https://github.com/creusot-rs/creusot"
 license = "LGPL-2.1-or-later"
 description = "Why3 AST and pretty printers"
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This adds links to the repository + documentation in Cargo.toml files, as well as keyword(s).

It was really sad to go to <https://crates.io/crates/creusot-std> and see "no README file"... :'(