### PR TITLE
Fix termination checker

### DIFF
--- a/creusot-std/src/stubs.rs
+++ b/creusot-std/src/stubs.rs
@@ -46,6 +46,7 @@ pub fn old<'a, T: ?Sized>(_: T) -> &'a T {
     dead
 }
 
+#[creusot::no_translate] // avoid the termination checker
 #[logic(opaque)]
 #[intrinsic("dead")]
 #[allow(unconditional_recursion)]

--- a/creusot/src/backend/logic/vcgen.rs
+++ b/creusot/src/backend/logic/vcgen.rs
@@ -16,10 +16,7 @@ use crate::{
     ctx::{HasTyCtxt, PreMod},
     naming::name,
     translation::{
-        pearlite::{
-            BinOp, Literal, Pattern, Term, TermKind, UnOp,
-            visit::{TermVisitor, super_visit_term},
-        },
+        pearlite::{BinOp, Literal, Pattern, Term, TermKind, UnOp},
         traits::TraitResolved,
     },
     util::erased_identity_for_item,
@@ -30,10 +27,7 @@ use rustc_middle::{
     ty::{EarlyBinder, Ty, TyCtxt, TyKind, TypingEnv},
 };
 use rustc_span::Span;
-use std::{
-    collections::{HashMap, HashSet},
-    iter::repeat_n,
-};
+use std::{collections::HashMap, iter::repeat_n};
 use why3::{
     Exp, Ident, Name,
     declaration::Attribute,
@@ -61,7 +55,6 @@ struct VCGen<'a, 'tcx> {
     ctx: &'a Why3Generator<'tcx>,
     names: &'a Dependencies<'a, 'tcx>,
     self_id: DefId,
-    structurally_recursive: bool,
     args_names: Vec<Ident>,
     variant: Option<Exp>,
     typing_env: TypingEnv<'tcx>,
@@ -78,131 +71,9 @@ pub(super) fn wp<'tcx>(
     dest: Ident,
     post: Exp,
 ) -> Exp {
-    let structurally_recursive = is_structurally_recursive(ctx, self_id, &t);
-    let vcgen = VCGen {
-        typing_env: ctx.typing_env(self_id),
-        ctx,
-        names,
-        self_id,
-        structurally_recursive,
-        args_names,
-        variant,
-    };
+    let vcgen =
+        VCGen { typing_env: ctx.typing_env(self_id), ctx, names, self_id, args_names, variant };
     vcgen.build_wp(&t, &|exp| Exp::let_(dest, exp, post.clone()))
-}
-
-/// Verifies whether a given term is structurally recursive: that is, each
-/// recursive call is made to a component of an argument to the prior call.
-///
-/// The check must also ensure that we are always recursing on the *same*
-/// argument since otherwise we could 'ping pong' infinitely.
-///
-/// Currently, the check is *very* naive: we only consider variables and only
-/// check `match`. This means that something like the following would fail:
-///
-/// ``` match x { Cons(_, tl) => recursive((tl, 0).0) } ```
-///
-/// This check can be extended in the future
-fn is_structurally_recursive<'tcx>(
-    ctx: &Why3Generator<'tcx>,
-    self_id: DefId,
-    t: &Term<'tcx>,
-) -> bool {
-    struct StructuralRecursion {
-        smaller_than: HashMap<Ident, Ident>,
-        self_id: DefId,
-        /// Index of the decreasing argument
-        decreasing_args: HashSet<Ident>,
-        orig_args: Vec<Ident>,
-    }
-
-    impl StructuralRecursion {
-        fn valid(&self) -> bool {
-            self.decreasing_args.len() == 1
-        }
-
-        /// Is `t` smaller than the argument `nm`?
-        fn is_smaller_than(&self, t: &Term, nm: Ident) -> bool {
-            match &t.kind {
-                TermKind::Var(s) => self.smaller_than.get(&s.0) == Some(&nm),
-                TermKind::Coerce { arg } => self.is_smaller_than(arg, nm),
-                _ => false,
-            }
-        }
-
-        // TODO: could make this a `pattern` to term comparison to make it more powerful
-        /// Mark `nm` as smaller than `term`. Currently, this only updates the relation if `term` is a variable.
-        fn smaller_than(&mut self, nm: Ident, term: &Term<'_>) {
-            match &term.kind {
-                TermKind::Var(var) => {
-                    let parent = self.smaller_than.get(&var.0).unwrap_or(&var.0);
-                    self.smaller_than.insert(nm, *parent);
-                }
-                TermKind::Coerce { arg } => self.smaller_than(nm, arg),
-                _ => (),
-            }
-        }
-    }
-
-    impl TermVisitor<'_> for StructuralRecursion {
-        fn visit_term(&mut self, term: &Term<'_>) {
-            match &term.kind {
-                TermKind::Call { id, args, .. } if *id == self.self_id => {
-                    for (arg, nm) in args.iter().zip(self.orig_args.iter()) {
-                        if self.is_smaller_than(arg, *nm) {
-                            self.decreasing_args.insert(*nm);
-                        }
-                    }
-                }
-                TermKind::Quant { binder, body, .. } => {
-                    let old_smaller = self.smaller_than.clone();
-                    for (name, _) in binder {
-                        self.smaller_than.remove(&name.0);
-                    }
-                    self.visit_term(body);
-                    self.smaller_than = old_smaller;
-                }
-
-                TermKind::Let { pattern, arg, body } => {
-                    self.visit_term(arg);
-                    let mut binds = Default::default();
-                    pattern.binds(&mut binds);
-                    let old_smaller = self.smaller_than.clone();
-                    self.smaller_than.retain(|nm, _| !binds.contains(nm));
-                    binds.into_iter().for_each(|b| self.smaller_than(b, arg));
-                    self.visit_term(body);
-                    self.smaller_than = old_smaller;
-                }
-
-                TermKind::Match { arms, scrutinee } => {
-                    self.visit_term(scrutinee);
-
-                    for (pat, exp) in arms {
-                        let mut binds = Default::default();
-                        pat.binds(&mut binds);
-                        let old_smaller = self.smaller_than.clone();
-                        self.smaller_than.retain(|nm, _| !binds.contains(nm));
-                        binds.into_iter().for_each(|b| self.smaller_than(b, scrutinee));
-                        self.visit_term(exp);
-                        self.smaller_than = old_smaller;
-                    }
-                }
-                _ => super_visit_term(term, self),
-            }
-        }
-    }
-
-    let orig_args = ctx.sig(self_id).inputs.iter().map(|a| a.0.0).collect();
-    let mut s = StructuralRecursion {
-        self_id,
-        smaller_than: Default::default(),
-        decreasing_args: Default::default(),
-        orig_args,
-    };
-
-    s.visit_term(t);
-
-    s.valid()
 }
 
 // We use Fn because some continuations may be called several times (in the case
