### PR TITLE
Prefer Alt-ergo and Z3

### DIFF
--- a/why3find.json
+++ b/why3find.json
@@ -3,7 +3,7 @@
   "time": 1,
   "depth": 6,
   "packages": [ "creusot" ],
-  "provers": [ "cvc5", "cvc4", "z3", "alt-ergo" ],
+  "provers": [ "alt-ergo", "z3", "cvc5", "cvc4" ],
   "tactics": [ "compute_specified", "split_vc" ],
   "drivers": [],
   "warnoff": [ "unused_variable", "axiom_abstract" ],


### PR DESCRIPTION
CVC5 apparently behaves inconsistently between Linux and MacOS (see also #1892) so we give it a smaller priority (this also matches the current custom strategy in Why3 IDE).