### PR TITLE
Improve test scripts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -212,32 +212,8 @@ jobs:
         opam --cli=2.1 var --global in-creusot-ci=true
     - run: ./INSTALL
     - name: test cargo creusot new
-      run: |
-        set -x
-        cd ..
-        cargo creusot new test-project --main --creusot-std ../creusot/creusot-std
-        cd test-project
-        cargo fmt --check
-        cargo build
-        cargo creusot
-        cargo creusot prove
-      env:
-        RUSTFLAGS: -D warnings
+      run: ./tests/build-new.sh
     - name: test no_std build
-      run: |
-        set -x
-        TLC=$(rustup show active-toolchain | cut -d " " -f1)
-        rustup component add --toolchain $TLC rustfmt
-        rustup component add --toolchain $TLC rust-src
-        rustup target add thumbv7em-none-eabi
-        cd ..
-        cargo creusot new test-project-nostd --no-std --creusot-std ../creusot/creusot-std
-        cd test-project-nostd
-        echo $TLC > rust-toolchain
-        cargo fmt --check
-        cargo build
-        cargo build --target thumbv7em-none-eabi -Zbuild-std=core,alloc
-        cargo creusot prove
-        cargo creusot prove -- --target thumbv7em-none-eabi -Zbuild-std=core,alloc
+      run: ./tests/build-new-no-std.sh
     - name: Minimize Opam cache
       run: opam clean --all-switches --download-cache --logs --repo-cache

--- a/fmt
+++ b/fmt
@@ -1,8 +1,28 @@
 #!/usr/bin/env bash
 
 set -e
-
 SCRIPTPATH=$(dirname "$BASH_SOURCE")
 pushd $SCRIPTPATH > /dev/null
-rustfmt $@ $(git ls-files '*.rs')
+for i in "$@" ; do
+  case $1 in
+    --all)
+      FILES=$(git ls-files '*.rs')
+      ;;
+    --check)
+      ARGS=--check
+      ;;
+    -*)
+      echo "Unrecognized option $i"
+      exit 1;
+      ;;
+    *)
+      FILES+=" $i"
+      ;;
+  esac
+done
+if [ ! "$FILES" ] ; then
+  FILES=$(git diff --name-only origin/master '*.rs')
+  [ "$FILES" ] || exit 0
+fi
+rustfmt $ARGS $FILES
 popd > /dev/null

--- a/tests/build-new-no-std.sh
+++ b/tests/build-new-no-std.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Test that we can build a minimal no-std project
+set -x
+TLC=$(rustup show active-toolchain | cut -d " " -f1)
+rustup component add --toolchain $TLC rustfmt
+rustup component add --toolchain $TLC rust-src
+rustup target add thumbv7em-none-eabi
+cd ..
+DIR=creusot-test-please-ignore
+rm -rf $DIR
+cargo creusot new $DIR --no-std --creusot-std ../creusot/creusot-std
+cd $DIR
+echo $TLC > rust-toolchain
+cargo fmt --check
+cargo build
+cargo build --target thumbv7em-none-eabi -Zbuild-std=core,alloc
+cargo creusot prove
+cargo creusot prove -- --target thumbv7em-none-eabi -Zbuild-std=core,alloc

--- a/tests/build-new.sh
+++ b/tests/build-new.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+export RUSTFLAGS="-D warnings"
+cd ..
+DIR=creusot-test-please-ignore
+rm -rf $DIR
+cargo creusot new $DIR --main --creusot-std ../creusot/creusot-std
+cd $DIR
+cargo fmt --check
+cargo build
+cargo creusot
+cargo creusot prove

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Most common tests
+for i in "$@"; do
+  case $i in
+    --help)
+      echo "Available options:"
+      echo "    --update   Update files when possible"
+      echo "    [STRING]    Only run tests for files containing this string"
+      echo "Debugging options"
+      echo "    --debug    Print commands as they are run"
+      echo "    --dry-run  Print commands without running them"
+      exit 0
+      ;;
+    --update)
+      UPDATE=1
+      shift
+      ;;
+    --dry-run)
+      # Just print the commands
+      ECHO_IF_DRY=echo
+      shift
+      ;;
+    --debug)
+      DEBUG=1
+      shift
+      ;;
+    -*)
+      echo "Unrecognized option $i"
+      exit 1
+      ;;
+    *)
+      NAMED=1
+      PARAMS+=" \"$i\""
+      shift
+      ;;
+  esac
+done
+UI_ARGS=$PARAMS
+WHY3_ARGS=$PARAMS
+if [ $UPDATE ] ; then
+    UI_ARGS+=' --bless'
+    WHY3_ARGS_=' --update'
+else
+    FMT_ARGS+=' --check'
+fi
+if [ ! $NAMED ] ; then
+    WHY3_ARGS+=' --diff-from=origin/master'
+fi
+if [ $DEBUG ] ; then
+    set -x
+fi
+cd $(dirname "${BASH_SOURCE}")/..
+fmt() {
+  $ECHO_IF_DRY ./fmt $FMT_ARGS
+}
+ui() {
+    $ECHO_IF_DRY cargo test --test ui -- $UI_ARGS
+}
+why3() {
+    $ECHO_IF_DRY cargo test --test why3 -- $WHY3_ARGS
+}
+fmt
+ui
+why3


### PR DESCRIPTION
- Extract some scripts for easier local testing (tests that build `cargo creusot new` projects)
- Add `tests/run.sh` to run common scripts
- Only run `rustfmt` on files that have changed, by default