@@ -353,8 +224,6 @@ impl<'tcx> VCGen<'_, 'tcx> {
                     let variant = pre_sig.contract.variant.clone();
                     if let Some(variant) = variant {
                         self.build_variant(&args, variant)
-                    } else if self.structurally_recursive {
-                        Exp::mk_true()
                     } else {
                         self.ctx.crash_and_error(
                             self.ctx.def_span(self.self_id),

--- a/creusot/src/translation/pearlite.rs
+++ b/creusot/src/translation/pearlite.rs
@@ -419,6 +419,29 @@ impl<'tcx> Pattern<'tcx> {
             PatternKind::Or(patterns) => patterns.iter().for_each(|f| f.binds(binders)),
         }
     }
+
+    /// Collect bound variables along with whether they represent "stricly smaller" values
+    /// than the scrutinee (this is for the structural recursion check)
+    pub(crate) fn binds_smaller(&self, strictly: bool, binders: &mut Vec<(Ident, bool)>) {
+        match &self.kind {
+            PatternKind::Constructor(_, fields) => {
+                fields.iter().for_each(|(_, f)| f.binds_smaller(true, binders))
+            }
+            PatternKind::Tuple(fields) => {
+                fields.iter().for_each(|f| f.binds_smaller(true, binders))
+            }
+            PatternKind::Wildcard => {}
+            PatternKind::Binder(s, pat) => {
+                binders.push((s.0, strictly));
+                pat.binds_smaller(strictly, binders);
+            }
+            PatternKind::Bool(_) => {}
+            PatternKind::Deref(pointee) => pointee.binds_smaller(strictly, binders),
+            PatternKind::Or(patterns) => {
+                patterns.iter().for_each(|f| f.binds_smaller(strictly, binders))
+            }
+        }
+    }
 }
 
 impl<'tcx> Term<'tcx> {

--- a/creusot/src/validate/terminates.rs
+++ b/creusot/src/validate/terminates.rs
@@ -42,7 +42,7 @@ use crate::{
     ctx::{HasTyCtxt as _, TranslationCtx},
     translation::{
         pearlite::{
-            Term, TermKind,
+            Ident, PIdent, Pattern, ScopedTerm, Term, TermKind,
             visit::{TermVisitor, super_visit_term},
         },
         traits::{ImplSource_, TraitResolved},
@@ -59,6 +59,7 @@ use rustc_hir::{
     def::DefKind,
     def_id::{DefId, LocalDefId},
 };
+use rustc_index::bit_set::DenseBitSet;
 use rustc_infer::{infer::TyCtxtInferExt as _, traits::ObligationCause};
 use rustc_middle::{
     thir::{self, visit::Visitor},
@@ -70,7 +71,7 @@ use rustc_span::Span;
 use rustc_trait_selection::traits::{
     normalize_param_env_or_error, specialization_graph, translate_args,
 };
-use std::iter::repeat;
+use std::{collections::HashMap, iter::repeat};
 
 pub(crate) type RecursiveCalls = IndexMap<DefId, IndexSet<DefId>>;
 
@@ -110,24 +111,28 @@ pub(crate) fn validate_terminates(ctx: &TranslationCtx) -> RecursiveCalls {
     for fun_index in call_graph.node_indices() {
         let def_id = call_graph.node_weight(fun_index).unwrap().def_id();
         if let Some(self_edge) = call_graph.edges_connecting(fun_index, fun_index).next() {
+            assert!(def_id.is_local());
             let (self_edge, call) = (self_edge.id(), *self_edge.weight());
             let CallKind::Direct(span) = call else { continue };
             call_graph.remove_edge(self_edge);
-            if !is_pearlite(ctx.tcx, def_id)
-                && !has_variant_clause(ctx.tcx, def_id)
-                && def_id.is_local()
-            {
-                let fun_span = ctx.def_span(def_id);
-                let mut error =
-                    ctx.error(fun_span, "Recursive function without a `#[variant]` clause");
-                error.span_note(span, "Recursive call happens here");
-                error.emit();
-            }
-            if is_pearlite(ctx.tcx, def_id) && !has_variant_clause(ctx.tcx, def_id) {
-                // Allow simple recursion in logic functions
+            if has_variant_clause(ctx.tcx, def_id) {
+                recursive_calls.entry(def_id).or_default().insert(def_id);
                 continue;
             }
-            recursive_calls.entry(def_id).or_default().insert(def_id);
+            let pearlite = is_pearlite(ctx.tcx, def_id);
+            if pearlite && is_structurally_recursive(ctx, def_id) {
+                // Termination is guaranteed, we can forget that this function is recursive.
+                continue;
+            }
+            let fun_span = ctx.def_span(def_id);
+            let msg = if pearlite {
+                "Recursive logic function without a #[variant] clause or a structurally decreasing argument"
+            } else {
+                "Recursive program function without a `#[variant]` clause"
+            };
+            let mut error = ctx.error(fun_span, msg);
+            error.span_note(span, "Recursive call happens here");
+            error.emit();
         };
     }
 
@@ -652,4 +657,114 @@ impl<'tcx> TermVisitor<'tcx> for TermCalls<'tcx> {
             self.results.insert((*id, subst, term.span));
         }
     }
+}
+
+/// Verifies whether a given term is structurally recursive: that is, each
+/// recursive call is made to a component of an argument to the prior call.
+///
+/// The check must also ensure that we are always recursing on the *same*
+/// argument since otherwise we could 'ping pong' infinitely.
+///
+/// This check can be extended in the future
+fn is_structurally_recursive<'tcx>(ctx: &TranslationCtx<'tcx>, self_id: DefId) -> bool {
+    struct StructuralRecursion<'a> {
+        /// A tuple `(v, (root, strictly))` in this map means that
+        /// `v` is smaller than `root` (or `strictly` smaller)
+        smaller_than: HashMap<Ident, (Ident, bool)>,
+        self_id: DefId,
+        /// Candidate decreasing arguments
+        decreasing_args: DenseBitSet<usize>,
+        args: &'a [PIdent],
+    }
+
+    impl StructuralRecursion<'_> {
+        fn valid(&self) -> bool {
+            !self.decreasing_args.is_empty()
+        }
+
+        /// `t` is strictly smaller than `arg`
+        fn is_smaller_than(&self, t: &Term, arg: Ident) -> bool {
+            self.root(t) == Some((arg, true))
+        }
+
+        /// Find argument that `t` is smaller than, if any
+        fn root(&self, t: &Term) -> Option<(Ident, bool)> {
+            let (var, strictly) = local_root(t)?;
+            let &(nm, strictly2) = self.smaller_than.get(&var)?;
+            Some((nm, strictly || strictly2))
+        }
+
+        /// Record that the variables in `pat` are smaller (possibly `strictly`) than the root, if any
+        fn bind_smaller(&mut self, root: Ident, strictly: bool, pat: &Pattern) {
+            let mut binds = Vec::new();
+            pat.binds_smaller(false, &mut binds);
+            binds.into_iter().for_each(|(b, strictly2)| {
+                self.smaller_than.insert(b, (root, strictly || strictly2));
+            })
+        }
+    }
+
+    /// Return a variable `v` such that the value of `t` is a substructure of `v`,
+    /// and `true` if it is a strictly smaller substructure.
+    fn local_root(mut t: &Term) -> Option<(Ident, bool)> {
+        let mut strictly = false;
+        loop {
+            match &t.kind {
+                TermKind::Var(var) => return Some((var.0, strictly)),
+                TermKind::Coerce { arg } => {
+                    t = arg;
+                    continue;
+                }
+                TermKind::Projection { lhs, .. } => {
+                    t = lhs;
+                    strictly = true;
+                    continue;
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    impl TermVisitor<'_> for StructuralRecursion<'_> {
+        fn visit_term(&mut self, term: &Term<'_>) {
+            match &term.kind {
+                TermKind::Call { id, args, .. } if *id == self.self_id => {
+                    for (i, (arg, nm)) in args.iter().zip(self.args.iter()).enumerate() {
+                        if !self.is_smaller_than(arg, nm.0) {
+                            self.decreasing_args.remove(i);
+                        }
+                    }
+                }
+                // Recall that binders in `Term` are already unique, so we can just process all the binders
+                // ahead of time, without deleting unbound variables when descending in different subterms.
+                TermKind::Let { pattern, arg, .. } => {
+                    if let Some((root, strictly)) = self.root(arg) {
+                        self.bind_smaller(root, strictly, pattern);
+                    }
+                }
+                TermKind::Match { arms, scrutinee } => {
+                    if let Some((root, strictly)) = self.root(scrutinee) {
+                        for (pat, _) in arms {
+                            self.bind_smaller(root, strictly, pat);
+                        }
+                    }
+                }
+                _ => {}
+            }
+            super_visit_term(term, self)
+        }
+    }
+
+    let ScopedTerm(args, term) = &ctx.term(self_id).unwrap();
+
+    let mut s = StructuralRecursion {
+        self_id,
+        smaller_than: args.iter().map(|ident| (ident.0, (ident.0, false))).collect(),
+        decreasing_args: DenseBitSet::new_filled(args.len()),
+        args,
+    };
+
+    s.visit_term(term);
+
+    s.valid()
 }

--- a/tests/should_fail/bug/1966.rs
+++ b/tests/should_fail/bug/1966.rs
@@ -1,0 +1,50 @@
+// SHORT_ERROR
+extern crate creusot_std;
+use creusot_std::prelude::*;
+
+#[logic]
+#[ensures(false)]
+#[allow(unconditional_recursion)]
+pub fn falso() {
+    falso()
+}
+
+pub trait Tr {
+    #[logic]
+    fn me(self);
+}
+
+impl<T> Tr for T {
+    #[logic]
+    #[allow(unconditional_recursion)]
+    fn me(self) {
+        self.me() // Make sure to resolve the instance to see the loop
+    }
+}
+
+pub struct Never(Box<Never>);
+
+#[logic]
+#[allow(unconditional_recursion)]
+pub fn sneak(n: Never) {
+    match n {
+        Never(m) => sneak(*m),
+    }
+    sneak(n) // the termination check once accepted if the argument decreased in at least one call
+}
+
+#[logic]
+#[allow(unconditional_recursion)]
+pub fn nonstrictly(i: usize) {
+    match i {
+        i => nonstrictly(i), // not strict subterm
+    }
+}
+
+#[logic]
+#[allow(unconditional_recursion)]
+pub fn nested(n: Never, _: ()) {
+    match n {
+        Never(m) => nested(*m, nested(n, ())), // remember to check arguments of the recursive function!
+    }
+}

--- a/tests/should_fail/bug/1966.stderr
+++ b/tests/should_fail/bug/1966.stderr
@@ -1,0 +1,6 @@
+1966.rs:8:1: error: Recursive logic function without a #[variant] clause or a structurally decreasing argument
+1966.rs:20:5: error: Recursive logic function without a #[variant] clause or a structurally decreasing argument
+1966.rs:29:1: error: Recursive logic function without a #[variant] clause or a structurally decreasing argument
+1966.rs:38:1: error: Recursive logic function without a #[variant] clause or a structurally decreasing argument
+1966.rs:46:1: error: Recursive logic function without a #[variant] clause or a structurally decreasing argument
+error: aborting due to 5 previous errors

--- a/tests/should_fail/terminates/invalid_variant_type.stderr
+++ b/tests/should_fail/terminates/invalid_variant_type.stderr
@@ -20,7 +20,7 @@ help: the trait `creusot_std::logic::WellFounded` is not implemented for `S`
             (T0, T1, T2, T3, T4, T5, T6)
           and 16 others
 note: required by a bound in `creusot_std::__stubs::variant_check`
- --> creusot-std/src/stubs.rs:58:0
+ --> creusot-std/src/stubs.rs:59:0
 
 error: aborting due to 1 previous error
 

--- a/tests/should_fail/terminates/simple_recursion.stderr
+++ b/tests/should_fail/terminates/simple_recursion.stderr
@@ -1,4 +1,4 @@
-error: Recursive function without a `#[variant]` clause
+error: Recursive program function without a `#[variant]` clause
  --> simple_recursion.rs:6:1
   |
 6 | fn recurses(b: bool) {


### PR DESCRIPTION
Fix #1966

~~There are quite a few tests with structurally recursive functions, so they need `#[trusted]`. Or we could implement a check for structural recursion, or define it as a well-founded relation.~~ EDIT: see first comment.