### PR TITLE
Remove dead locals: do not remove locals used in a RValue::Ptr.

### DIFF
--- a/creusot/src/backend/optimization/remove_dead_locals.rs
+++ b/creusot/src/backend/optimization/remove_dead_locals.rs
@@ -83,6 +83,9 @@ impl<'tcx> FmirVisitor<'tcx> for LocalReads<'_, 'tcx> {
 
     fn visit_rvalue(&mut self, r: &RValue<'tcx>) {
         super_visit_rvalue(self, r);
+        if let RValue::Ptr(p) = r {
+            self.live.insert(p.local);
+        }
     }
 
     fn visit_operand(&mut self, op: &Operand<'tcx>) {

--- a/tests/should_succeed/bug/1921.coma
+++ b/tests/should_succeed/bug/1921.coma
@@ -1,0 +1,25 @@
+module M_foo
+  use creusot.prelude.Opaque
+  use creusot.prelude.Any
+  
+  type t_T
+  
+  predicate inv_T (_1: t_T)
+  
+  predicate invariant_ref_T [@inline:trivial] (self: t_T) = inv_T self
+  
+  meta "rewrite_def" predicate invariant_ref_T
+  
+  predicate inv_ref_T [@inline:trivial] (_1: t_T) = invariant_ref_T _1
+  
+  meta "rewrite_def" predicate inv_ref_T
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec foo_T (x: t_T) (return (x'0: Opaque.ptr)) = {[@stop_split] [@expl:foo 'x' type invariant] inv_ref_T x}
+    (! bb0
+    [ bb0 = s0 [ s0 = Opaque.fresh_ptr (fun (_ptr: Opaque.ptr) -> [ &_ret <- _ptr ] s1) | s1 = return {_ret} ] ]
+    [ & _ret: Opaque.ptr = Any.any_l () | & x: t_T = x ]) [ return (result: Opaque.ptr) -> (! return {result}) ]
+end

--- a/tests/should_succeed/bug/1921.rs
+++ b/tests/should_succeed/bug/1921.rs
@@ -1,0 +1,6 @@
+use creusot_std::prelude::*;
+
+#[ensures(true)]
+pub fn foo<T>(x: &T) -> *const T {
+    x
+}

--- a/tests/should_succeed/bug/1921/proof.json
+++ b/tests/should_succeed/bug/1921/proof.json
@@ -1,0 +1,6 @@
+{
+  "profile": [],
+  "proofs": {
+    "M_foo": { "vc_foo_T": { "prover": "cvc5@1.3.1", "time": 0.037 } }
+  }
+}


### PR DESCRIPTION
Fixes #1921.