### PR TITLE
Improve erasure of function values

### DIFF
--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -3,7 +3,7 @@ use crate::{
     callbacks,
     contracts_items::{
         Intrinsic, gather_intrinsics, get_creusot_item, is_extern_spec, is_logic, is_opaque,
-        is_open_inv_param, is_prophetic, opacity_witness_name,
+        is_open_inv_param, is_prophetic, is_trusted, opacity_witness_name,
     },
     metadata::{BinaryMetadata, Metadata, encode_def_ids, get_erasure_required},
     naming::{ComaNames, ModulePath, lowercase_prefix},
@@ -176,7 +176,7 @@ pub struct TranslationCtx<'tcx> {
     extern_specs: HashMap<DefId, ExternSpec<'tcx>>,
     extern_spec_items: HashMap<LocalDefId, DefId>,
     erased_local_defid: HashMap<LocalDefId, Option<Erasure<'tcx>>>,
-    erasures_to_check: IndexMap<LocalDefId, Erasure<'tcx>>,
+    erasures_to_check: IndexSet<LocalDefId>,
     coma_names: ComaNames,
     params_open_inv: HashMap<DefId, DenseBitSet<usize>>,
     laws: OnceMap<DefId, Vec<DefId>>,
@@ -547,13 +547,13 @@ impl<'tcx> TranslationCtx<'tcx> {
     pub(crate) fn load_erasures(&mut self) {
         for def_id in self.tcx.hir_body_owners() {
             let thir = self.tcx.thir_body(def_id).unwrap_or_else(|err| err.raise_fatal());
-            let Some((eraser, erasure, to_check)) = extract_erasure_from_item(self, def_id, thir)
-            else {
+            let Some((eraser, erasure)) = extract_erasure_from_item(self, def_id, thir) else {
                 continue;
             };
             self.erased_local_defid.insert(eraser, erasure);
-            if let Some(to_check) = to_check {
-                self.erasures_to_check.insert(eraser, to_check);
+            if !is_trusted(self.tcx, eraser.to_def_id()) {
+                // erasure can't be None (`#[erasure(_)]` must be `#[trusted]`)
+                self.erasures_to_check.insert(eraser);
             }
         }
         if self.erasures_to_check.is_empty() {
@@ -561,8 +561,8 @@ impl<'tcx> TranslationCtx<'tcx> {
         }
         for def_id in self.tcx.hir_body_owners() {
             if let Some(erasure) = extract_erasure_from_child(self, def_id) {
-                self.erased_local_defid.insert(def_id, Some(erasure.clone()));
-                self.erasures_to_check.insert(def_id, erasure);
+                self.erased_local_defid.insert(def_id, Some(erasure));
+                self.erasures_to_check.insert(def_id);
             }
         }
     }
@@ -570,7 +570,7 @@ impl<'tcx> TranslationCtx<'tcx> {
     pub(crate) fn iter_erasures_to_check(
         &self,
     ) -> impl Iterator<Item = (&LocalDefId, &Erasure<'tcx>)> {
-        self.erasures_to_check.iter()
+        self.erasures_to_check.iter().map(|id| (id, self.erased_local_defid[id].as_ref().unwrap()))
     }
 
     pub(crate) fn write_erasure_required(&self) {
@@ -640,10 +640,6 @@ impl<'tcx> TranslationCtx<'tcx> {
             Some(local) => self.erased_local_defid.get(&local),
             None => self.externs.erasure(def_id),
         }
-    }
-
-    pub(crate) fn erasure_to_check(&self, def_id: LocalDefId) -> Option<&Erasure<'tcx>> {
-        self.erasures_to_check.get(&def_id)
     }
 
     /// If `true`, the type is definitely non-zero sized. This is a best-effort underapproximation.

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -199,75 +199,64 @@ impl<'a, 'tcx> thir::visit::Visitor<'a, 'tcx> for ExtractExternItem<'a, 'tcx> {
 /// Input: `local_def_id` of a `#[creusot::spec::erasure]` closure.
 /// Output:
 /// - `LocalDefId` of the original `#[erasure]` item (the parent of the input id)
-/// - `Option<Erasure<'tcx>>` info about the erased function from the point of view of callers
-///   (THIR trait method calls are not resolved), or `None` for ghost .
-/// - `Option<Erasure<'tcx>>` of the actual body of the erased function, if
-///   the `#[erasure]`-carrying function is not also `#[trusted]`.
+/// - `Option<Erasure<'tcx>>` of that item, or `None` for ghost erasures.
 pub(crate) fn extract_erasure_from_item<'tcx>(
     ctx: &TranslationCtx<'tcx>,
     local_def_id: LocalDefId,
     (thir, expr): ThirExpr<'tcx>,
-) -> Option<(LocalDefId, Option<Erasure<'tcx>>, Option<Erasure<'tcx>>)> {
+) -> Option<(LocalDefId, Option<Erasure<'tcx>>)> {
     let def_id = local_def_id.to_def_id();
-    let (id_this, (id_erased, subst_erased), (id_resolved, subst_resolved)) =
-        match get_erasure(ctx.tcx, def_id) {
-            None => return None,
-            Some(ErasureKind::Parent) => {
-                let parent = ctx.tcx.parent(def_id);
-                let (id_erased, subst_erased) = extract_extern_item(&thir.borrow(), expr).unwrap();
-                debug!("extract_erasure_from_item: {parent:?} erases to {id_erased:?}");
-                let (id_resolved, subst_resolved) = TraitResolved::resolve_item(
-                    ctx.tcx,
-                    ctx.typing_env(def_id),
-                    id_erased,
-                    subst_erased,
+    let (id_this, (id_resolved, subst_resolved)) = match get_erasure(ctx.tcx, def_id) {
+        None => return None,
+        Some(ErasureKind::Parent) => {
+            let parent = ctx.tcx.parent(def_id);
+            let (id_erased, subst_erased) = extract_extern_item(&thir.borrow(), expr).unwrap();
+            debug!("extract_erasure_from_item: {parent:?} erases to {id_erased:?}");
+            let (id_resolved, subst_resolved) = TraitResolved::resolve_item(
+                ctx.tcx,
+                ctx.typing_env(def_id),
+                id_erased,
+                subst_erased,
+            )
+            .to_opt(id_erased, subst_erased)
+            .unwrap_or_else(|| {
+                ctx.crash_and_error(ctx.def_span(def_id), "could not resolve `#[erasure]` target")
+            });
+            (parent, (id_resolved, subst_resolved))
+        }
+        Some(ErasureKind::Private(path)) => {
+            debug!("extract_erasure_from_item: {def_id:?} erases to private {path:?}");
+            let id_erased = forge_def_id(ctx.tcx, &path)
+                .unwrap_or_else(|e| ctx.crash_and_error(ctx.def_span(def_id), e));
+            let subst_erased = erased_identity_for_item(ctx.tcx, id_erased);
+            let subst_this = erased_identity_for_item(ctx.tcx, def_id);
+            if !eq_nameless_generic_args(subst_erased, subst_this) {
+                ctx.crash_and_error(
+                    ctx.def_span(def_id),
+                    format!(
+                        "#[erasure] generics don't match\n {} {:?}\n {} {:?}",
+                        ctx.def_path_str(def_id),
+                        subst_this,
+                        ctx.def_path_str(id_erased),
+                        subst_erased,
+                    ),
                 )
-                .to_opt(id_erased, subst_erased)
-                .unwrap_or_else(|| {
-                    ctx.crash_and_error(
-                        ctx.def_span(def_id),
-                        "could not resolve `#[erasure]` target",
-                    )
-                });
-                (parent, (id_erased, subst_erased), (id_resolved, subst_resolved))
             }
-            Some(ErasureKind::Private(path)) => {
-                debug!("extract_erasure_from_item: {def_id:?} erases to private {path:?}");
-                let id_erased = forge_def_id(ctx.tcx, &path)
-                    .unwrap_or_else(|e| ctx.crash_and_error(ctx.def_span(def_id), e));
-                let subst_erased = erased_identity_for_item(ctx.tcx, id_erased);
-                let subst_this = erased_identity_for_item(ctx.tcx, def_id);
-                if !eq_nameless_generic_args(subst_erased, subst_this) {
-                    ctx.crash_and_error(
-                        ctx.def_span(def_id),
-                        format!(
-                            "#[erasure] generics don't match\n {} {:?}\n {} {:?}",
-                            ctx.def_path_str(def_id),
-                            subst_this,
-                            ctx.def_path_str(id_erased),
-                            subst_erased,
-                        ),
-                    )
-                }
-                (def_id, (id_erased, subst_erased), (id_erased, subst_erased))
+            (def_id, (id_erased, subst_erased))
+        }
+        Some(ErasureKind::Ghost) => {
+            if !is_trusted(ctx.tcx, def_id) {
+                ctx.crash_and_error(
+                    ctx.def_span(def_id),
+                    format!("#[erasure(_)] requires the #[trusted] attribute"),
+                )
             }
-            Some(ErasureKind::Ghost) => {
-                if !is_trusted(ctx.tcx, def_id) {
-                    ctx.crash_and_error(
-                        ctx.def_span(def_id),
-                        format!("#[erasure(_)] requires the #[trusted] attribute"),
-                    )
-                }
-                return Some((local_def_id, None, None));
-            }
-        };
-    let erased = build_erased(ctx.tcx, ctx.typing_env(id_this), id_this, id_erased, subst_erased);
-    let to_check = if is_trusted(ctx.tcx, id_this) {
-        None
-    } else {
-        Some(Erasure { def: (id_resolved, subst_resolved), erase_args: erased.erase_args.clone() })
+            return Some((local_def_id, None));
+        }
     };
-    Some((id_this.expect_local(), Some(erased), to_check))
+    let erased =
+        build_erased(ctx.tcx, ctx.typing_env(id_this), id_this, id_resolved, subst_resolved);
+    Some((id_this.expect_local(), Some(erased)))
 }
 
 /// Extract erasure for nested items
@@ -291,11 +280,10 @@ pub(crate) fn extract_erasure_from_child<'tcx>(
         if is_trusted(ctx.tcx, parent) {
             return None;
         };
-        match ctx.erasure_to_check(LocalDefId { local_def_index: parent.index }) {
-            Some(erased) => break erased,
-            None => {
-                continue;
-            }
+        if let Some(Some(erased)) =
+            ctx.erasure(LocalDefId { local_def_index: parent.index }.to_def_id())
+        {
+            break erased;
         }
     };
     debug!("extract_erasure_from_child: child: {local_def_id:?} parent: {:?}", erased_parent.def.0);

--- a/creusot/src/validate/erasure.rs
+++ b/creusot/src/validate/erasure.rs
@@ -31,7 +31,7 @@ use rustc_middle::{
 };
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_span::{DUMMY_SP, Span, SpanDecoder, SpanEncoder};
-use rustc_type_ir::{Interner, VisitorResult as _};
+use rustc_type_ir::{Interner, TypeFoldable, TypeSuperFoldable as _, VisitorResult as _};
 
 use crate::{
     backend::is_trusted_item,
@@ -450,10 +450,16 @@ enum AnfPattern {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, TypeVisitable, TypeFoldable, TyDecodable, TyEncodable)]
+enum ErasureInfo {
+    Ghost,
+    EraseArgs(Vec<bool>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, TypeVisitable, TypeFoldable, TyDecodable, TyEncodable)]
 enum AnfValue<'tcx> {
     Unit,
     Var(Var),
-    Fn(DefId, NamelessGenericArgs<'tcx>),
+    Fn(DefId, NamelessGenericArgs<'tcx>, Option<ErasureInfo>),
     Literal(
         #[type_visitable(ignore)]
         #[type_foldable(identity)]
@@ -794,49 +800,36 @@ impl<'a, 'tcx> AnfBuilder<'a, 'tcx> {
             Call { fun, args, .. } => {
                 let fun = self.a_normal_form_expr(*fun, stmts)?;
                 match fun.0 {
-                    AnfValue::Fn(fun_id, _)
+                    AnfValue::Fn(fun_id, _, _)
                         if let Some(ctx) = self.ctx
                             && Intrinsic::SnapshotFromFn.is(ctx, fun_id) =>
                     {
                         AnfValue::Unit
                     }
-                    AnfValue::Fn(fun_id, subst) => 'fun: {
+                    AnfValue::Fn(fun_id, subst, ref erasure) => 'fun: {
                         let args = args
                             .iter()
                             .map(|arg| self.a_normal_form_expr(*arg, stmts))
                             .collect::<Result<Vec<_>, _>>()?;
-                        let (fun_id_resolved, subst_resolved) =
-                            TraitResolved::resolve_item(self.tcx, self.typing_env, fun_id, subst.0)
-                                .to_opt(fun_id, subst.0)
-                                .unwrap_or_else(|| {
-                                    self.tcx.crash_and_error(
-                                        self.span(),
-                                        "could not resolve call in `#[erasure]` check",
-                                    )
-                                });
-                        let (fun_id, subst, args) = if let Some(erased) =
-                            self.ctx.and_then(|ctx| ctx.erasure(fun_id_resolved))
-                        {
-                            let Some(erased) = erased else { break 'fun AnfValue::Unit };
-                            let args = args
-                                .into_iter()
-                                .zip(&erased.erase_args)
+                        let args = if let Some(erasure) = erasure {
+                            let ErasureInfo::EraseArgs(erased) = erasure else {
+                                break 'fun AnfValue::Unit;
+                            };
+                            args.into_iter()
+                                .zip(erased)
                                 .filter_map(|(arg, &erase)| if erase { None } else { Some(arg) })
-                                .collect();
-                            let subst = ty::EarlyBinder::bind(erased.def.1)
-                                .instantiate(self.tcx, subst_resolved);
-                            (erased.def.0, (*subst).into(), args)
-                        } else if let Some(ctx) = self.ctx
+                                .collect()
+                        } else {
+                            args
+                        };
+                        if let Some(ctx) = self.ctx
                             && let Intrinsic::PermAsRef | Intrinsic::PermAsMut =
                                 ctx.intrinsic(fun_id)
                         {
                             let arg0 = args.into_iter().next().unwrap();
                             let mut place = std::boxed::Box::new(AnfPlace::immut(arg0.0));
                             place.add_deref(true); // Add unsafe deref
-                            break 'fun bind_var(
-                                stmts,
-                                AnfOp::unsafe_borrow((AnfValue::Borrow(place), arg0.1)),
-                            );
+                            bind_var(stmts, AnfOp::unsafe_borrow((AnfValue::Borrow(place), arg0.1)))
                         } else if let Some(ctx) = self.ctx
                             && let Intrinsic::PermFromRef | Intrinsic::PermFromMut =
                                 ctx.intrinsic(fun_id)
@@ -844,11 +837,10 @@ impl<'a, 'tcx> AnfBuilder<'a, 'tcx> {
                             let arg0 = args.into_iter().next().unwrap();
                             let mut place = AnfPlace::immut(arg0.0);
                             place.add_deref(false);
-                            break 'fun place.raw_borrow();
+                            place.raw_borrow()
                         } else {
-                            (fun_id, subst, args)
-                        };
-                        bind_var(stmts, AnfOp::call(fun_id, subst, args))
+                            bind_var(stmts, AnfOp::call(fun_id, subst, args))
+                        }
                     }
                     _ => {
                         return Err(
@@ -858,7 +850,33 @@ impl<'a, 'tcx> AnfBuilder<'a, 'tcx> {
                 }
             }
             ZstLiteral { .. } => match expr.ty.kind() {
-                ty::TyKind::FnDef(def_id, subst) => AnfValue::Fn(*def_id, (*subst).into()),
+                &ty::TyKind::FnDef(fun_id, subst) => {
+                    let (mut fun_id, mut subst) =
+                        TraitResolved::resolve_item(self.tcx, self.typing_env, fun_id, subst)
+                            .to_opt(fun_id, subst)
+                            .unwrap_or_else(|| {
+                                self.tcx.crash_and_error(
+                                    self.span(),
+                                    "could not resolve call in `#[erasure]` check",
+                                )
+                            });
+                    let mut erasure_info = None;
+                    if let Some(ctx) = self.ctx {
+                        subst = erase_types(ctx, subst);
+                        if let Some(erasure) = ctx.erasure(fun_id) {
+                            if let Some(erasure) = erasure {
+                                fun_id = erasure.def.0;
+                                subst = ty::EarlyBinder::bind(erasure.def.1)
+                                    .instantiate(self.tcx, subst);
+                                erasure_info =
+                                    Some(ErasureInfo::EraseArgs(erasure.erase_args.clone()));
+                            } else {
+                                erasure_info = Some(ErasureInfo::Ghost);
+                            }
+                        }
+                    }
+                    AnfValue::Fn(fun_id, subst.into(), erasure_info)
+                }
                 _ => AnfValue::Unit,
             },
             Binary { op, lhs, rhs } => {
@@ -1316,6 +1334,37 @@ fn is_erasable(tcx: TyCtxt, thir: &Thir, expr: ExprId) -> bool {
     }
 }
 
+/// Replace function types with their erasure when it exists
+/// (This is very simplistic and experimental)
+fn erase_types<'tcx, T: TypeFoldable<TyCtxt<'tcx>>>(ctx: &TranslationCtx<'tcx>, t: T) -> T {
+    struct Eraser<'a, 'tcx>(&'a TranslationCtx<'tcx>);
+
+    impl<'tcx> ty::TypeFolder<TyCtxt<'tcx>> for Eraser<'_, 'tcx> {
+        fn cx(&self) -> TyCtxt<'tcx> {
+            self.0.tcx()
+        }
+
+        fn fold_ty(&mut self, t: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
+            match t.kind() {
+                &ty::TyKind::FnDef(fun_id, args)
+                    if let Some(Some(erasure)) = self.0.erasure(fun_id) =>
+                {
+                    let tcx = self.cx();
+                    ty::Ty::new_fn_def(
+                        tcx,
+                        erasure.def.0,
+                        ty::EarlyBinder::bind(erasure.def.1).instantiate(tcx, args),
+                    )
+                }
+                _ => t,
+            }
+            .super_fold_with(self)
+        }
+    }
+
+    t.fold_with(&mut Eraser(ctx))
+}
+
 ////////////////////////////////////////////////////////////////
 // * Equality checking
 ////////////////////////////////////////////////////////////////
@@ -1357,7 +1406,7 @@ impl<'tcx> EqualityChecker<'tcx> {
             (Field(variant1, field1, v1), Field(variant2, field2, v2)) => {
                 variant1 == variant2 && field1 == field2 && self.equate_value(v1, v2)
             }
-            (Fn(f1, s1), Fn(f2, s2)) => f1 == f2 && s1 == s2,
+            (Fn(f1, s1, _), Fn(f2, s2, _)) => f1 == f2 && s1 == s2,
             (Cast(from1, to1, value1), Cast(from2, to2, value2)) => {
                 from1 == from2 && to1 == to2 && self.equate_value(value1, value2)
             }
@@ -1796,7 +1845,7 @@ impl<'tcx> PrintAnf<'tcx> {
                 self.print_value(value, f)?;
                 write!(f, ")")
             }
-            &Fn(def_id, subst) => write!(
+            &Fn(def_id, subst, _) => write!(
                 f,
                 "fn {}{}",
                 self.tcx.def_path_str(def_id),

--- a/tests/should_succeed/specification/erasure.coma
+++ b/tests/should_succeed/specification/erasure.coma
@@ -1062,3 +1062,76 @@ module M_slice_as_mut_ptr_perm
     {[@stop_split] [@expl:slice_as_mut_ptr_perm result type invariant] inv_tup2_ptr_T_Ghost_refmut_Perm_ptr_slice_T result}
       (! return {result}) ]
 end
+module M_apply
+  use creusot.int.Int32
+  use creusot.prelude.Any
+  
+  type t_F
+  
+  predicate inv_F (_1: t_F)
+  
+  predicate precondition_F (self: t_F) (args: Int32.t)
+  
+  predicate postcondition_once_F (self: t_F) (args: Int32.t) (result: Int32.t)
+  
+  let rec call_once_F (self_: t_F) (arg: Int32.t) (return (x: Int32.t)) =
+    {[@stop_split] [@expl:call_once_F requires] ([@stop_split] [@expl:call_once 'self_' type invariant] inv_F self_)
+    /\ ([@stop_split] [@expl:call_once requires] precondition_F self_ arg)}
+    any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:call_once ensures] postcondition_once_F self_ arg result}
+      (! return {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec apply_F (f: t_F) (return (x: Int32.t)) =
+    {[@stop_split] [@expl:apply_F requires] ([@stop_split] [@expl:apply 'f' type invariant] inv_F f)
+    /\ ([@stop_split] [@expl:apply requires] precondition_F f (0: Int32.t))}
+    (! bb0
+    [ bb0 = s0
+      [ s0 = [ &_5 <- (0: Int32.t) ] s1
+      | s1 = call_once_F {f} {_5} (fun (_x: Int32.t) -> [ &_ret <- _x ] s2)
+      | s2 = return {_ret} ] ] [ & _ret: Int32.t = Any.any_l () | & f: t_F = f | & _5: Int32.t = Any.any_l () ])
+    [ return (result: Int32.t) -> (! return {result}) ]
+end
+module M_apply_test
+  use creusot.int.Int32
+  use creusot.prelude.Any
+  
+  predicate precondition_foo [@inline:trivial] (self: ()) (args: Int32.t) = let x = args in true
+  
+  meta "rewrite_def" predicate precondition_foo
+  
+  let rec apply_foo (f: ()) (return (x: Int32.t)) =
+    {[@stop_split] [@expl:apply requires] precondition_foo f (0: Int32.t)}
+    any [ return (result: Int32.t) -> (! return {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec apply_test (return (x: Int32.t)) = (! bb0
+    [ bb0 = s0 [ s0 = apply_foo {()} (fun (_x: Int32.t) -> [ &_ret <- _x ] s1) | s1 = return {_ret} ] ]
+    [ & _ret: Int32.t = Any.any_l () ]) [ return (result: Int32.t) -> (! return {result}) ]
+end
+module M_apply_test2
+  use creusot.int.Int32
+  use creusot.prelude.Any
+  
+  predicate precondition_foo3 [@inline:trivial] (self: ()) (args: Int32.t) = let x = args in true
+  
+  meta "rewrite_def" predicate precondition_foo3
+  
+  let rec apply_foo3 (f: ()) (return (x: Int32.t)) =
+    {[@stop_split] [@expl:apply requires] precondition_foo3 f (0: Int32.t)}
+    any [ return (result: Int32.t) -> (! return {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec apply_test2 (return (x: Int32.t)) = (! bb0
+    [ bb0 = s0 [ s0 = apply_foo3 {()} (fun (_x: Int32.t) -> [ &_ret <- _x ] s1) | s1 = return {_ret} ] ]
+    [ & _ret: Int32.t = Any.any_l () ]) [ return (result: Int32.t) -> (! return {result}) ]
+end

--- a/tests/should_succeed/specification/erasure.rs
+++ b/tests/should_succeed/specification/erasure.rs
@@ -1,3 +1,4 @@
+#![feature(core_intrinsics)]
 extern crate creusot_std;
 use creusot_std::{ghost::perm::Perm, prelude::*};
 
@@ -180,4 +181,18 @@ pub fn slice_as_mut_ptr<T>(s: &mut [T]) -> *mut T {
 #[erasure(slice_as_mut_ptr)]
 pub fn slice_as_mut_ptr_perm<T>(s: &mut [T]) -> (*mut T, Ghost<&mut Perm<*const [T]>>) {
     s.as_mut_ptr_perm()
+}
+
+#[requires(f.precondition((0i32,)))]
+pub fn apply<F: FnOnce(i32) -> i32>(f: F) -> i32 {
+    f(0)
+}
+
+pub fn apply_test() -> i32 {
+    apply(foo)
+}
+
+#[erasure(apply_test)]
+pub fn apply_test2() -> i32 {
+    apply(foo3)
 }

--- a/tests/should_succeed/specification/erasure/proof.json
+++ b/tests/should_succeed/specification/erasure/proof.json
@@ -6,6 +6,18 @@
     { "prover": "cvc4@1.8", "size": 45, "time": 0.45 }
   ],
   "proofs": {
+    "M_apply": {
+      "vc_apply_F": { "tactic": "compute_specified", "children": [] },
+      "vc_call_once_F": { "prover": "alt-ergo@2.6.2", "time": 0.015 }
+    },
+    "M_apply_test": {
+      "vc_apply_foo": { "prover": "alt-ergo@2.6.2", "time": 0.016 },
+      "vc_apply_test": { "prover": "alt-ergo@2.6.2", "time": 0.015 }
+    },
+    "M_apply_test2": {
+      "vc_apply_foo3": { "prover": "alt-ergo@2.6.2", "time": 0.018 },
+      "vc_apply_test2": { "prover": "alt-ergo@2.6.2", "time": 0.017 }
+    },
     "M_baz": { "vc_baz": { "prover": "cvc5@1.3.1", "time": 0.012 } },
     "M_foo": { "vc_foo": { "prover": "cvc5@1.3.1", "time": 0.01 } },
     "M_foo2": { "vc_foo2": { "prover": "cvc5@1.3.1", "time": 0.01 } },


### PR DESCRIPTION
Context: `core` uses [`const_eval_select`](https://doc.rust-lang.org/std/intrinsics/fn.const_eval_select.html) to select between private functions that may or may not perform debug assertions. So in my verified version of `core` functions, erasure needs to transform my private functions that are passed as arguments to `const_eval_select` into their `core` versions.