### PR TITLE
Allow naming of result in `#[ensures]`

### DIFF
--- a/creusot-std-proc/src/creusot/specs.rs
+++ b/creusot-std-proc/src/creusot/specs.rs
@@ -12,7 +12,7 @@ use proc_macro::TokenStream as TS1;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
-    Attribute, Ident, Item, Path, ReturnType, Signature, Stmt, Token, Type, parenthesized,
+    Attribute, Ident, Item, Pat, Path, ReturnType, Signature, Stmt, Token, Type, parenthesized,
     parse::{self, Parse},
     parse_macro_input, parse_quote,
     punctuated::Punctuated,
@@ -78,6 +78,30 @@ pub fn ensures(attr: TS1, tokens: TS1) -> TS1 {
 
     let mut item = parse_macro_input!(tokens as ContractSubject);
     let term = parse_macro_input!(attr as Term);
+    let (result, term) = match term {
+        Term::Closure(closure) => {
+            if closure.inputs.len() != 1 {
+                let span = if closure.inputs.len() == 0 {
+                    closure
+                        .or1_token
+                        .span()
+                        .join(closure.or2_token.span())
+                        .unwrap_or_else(|| Span::call_site())
+                } else {
+                    closure.inputs.span()
+                };
+                return quote::quote_spanned! { span=>
+                    compile_error!{"`#[ensures]` clause expects only one result parameter"}
+                }
+                .into();
+            }
+            (closure.inputs.into_iter().next().unwrap(), *closure.body)
+        }
+        _ => {
+            let result = ident_to_pat(Ident::new("result", Span::call_site()));
+            (result, term)
+        }
+    };
     item.mark_unused();
 
     let ens_name = crate::creusot::generate_unique_ident(&item.name(), Span::call_site());
@@ -87,8 +111,8 @@ pub fn ensures(attr: TS1, tokens: TS1) -> TS1 {
             let attrs = std::mem::take(&mut s.attrs);
             let mut sig = s.sig.clone();
             let result = match sig.output {
-                ReturnType::Default => parse_quote! { result: () },
-                ReturnType::Type(_, ty) => parse_quote! { result: #ty },
+                ReturnType::Default => parse_quote! { #result: () },
+                ReturnType::Type(_, ty) => parse_quote! { #result: #ty },
             };
 
             sig.ident = ens_name.clone();
@@ -109,7 +133,8 @@ pub fn ensures(attr: TS1, tokens: TS1) -> TS1 {
                 ReturnType::Default => parse_quote! { () },
                 ReturnType::Type(_, ref ty) => (**ty).clone(),
             };
-            let ensures_tokens = fn_spec_item(ens_name, FnSpecResultKind::Typed(ty_result), term);
+            let ensures_tokens =
+                fn_spec_item(ens_name, FnSpecResultKind::Typed(result, ty_result), term);
             if let Some(b) = f.body.as_mut() {
                 b.stmts.insert(0, Stmt::Item(Item::Verbatim(ensures_tokens)))
             }
@@ -123,7 +148,7 @@ pub fn ensures(attr: TS1, tokens: TS1) -> TS1 {
         ContractSubject::Closure(mut clos) => {
             let res_id = Ident::new("res", Span::mixed_site());
             let ensures_tokens =
-                fn_spec_item(ens_name, FnSpecResultKind::Unified(res_id.clone()), term);
+                fn_spec_item(ens_name, FnSpecResultKind::Unified(result, res_id.clone()), term);
 
             let body = &clos.body;
             *clos.body = parse_quote!({
@@ -238,9 +263,9 @@ fn spec_attrs(tag: Ident) -> TokenStream {
 }
 
 enum FnSpecResultKind {
-    NoResult,       // No result identifier (for ensures clauses)
-    Typed(Type),    // The result identifier is typed explicitely (i.e. |result : #ty| ... )
-    Unified(Ident), // The type of the result identifier is unified with the type of another variable
+    NoResult,            // No result identifier (for ensures clauses)
+    Typed(Pat, Type),    // The result identifier is typed explicitly (i.e. `|result : #ty| ...`)
+    Unified(Pat, Ident), // The type of the result identifier is unified with the type of another variable
 }
 
 // Generate a token stream for the item representing a specific
@@ -248,9 +273,8 @@ enum FnSpecResultKind {
 fn fn_spec_item(tag: Ident, reskind: FnSpecResultKind, p: Term) -> TokenStream {
     let fn_spec_body = pretyping::encode_term(&p);
     let attrs = spec_attrs(tag);
-    let result = Ident::new("result", Span::call_site());
 
-    let unify_ty_result = if let FnSpecResultKind::Unified(res) = &reskind {
+    let unify_ty_result = if let FnSpecResultKind::Unified(result, res) = &reskind {
         // Tell type inference that res and result have the same type
         quote! { ::creusot_std::__stubs::closure_result(#res, #result); }
     } else {
@@ -259,8 +283,8 @@ fn fn_spec_item(tag: Ident, reskind: FnSpecResultKind, p: Term) -> TokenStream {
 
     let result_bind = match &reskind {
         FnSpecResultKind::NoResult => quote! {},
-        FnSpecResultKind::Unified(_) => quote! { #result },
-        FnSpecResultKind::Typed(ty) => quote! { #result: #ty },
+        FnSpecResultKind::Unified(result, _) => quote! { #result },
+        FnSpecResultKind::Typed(result, ty) => quote! { #result: #ty },
     };
 
     quote! {
@@ -377,4 +401,8 @@ fn maintains_impl(attr: TS1, body: TS1) -> syn::Result<TS1> {
       #body
     }
     .into())
+}
+
+fn ident_to_pat(i: Ident) -> Pat {
+    Pat::Path(syn::ExprPath { attrs: vec![], qself: None, path: i.into() })
 }

--- a/creusot-std/src/lib.rs
+++ b/creusot-std/src/lib.rs
@@ -105,8 +105,8 @@ pub mod macros {
 
     /// A post-condition of a function or trait item
     ///
-    /// The post-condition can refer to the result of the function using
-    /// the special variable `result`.
+    /// The post-condition can refer to the result of the function as
+    /// `result` by default, or by naming it explicitly; see example below.
     ///
     /// The inside of a `ensures` may look like Rust code, but it is in fact
     /// [pearlite](https://creusot-rs.github.io/creusot/guide/pearlite).
@@ -118,6 +118,7 @@ pub mod macros {
     /// ```
     /// # use creusot_std::prelude::*;
     /// #[ensures(result@ == 1)]
+    /// #[ensures(|one| one@ == 1)] // Explicitly name the result variable `one`
     /// fn foo() -> i32 { 1 }
     /// ```
     pub use base_macros::ensures;

--- a/creusot/src/lints.rs
+++ b/creusot/src/lints.rs
@@ -1,5 +1,6 @@
 mod contractless_external_function;
 mod experimental_types;
+mod result_param;
 mod trusted;
 
 use rustc_lint::LintStore;
@@ -8,13 +9,11 @@ use rustc_session::Session;
 use rustc_span::{Span, Symbol};
 
 pub(crate) use contractless_external_function::CONTRACTLESS_EXTERNAL_FUNCTION;
+pub(crate) use result_param::RESULT_PARAM;
 
 use crate::validate;
 
 // Diagnostics for creusot's lints.
-//
-// This only describes the structure of the diagnostics. The actual messages
-// are defined in `creusot/messages.ftl`
 #[derive(Debug, Diagnostic)]
 pub(crate) enum Diagnostics {
     #[diag("used the `#[trusted]` attribute")]
@@ -36,6 +35,10 @@ pub(crate) enum Diagnostics {
     },
     #[diag("support for trait objects (dyn) is limited and experimental")]
     DynExperimental,
+    #[diag(
+        "`result` used as a parameter name. It is confusing because it is also the default name of the function's result"
+    )]
+    ResultParam,
 }
 
 pub fn register_lints(_sess: &Session, store: &mut LintStore) {
@@ -43,6 +46,7 @@ pub fn register_lints(_sess: &Session, store: &mut LintStore) {
         experimental_types::EXPERIMENTAL,
         contractless_external_function::CONTRACTLESS_EXTERNAL_FUNCTION,
         trusted::TRUSTED_CODE,
+        result_param::RESULT_PARAM,
     ]);
     store.register_late_pass(move |_| Box::new(validate::GhostValidate {}));
     store.register_late_pass(move |_| Box::new(experimental_types::Experimental {}));

--- a/creusot/src/lints/result_param.rs
+++ b/creusot/src/lints/result_param.rs
@@ -1,0 +1,8 @@
+use rustc_session::declare_tool_lint;
+
+declare_tool_lint! {
+    /// The `result_param` lint warns when a function parameter is named `result`.
+    pub(crate) creusot::RESULT_PARAM,
+    Warn,
+    "`result` as a parameter name is confusing"
+}

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -2,11 +2,12 @@ use crate::{
     backend::closures::ClosSubst,
     contracts_items::{Intrinsic, creusot_clause_attrs, is_check_ghost, is_check_terminates},
     ctx::*,
+    lints::{Diagnostics, RESULT_PARAM},
     naming::{lowercase_prefix, name},
     translation::pearlite::{Ident, PIdent, Term, normalize},
     util::erased_identity_for_item,
 };
-use rustc_hir::{AttrArgs, Safety, def::DefKind, def_id::DefId};
+use rustc_hir::{AttrArgs, HirId, Safety, def::DefKind, def_id::DefId};
 use rustc_macros::{TyDecodable, TyEncodable, TypeFoldable, TypeVisitable};
 use rustc_middle::{
     thir::{BodyTy, Pat, PatKind, Thir},
@@ -375,7 +376,7 @@ pub(crate) fn pre_sig_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pre
     }
 
     if !presig.contract.extern_no_spec {
-        for (input, _, _) in &presig.inputs {
+        for &(input, span, _) in &presig.inputs {
             if input.0.name() == why3::Symbol::intern("result")
                 && !matches!(
                     ctx.intrinsic(def_id),
@@ -386,10 +387,8 @@ pub(crate) fn pre_sig_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pre
                         | Intrinsic::Precondition
                 )
             {
-                ctx.crash_and_error(
-                    ctx.def_span(def_id),
-                    "`result` is not allowed as a parameter name",
-                )
+                let hir = HirId::make_owner(def_id.expect_local());
+                ctx.tcx.emit_node_span_lint(RESULT_PARAM, hir, span, Diagnostics::ResultParam);
             }
         }
     }

--- a/guide/src/basic_concepts/requires_ensures.md
+++ b/guide/src/basic_concepts/requires_ensures.md
@@ -29,7 +29,8 @@ To learn more, see the chapter on [Pearlite](../pearlite.md) and [Views](../view
 
 ## Postconditions with `ensures`
 
-A _postcondition_ is an assertions that is proven true at the end of the function. The return value of the function can be accessed via the `result` keyword.
+A _postcondition_ is an assertion that is proven true at the end of the function.
+The return value of the function is named `result` by default.
 
 In the case of the example above, we want to assert that the returned integer is the first of the slice:
 
@@ -44,3 +45,18 @@ fn head(v: &[i32]) -> i32 {
 Note that we:
 - use the `@` operator on the slice to get a `Seq<i32>`
 - we can then index this `Seq<i32>` to get a `i32`.
+
+The result variable in an `ensures` clause can be bound explicitly using closure notation:
+
+```rust
+#[ensures(|resultat| v@[0] == resultat)]
+```
+
+The result binder can also be an irrefutable pattern.
+
+```rust
+#[ensures(|(fst, snd)| fst <= snd)]
+pub fn apair() -> (i32, i32) {
+    (0, 1)
+}
+```

--- a/tests/should_fail/result_param.rs
+++ b/tests/should_fail/result_param.rs
@@ -1,6 +1,0 @@
-extern crate creusot_std;
-use creusot_std::prelude::*;
-
-// Should fail saying result is not a valid parameter name
-#[ensures(result == result)]
-pub fn result_arg(result: u32) {}

--- a/tests/should_fail/result_param.stderr
+++ b/tests/should_fail/result_param.stderr
@@ -1,8 +1,0 @@
-error: `result` is not allowed as a parameter name
- --> result_param.rs:6:1
-  |
-6 | pub fn result_arg(result: u32) {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 1 previous error
-

--- a/tests/should_succeed/syntax/05_annotations.coma
+++ b/tests/should_succeed/syntax/05_annotations.coma
@@ -31,3 +31,20 @@ module M_assume
     [ bb0 = s0 [ s0 = -{[@expl:assertion] b}- s1 | s1 = return {_ret} ] ] [ & _ret: () = Any.any_l () | & b: bool = b ])
     [ return (result: ()) -> {[@stop_split] [@expl:assume ensures] b} (! return {result}) ]
 end
+module M_apair
+  use creusot.int.Int64
+  use creusot.prelude.Any
+  
+  type tup2_i64_i64 = { f0: Int64.t; f1: Int64.t }
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec apair (result: Int64.t) (return (x: tup2_i64_i64)) = (! bb0
+    [ bb0 = s0 [ s0 = [ &_ret <- { f0 = result; f1 = result } ] s1 | s1 = return {_ret} ] ]
+    [ & _ret: tup2_i64_i64 = Any.any_l () | & result: Int64.t = result ])
+    [ return (result'0: tup2_i64_i64) -> {[@stop_split] [@expl:apair ensures] let {f0 = fst; f1 = snd} = result'0 in fst
+      = snd}
+      (! return {result'0}) ]
+end

--- a/tests/should_succeed/syntax/05_annotations.rs
+++ b/tests/should_succeed/syntax/05_annotations.rs
@@ -11,3 +11,8 @@ pub fn assume(b: bool) {
     #[trusted]
     proof_assert! { b };
 }
+
+#[ensures(|(fst, snd)| fst == snd)]
+pub fn apair(result: i64) -> (i64, i64) {
+    (result, result)
+}

--- a/tests/should_succeed/syntax/05_annotations.stderr
+++ b/tests/should_succeed/syntax/05_annotations.stderr
@@ -1,0 +1,10 @@
+warning: `result` used as a parameter name. It is confusing because it is also the default name of the function's result
+  --> 05_annotations.rs:16:14
+   |
+16 | pub fn apair(result: i64) -> (i64, i64) {
+   |              ^^^^^^
+   |
+   = note: `#[warn(creusot::result_param)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/should_succeed/syntax/05_annotations/proof.json
+++ b/tests/should_succeed/syntax/05_annotations/proof.json
@@ -6,6 +6,7 @@
     { "prover": "cvc4@1.8", "size": 40, "time": 0.506 }
   ],
   "proofs": {
+    "M_apair": { "vc_apair": { "prover": "alt-ergo@2.6.2", "time": 0.01 } },
     "M_assertion": {
       "vc_assertion_T": { "prover": "cvc5@1.3.1", "time": 0.026 }
     },


### PR DESCRIPTION
This allows writing `#[ensures(|myresult| myresult == blah())]`

And warn instead of error when `result` is used as parameter name.

Close #1735 