### PR TITLE
Make `NonAtomicInvariant` invariant and non-`Sync`

### DIFF
--- a/creusot-std/src/ghost/invariant.rs
+++ b/creusot-std/src/ghost/invariant.rs
@@ -238,7 +238,7 @@ pub trait Protocol {
 }
 
 #[opaque]
-pub struct AtomicInvariant<T>(PhantomData<T>);
+pub struct AtomicInvariant<T>(PhantomData<*mut T>);
 
 unsafe impl<T: Send> Sync for AtomicInvariant<T> {}
 


### PR DESCRIPTION
For the fact that `NonAtomicInvariant` should be invariant (as in subtyping) (that's a lot of invariants!), here is an example:
```rust
use creusot_std::{
    ghost::invariant::{
        NonAtomicInvariant, NonAtomicInvariantExt, Protocol, Tokens, declare_namespace,
    },
    prelude::*,
};

struct Bor<'a>(&'a i32);

impl<'a> Protocol for Bor<'a> {
    type Public = ();
    #[logic]
    fn protocol(self, _: Self::Public) -> bool { true }
}

declare_namespace! { NS }

#[requires(tokens.contains(NS()))]
pub fn bad(tokens: Ghost<Tokens>) {
    let x = ghost!(1i32);
    let inv = NonAtomicInvariant::new(ghost!(Bor(&*x)), snapshot!(()), snapshot!(NS()));

    {
        let y = ghost!(2i32);
        inv.open(tokens, |mut b: Ghost<&mut Bor>| {
            ghost! {
                **b = Bor(&*y);
            };
        });
    }
    let inner = ghost!(inv.into_inner().into_inner()); // points to uninitialized variable.
}
```
Technically *this* is not unsound since `inner` is wrapped in `Ghost`, but I think this can be used to derive an unsoundness by using `Perm<Bor<'a>>`.