### PR TITLE
Rename `AddLogic::add` to `AddLogic::add_logic`, etc.

### DIFF
--- a/creusot-std-proc/src/creusot/pretyping.rs
+++ b/creusot-std-proc/src/creusot/pretyping.rs
@@ -3,7 +3,7 @@
 //! Some macros accept pearlite rather than Rust. This module converts the
 //! latter to the former.
 //!
-//! For example, `1 + 2` becomes `creusot_std::logic::AddLogic::add(Int::new(1), Int::new(2))`.
+//! For example, `1 + 2` becomes `creusot_std::logic::AddLogic::add_logic(Int::new(1), Int::new(2))`.
 
 use pearlite_syn::{Term, term::*};
 use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree};
@@ -198,23 +198,23 @@ fn encode_term_(term: &Term, locals: &mut Locals) -> Result<EncodingResult, Enco
                         .into())
                 }
                 Add(_) => Ok(
-                    quote_spanned! {sp=> ::creusot_std::logic::ops::AddLogic::add(#left, #right) }
+                    quote_spanned! {sp=> ::creusot_std::logic::ops::AddLogic::add_logic(#left, #right) }
                         .into(),
                 ),
                 Sub(_) => Ok(
-                    quote_spanned! {sp=> ::creusot_std::logic::ops::SubLogic::sub(#left, #right) }
+                    quote_spanned! {sp=> ::creusot_std::logic::ops::SubLogic::sub_logic(#left, #right) }
                         .into(),
                 ),
                 Mul(_) => Ok(
-                    quote_spanned! {sp=> ::creusot_std::logic::ops::MulLogic::mul(#left, #right) }
+                    quote_spanned! {sp=> ::creusot_std::logic::ops::MulLogic::mul_logic(#left, #right) }
                         .into(),
                 ),
                 Div(_) => Ok(
-                    quote_spanned! {sp=> ::creusot_std::logic::ops::DivLogic::div(#left, #right) }
+                    quote_spanned! {sp=> ::creusot_std::logic::ops::DivLogic::div_logic(#left, #right) }
                         .into(),
                 ),
                 Rem(_) => Ok(
-                    quote_spanned! {sp=> ::creusot_std::logic::ops::RemLogic::rem(#left, #right) }
+                    quote_spanned! {sp=> ::creusot_std::logic::ops::RemLogic::rem_logic(#left, #right) }
                         .into(),
                 ),
                 _ => Ok(quote_spanned! {sp=> #left #op #right }.into()),
@@ -400,7 +400,8 @@ fn encode_term_(term: &Term, locals: &mut Locals) -> Result<EncodingResult, Enco
         Term::Unary(TermUnary { op, expr }) => match op {
             UnOp::Neg(_) => {
                 let term = encode_term_(expr, locals)?.toks();
-                Ok(quote_spanned! {sp=> ::creusot_std::logic::ops::NegLogic::neg(#term) }.into())
+                Ok(quote_spanned! {sp=> ::creusot_std::logic::ops::NegLogic::neg_logic(#term) }
+                    .into())
             }
             UnOp::Deref(_) => {
                 let EncodingResult { toks, deref_bor } = encode_term_(expr, locals)?;

--- a/creusot-std/src/logic/int.rs
+++ b/creusot-std/src/logic/int.rs
@@ -160,7 +160,7 @@ impl AddLogic for Int {
     #[logic]
     #[builtin("int.Int.(+)")]
     #[allow(unused_variables)]
-    fn add(self, other: Self) -> Self {
+    fn add_logic(self, other: Self) -> Self {
         dead
     }
 }
@@ -170,7 +170,7 @@ impl SubLogic for Int {
     #[logic]
     #[builtin("int.Int.(-)")]
     #[allow(unused_variables)]
-    fn sub(self, other: Self) -> Self {
+    fn sub_logic(self, other: Self) -> Self {
         dead
     }
 }
@@ -180,7 +180,7 @@ impl MulLogic for Int {
     #[logic]
     #[builtin("int.Int.(*)")]
     #[allow(unused_variables)]
-    fn mul(self, other: Self) -> Self {
+    fn mul_logic(self, other: Self) -> Self {
         dead
     }
 }
@@ -190,7 +190,7 @@ impl DivLogic for Int {
     #[logic]
     #[builtin("int.ComputerDivision.div")]
     #[allow(unused_variables)]
-    fn div(self, other: Self) -> Self {
+    fn div_logic(self, other: Self) -> Self {
         dead
     }
 }
@@ -200,7 +200,7 @@ impl RemLogic for Int {
     #[logic]
     #[builtin("int.ComputerDivision.mod")]
     #[allow(unused_variables)]
-    fn rem(self, other: Self) -> Self {
+    fn rem_logic(self, other: Self) -> Self {
         dead
     }
 }
@@ -209,7 +209,7 @@ impl NegLogic for Int {
     type Output = Self;
     #[logic]
     #[builtin("int.Int.(-_)")]
-    fn neg(self) -> Self {
+    fn neg_logic(self) -> Self {
         dead
     }
 }
@@ -455,7 +455,7 @@ impl AddLogic for Nat {
     type Output = Self;
     #[logic]
     #[ensures(result.to_int() == self.to_int() + other.to_int())]
-    fn add(self, other: Self) -> Self {
+    fn add_logic(self, other: Self) -> Self {
         Self::new(self.to_int() + other.to_int())
     }
 }
@@ -464,7 +464,7 @@ impl MulLogic for Nat {
     type Output = Self;
     #[logic]
     #[ensures(result.to_int() == self.to_int() * other.to_int())]
-    fn mul(self, other: Self) -> Self {
+    fn mul_logic(self, other: Self) -> Self {
         Self::new(self.to_int() * other.to_int())
     }
 }

--- a/creusot-std/src/logic/ops/arithmetic.rs
+++ b/creusot-std/src/logic/ops/arithmetic.rs
@@ -11,7 +11,7 @@ pub trait AddLogic<Rhs = Self> {
     type Output;
 
     #[logic]
-    fn add(self, other: Rhs) -> Self::Output;
+    fn add_logic(self, other: Rhs) -> Self::Output;
 }
 
 /// Trait for subtraction (`-`) in logic code.
@@ -23,7 +23,7 @@ pub trait SubLogic<Rhs = Self> {
     type Output;
 
     #[logic]
-    fn sub(self, other: Rhs) -> Self::Output;
+    fn sub_logic(self, other: Rhs) -> Self::Output;
 }
 
 /// Trait for multiplication (`*`) in logic code.
@@ -35,7 +35,7 @@ pub trait MulLogic<Rhs = Self> {
     type Output;
 
     #[logic]
-    fn mul(self, other: Rhs) -> Self::Output;
+    fn mul_logic(self, other: Rhs) -> Self::Output;
 }
 
 /// Trait for division (`/`) in logic code.
@@ -47,7 +47,7 @@ pub trait DivLogic<Rhs = Self> {
     type Output;
 
     #[logic]
-    fn div(self, other: Rhs) -> Self::Output;
+    fn div_logic(self, other: Rhs) -> Self::Output;
 }
 
 /// Trait for remainder (`%`) in logic code.
@@ -59,7 +59,7 @@ pub trait RemLogic<Rhs = Self> {
     type Output;
 
     #[logic]
-    fn rem(self, other: Rhs) -> Self::Output;
+    fn rem_logic(self, other: Rhs) -> Self::Output;
 }
 
 /// Trait for negation (unary `-`) in logic code.
@@ -71,7 +71,7 @@ pub trait NegLogic {
     type Output;
 
     #[logic]
-    fn neg(self) -> Self::Output;
+    fn neg_logic(self) -> Self::Output;
 }
 
 /// Trait for the nth bit of a bitvector in logic code.

--- a/creusot-std/src/logic/real.rs
+++ b/creusot-std/src/logic/real.rs
@@ -73,7 +73,7 @@ impl AddLogic for Real {
     #[logic]
     #[builtin("real.Real.(+)")]
     #[allow(unused_variables)]
-    fn add(self, other: Self) -> Self {
+    fn add_logic(self, other: Self) -> Self {
         dead
     }
 }
@@ -83,7 +83,7 @@ impl SubLogic for Real {
     #[logic]
     #[builtin("real.Real.(-)")]
     #[allow(unused_variables)]
-    fn sub(self, other: Self) -> Self {
+    fn sub_logic(self, other: Self) -> Self {
         dead
     }
 }
@@ -93,7 +93,7 @@ impl MulLogic for Real {
     #[logic]
     #[builtin("real.Real.(*)")]
     #[allow(unused_variables)]
-    fn mul(self, other: Self) -> Self {
+    fn mul_logic(self, other: Self) -> Self {
         dead
     }
 }
@@ -103,7 +103,7 @@ impl DivLogic for Real {
     #[logic]
     #[builtin("real.Real.(/)")]
     #[allow(unused_variables)]
-    fn div(self, other: Self) -> Self {
+    fn div_logic(self, other: Self) -> Self {
         dead
     }
 }
@@ -112,7 +112,7 @@ impl NegLogic for Real {
     type Output = Self;
     #[logic]
     #[builtin("real.Real.(-_)")]
-    fn neg(self) -> Self {
+    fn neg_logic(self) -> Self {
         dead
     }
 }
@@ -197,7 +197,7 @@ impl AddLogic for PositiveReal {
     type Output = Self;
     #[logic]
     #[ensures(result.to_real() == self.to_real() + other.to_real())]
-    fn add(self, other: Self) -> Self {
+    fn add_logic(self, other: Self) -> Self {
         Self::new(self.to_real() + other.to_real())
     }
 }
@@ -206,7 +206,7 @@ impl MulLogic for PositiveReal {
     type Output = Self;
     #[logic]
     #[ensures(result.to_real() == self.to_real() * other.to_real())]
-    fn mul(self, other: Self) -> Self {
+    fn mul_logic(self, other: Self) -> Self {
         Self::new(self.to_real() * other.to_real())
     }
 }
@@ -215,7 +215,7 @@ impl DivLogic for PositiveReal {
     type Output = Self;
     #[logic]
     #[ensures(result.to_real() == self.to_real() / other.to_real())]
-    fn div(self, other: Self) -> Self {
+    fn div_logic(self, other: Self) -> Self {
         Self::new(self.to_real() / other.to_real())
     }
 }

--- a/creusot-std/src/std/num.rs
+++ b/creusot-std/src/std/num.rs
@@ -54,7 +54,7 @@ macro_rules! mach_int {
             #[logic]
             #[builtin(concat!($ty_nm, ".add"))]
             #[allow(unused_variables)]
-            fn add(self, other: Self) -> Self {
+            fn add_logic(self, other: Self) -> Self {
                 dead
             }
         }
@@ -64,7 +64,7 @@ macro_rules! mach_int {
             #[logic]
             #[builtin(concat!($ty_nm, ".sub"))]
             #[allow(unused_variables)]
-            fn sub(self, other: Self) -> Self {
+            fn sub_logic(self, other: Self) -> Self {
                 dead
             }
         }
@@ -74,7 +74,7 @@ macro_rules! mach_int {
             #[logic]
             #[builtin(concat!($ty_nm, ".mul"))]
             #[allow(unused_variables)]
-            fn mul(self, other: Self) -> Self {
+            fn mul_logic(self, other: Self) -> Self {
                 dead
             }
         }
@@ -83,7 +83,7 @@ macro_rules! mach_int {
             type Output = Self;
             #[logic]
             #[builtin(concat!($ty_nm, ".neg"))]
-            fn neg(self) -> Self {
+            fn neg_logic(self) -> Self {
                 dead
             }
         }

--- a/tests/creusot-std/creusot-std.coma
+++ b/tests/creusot-std/creusot-std.coma
@@ -6735,7 +6735,7 @@ module M_logic__int__impl_Nat__ext_eq (* logic::int::Nat *)
     -> ([@stop_split] [@expl:to_int ensures] to_int other >= 0)
     -> ([@stop_split] [@expl:ext_eq ensures] (to_int self = to_int other) = (self = other))
 end
-module M_logic__int__impl_AddLogic_for_Nat__add (* <logic::int::Nat as logic::ops::arithmetic::AddLogic> *)
+module M_logic__int__impl_AddLogic_for_Nat__add_logic (* <logic::int::Nat as logic::ops::arithmetic::AddLogic> *)
   type namespace_other
   
   type t_Namespace = Other namespace_other
@@ -6780,9 +6780,9 @@ module M_logic__int__impl_AddLogic_for_Nat__add (* <logic::int::Nat as logic::op
     -> ([@stop_split] [@expl:to_int ensures] to_int other >= 0)
     -> ([@stop_split] [@expl:new requires] to_int self + to_int other >= 0)
     /\ (([@stop_split] [@expl:new ensures] to_int (new (to_int self + to_int other)) = to_int self + to_int other)
-    -> ([@stop_split] [@expl:add ensures] to_int (new (to_int self + to_int other)) = to_int self + to_int other))
+    -> ([@stop_split] [@expl:add_logic ensures] to_int (new (to_int self + to_int other)) = to_int self + to_int other))
 end
-module M_logic__int__impl_MulLogic_for_Nat__mul (* <logic::int::Nat as logic::ops::arithmetic::MulLogic> *)
+module M_logic__int__impl_MulLogic_for_Nat__mul_logic (* <logic::int::Nat as logic::ops::arithmetic::MulLogic> *)
   type namespace_other
   
   type t_Namespace = Other namespace_other
@@ -6827,7 +6827,7 @@ module M_logic__int__impl_MulLogic_for_Nat__mul (* <logic::int::Nat as logic::op
     -> ([@stop_split] [@expl:to_int ensures] to_int other >= 0)
     -> ([@stop_split] [@expl:new requires] to_int self * to_int other >= 0)
     /\ (([@stop_split] [@expl:new ensures] to_int (new (to_int self * to_int other)) = to_int self * to_int other)
-    -> ([@stop_split] [@expl:mul ensures] to_int (new (to_int self * to_int other)) = to_int self * to_int other))
+    -> ([@stop_split] [@expl:mul_logic ensures] to_int (new (to_int self * to_int other)) = to_int self * to_int other))
 end
 module M_logic__ord__impl_OrdLogic_for_ref_T__cmp_le_log (* <&T as logic::ord::OrdLogic> *)
   type namespace_other
@@ -26600,7 +26600,7 @@ module M_logic__real__impl_OrdLogic_for_PositiveReal__eq_cmp (* <logic::real::Po
   
   goal vc_eq_cmp_PositiveReal: [@stop_split] [@expl:eq_cmp ensures] (x = y) = (cmp_log_PositiveReal x y = Equal)
 end
-module M_logic__real__impl_AddLogic_for_PositiveReal__add (* <logic::real::PositiveReal as logic::ops::arithmetic::AddLogic> *)
+module M_logic__real__impl_AddLogic_for_PositiveReal__add_logic (* <logic::real::PositiveReal as logic::ops::arithmetic::AddLogic> *)
   type namespace_other
   
   type t_Namespace = Other namespace_other
@@ -26694,10 +26694,10 @@ module M_logic__real__impl_AddLogic_for_PositiveReal__add (* <logic::real::Posit
     -> ([@stop_split] [@expl:new requires] Real.(>) (Real.(+) (to_real self) (to_real other)) (FromInt.from_int 0))
     /\ (([@stop_split] [@expl:new ensures] to_real (new (Real.(+) (to_real self) (to_real other)))
       = Real.(+) (to_real self) (to_real other))
-    -> ([@stop_split] [@expl:add ensures] to_real (new (Real.(+) (to_real self) (to_real other)))
+    -> ([@stop_split] [@expl:add_logic ensures] to_real (new (Real.(+) (to_real self) (to_real other)))
     = Real.(+) (to_real self) (to_real other)))
 end
-module M_logic__real__impl_MulLogic_for_PositiveReal__mul (* <logic::real::PositiveReal as logic::ops::arithmetic::MulLogic> *)
+module M_logic__real__impl_MulLogic_for_PositiveReal__mul_logic (* <logic::real::PositiveReal as logic::ops::arithmetic::MulLogic> *)
   type namespace_other
   
   type t_Namespace = Other namespace_other
@@ -26791,10 +26791,10 @@ module M_logic__real__impl_MulLogic_for_PositiveReal__mul (* <logic::real::Posit
     -> ([@stop_split] [@expl:new requires] Real.(>) (Real.(*) (to_real self) (to_real other)) (FromInt.from_int 0))
     /\ (([@stop_split] [@expl:new ensures] to_real (new (Real.(*) (to_real self) (to_real other)))
       = Real.(*) (to_real self) (to_real other))
-    -> ([@stop_split] [@expl:mul ensures] to_real (new (Real.(*) (to_real self) (to_real other)))
+    -> ([@stop_split] [@expl:mul_logic ensures] to_real (new (Real.(*) (to_real self) (to_real other)))
     = Real.(*) (to_real self) (to_real other)))
 end
-module M_logic__real__impl_DivLogic_for_PositiveReal__div (* <logic::real::PositiveReal as logic::ops::arithmetic::DivLogic> *)
+module M_logic__real__impl_DivLogic_for_PositiveReal__div_logic (* <logic::real::PositiveReal as logic::ops::arithmetic::DivLogic> *)
   type namespace_other
   
   type t_Namespace = Other namespace_other
@@ -26888,7 +26888,7 @@ module M_logic__real__impl_DivLogic_for_PositiveReal__div (* <logic::real::Posit
     -> ([@stop_split] [@expl:new requires] Real.(>) (Real.(/) (to_real self) (to_real other)) (FromInt.from_int 0))
     /\ (([@stop_split] [@expl:new ensures] to_real (new (Real.(/) (to_real self) (to_real other)))
       = Real.(/) (to_real self) (to_real other))
-    -> ([@stop_split] [@expl:div ensures] to_real (new (Real.(/) (to_real self) (to_real other)))
+    -> ([@stop_split] [@expl:div_logic ensures] to_real (new (Real.(/) (to_real self) (to_real other)))
     = Real.(/) (to_real self) (to_real other)))
 end
 module M_logic__seq__impl_Seq_T__map (* logic::seq::Seq<T> *)

--- a/tests/creusot-std/creusot-std/why3session.xml
+++ b/tests/creusot-std/creusot-std/why3session.xml
@@ -426,14 +426,14 @@
  <proof prover="0"><result status="valid" time="0.005764" steps="1373"/></proof>
  </goal>
 </theory>
-<theory name="M_logic__int__impl_AddLogic_for_Nat__add" proved="true">
+<theory name="M_logic__int__impl_AddLogic_for_Nat__add_logic" proved="true">
  <goal name="vc_add_Nat" proved="true">
- <proof prover="2" timelimit="5"><result status="valid" time="0.015977" steps="309"/></proof>
+ <proof prover="2" timelimit="5"><result status="valid" time="0.033181" steps="309"/></proof>
  </goal>
 </theory>
-<theory name="M_logic__int__impl_MulLogic_for_Nat__mul" proved="true">
+<theory name="M_logic__int__impl_MulLogic_for_Nat__mul_logic" proved="true">
  <goal name="vc_mul_Nat" proved="true">
- <proof prover="0"><result status="valid" time="0.005644" steps="1021"/></proof>
+ <proof prover="0"><result status="valid" time="0.008171" steps="1021"/></proof>
  </goal>
 </theory>
 <theory name="M_logic__ord__impl_OrdLogic_for_ref_T__cmp_le_log" proved="true">
@@ -2236,19 +2236,19 @@
  <proof prover="2"><result status="valid" time="0.028700" steps="2713"/></proof>
  </goal>
 </theory>
-<theory name="M_logic__real__impl_AddLogic_for_PositiveReal__add" proved="true">
+<theory name="M_logic__real__impl_AddLogic_for_PositiveReal__add_logic" proved="true">
  <goal name="vc_add_PositiveReal" proved="true">
- <proof prover="3" timelimit="5"><result status="valid" time="0.027076" steps="2"/></proof>
+ <proof prover="0"><result status="valid" time="0.000001" steps="5955"/></proof>
  </goal>
 </theory>
-<theory name="M_logic__real__impl_MulLogic_for_PositiveReal__mul" proved="true">
+<theory name="M_logic__real__impl_MulLogic_for_PositiveReal__mul_logic" proved="true">
  <goal name="vc_mul_PositiveReal" proved="true">
- <proof prover="2" timelimit="5"><result status="valid" time="0.042151" steps="3000"/></proof>
+ <proof prover="1"><result status="valid" time="0.022925" steps="3718"/></proof>
  </goal>
 </theory>
-<theory name="M_logic__real__impl_DivLogic_for_PositiveReal__div" proved="true">
+<theory name="M_logic__real__impl_DivLogic_for_PositiveReal__div_logic" proved="true">
  <goal name="vc_div_PositiveReal" proved="true">
- <proof prover="0"><result status="valid" time="0.010063" steps="6554"/></proof>
+ <proof prover="3" timelimit="5"><result status="valid" time="0.014818" steps="4"/></proof>
  </goal>
 </theory>
 <theory name="M_logic__seq__impl_Seq_T__map" proved="true">

--- a/tests/should_fail/bug/1544_1.stderr
+++ b/tests/should_fail/bug/1544_1.stderr
@@ -1,11 +1,11 @@
-error[E0046]: not all trait items implemented, missing: `Output`, `add`
+error[E0046]: not all trait items implemented, missing: `Output`, `add_logic`
   --> 1544_1.rs:10:1
    |
 10 | impl<const X: usize> AddLogic for S<X> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Output`, `add` in implementation
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Output`, `add_logic` in implementation
    |
    = help: implement the missing item: `type Output = /* Type */;`
-   = help: implement the missing item: `fn add(self, _: S<X>) -> <Self as creusot_std::logic::ops::AddLogic<S<X>>>::Output { todo!() }`
+   = help: implement the missing item: `fn add_logic(self, _: S<X>) -> <Self as creusot_std::logic::ops::AddLogic<S<X>>>::Output { todo!() }`
 
 error[E0046]: not all trait items implemented, missing: `eq`
   --> 1544_1.rs:17:1


### PR DESCRIPTION
Avoid collision with `Add::add` that happened when I tried to add an extern spec to an impl for `Add`, in a module where `AddLogic` was imported. This also points to a flaw in `extern_spec!` for trait impls (it throws away the trait, which results in the above ambiguity) to be fixed soon.