### PR TITLE
New version of message passing sc, using options instead of a big sum type

### DIFF
--- a/examples/message_passing_sc_options.coma
+++ b/examples/message_passing_sc_options.coma
@@ -1,0 +1,1304 @@
+module M_message_passing
+  type namespace_other
+  
+  type t_Namespace = Namespace_MESSAGE_PASSING int | Other namespace_other
+  
+  use creusot.int.Int32
+  use map.Map
+  use creusot.prelude.MutBorrow
+  use creusot.prelude.Any
+  use set.Set
+  
+  type t_AtomicI32
+  
+  type t_Perm_AtomicI32
+  
+  type tup2_AtomicI32_Ghost_Box_Perm_AtomicI32_Global = { f0: t_AtomicI32; f1: t_Perm_AtomicI32 }
+  
+  predicate inv_AtomicI32 (_1: t_AtomicI32)
+  
+  predicate inv_tup2_AtomicI32_Ghost_Box_Perm_AtomicI32_Global [@inline:trivial] (_1: tup2_AtomicI32_Ghost_Box_Perm_AtomicI32_Global) =
+    inv_AtomicI32 _1.f0
+  
+  meta "rewrite_def" predicate inv_tup2_AtomicI32_Ghost_Box_Perm_AtomicI32_Global
+  
+  function val_AtomicI32 (self: t_Perm_AtomicI32) : Int32.t
+  
+  function ward_AtomicI32 (self: t_Perm_AtomicI32) : t_AtomicI32
+  
+  let rec new (val': Int32.t) (return (x: tup2_AtomicI32_Ghost_Box_Perm_AtomicI32_Global)) = any
+    [ return (result: tup2_AtomicI32_Ghost_Box_Perm_AtomicI32_Global) ->
+    {[@stop_split] [@expl:new ensures] ([@stop_split] [@expl:new result type invariant] inv_tup2_AtomicI32_Ghost_Box_Perm_AtomicI32_Global result)
+      /\ ([@stop_split] [@expl:new ensures #0] val_AtomicI32 result.f1 = val')
+      /\ ([@stop_split] [@expl:new ensures #1] ward_AtomicI32 result.f1 = result.f0)}
+      (! return {result}) ]
+  
+  type t_PermCell_i32
+  
+  type t_Perm_PermCell_i32
+  
+  type tup2_PermCell_i32_Ghost_Box_Perm_PermCell_i32_Global = { f0'0: t_PermCell_i32; f1'0: t_Perm_PermCell_i32 }
+  
+  function ward_PermCell_i32 (self: t_Perm_PermCell_i32) : t_PermCell_i32
+  
+  function val_PermCell_i32 (self: t_Perm_PermCell_i32) : Int32.t
+  
+  function view_Perm_PermCell_i32 [@inline:trivial] (self: t_Perm_PermCell_i32) : Int32.t = val_PermCell_i32 self
+  
+  meta "rewrite_def" function view_Perm_PermCell_i32
+  
+  function view_Box_Perm_PermCell_i32_Global [@inline:trivial] (self: t_Perm_PermCell_i32) : Int32.t =
+    view_Perm_PermCell_i32 self
+  
+  meta "rewrite_def" function view_Box_Perm_PermCell_i32_Global
+  
+  let rec new_i32 (value: Int32.t) (return (x: tup2_PermCell_i32_Ghost_Box_Perm_PermCell_i32_Global)) = any
+    [ return (result: tup2_PermCell_i32_Ghost_Box_Perm_PermCell_i32_Global) ->
+    {[@stop_split] [@expl:new_i32 ensures] ([@stop_split] [@expl:new ensures #0] result.f0'0
+        = ward_PermCell_i32 result.f1'0)
+      /\ ([@stop_split] [@expl:new ensures #1] view_Box_Perm_PermCell_i32_Global result.f1'0 = value)}
+      (! return {result}) ]
+  
+  type t_Excl_unit = { f0'1: () }
+  
+  type t_Option_Excl_unit = None | Some t_Excl_unit
+  
+  type t_Resource_Option_Excl_unit
+  
+  function val_Option_Excl_unit (self: t_Resource_Option_Excl_unit) : t_Option_Excl_unit
+  
+  function view_Resource_Option_Excl_unit [@inline:trivial] (self: t_Resource_Option_Excl_unit) : t_Option_Excl_unit =
+    val_Option_Excl_unit self
+  
+  meta "rewrite_def" function view_Resource_Option_Excl_unit
+  
+  let rec alloc_Option_Excl_unit (r: t_Option_Excl_unit) (return (x: t_Resource_Option_Excl_unit)) = any
+    [ return (result: t_Resource_Option_Excl_unit) ->
+    {[@stop_split] [@expl:alloc ensures] view_Resource_Option_Excl_unit result = r}
+      (! return {result}) ]
+  
+  let rec into_inner_Box_Perm_AtomicI32_Global (self: t_Perm_AtomicI32) (return (x: t_Perm_AtomicI32)) = any
+    [ return (result: t_Perm_AtomicI32) -> {[@stop_split] [@expl:into_inner ensures] result = self}
+      (! return {result}) ]
+  
+  type t_Option_Box_Perm_PermCell_i32_Global = None'0 | Some'0 t_Perm_PermCell_i32
+  
+  let rec deref_Ghost_Resource_Option_Excl_unit (self: t_Resource_Option_Excl_unit)
+    (return (x: t_Resource_Option_Excl_unit)) = any
+    [ return (result: t_Resource_Option_Excl_unit) -> {[@stop_split] [@expl:deref ensures] result = self}
+      (! return {result}) ]
+  
+  type t_Id
+  
+  function id_Option_Excl_unit (self: t_Resource_Option_Excl_unit) : t_Id
+  
+  let rec id_ghost_Option_Excl_unit (self: t_Resource_Option_Excl_unit) (return (x: t_Id)) = any
+    [ return (result: t_Id) -> {[@stop_split] [@expl:id_ghost ensures] result = id_Option_Excl_unit self}
+      (! return {result}) ]
+  
+  type t_Option_Option_Excl_unit = None'1 | Some'1 t_Option_Excl_unit
+  
+  type tup2_Option_Excl_unit_Option_Excl_unit = { f0'2: t_Option_Excl_unit; f1'2: t_Option_Excl_unit }
+  
+  function map_Option_Excl_unit (self: t_Option_Excl_unit) (f: Map.map t_Excl_unit t_Option_Excl_unit) : t_Option_Option_Excl_unit
+   = match self with
+      | None -> None'1
+      | Some x -> Some'1 (Map.get f x)
+      end
+  
+  function op_Excl_unit (self: t_Excl_unit) (_other: t_Excl_unit) : t_Option_Excl_unit = None
+  
+  function commutative_Excl_unit (a: t_Excl_unit) (b: t_Excl_unit) : ()
+  
+  axiom commutative_Excl_unit_spec: forall a: t_Excl_unit, b: t_Excl_unit. op_Excl_unit a b = op_Excl_unit b a
+  
+  function op_Option_Excl_unit (self: t_Option_Excl_unit) (other: t_Option_Excl_unit) : t_Option_Option_Excl_unit =
+    match { f0'2 = self; f1'2 = other } with
+      | {f0'2 = None} -> Some'1 other
+      | {f1'2 = None} -> Some'1 self
+      | {f0'2 = Some x; f1'2 = Some y} -> map_Option_Excl_unit (op_Excl_unit x y) (fun (z: t_Excl_unit) -> Some z)
+      end
+  
+  function commutative_Option_Excl_unit (a: t_Option_Excl_unit) (b: t_Option_Excl_unit) : ()
+  
+  axiom commutative_Option_Excl_unit_spec: forall a: t_Option_Excl_unit, b: t_Option_Excl_unit. op_Option_Excl_unit a b
+      = op_Option_Excl_unit b a
+  
+  constant unit_Option_Excl_unit: t_Option_Excl_unit = None
+  
+  axiom unit_Option_Excl_unit_spec:
+    forall x: t_Option_Excl_unit [op_Option_Excl_unit x unit_Option_Excl_unit]. op_Option_Excl_unit x unit_Option_Excl_unit
+      = Some'1 x
+  
+  let rec new_unit_Option_Excl_unit (id: t_Id) (return (x: t_Resource_Option_Excl_unit)) = any
+    [ return (result: t_Resource_Option_Excl_unit) ->
+    {[@stop_split] [@expl:new_unit ensures] view_Resource_Option_Excl_unit result = unit_Option_Excl_unit
+      /\ id_Option_Excl_unit result = id}
+      (! return {result}) ]
+  
+  type t_MessagePassingAtomicInv = {
+    atomic_own: t_Perm_AtomicI32;
+    data_own: t_Option_Box_Perm_PermCell_i32_Global;
+    tok: t_Resource_Option_Excl_unit }
+  
+  let rec new_MessagePassingAtomicInv (x: t_MessagePassingAtomicInv) (return (x'0: t_MessagePassingAtomicInv)) = any
+    [ return (result: t_MessagePassingAtomicInv) -> {[@stop_split] [@expl:new ensures] result = x} (! return {result}) ]
+  
+  type tup3_AtomicI32_PermCell_i32_Id = { f0'3: t_AtomicI32; f1'3: t_PermCell_i32; f2'3: t_Id }
+  
+  type t_AtomicInvariant_MessagePassingAtomicInv
+  
+  predicate protocol_MessagePassingAtomicInv [@inline:trivial] (self: t_MessagePassingAtomicInv) (data: tup3_AtomicI32_PermCell_i32_Id) =
+    data.f0'3 = ward_AtomicI32 self.atomic_own
+    /\ data.f2'3 = id_Option_Excl_unit self.tok
+    /\ (Int32.to_int (val_AtomicI32 self.atomic_own) = 0
+    \/ match self.data_own with
+      | Some'0 data_own'0 -> data.f1'3 = ward_PermCell_i32 data_own'0
+      /\ Int32.to_int (val_AtomicI32 self.atomic_own) = 1 /\ Int32.to_int (val_PermCell_i32 data_own'0) = 1
+      | None'0 -> val_Option_Excl_unit self.tok = Some { f0'1 = () }
+      end)
+  
+  meta "rewrite_def" predicate protocol_MessagePassingAtomicInv
+  
+  function public_MessagePassingAtomicInv (self: t_AtomicInvariant_MessagePassingAtomicInv) : tup3_AtomicI32_PermCell_i32_Id
+  
+  function namespace_MessagePassingAtomicInv (self: t_AtomicInvariant_MessagePassingAtomicInv) : t_Namespace
+  
+  let rec new_MessagePassingAtomicInv'0 (value: t_MessagePassingAtomicInv) (public: tup3_AtomicI32_PermCell_i32_Id)
+    (namespace: t_Namespace) (return (x: t_AtomicInvariant_MessagePassingAtomicInv)) =
+    {[@stop_split] [@expl:new requires] protocol_MessagePassingAtomicInv value public}
+    any
+    [ return (result: t_AtomicInvariant_MessagePassingAtomicInv) ->
+    {[@stop_split] [@expl:new_MessagePassingAtomicInv ensures] ([@stop_split] [@expl:new ensures #0] public_MessagePassingAtomicInv result
+        = public)
+      /\ ([@stop_split] [@expl:new ensures #1] namespace_MessagePassingAtomicInv result = namespace)}
+      (! return {result}) ]
+  
+  predicate resolve_AtomicInvariant_MessagePassingAtomicInv (_1: t_AtomicInvariant_MessagePassingAtomicInv)
+  
+  predicate resolve_Ghost_AtomicInvariant_MessagePassingAtomicInv [@inline:trivial] (_1: t_AtomicInvariant_MessagePassingAtomicInv) =
+    resolve_AtomicInvariant_MessagePassingAtomicInv _1
+  
+  meta "rewrite_def" predicate resolve_Ghost_AtomicInvariant_MessagePassingAtomicInv
+  
+  predicate resolve_PermCell_i32 (_1: t_PermCell_i32)
+  
+  predicate resolve_AtomicI32 (_1: t_AtomicI32)
+  
+  type closure0 = {
+    c0: t_AtomicInvariant_MessagePassingAtomicInv;
+    c1: t_PermCell_i32;
+    c2: t_AtomicI32;
+    c3: t_Perm_PermCell_i32;
+    c4: t_Resource_Option_Excl_unit }
+  
+  let rec borrow_AtomicInvariant_MessagePassingAtomicInv (self: t_AtomicInvariant_MessagePassingAtomicInv)
+    (return (x: t_AtomicInvariant_MessagePassingAtomicInv)) = any
+    [ return (result: t_AtomicInvariant_MessagePassingAtomicInv) -> {[@stop_split] [@expl:borrow ensures] result = self}
+      (! return {result}) ]
+  
+  type closure0'0 = {
+    c0'0: t_PermCell_i32;
+    c1'0: t_Perm_PermCell_i32;
+    c2'0: t_AtomicI32;
+    c3'0: t_AtomicInvariant_MessagePassingAtomicInv }
+  
+  let rec deref_mut_Ghost_Box_Perm_PermCell_i32_Global (self: MutBorrow.t t_Perm_PermCell_i32)
+    (return (x: MutBorrow.t t_Perm_PermCell_i32)) = any
+    [ return (result: MutBorrow.t t_Perm_PermCell_i32) -> {[@stop_split] [@expl:deref_mut ensures] result = self}
+      (! return {result}) ]
+  
+  predicate resolve_refmut_Box_Perm_PermCell_i32_Global [@inline:trivial] (_1: MutBorrow.t t_Perm_PermCell_i32) =
+    _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Box_Perm_PermCell_i32_Global
+  
+  predicate resolve_refmut_Perm_PermCell_i32 [@inline:trivial] (_1: MutBorrow.t t_Perm_PermCell_i32) =
+    _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Perm_PermCell_i32
+  
+  let rec new_refmut_Perm_PermCell_i32 (x: MutBorrow.t t_Perm_PermCell_i32)
+    (return (x'0: MutBorrow.t t_Perm_PermCell_i32)) = any
+    [ return (result: MutBorrow.t t_Perm_PermCell_i32) -> {[@stop_split] [@expl:new ensures] result = x}
+      (! return {result}) ]
+  
+  function fin_Ghost_refmut_Perm_PermCell_i32 [@inline:trivial] (self: MutBorrow.t t_Perm_PermCell_i32) : t_Perm_PermCell_i32
+   = self.final
+  
+  meta "rewrite_def" function fin_Ghost_refmut_Perm_PermCell_i32
+  
+  let rec borrow_mut_i32 (self: t_PermCell_i32) (perm: MutBorrow.t t_Perm_PermCell_i32)
+    (return (x: MutBorrow.t Int32.t)) = {[@stop_split] [@expl:borrow_mut requires] self
+    = ward_PermCell_i32 perm.current}
+    any
+    [ return (result: MutBorrow.t Int32.t) ->
+    {[@stop_split] [@expl:borrow_mut_i32 ensures] ([@stop_split] [@expl:borrow_mut ensures #0] self
+        = ward_PermCell_i32 (fin_Ghost_refmut_Perm_PermCell_i32 perm))
+      /\ ([@stop_split] [@expl:borrow_mut ensures #1] result.current = view_Perm_PermCell_i32 perm.current)
+      /\ ([@stop_split] [@expl:borrow_mut ensures #2] result.final
+      = view_Perm_PermCell_i32 (fin_Ghost_refmut_Perm_PermCell_i32 perm))}
+      (! return {result}) ]
+  
+  predicate resolve_refmut_i32 [@inline:trivial] (_1: MutBorrow.t Int32.t) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_i32
+  
+  type t_Tokens
+  
+  type closure0'1 = { c0'1: t_AtomicInvariant_MessagePassingAtomicInv; c1'1: t_Tokens; c2'1: t_Perm_PermCell_i32 }
+  
+  let rec deref_Ghost_ref_AtomicInvariant_MessagePassingAtomicInv (self: t_AtomicInvariant_MessagePassingAtomicInv)
+    (return (x: t_AtomicInvariant_MessagePassingAtomicInv)) = any
+    [ return (result: t_AtomicInvariant_MessagePassingAtomicInv) -> {[@stop_split] [@expl:deref ensures] result = self}
+      (! return {result}) ]
+  
+  let rec into_inner_Tokens (self: t_Tokens) (return (x: t_Tokens)) = any
+    [ return (result: t_Tokens) -> {[@stop_split] [@expl:into_inner ensures] result = self} (! return {result}) ]
+  
+  type t_Committer_AtomicI32
+  
+  type closure0'2 = { c0'2: t_Perm_PermCell_i32; c1'2: MutBorrow.t t_Committer_AtomicI32 }
+  
+  let rec into_inner_Box_Perm_PermCell_i32_Global (self: t_Perm_PermCell_i32) (return (x: t_Perm_PermCell_i32)) = any
+    [ return (result: t_Perm_PermCell_i32) -> {[@stop_split] [@expl:into_inner ensures] result = self}
+      (! return {result}) ]
+  
+  predicate resolve_ref_i32 [@inline:trivial] (_1: Int32.t) = true
+  
+  meta "rewrite_def" predicate resolve_ref_i32
+  
+  predicate resolve_Perm_PermCell_i32 [@inline:trivial] (self: t_Perm_PermCell_i32) =
+    resolve_ref_i32 (val_PermCell_i32 self)
+  
+  meta "rewrite_def" predicate resolve_Perm_PermCell_i32
+  
+  predicate resolve_Perm_PermCell_i32'0 (_1: t_Perm_PermCell_i32)
+  
+  axiom resolve_axiom: forall x: t_Perm_PermCell_i32 [resolve_Perm_PermCell_i32'0 x]. resolve_Perm_PermCell_i32'0 x
+      -> resolve_Perm_PermCell_i32 x
+  
+  predicate resolve_Box_Perm_PermCell_i32_Global [@inline:trivial] (_1: t_Perm_PermCell_i32) =
+    resolve_Perm_PermCell_i32'0 _1
+  
+  meta "rewrite_def" predicate resolve_Box_Perm_PermCell_i32_Global
+  
+  predicate resolve_Option_Box_Perm_PermCell_i32_Global (_1: t_Option_Box_Perm_PermCell_i32_Global)
+  
+  axiom resolve_axiom'0 [@rewrite]:
+    forall x: t_Option_Box_Perm_PermCell_i32_Global [resolve_Option_Box_Perm_PermCell_i32_Global x]. resolve_Option_Box_Perm_PermCell_i32_Global x
+      = match x with
+        | None'0 -> true
+        | Some'0 x0 -> resolve_Box_Perm_PermCell_i32_Global x0
+        end
+  
+  predicate shot_AtomicI32 (self: t_Committer_AtomicI32)
+  
+  function ward_AtomicI32'0 (self: t_Committer_AtomicI32) : t_AtomicI32
+  
+  function old_value_AtomicI32 (self: t_Committer_AtomicI32) : Int32.t
+  
+  function new_value_AtomicI32 (self: t_Committer_AtomicI32) : Int32.t
+  
+  let rec shoot_AtomicI32 (self: MutBorrow.t t_Committer_AtomicI32) (own: MutBorrow.t t_Perm_AtomicI32)
+    (return (x: ())) =
+    {[@stop_split] [@expl:shoot_AtomicI32 requires] ([@stop_split] [@expl:shoot requires #0] not shot_AtomicI32 self.current)
+    /\ ([@stop_split] [@expl:shoot requires #1] ward_AtomicI32'0 self.current = ward_AtomicI32 own.current)}
+    any
+    [ return (result: ()) ->
+    {[@stop_split] [@expl:shoot_AtomicI32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_AtomicI32 self.final)
+      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32 own.final = ward_AtomicI32 own.current)
+      /\ ([@stop_split] [@expl:shoot ensures #2] val_AtomicI32 own.current = old_value_AtomicI32 self.current)
+      /\ ([@stop_split] [@expl:shoot ensures #3] val_AtomicI32 own.final = new_value_AtomicI32 self.current)}
+      (! return {result}) ]
+  
+  predicate resolve_refmut_Box_Perm_AtomicI32_Global [@inline:trivial] (_1: MutBorrow.t t_Perm_AtomicI32) =
+    _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Box_Perm_AtomicI32_Global
+  
+  predicate resolve_refmut_MessagePassingAtomicInv [@inline:trivial] (_1: MutBorrow.t t_MessagePassingAtomicInv) =
+    _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_MessagePassingAtomicInv
+  
+  predicate resolve_refmut_Committer_AtomicI32 [@inline:trivial] (_1: MutBorrow.t t_Committer_AtomicI32) =
+    _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Committer_AtomicI32
+  
+  let rec closure0 [@coma:extspec] (self: closure0'2) (inv: MutBorrow.t t_MessagePassingAtomicInv) (return (x: ())) =
+    bb0
+    [ bb0 = s0
+      [ s0 = into_inner_Box_Perm_PermCell_i32_Global {self.c0'2} (fun (_x: t_Perm_PermCell_i32) -> [ &_4 <- _x ] s1)
+      | s1 = [ &_3 <- Some'0 _4 ] s2
+      | s2 = -{resolve_Option_Box_Perm_PermCell_i32_Global inv.current.data_own}- s3
+      | s3 = [ &inv <- { inv with current = { inv.current with data_own = _3 } } ] s4
+      | s4 = MutBorrow.borrow_final <t_Perm_AtomicI32> {inv.current.atomic_own}
+          {MutBorrow.inherit_id (MutBorrow.get_id inv) 0}
+          (fun (_bor: MutBorrow.t t_Perm_AtomicI32) ->
+            [ &_9 <- _bor ] [ &inv <- { inv with current = { inv.current with atomic_own = _bor.final } } ] s5)
+      | s5 = MutBorrow.borrow_final <t_Committer_AtomicI32> {self.c1'2.current} {MutBorrow.get_id self.c1'2}
+          (fun (_bor: MutBorrow.t t_Committer_AtomicI32) ->
+            [ &_7 <- _bor ] [ &self <- { self with c1'2 = { self.c1'2 with current = _bor.final } } ] s6)
+      | s6 = MutBorrow.borrow_final <t_Perm_AtomicI32> {_9.current} {MutBorrow.get_id _9}
+          (fun (_bor: MutBorrow.t t_Perm_AtomicI32) -> [ &_8 <- _bor ] [ &_9 <- { _9 with current = _bor.final } ] s7)
+      | s7 = shoot_AtomicI32 {_7} {_8} (fun (_x: ()) -> [ &_6 <- _x ] s8)
+      | s8 = -{resolve_refmut_Box_Perm_AtomicI32_Global _9}- s9
+      | s9 = -{resolve_refmut_MessagePassingAtomicInv inv}- s10
+      | s10 = -{match self with
+          | {c1'2 = x} -> resolve_refmut_Committer_AtomicI32 x
+          | _ -> true
+          end}-
+        s11
+      | s11 = return {_ret} ] ]
+    [ & _ret: () = Any.any_l ()
+    | & self: closure0'2 = self
+    | & inv: MutBorrow.t t_MessagePassingAtomicInv = inv
+    | & _3: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _4: t_Perm_PermCell_i32 = Any.any_l ()
+    | & _6: () = Any.any_l ()
+    | & _7: MutBorrow.t t_Committer_AtomicI32 = Any.any_l ()
+    | & _8: MutBorrow.t t_Perm_AtomicI32 = Any.any_l ()
+    | & _9: MutBorrow.t t_Perm_AtomicI32 = Any.any_l () ] [ return (result: ()) -> return {result} ]
+  
+  meta "rewrite_def" predicate closure0'pre
+  
+  meta "rewrite_def" predicate closure0'post'return
+  
+  type t_FnGhostWrapper_closure0 = { f0'4: closure0'2 }
+  
+  let rec __new_closure0 (f: closure0'2) (return (x: t_FnGhostWrapper_closure0)) = any
+    [ return (result: t_FnGhostWrapper_closure0) -> {[@stop_split] [@expl:__new ensures] result.f0'4 = f}
+      (! return {result}) ]
+  
+  predicate contains_Namespace [@inline:trivial] (self: Set.set t_Namespace) (e: t_Namespace) = Set.mem e self
+  
+  meta "rewrite_def" predicate contains_Namespace
+  
+  function namespaces (self: t_Tokens) : Set.set t_Namespace
+  
+  predicate contains (self: t_Tokens) (namespace: t_Namespace) = contains_Namespace (namespaces self) namespace
+  
+  predicate inv_refmut_MessagePassingAtomicInv [@inline:trivial] (_1: MutBorrow.t t_MessagePassingAtomicInv) = true
+  
+  meta "rewrite_def" predicate inv_refmut_MessagePassingAtomicInv
+  
+  predicate precondition_closure0 [@inline:trivial] (self: closure0'2) (args: MutBorrow.t t_MessagePassingAtomicInv) =
+    let inv = args in closure0'pre self inv
+  
+  meta "rewrite_def" predicate precondition_closure0
+  
+  predicate precondition_FnGhostWrapper_closure0 [@inline:trivial] (self: t_FnGhostWrapper_closure0) (args: MutBorrow.t t_MessagePassingAtomicInv) =
+    precondition_closure0 self.f0'4 args
+  
+  meta "rewrite_def" predicate precondition_FnGhostWrapper_closure0
+  
+  predicate postcondition_once_closure0 [@inline:trivial] (self: closure0'2) (args: MutBorrow.t t_MessagePassingAtomicInv) (result: ()) =
+    let inv = args in closure0'post'return self inv result
+  
+  meta "rewrite_def" predicate postcondition_once_closure0
+  
+  predicate postcondition_once_FnGhostWrapper_closure0 [@inline:trivial] (self: t_FnGhostWrapper_closure0) (args: MutBorrow.t t_MessagePassingAtomicInv) (result: ()) =
+    postcondition_once_closure0 self.f0'4 args result
+  
+  meta "rewrite_def" predicate postcondition_once_FnGhostWrapper_closure0
+  
+  let rec open_MessagePassingAtomicInv (self: t_AtomicInvariant_MessagePassingAtomicInv) (tokens: t_Tokens)
+    (f: t_FnGhostWrapper_closure0) (return (x: ())) =
+    {[@stop_split] [@expl:open_MessagePassingAtomicInv requires] ([@stop_split] [@expl:open requires #0] contains tokens (namespace_MessagePassingAtomicInv self))
+    /\ ([@stop_split] [@expl:open requires #1] forall t: MutBorrow.t t_MessagePassingAtomicInv. protocol_MessagePassingAtomicInv t.current (public_MessagePassingAtomicInv self)
+        /\ inv_refmut_MessagePassingAtomicInv t
+      -> precondition_FnGhostWrapper_closure0 f t
+      /\ (forall res: (). postcondition_once_FnGhostWrapper_closure0 f t res
+        -> protocol_MessagePassingAtomicInv t.final (public_MessagePassingAtomicInv self)))}
+    any
+    [ return (result: ()) ->
+    {[@stop_split] [@expl:open ensures] exists t: MutBorrow.t t_MessagePassingAtomicInv. inv_refmut_MessagePassingAtomicInv t
+        /\ protocol_MessagePassingAtomicInv t.current (public_MessagePassingAtomicInv self)
+        /\ postcondition_once_FnGhostWrapper_closure0 f t result}
+      (! return {result}) ]
+  
+  let rec closure0'0 [@coma:extspec] (self: closure0'1) (c: MutBorrow.t t_Committer_AtomicI32) (return (x: ())) = bb0
+    [ bb0 = s0
+      [ s0 = deref_Ghost_ref_AtomicInvariant_MessagePassingAtomicInv {self.c0'1}
+          (fun (_x: t_AtomicInvariant_MessagePassingAtomicInv) -> [ &_4 <- _x ] s1)
+      | s1 = into_inner_Tokens {self.c1'1} (fun (_x: t_Tokens) -> [ &_6 <- _x ] s2)
+      | s2 = MutBorrow.borrow_final <t_Committer_AtomicI32> {c.current} {MutBorrow.get_id c}
+          (fun (_bor: MutBorrow.t t_Committer_AtomicI32) ->
+            [ &_10 <- _bor ] [ &c <- { c with current = _bor.final } ] s3)
+      | s3 = [ &_9 <- { c0'2 = self.c2'1; c1'2 = _10 } ] s4
+      | s4 = __new_closure0 {_9} (fun (_x: t_FnGhostWrapper_closure0) -> [ &_8 <- _x ] s5)
+      | s5 = open_MessagePassingAtomicInv {_4} {_6} {_8} (fun (_x: ()) -> [ &_ret <- _x ] s6)
+      | s6 = -{resolve_refmut_Committer_AtomicI32 c}- s7
+      | s7 = return {_ret} ] ]
+    [ & _ret: () = Any.any_l ()
+    | & self: closure0'1 = self
+    | & c: MutBorrow.t t_Committer_AtomicI32 = c
+    | & _4: t_AtomicInvariant_MessagePassingAtomicInv = Any.any_l ()
+    | & _6: t_Tokens = Any.any_l ()
+    | & _8: t_FnGhostWrapper_closure0 = Any.any_l ()
+    | & _9: closure0'2 = Any.any_l ()
+    | & _10: MutBorrow.t t_Committer_AtomicI32 = Any.any_l () ] [ return (result: ()) -> return {result} ]
+  
+  meta "rewrite_def" predicate closure0'0'pre
+  
+  meta "rewrite_def" predicate closure0'0'post'return
+  
+  type t_FnGhostWrapper_closure0'0 = { f0'5: closure0'1 }
+  
+  let rec __new_closure0'0 (f: closure0'1) (return (x: t_FnGhostWrapper_closure0'0)) = any
+    [ return (result: t_FnGhostWrapper_closure0'0) -> {[@stop_split] [@expl:__new ensures] result.f0'5 = f}
+      (! return {result}) ]
+  
+  let rec new_FnGhostWrapper_closure0 (x: t_FnGhostWrapper_closure0'0) (return (x'0: t_FnGhostWrapper_closure0'0)) = any
+    [ return (result: t_FnGhostWrapper_closure0'0) -> {[@stop_split] [@expl:new ensures] result = x}
+      (! return {result}) ]
+  
+  predicate invariant_ref_AtomicI32 [@inline:trivial] (self: t_AtomicI32) = inv_AtomicI32 self
+  
+  meta "rewrite_def" predicate invariant_ref_AtomicI32
+  
+  predicate inv_ref_AtomicI32 [@inline:trivial] (_1: t_AtomicI32) = invariant_ref_AtomicI32 _1
+  
+  meta "rewrite_def" predicate inv_ref_AtomicI32
+  
+  predicate precondition_closure0'0 [@inline:trivial] (self: closure0'1) (args: MutBorrow.t t_Committer_AtomicI32) =
+    let c = args in closure0'0'pre self c
+  
+  meta "rewrite_def" predicate precondition_closure0'0
+  
+  predicate precondition_FnGhostWrapper_closure0'0 [@inline:trivial] (self: t_FnGhostWrapper_closure0'0) (args: MutBorrow.t t_Committer_AtomicI32) =
+    precondition_closure0'0 self.f0'5 args
+  
+  meta "rewrite_def" predicate precondition_FnGhostWrapper_closure0'0
+  
+  predicate postcondition_once_closure0'0 [@inline:trivial] (self: closure0'1) (args: MutBorrow.t t_Committer_AtomicI32) (result: ()) =
+    let c = args in closure0'0'post'return self c result
+  
+  meta "rewrite_def" predicate postcondition_once_closure0'0
+  
+  predicate postcondition_once_FnGhostWrapper_closure0'0 [@inline:trivial] (self: t_FnGhostWrapper_closure0'0) (args: MutBorrow.t t_Committer_AtomicI32) (result: ()) =
+    postcondition_once_closure0'0 self.f0'5 args result
+  
+  meta "rewrite_def" predicate postcondition_once_FnGhostWrapper_closure0'0
+  
+  let rec store_unit (self: t_AtomicI32) (val': Int32.t) (f: t_FnGhostWrapper_closure0'0) (return (x: ())) =
+    {[@stop_split] [@expl:store_unit requires] ([@stop_split] [@expl:store 'self' type invariant] inv_ref_AtomicI32 self)
+    /\ ([@stop_split] [@expl:store requires] forall c: MutBorrow.t t_Committer_AtomicI32. not shot_AtomicI32 c.current
+      -> ward_AtomicI32'0 c.current = self
+      -> new_value_AtomicI32 c.current = val'
+      -> precondition_FnGhostWrapper_closure0'0 f c
+      /\ (forall r: (). postcondition_once_FnGhostWrapper_closure0'0 f c r -> shot_AtomicI32 c.final))}
+    any
+    [ return (result: ()) ->
+    {[@stop_split] [@expl:store ensures] exists c: MutBorrow.t t_Committer_AtomicI32. not shot_AtomicI32 c.current
+        /\ ward_AtomicI32'0 c.current = self
+        /\ new_value_AtomicI32 c.current = val' /\ postcondition_once_FnGhostWrapper_closure0'0 f c result}
+      (! return {result}) ]
+  
+  predicate inv_closure0 [@inline:trivial] (_1: closure0'0) =
+    let {c0'0 = x0; c1'0 = x1; c2'0 = x2; c3'0 = x3} = _1 in inv_ref_AtomicI32 x2
+  
+  meta "rewrite_def" predicate inv_closure0
+  
+  let rec closure0'1 [@coma:extspec] (self: closure0'0) (tokens: t_Tokens) (return (x: ())) =
+    {[@stop_split] [@expl:closure 'self' type invariant] inv_closure0 self}
+    bb0
+    [ bb0 = s0
+      [ s0 = [ &_5 <- self.c0'0 ] s1
+      | s1 = MutBorrow.borrow_mut <t_Perm_PermCell_i32> {self.c1'0}
+          (fun (_bor: MutBorrow.t t_Perm_PermCell_i32) ->
+            [ &_12 <- _bor ] [ &self <- { self with c1'0 = _bor.final } ] s2)
+      | s2 = deref_mut_Ghost_Box_Perm_PermCell_i32_Global {_12}
+          (fun (_x: MutBorrow.t t_Perm_PermCell_i32) -> [ &_11 <- _x ] s3)
+      | s3 = MutBorrow.borrow_final <t_Perm_PermCell_i32> {_11.current} {MutBorrow.get_id _11}
+          (fun (_bor: MutBorrow.t t_Perm_PermCell_i32) ->
+            [ &_10 <- _bor ] [ &_11 <- { _11 with current = _bor.final } ] s4)
+      | s4 = MutBorrow.borrow_final <t_Perm_PermCell_i32> {_10.current} {MutBorrow.get_id _10}
+          (fun (_bor: MutBorrow.t t_Perm_PermCell_i32) ->
+            [ &_9 <- _bor ] [ &_10 <- { _10 with current = _bor.final } ] s5)
+      | s5 = -{resolve_refmut_Box_Perm_PermCell_i32_Global _11}- s6
+      | s6 = -{resolve_refmut_Perm_PermCell_i32 _10}- s7
+      | s7 = MutBorrow.borrow_final <t_Perm_PermCell_i32> {_9.current} {MutBorrow.get_id _9}
+          (fun (_bor: MutBorrow.t t_Perm_PermCell_i32) ->
+            [ &_8 <- _bor ] [ &_9 <- { _9 with current = _bor.final } ] s8)
+      | s8 = -{resolve_refmut_Perm_PermCell_i32 _9}- s9
+      | s9 = MutBorrow.borrow_final <t_Perm_PermCell_i32> {_8.current} {MutBorrow.get_id _8}
+          (fun (_bor: MutBorrow.t t_Perm_PermCell_i32) ->
+            [ &_7 <- _bor ] [ &_8 <- { _8 with current = _bor.final } ] s10)
+      | s10 = new_refmut_Perm_PermCell_i32 {_7} (fun (_x: MutBorrow.t t_Perm_PermCell_i32) -> [ &_6 <- _x ] s11)
+      | s11 = -{resolve_refmut_Perm_PermCell_i32 _8}- s12
+      | s12 = borrow_mut_i32 {_5} {_6} (fun (_x: MutBorrow.t Int32.t) -> [ &_4 <- _x ] s13)
+      | s13 = [ &_4 <- { _4 with current = (1: Int32.t) } ] s14
+      | s14 = -{resolve_refmut_i32 _4}- s15
+      | s15 = [ &_17 <- { c0'1 = self.c3'0; c1'1 = tokens; c2'1 = self.c1'0 } ] s16
+      | s16 = __new_closure0'0 {_17} (fun (_x: t_FnGhostWrapper_closure0'0) -> [ &_16 <- _x ] s17)
+      | s17 = new_FnGhostWrapper_closure0 {_16} (fun (_x: t_FnGhostWrapper_closure0'0) -> [ &_15 <- _x ] s18)
+      | s18 = store_unit {self.c2'0} {(1: Int32.t)} {_15} (fun (_x: ()) -> [ &_13 <- _x ] s19)
+      | s19 = return {_ret} ] ]
+    [ & _ret: () = Any.any_l ()
+    | & self: closure0'0 = self
+    | & tokens: t_Tokens = tokens
+    | & _4: MutBorrow.t Int32.t = Any.any_l ()
+    | & _5: t_PermCell_i32 = Any.any_l ()
+    | & _6: MutBorrow.t t_Perm_PermCell_i32 = Any.any_l ()
+    | & _7: MutBorrow.t t_Perm_PermCell_i32 = Any.any_l ()
+    | & _8: MutBorrow.t t_Perm_PermCell_i32 = Any.any_l ()
+    | & _9: MutBorrow.t t_Perm_PermCell_i32 = Any.any_l ()
+    | & _10: MutBorrow.t t_Perm_PermCell_i32 = Any.any_l ()
+    | & _11: MutBorrow.t t_Perm_PermCell_i32 = Any.any_l ()
+    | & _12: MutBorrow.t t_Perm_PermCell_i32 = Any.any_l ()
+    | & _13: () = Any.any_l ()
+    | & _15: t_FnGhostWrapper_closure0'0 = Any.any_l ()
+    | & _16: t_FnGhostWrapper_closure0'0 = Any.any_l ()
+    | & _17: closure0'1 = Any.any_l () ] [ return (result: ()) -> return {result} ]
+  
+  meta "rewrite_def" predicate closure0'1'pre
+  
+  meta "rewrite_def" predicate closure0'1'post'return
+  
+  type t_Scope
+  
+  predicate inv_Scope (_1: t_Scope)
+  
+  type t_ScopedJoinHandle_unit
+  
+  predicate invariant_refmut_Scope [@inline:trivial] (self: MutBorrow.t t_Scope) =
+    inv_Scope self.current /\ inv_Scope self.final
+  
+  meta "rewrite_def" predicate invariant_refmut_Scope
+  
+  predicate inv_refmut_Scope [@inline:trivial] (_1: MutBorrow.t t_Scope) = invariant_refmut_Scope _1
+  
+  meta "rewrite_def" predicate inv_refmut_Scope
+  
+  predicate precondition_closure0'1 [@inline:trivial] (self: closure0'0) (args: t_Tokens) =
+    let tokens = args in closure0'1'pre self tokens
+  
+  meta "rewrite_def" predicate precondition_closure0'1
+  
+  predicate inv_ScopedJoinHandle_unit (_1: t_ScopedJoinHandle_unit)
+  
+  predicate valid_result_ScopedJoinHandle_unit (self: t_ScopedJoinHandle_unit) (_x: ())
+  
+  predicate postcondition_once_closure0'1 [@inline:trivial] (self: closure0'0) (args: t_Tokens) (result: ()) =
+    let tokens = args in closure0'1'post'return self tokens result
+  
+  meta "rewrite_def" predicate postcondition_once_closure0'1
+  
+  let rec spawn_closure0 (self: MutBorrow.t t_Scope) (f: closure0'0) (return (x: t_ScopedJoinHandle_unit)) =
+    {[@stop_split] [@expl:spawn_closure0 requires] ([@stop_split] [@expl:spawn 'self' type invariant] inv_refmut_Scope self)
+    /\ ([@stop_split] [@expl:spawn 'f' type invariant] inv_closure0 f)
+    /\ ([@stop_split] [@expl:spawn requires] forall t: t_Tokens. (forall ns: t_Namespace. contains t ns)
+      -> precondition_closure0'1 f t)}
+    any
+    [ return (result: t_ScopedJoinHandle_unit) ->
+    {[@stop_split] [@expl:spawn_closure0 ensures] ([@stop_split] [@expl:spawn result type invariant] inv_ScopedJoinHandle_unit result)
+      /\ ([@stop_split] [@expl:spawn ensures] exists t: t_Tokens. (forall ns: t_Namespace. contains t ns)
+        /\ (forall r: (). valid_result_ScopedJoinHandle_unit result r -> postcondition_once_closure0'1 f t r))}
+      (! return {result}) ]
+  
+  type closure1 = {
+    c0'3: t_Resource_Option_Excl_unit;
+    c1'3: t_AtomicI32;
+    c2'3: t_AtomicInvariant_MessagePassingAtomicInv;
+    c3'3: t_PermCell_i32 }
+  
+  type closure4 = {
+    c0'4: t_AtomicInvariant_MessagePassingAtomicInv;
+    c1'4: MutBorrow.t t_Tokens;
+    c2'4: MutBorrow.t t_Resource_Option_Excl_unit }
+  
+  let rec deref_mut_Ghost_Tokens (self: MutBorrow.t t_Tokens) (return (x: MutBorrow.t t_Tokens)) = any
+    [ return (result: MutBorrow.t t_Tokens) -> {[@stop_split] [@expl:deref_mut ensures] result = self}
+      (! return {result}) ]
+  
+  let rec reborrow (self: MutBorrow.t t_Tokens) (return (x: t_Tokens)) = any
+    [ return (result: t_Tokens) -> {[@stop_split] [@expl:reborrow ensures] result = self.current
+      /\ self.final = self.current}
+      (! return {result}) ]
+  
+  type closure0'3 = {
+    c0'5: MutBorrow.t t_Resource_Option_Excl_unit;
+    c1'5: MutBorrow.t (MutBorrow.t t_Committer_AtomicI32) }
+  
+  let rec deref_mut_Ghost_Resource_Option_Excl_unit (self: MutBorrow.t t_Resource_Option_Excl_unit)
+    (return (x: MutBorrow.t t_Resource_Option_Excl_unit)) = any
+    [ return (result: MutBorrow.t t_Resource_Option_Excl_unit) -> {[@stop_split] [@expl:deref_mut ensures] result
+      = self}
+      (! return {result}) ]
+  
+  let rec valid_op_lemma_Option_Excl_unit (self: MutBorrow.t t_Resource_Option_Excl_unit)
+    (other: t_Resource_Option_Excl_unit) (return (x: ())) =
+    {[@stop_split] [@expl:valid_op_lemma requires] id_Option_Excl_unit self.current = id_Option_Excl_unit other}
+    any
+    [ return (result: ()) ->
+    {[@stop_split] [@expl:valid_op_lemma_Option_Excl_unit ensures] ([@stop_split] [@expl:valid_op_lemma ensures #0] self.final
+        = self.current)
+      /\ ([@stop_split] [@expl:valid_op_lemma ensures #1] op_Option_Excl_unit (view_Resource_Option_Excl_unit self.current) (view_Resource_Option_Excl_unit other)
+      <> None'1)}
+      (! return {result}) ]
+  
+  predicate resolve_refmut_Resource_Option_Excl_unit [@inline:trivial] (_1: MutBorrow.t t_Resource_Option_Excl_unit) =
+    _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Resource_Option_Excl_unit
+  
+  let rec into_ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:into_ghost ensures] result = self} (! return {result}) ]
+  
+  let rec into_inner_i32 (self: Int32.t) (return (x: Int32.t)) = any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:into_inner ensures] result = self} (! return {result}) ]
+  
+  let rec swap_Resource_Option_Excl_unit (x: MutBorrow.t t_Resource_Option_Excl_unit)
+    (y: MutBorrow.t t_Resource_Option_Excl_unit) (return (x'0: ())) = any
+    [ return (result: ()) ->
+    {[@stop_split] [@expl:swap_Resource_Option_Excl_unit ensures] ([@stop_split] [@expl:swap ensures #0] x.final
+        = y.current)
+      /\ ([@stop_split] [@expl:swap ensures #1] y.final = x.current)}
+      (! return {result}) ]
+  
+  predicate resolve_refmut_closure0 [@inline:trivial] (_1: MutBorrow.t closure0'3) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_closure0
+  
+  let rec take_Box_Perm_PermCell_i32_Global (self_: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global)
+    (return (x: t_Option_Box_Perm_PermCell_i32_Global)) = any
+    [ return (result: t_Option_Box_Perm_PermCell_i32_Global) -> {[@stop_split] [@expl:take ensures] result
+        = self_.current
+      /\ self_.final = None'0}
+      (! return {result}) ]
+  
+  predicate resolve_refmut_refmut_Committer_AtomicI32 [@inline:trivial] (_1: MutBorrow.t (MutBorrow.t t_Committer_AtomicI32)) =
+    _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_refmut_Committer_AtomicI32
+  
+  predicate resolve_refmut_Ghost_Resource_Option_Excl_unit [@inline:trivial] (_1: MutBorrow.t t_Resource_Option_Excl_unit) =
+    _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Ghost_Resource_Option_Excl_unit
+  
+  predicate resolve_closure0 [@inline:trivial] (_1: closure0'3) =
+    resolve_refmut_refmut_Committer_AtomicI32 _1.c1'5 /\ resolve_refmut_Ghost_Resource_Option_Excl_unit _1.c0'5
+  
+  meta "rewrite_def" predicate resolve_closure0
+  
+  predicate hist_inv_closure0 [@inline:trivial] (self: closure0'3) (result_state: closure0'3) =
+    result_state.c0'5.final = self.c0'5.final /\ result_state.c1'5.final = self.c1'5.final
+  
+  meta "rewrite_def" predicate hist_inv_closure0
+  
+  let rec closure0'2 [@coma:extspec] (self: MutBorrow.t closure0'3) (inv: MutBorrow.t t_MessagePassingAtomicInv)
+    (return (x: t_Option_Box_Perm_PermCell_i32_Global)) = bb0
+    [ bb0 = s0
+      [ s0 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c0'5.current}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_6 <- _bor ]
+            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
+            s1)
+      | s1 = deref_mut_Ghost_Resource_Option_Excl_unit {_6}
+          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_5 <- _x ] s2)
+      | s2 = [ &_8 <- inv.current.tok ] s3
+      | s3 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_5.current} {MutBorrow.get_id _5}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_4 <- _bor ] [ &_5 <- { _5 with current = _bor.final } ] s4)
+      | s4 = valid_op_lemma_Option_Excl_unit {_4} {_8} (fun (_x: ()) -> [ &_3 <- _x ] s5)
+      | s5 = -{resolve_refmut_Resource_Option_Excl_unit _5}- s6
+      | s6 = into_ghost_i32 {old_value_AtomicI32 self.current.c1'5.current.current}
+          (fun (_x: Int32.t) -> [ &_12 <- _x ] s7)
+      | s7 = into_inner_i32 {_12} (fun (_x: Int32.t) -> [ &_11 <- _x ] s8)
+      | s8 = [ &_10 <- _11 = (1: Int32.t) ] s9
+      | s9 = any [ br0 -> {_10 = false} (! bb10) | br1 -> {_10} (! bb6) ] ]
+    | bb6 = s0
+      [ s0 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {inv.current.tok}
+          {MutBorrow.inherit_id (MutBorrow.get_id inv) 2}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_18 <- _bor ] [ &inv <- { inv with current = { inv.current with tok = _bor.final } } ] s1)
+      | s1 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c0'5.current}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_22 <- _bor ]
+            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
+            s2)
+      | s2 = deref_mut_Ghost_Resource_Option_Excl_unit {_22}
+          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_21 <- _x ] s3)
+      | s3 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_21.current} {MutBorrow.get_id _21}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_20 <- _bor ] [ &_21 <- { _21 with current = _bor.final } ] s4)
+      | s4 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_18.current} {MutBorrow.get_id _18}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_17 <- _bor ] [ &_18 <- { _18 with current = _bor.final } ] s5)
+      | s5 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_20.current} {MutBorrow.get_id _20}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_19 <- _bor ] [ &_20 <- { _20 with current = _bor.final } ] s6)
+      | s6 = swap_Resource_Option_Excl_unit {_17} {_19} (fun (_x: ()) -> [ &_16 <- _x ] s7)
+      | s7 = -{resolve_refmut_Resource_Option_Excl_unit _21}- s8
+      | s8 = -{resolve_refmut_Resource_Option_Excl_unit _20}- s9
+      | s9 = -{resolve_refmut_Resource_Option_Excl_unit _18}- s10
+      | s10 = bb10 ]
+    | bb10 = s0
+      [ s0 = MutBorrow.borrow_final <t_Perm_AtomicI32> {inv.current.atomic_own}
+          {MutBorrow.inherit_id (MutBorrow.get_id inv) 0}
+          (fun (_bor: MutBorrow.t t_Perm_AtomicI32) ->
+            [ &_26 <- _bor ] [ &inv <- { inv with current = { inv.current with atomic_own = _bor.final } } ] s1)
+      | s1 = MutBorrow.borrow_mut <t_Committer_AtomicI32> {self.current.c1'5.current.current}
+          (fun (_bor: MutBorrow.t t_Committer_AtomicI32) ->
+            [ &_24 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = { self.current.c1'5.current with current = _bor.final } } } } ]
+            s2)
+      | s2 = MutBorrow.borrow_final <t_Perm_AtomicI32> {_26.current} {MutBorrow.get_id _26}
+          (fun (_bor: MutBorrow.t t_Perm_AtomicI32) ->
+            [ &_25 <- _bor ] [ &_26 <- { _26 with current = _bor.final } ] s3)
+      | s3 = shoot_AtomicI32 {_24} {_25} (fun (_x: ()) -> [ &_23 <- _x ] s4)
+      | s4 = -{resolve_refmut_Box_Perm_AtomicI32_Global _26}- s5
+      | s5 = -{resolve_refmut_closure0 self}- s6
+      | s6 = MutBorrow.borrow_final <t_Option_Box_Perm_PermCell_i32_Global> {inv.current.data_own}
+          {MutBorrow.inherit_id (MutBorrow.get_id inv) 1}
+          (fun (_bor: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global) ->
+            [ &_27 <- _bor ] [ &inv <- { inv with current = { inv.current with data_own = _bor.final } } ] s7)
+      | s7 = take_Box_Perm_PermCell_i32_Global {_27}
+          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_ret <- _x ] s8)
+      | s8 = -{resolve_refmut_MessagePassingAtomicInv inv}- s9
+      | s9 = return {_ret} ] ]
+    [ & _ret: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & self: MutBorrow.t closure0'3 = self
+    | & inv: MutBorrow.t t_MessagePassingAtomicInv = inv
+    | & _3: () = Any.any_l ()
+    | & _4: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _5: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _6: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _8: t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _10: bool = Any.any_l ()
+    | & _11: Int32.t = Any.any_l ()
+    | & _12: Int32.t = Any.any_l ()
+    | & _16: () = Any.any_l ()
+    | & _17: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _18: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _19: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _20: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _21: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _22: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _23: () = Any.any_l ()
+    | & _24: MutBorrow.t t_Committer_AtomicI32 = Any.any_l ()
+    | & _25: MutBorrow.t t_Perm_AtomicI32 = Any.any_l ()
+    | & _26: MutBorrow.t t_Perm_AtomicI32 = Any.any_l ()
+    | & _27: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global = Any.any_l () ]
+    [ return (result: t_Option_Box_Perm_PermCell_i32_Global) ->
+    {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure0 self.current self.final}
+      return {result} ]
+  
+  meta "rewrite_def" predicate closure0'2'pre
+  
+  meta "rewrite_def" predicate closure0'2'post'return
+  
+  predicate postcondition_once_closure0'2 [@inline:trivial] (self: closure0'3) (args: MutBorrow.t t_MessagePassingAtomicInv) (result: t_Option_Box_Perm_PermCell_i32_Global) =
+    let inv = args in exists e: closure0'3. (exists bor_self: MutBorrow.t closure0'3. bor_self.current = self
+          /\ bor_self.final = e /\ closure0'2'post'return bor_self inv result /\ hist_inv_closure0 self e)
+      /\ resolve_closure0 e
+  
+  meta "rewrite_def" predicate postcondition_once_closure0'2
+  
+  predicate postcondition_mut_closure0 [@inline:trivial] (self: closure0'3) (args: MutBorrow.t t_MessagePassingAtomicInv) (result_state: closure0'3) (result: t_Option_Box_Perm_PermCell_i32_Global) =
+    let inv = args in exists bor_self: MutBorrow.t closure0'3. bor_self.current = self
+      /\ bor_self.final = result_state
+      /\ closure0'2'post'return bor_self inv result /\ hist_inv_closure0 self result_state
+  
+  meta "rewrite_def" predicate postcondition_mut_closure0
+  
+  function fn_mut_once_closure0 (self: closure0'3) (args: MutBorrow.t t_MessagePassingAtomicInv) (res: t_Option_Box_Perm_PermCell_i32_Global) : ()
+  
+  axiom fn_mut_once_closure0_spec:
+    forall self: closure0'3, args: MutBorrow.t t_MessagePassingAtomicInv, res: t_Option_Box_Perm_PermCell_i32_Global. postcondition_once_closure0'2 self args res
+      = (exists res_state: closure0'3. postcondition_mut_closure0 self args res_state res /\ resolve_closure0 res_state)
+  
+  function hist_inv_trans_closure0 (self: closure0'3) (b: closure0'3) (c: closure0'3) : ()
+  
+  axiom hist_inv_trans_closure0_spec: forall self: closure0'3, b: closure0'3, c: closure0'3. hist_inv_closure0 self b
+      -> hist_inv_closure0 b c -> hist_inv_closure0 self c
+  
+  function hist_inv_refl_closure0 (self: closure0'3) : ()
+  
+  axiom hist_inv_refl_closure0_spec: forall self: closure0'3. hist_inv_closure0 self self
+  
+  function postcondition_mut_hist_inv_closure0 (self: closure0'3) (args: MutBorrow.t t_MessagePassingAtomicInv) (res_state: closure0'3) (res: t_Option_Box_Perm_PermCell_i32_Global) : ()
+  
+  axiom postcondition_mut_hist_inv_closure0_spec:
+    forall self: closure0'3, args: MutBorrow.t t_MessagePassingAtomicInv, res_state: closure0'3, res: t_Option_Box_Perm_PermCell_i32_Global. postcondition_mut_closure0 self args res_state res
+      -> hist_inv_closure0 self res_state
+  
+  type t_FnGhostWrapper_closure0'1 = { f0'6: closure0'3 }
+  
+  let rec __new_closure0'1 (f: closure0'3) (return (x: t_FnGhostWrapper_closure0'1)) = any
+    [ return (result: t_FnGhostWrapper_closure0'1) -> {[@stop_split] [@expl:__new ensures] result.f0'6 = f}
+      (! return {result}) ]
+  
+  predicate precondition_closure0'2 [@inline:trivial] (self: closure0'3) (args: MutBorrow.t t_MessagePassingAtomicInv) =
+    let inv = args in forall bor_self: MutBorrow.t closure0'3. bor_self.current = self -> closure0'2'pre bor_self inv
+  
+  meta "rewrite_def" predicate precondition_closure0'2
+  
+  predicate precondition_FnGhostWrapper_closure0'1 [@inline:trivial] (self: t_FnGhostWrapper_closure0'1) (args: MutBorrow.t t_MessagePassingAtomicInv) =
+    precondition_closure0'2 self.f0'6 args
+  
+  meta "rewrite_def" predicate precondition_FnGhostWrapper_closure0'1
+  
+  predicate postcondition_once_FnGhostWrapper_closure0'1 [@inline:trivial] (self: t_FnGhostWrapper_closure0'1) (args: MutBorrow.t t_MessagePassingAtomicInv) (result: t_Option_Box_Perm_PermCell_i32_Global) =
+    postcondition_once_closure0'2 self.f0'6 args result
+  
+  meta "rewrite_def" predicate postcondition_once_FnGhostWrapper_closure0'1
+  
+  let rec open_MessagePassingAtomicInv'0 (self: t_AtomicInvariant_MessagePassingAtomicInv) (tokens: t_Tokens)
+    (f: t_FnGhostWrapper_closure0'1) (return (x: t_Option_Box_Perm_PermCell_i32_Global)) =
+    {[@stop_split] [@expl:open_MessagePassingAtomicInv requires] ([@stop_split] [@expl:open requires #0] contains tokens (namespace_MessagePassingAtomicInv self))
+    /\ ([@stop_split] [@expl:open requires #1] forall t: MutBorrow.t t_MessagePassingAtomicInv. protocol_MessagePassingAtomicInv t.current (public_MessagePassingAtomicInv self)
+        /\ inv_refmut_MessagePassingAtomicInv t
+      -> precondition_FnGhostWrapper_closure0'1 f t
+      /\ (forall res: t_Option_Box_Perm_PermCell_i32_Global. postcondition_once_FnGhostWrapper_closure0'1 f t res
+        -> protocol_MessagePassingAtomicInv t.final (public_MessagePassingAtomicInv self)))}
+    any
+    [ return (result: t_Option_Box_Perm_PermCell_i32_Global) ->
+    {[@stop_split] [@expl:open ensures] exists t: MutBorrow.t t_MessagePassingAtomicInv. inv_refmut_MessagePassingAtomicInv t
+        /\ protocol_MessagePassingAtomicInv t.current (public_MessagePassingAtomicInv self)
+        /\ postcondition_once_FnGhostWrapper_closure0'1 f t result}
+      (! return {result}) ]
+  
+  predicate resolve_refmut_Tokens [@inline:trivial] (_1: MutBorrow.t t_Tokens) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Tokens
+  
+  predicate resolve_refmut_closure4 [@inline:trivial] (_1: MutBorrow.t closure4) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_closure4
+  
+  predicate resolve_refmut_Ghost_Tokens [@inline:trivial] (_1: MutBorrow.t t_Tokens) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Ghost_Tokens
+  
+  predicate resolve_closure4 [@inline:trivial] (_1: closure4) =
+    resolve_refmut_Ghost_Resource_Option_Excl_unit _1.c2'4 /\ resolve_refmut_Ghost_Tokens _1.c1'4
+  
+  meta "rewrite_def" predicate resolve_closure4
+  
+  predicate hist_inv_closure4 [@inline:trivial] (self: closure4) (result_state: closure4) =
+    result_state.c0'4 = self.c0'4
+    /\ result_state.c1'4.final = self.c1'4.final /\ result_state.c2'4.final = self.c2'4.final
+  
+  meta "rewrite_def" predicate hist_inv_closure4
+  
+  let rec closure4 [@coma:extspec] (self: MutBorrow.t closure4) (c: MutBorrow.t t_Committer_AtomicI32)
+    (return (x: t_Option_Box_Perm_PermCell_i32_Global)) = bb0
+    [ bb0 = s0
+      [ s0 = deref_Ghost_ref_AtomicInvariant_MessagePassingAtomicInv {self.current.c0'4}
+          (fun (_x: t_AtomicInvariant_MessagePassingAtomicInv) -> [ &_4 <- _x ] s1)
+      | s1 = MutBorrow.borrow_mut <t_Tokens> {self.current.c1'4.current}
+          (fun (_bor: MutBorrow.t t_Tokens) ->
+            [ &_9 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'4 = { self.current.c1'4 with current = _bor.final } } } ]
+            s2)
+      | s2 = deref_mut_Ghost_Tokens {_9} (fun (_x: MutBorrow.t t_Tokens) -> [ &_8 <- _x ] s3)
+      | s3 = MutBorrow.borrow_final <t_Tokens> {_8.current} {MutBorrow.get_id _8}
+          (fun (_bor: MutBorrow.t t_Tokens) -> [ &_7 <- _bor ] [ &_8 <- { _8 with current = _bor.final } ] s4)
+      | s4 = reborrow {_7} (fun (_x: t_Tokens) -> [ &_6 <- _x ] s5)
+      | s5 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c2'4.current}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_12 <- _bor ]
+            [ &self <- { self with current = { self.current with c2'4 = { self.current.c2'4 with current = _bor.final } } } ]
+            s6)
+      | s6 = MutBorrow.borrow_mut <MutBorrow.t t_Committer_AtomicI32> {c}
+          (fun (_bor: MutBorrow.t (MutBorrow.t t_Committer_AtomicI32)) -> [ &_13 <- _bor ] [ &c <- _bor.final ] s7)
+      | s7 = [ &_11 <- { c0'5 = _12; c1'5 = _13 } ] s8
+      | s8 = __new_closure0'1 {_11} (fun (_x: t_FnGhostWrapper_closure0'1) -> [ &_10 <- _x ] s9)
+      | s9 = open_MessagePassingAtomicInv'0 {_4} {_6} {_10}
+          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_ret <- _x ] s10)
+      | s10 = -{resolve_refmut_Tokens _8}- s11
+      | s11 = -{resolve_refmut_Committer_AtomicI32 c}- s12
+      | s12 = -{resolve_refmut_closure4 self}- s13
+      | s13 = return {_ret} ] ]
+    [ & _ret: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & self: MutBorrow.t closure4 = self
+    | & c: MutBorrow.t t_Committer_AtomicI32 = c
+    | & _4: t_AtomicInvariant_MessagePassingAtomicInv = Any.any_l ()
+    | & _6: t_Tokens = Any.any_l ()
+    | & _7: MutBorrow.t t_Tokens = Any.any_l ()
+    | & _8: MutBorrow.t t_Tokens = Any.any_l ()
+    | & _9: MutBorrow.t t_Tokens = Any.any_l ()
+    | & _10: t_FnGhostWrapper_closure0'1 = Any.any_l ()
+    | & _11: closure0'3 = Any.any_l ()
+    | & _12: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _13: MutBorrow.t (MutBorrow.t t_Committer_AtomicI32) = Any.any_l () ]
+    [ return (result: t_Option_Box_Perm_PermCell_i32_Global) ->
+    {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure4 self.current self.final}
+      return {result} ]
+  
+  meta "rewrite_def" predicate closure4'pre
+  
+  meta "rewrite_def" predicate closure4'post'return
+  
+  predicate postcondition_once_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_Committer_AtomicI32) (result: t_Option_Box_Perm_PermCell_i32_Global) =
+    let c = args in exists e: closure4. (exists bor_self: MutBorrow.t closure4. bor_self.current = self
+          /\ bor_self.final = e /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self e)
+      /\ resolve_closure4 e
+  
+  meta "rewrite_def" predicate postcondition_once_closure4
+  
+  predicate postcondition_mut_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_Committer_AtomicI32) (result_state: closure4) (result: t_Option_Box_Perm_PermCell_i32_Global) =
+    let c = args in exists bor_self: MutBorrow.t closure4. bor_self.current = self
+      /\ bor_self.final = result_state /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self result_state
+  
+  meta "rewrite_def" predicate postcondition_mut_closure4
+  
+  function fn_mut_once_closure4 (self: closure4) (args: MutBorrow.t t_Committer_AtomicI32) (res: t_Option_Box_Perm_PermCell_i32_Global) : ()
+  
+  axiom fn_mut_once_closure4_spec:
+    forall self: closure4, args: MutBorrow.t t_Committer_AtomicI32, res: t_Option_Box_Perm_PermCell_i32_Global. postcondition_once_closure4 self args res
+      = (exists res_state: closure4. postcondition_mut_closure4 self args res_state res /\ resolve_closure4 res_state)
+  
+  function hist_inv_trans_closure4 (self: closure4) (b: closure4) (c: closure4) : ()
+  
+  axiom hist_inv_trans_closure4_spec: forall self: closure4, b: closure4, c: closure4. hist_inv_closure4 self b
+      -> hist_inv_closure4 b c -> hist_inv_closure4 self c
+  
+  function hist_inv_refl_closure4 (self: closure4) : ()
+  
+  axiom hist_inv_refl_closure4_spec: forall self: closure4. hist_inv_closure4 self self
+  
+  function postcondition_mut_hist_inv_closure4 (self: closure4) (args: MutBorrow.t t_Committer_AtomicI32) (res_state: closure4) (res: t_Option_Box_Perm_PermCell_i32_Global) : ()
+  
+  axiom postcondition_mut_hist_inv_closure4_spec:
+    forall self: closure4, args: MutBorrow.t t_Committer_AtomicI32, res_state: closure4, res: t_Option_Box_Perm_PermCell_i32_Global. postcondition_mut_closure4 self args res_state res
+      -> hist_inv_closure4 self res_state
+  
+  type t_FnGhostWrapper_closure4 = { f0'7: closure4 }
+  
+  let rec __new_closure4 (f: closure4) (return (x: t_FnGhostWrapper_closure4)) = any
+    [ return (result: t_FnGhostWrapper_closure4) -> {[@stop_split] [@expl:__new ensures] result.f0'7 = f}
+      (! return {result}) ]
+  
+  let rec new_FnGhostWrapper_closure4 (x: t_FnGhostWrapper_closure4) (return (x'0: t_FnGhostWrapper_closure4)) = any
+    [ return (result: t_FnGhostWrapper_closure4) -> {[@stop_split] [@expl:new ensures] result = x} (! return {result}) ]
+  
+  type tup2_i32_Ghost_Option_Box_Perm_PermCell_i32_Global = {
+    f0'8: Int32.t;
+    f1'8: t_Option_Box_Perm_PermCell_i32_Global }
+  
+  predicate precondition_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_Committer_AtomicI32) =
+    let c = args in forall bor_self: MutBorrow.t closure4. bor_self.current = self -> closure4'pre bor_self c
+  
+  meta "rewrite_def" predicate precondition_closure4
+  
+  predicate precondition_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_Committer_AtomicI32) =
+    precondition_closure4 self.f0'7 args
+  
+  meta "rewrite_def" predicate precondition_FnGhostWrapper_closure4
+  
+  predicate postcondition_once_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_Committer_AtomicI32) (result: t_Option_Box_Perm_PermCell_i32_Global) =
+    postcondition_once_closure4 self.f0'7 args result
+  
+  meta "rewrite_def" predicate postcondition_once_FnGhostWrapper_closure4
+  
+  let rec load_Option_Box_Perm_PermCell_i32_Global (self: t_AtomicI32) (f: t_FnGhostWrapper_closure4)
+    (return (x: tup2_i32_Ghost_Option_Box_Perm_PermCell_i32_Global)) =
+    {[@stop_split] [@expl:load_Option_Box_Perm_PermCell_i32_Global requires] ([@stop_split] [@expl:load 'self' type invariant] inv_ref_AtomicI32 self)
+    /\ ([@stop_split] [@expl:load requires] forall c: MutBorrow.t t_Committer_AtomicI32. not shot_AtomicI32 c.current
+      -> ward_AtomicI32'0 c.current = self
+      -> new_value_AtomicI32 c.current = old_value_AtomicI32 c.current
+      -> precondition_FnGhostWrapper_closure4 f c
+      /\ (forall r: t_Option_Box_Perm_PermCell_i32_Global. postcondition_once_FnGhostWrapper_closure4 f c r
+        -> shot_AtomicI32 c.final))}
+    any
+    [ return (result: tup2_i32_Ghost_Option_Box_Perm_PermCell_i32_Global) ->
+    {[@stop_split] [@expl:load ensures] exists c: MutBorrow.t t_Committer_AtomicI32. not shot_AtomicI32 c.current
+        /\ ward_AtomicI32'0 c.current = self
+        /\ new_value_AtomicI32 c.current = old_value_AtomicI32 c.current
+        /\ new_value_AtomicI32 c.current = result.f0'8 /\ postcondition_once_FnGhostWrapper_closure4 f c result.f1'8}
+      (! return {result}) ]
+  
+  predicate inv_closure1 [@inline:trivial] (_1: closure1) =
+    let {c0'3 = x0; c1'3 = x1; c2'3 = x2; c3'3 = x3} = _1 in inv_ref_AtomicI32 x1
+  
+  meta "rewrite_def" predicate inv_closure1
+  
+  predicate resolve_Ghost_Option_Box_Perm_PermCell_i32_Global [@inline:trivial] (_1: t_Option_Box_Perm_PermCell_i32_Global) =
+    resolve_Option_Box_Perm_PermCell_i32_Global _1
+  
+  meta "rewrite_def" predicate resolve_Ghost_Option_Box_Perm_PermCell_i32_Global
+  
+  predicate resolve_Tokens (_1: t_Tokens)
+  
+  predicate resolve_Ghost_Tokens [@inline:trivial] (_1: t_Tokens) = resolve_Tokens _1
+  
+  meta "rewrite_def" predicate resolve_Ghost_Tokens
+  
+  let rec into_inner_Option_Box_Perm_PermCell_i32_Global (self: t_Option_Box_Perm_PermCell_i32_Global)
+    (return (x: t_Option_Box_Perm_PermCell_i32_Global)) = any
+    [ return (result: t_Option_Box_Perm_PermCell_i32_Global) -> {[@stop_split] [@expl:into_inner ensures] result = self}
+      (! return {result}) ]
+  
+  let rec unwrap_Box_Perm_PermCell_i32_Global (self_: t_Option_Box_Perm_PermCell_i32_Global)
+    (return (x: t_Perm_PermCell_i32)) = {[@stop_split] [@expl:unwrap requires] self_ <> None'0}
+    any
+    [ return (result: t_Perm_PermCell_i32) -> {[@stop_split] [@expl:unwrap ensures] Some'0 result = self_}
+      (! return {result}) ]
+  
+  let rec new_Box_Perm_PermCell_i32_Global (x: t_Perm_PermCell_i32) (return (x'0: t_Perm_PermCell_i32)) = any
+    [ return (result: t_Perm_PermCell_i32) -> {[@stop_split] [@expl:new ensures] result = x} (! return {result}) ]
+  
+  predicate resolve_Resource_Option_Excl_unit (_1: t_Resource_Option_Excl_unit)
+  
+  predicate resolve_Ghost_Resource_Option_Excl_unit [@inline:trivial] (_1: t_Resource_Option_Excl_unit) =
+    resolve_Resource_Option_Excl_unit _1
+  
+  meta "rewrite_def" predicate resolve_Ghost_Resource_Option_Excl_unit
+  
+  predicate resolve_closure1 [@inline:trivial] (_1: closure1) = resolve_Ghost_Resource_Option_Excl_unit _1.c0'3
+  
+  meta "rewrite_def" predicate resolve_closure1
+  
+  predicate resolve_Ghost_Box_Perm_PermCell_i32_Global [@inline:trivial] (_1: t_Perm_PermCell_i32) =
+    resolve_Box_Perm_PermCell_i32_Global _1
+  
+  meta "rewrite_def" predicate resolve_Ghost_Box_Perm_PermCell_i32_Global
+  
+  let rec deref_Ghost_Box_Perm_PermCell_i32_Global (self: t_Perm_PermCell_i32) (return (x: t_Perm_PermCell_i32)) = any
+    [ return (result: t_Perm_PermCell_i32) -> {[@stop_split] [@expl:deref ensures] result = self} (! return {result}) ]
+  
+  let rec new_ref_Perm_PermCell_i32 (x: t_Perm_PermCell_i32) (return (x'0: t_Perm_PermCell_i32)) = any
+    [ return (result: t_Perm_PermCell_i32) -> {[@stop_split] [@expl:new ensures] result = x} (! return {result}) ]
+  
+  let rec get_i32 (self: t_PermCell_i32) (perm: t_Perm_PermCell_i32) (return (x: Int32.t)) =
+    {[@stop_split] [@expl:get requires] self = ward_PermCell_i32 perm}
+    any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:get ensures] result = view_Perm_PermCell_i32 perm}
+      (! return {result}) ]
+  
+  let rec closure1 [@coma:extspec] (self: closure1) (tokens: t_Tokens) (return (x: ())) =
+    {[@stop_split] [@expl:closure 'self' type invariant] inv_closure1 self}
+    bb0
+    [ bb0 = s0
+      [ s0 = [ &excl_snap <- self.c0'3 ] s1
+      | s1 = [ &_old <- self.c1'3 ] s2
+      | s2 = [ &_old'0 <- self.c2'3 ] s3
+      | s3 = [ &_old'1 <- self.c3'3 ] s4
+      | s4 = bb2 ]
+    | bb2 = bb2
+      [ bb2 = {[@expl:inferred invariant: type invariant] inv_closure1 self}
+        {[@expl:inferred invariant: unchanged value] _old'1 = self.c3'3}
+        {[@expl:inferred invariant: unchanged value] _old'0 = self.c2'3}
+        {[@expl:inferred invariant: unchanged value] _old = self.c1'3}
+        {[@expl:loop invariant #0] self.c0'3 = excl_snap}
+        {[@expl:loop invariant #1] contains tokens (Namespace_MESSAGE_PASSING 0)}
+        (! s0)
+        [ s0 = [ &_16 <- self.c1'3 ] s1
+        | s1 = [ &_20 <- self.c2'3 ] s2
+        | s2 = MutBorrow.borrow_mut <t_Tokens> {tokens}
+            (fun (_bor: MutBorrow.t t_Tokens) -> [ &_21 <- _bor ] [ &tokens <- _bor.final ] s3)
+        | s3 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.c0'3}
+            (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+              [ &_22 <- _bor ] [ &self <- { self with c0'3 = _bor.final } ] s4)
+        | s4 = [ &_19 <- { c0'4 = _20; c1'4 = _21; c2'4 = _22 } ] s5
+        | s5 = __new_closure4 {_19} (fun (_x: t_FnGhostWrapper_closure4) -> [ &_18 <- _x ] s6)
+        | s6 = new_FnGhostWrapper_closure4 {_18} (fun (_x: t_FnGhostWrapper_closure4) -> [ &_17 <- _x ] s7)
+        | s7 = load_Option_Box_Perm_PermCell_i32_Global {_16} {_17}
+            (fun (_x: tup2_i32_Ghost_Option_Box_Perm_PermCell_i32_Global) -> [ &_15 <- _x ] s8)
+        | s8 = [ &atomic_res <- _15.f0'8 ] s9
+        | s9 = [ &data_own'0 <- _15.f1'8 ] s10
+        | s10 = [ &_24 <- atomic_res <> (1: Int32.t) ] s11
+        | s11 = any [ br0 -> {_24 = false} (! bb8) | br1 -> {_24} (! bb7) ] ]
+        [ bb7 = s0 [ s0 = -{resolve_Ghost_Option_Box_Perm_PermCell_i32_Global data_own'0}- s1 | s1 = bb2 ] ] ]
+    | bb8 = s0
+      [ s0 = -{resolve_Ghost_Tokens tokens}- s1
+      | s1 = into_inner_Option_Box_Perm_PermCell_i32_Global {data_own'0}
+          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_29 <- _x ] s2)
+      | s2 = unwrap_Box_Perm_PermCell_i32_Global {_29} (fun (_x: t_Perm_PermCell_i32) -> [ &_28 <- _x ] s3)
+      | s3 = new_Box_Perm_PermCell_i32_Global {_28} (fun (_x: t_Perm_PermCell_i32) -> [ &data_own'1 <- _x ] s4)
+      | s4 = s5 [ _ck -> (! {[@expl:type invariant] inv_closure1 self} any) ]
+      | s5 = -{resolve_closure1 self}- s6
+      | s6 = -{resolve_Ghost_Box_Perm_PermCell_i32_Global data_own'1}- s7
+      | s7 = deref_Ghost_Box_Perm_PermCell_i32_Global {data_own'1} (fun (_x: t_Perm_PermCell_i32) -> [ &_36 <- _x ] s8)
+      | s8 = [ &_35 <- _36 ] s9
+      | s9 = new_ref_Perm_PermCell_i32 {_35} (fun (_x: t_Perm_PermCell_i32) -> [ &_33 <- _x ] s10)
+      | s10 = get_i32 {self.c3'3} {_33} (fun (_x: Int32.t) -> [ &res <- _x ] s11)
+      | s11 = {[@expl:assertion] res = (1: Int32.t)} s12
+      | s12 = return {_ret} ] ]
+    [ & _ret: () = Any.any_l ()
+    | & self: closure1 = self
+    | & tokens: t_Tokens = tokens
+    | & excl_snap: t_Resource_Option_Excl_unit = Any.any_l ()
+    | & atomic_res: Int32.t = Any.any_l ()
+    | & data_own'0: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _15: tup2_i32_Ghost_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _16: t_AtomicI32 = Any.any_l ()
+    | & _17: t_FnGhostWrapper_closure4 = Any.any_l ()
+    | & _18: t_FnGhostWrapper_closure4 = Any.any_l ()
+    | & _19: closure4 = Any.any_l ()
+    | & _20: t_AtomicInvariant_MessagePassingAtomicInv = Any.any_l ()
+    | & _21: MutBorrow.t t_Tokens = Any.any_l ()
+    | & _22: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _24: bool = Any.any_l ()
+    | & data_own'1: t_Perm_PermCell_i32 = Any.any_l ()
+    | & _28: t_Perm_PermCell_i32 = Any.any_l ()
+    | & _29: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & res: Int32.t = Any.any_l ()
+    | & _33: t_Perm_PermCell_i32 = Any.any_l ()
+    | & _35: t_Perm_PermCell_i32 = Any.any_l ()
+    | & _36: t_Perm_PermCell_i32 = Any.any_l ()
+    | & _old: t_AtomicI32 = Any.any_l ()
+    | & _old'0: t_AtomicInvariant_MessagePassingAtomicInv = Any.any_l ()
+    | & _old'1: t_PermCell_i32 = Any.any_l () ] [ return (result: ()) -> return {result} ]
+  
+  meta "rewrite_def" predicate closure1'pre
+  
+  meta "rewrite_def" predicate closure1'post'return
+  
+  predicate precondition_closure1 [@inline:trivial] (self: closure1) (args: t_Tokens) =
+    let tokens = args in closure1'pre self tokens
+  
+  meta "rewrite_def" predicate precondition_closure1
+  
+  predicate postcondition_once_closure1 [@inline:trivial] (self: closure1) (args: t_Tokens) (result: ()) =
+    let tokens = args in closure1'post'return self tokens result
+  
+  meta "rewrite_def" predicate postcondition_once_closure1
+  
+  let rec spawn_closure1 (self: MutBorrow.t t_Scope) (f: closure1) (return (x: t_ScopedJoinHandle_unit)) =
+    {[@stop_split] [@expl:spawn_closure1 requires] ([@stop_split] [@expl:spawn 'self' type invariant] inv_refmut_Scope self)
+    /\ ([@stop_split] [@expl:spawn 'f' type invariant] inv_closure1 f)
+    /\ ([@stop_split] [@expl:spawn requires] forall t: t_Tokens. (forall ns: t_Namespace. contains t ns)
+      -> precondition_closure1 f t)}
+    any
+    [ return (result: t_ScopedJoinHandle_unit) ->
+    {[@stop_split] [@expl:spawn_closure1 ensures] ([@stop_split] [@expl:spawn result type invariant] inv_ScopedJoinHandle_unit result)
+      /\ ([@stop_split] [@expl:spawn ensures] exists t: t_Tokens. (forall ns: t_Namespace. contains t ns)
+        /\ (forall r: (). valid_result_ScopedJoinHandle_unit result r -> postcondition_once_closure1 f t r))}
+      (! return {result}) ]
+  
+  predicate resolve_refmut_Scope [@inline:trivial] (_1: MutBorrow.t t_Scope) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Scope
+  
+  let rec join_unwrap_ScopedJoinHandle_unit (self: t_ScopedJoinHandle_unit) (return (x: ())) =
+    {[@stop_split] [@expl:join_unwrap 'self' type invariant] inv_ScopedJoinHandle_unit self}
+    any
+    [ return (result: ()) -> {[@stop_split] [@expl:join_unwrap ensures] valid_result_ScopedJoinHandle_unit self result}
+      (! return {result}) ]
+  
+  predicate inv_closure0'0 [@inline:trivial] (_1: closure0) =
+    let {c0 = x0; c1 = x1; c2 = x2; c3 = x3; c4 = x4} = _1 in inv_ref_AtomicI32 x2
+  
+  meta "rewrite_def" predicate inv_closure0'0
+  
+  let rec closure0'3 [@coma:extspec] (self: closure0) (s: MutBorrow.t t_Scope) (return (x: ())) =
+    {[@stop_split] [@expl:closure0 requires] ([@stop_split] [@expl:closure 'self' type invariant] inv_closure0'0 self)
+    /\ ([@stop_split] [@expl:closure 's' type invariant] inv_refmut_Scope s)}
+    bb0
+    [ bb0 = s0
+      [ s0 = borrow_AtomicInvariant_MessagePassingAtomicInv {self.c0}
+          (fun (_x: t_AtomicInvariant_MessagePassingAtomicInv) -> [ &inv <- _x ] s1)
+      | s1 = [ &data <- self.c1 ] s2
+      | s2 = [ &atomic <- self.c2 ] s3
+      | s3 = [ &_9 <- { c0'0 = data; c1'0 = self.c3; c2'0 = atomic; c3'0 = inv } ] s4
+      | s4 = MutBorrow.borrow_mut <t_Scope> {s.current}
+          (fun (_bor: MutBorrow.t t_Scope) ->
+            [ &_8 <- _bor ] -{inv_Scope _bor.final}-
+            [ &s <- { s with current = _bor.final } ] s5)
+        [ _ck -> (! {[@expl:type invariant] inv_Scope s.current} any) ]
+      | s5 = spawn_closure0 {_8} {_9} (fun (_x: t_ScopedJoinHandle_unit) -> [ &t1 <- _x ] s6)
+      | s6 = [ &_12 <- { c0'3 = self.c4; c1'3 = atomic; c2'3 = inv; c3'3 = data } ] s7
+      | s7 = MutBorrow.borrow_final <t_Scope> {s.current} {MutBorrow.get_id s}
+          (fun (_bor: MutBorrow.t t_Scope) ->
+            [ &_11 <- _bor ] -{inv_Scope _bor.final}-
+            [ &s <- { s with current = _bor.final } ] s8)
+        [ _ck -> (! {[@expl:type invariant] inv_Scope s.current} any) ]
+      | s8 = spawn_closure1 {_11} {_12} (fun (_x: t_ScopedJoinHandle_unit) -> [ &t2 <- _x ] s9)
+      | s9 = s10 [ _ck -> (! {[@expl:type invariant] inv_refmut_Scope s} any) ]
+      | s10 = -{resolve_refmut_Scope s}- s11
+      | s11 = join_unwrap_ScopedJoinHandle_unit {t1} (fun (_x: ()) -> [ &_13 <- _x ] s12)
+      | s12 = join_unwrap_ScopedJoinHandle_unit {t2} (fun (_x: ()) -> [ &_15 <- _x ] s13)
+      | s13 = return {_ret} ] ]
+    [ & _ret: () = Any.any_l ()
+    | & self: closure0 = self
+    | & s: MutBorrow.t t_Scope = s
+    | & inv: t_AtomicInvariant_MessagePassingAtomicInv = Any.any_l ()
+    | & data: t_PermCell_i32 = Any.any_l ()
+    | & atomic: t_AtomicI32 = Any.any_l ()
+    | & t1: t_ScopedJoinHandle_unit = Any.any_l ()
+    | & _8: MutBorrow.t t_Scope = Any.any_l ()
+    | & _9: closure0'0 = Any.any_l ()
+    | & t2: t_ScopedJoinHandle_unit = Any.any_l ()
+    | & _11: MutBorrow.t t_Scope = Any.any_l ()
+    | & _12: closure1 = Any.any_l ()
+    | & _13: () = Any.any_l ()
+    | & _15: () = Any.any_l () ] [ return (result: ()) -> return {result} ]
+  
+  meta "rewrite_def" predicate closure0'3'pre
+  
+  meta "rewrite_def" predicate closure0'3'post'return
+  
+  predicate precondition_closure0'3 [@inline:trivial] (self: closure0) (args: MutBorrow.t t_Scope) =
+    let s = args in closure0'3'pre self s
+  
+  meta "rewrite_def" predicate precondition_closure0'3
+  
+  predicate postcondition_once_closure0'3 [@inline:trivial] (self: closure0) (args: MutBorrow.t t_Scope) (result: ()) =
+    let s = args in closure0'3'post'return self s result
+  
+  meta "rewrite_def" predicate postcondition_once_closure0'3
+  
+  let rec scope_closure0 (f: closure0) (return (x: ())) =
+    {[@stop_split] [@expl:scope_closure0 requires] ([@stop_split] [@expl:scope 'f' type invariant] inv_closure0'0 f)
+    /\ ([@stop_split] [@expl:scope requires] forall s: MutBorrow.t t_Scope. inv_refmut_Scope s
+      -> precondition_closure0'3 f s)}
+    any
+    [ return (result: ()) -> {[@stop_split] [@expl:scope ensures] exists s: MutBorrow.t t_Scope. inv_refmut_Scope s
+        /\ postcondition_once_closure0'3 f s result}
+      (! return {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec message_passing (return (x: ())) = (! bb0
+    [ bb0 = s0
+      [ s0 = new {(0: Int32.t)} (fun (_x: tup2_AtomicI32_Ghost_Box_Perm_AtomicI32_Global) -> [ &_3 <- _x ] s1)
+      | s1 = [ &atomic <- _3.f0 ] s2
+      | s2 = [ &atomic_own'0 <- _3.f1 ] s3
+      | s3 = new_i32 {(0: Int32.t)} (fun (_x: tup2_PermCell_i32_Ghost_Box_Perm_PermCell_i32_Global) -> [ &_6 <- _x ] s4)
+      | s4 = [ &data <- _6.f0'0 ] s5
+      | s5 = [ &data_own'0 <- _6.f1'0 ] s6
+      | s6 = alloc_Option_Excl_unit {Some { f0'1 = () }} (fun (_x: t_Resource_Option_Excl_unit) -> [ &excl <- _x ] s7)
+      | s7 = into_inner_Box_Perm_AtomicI32_Global {atomic_own'0} (fun (_x: t_Perm_AtomicI32) -> [ &_13 <- _x ] s8)
+      | s8 = [ &_15 <- None'0 ] s9
+      | s9 = deref_Ghost_Resource_Option_Excl_unit {excl} (fun (_x: t_Resource_Option_Excl_unit) -> [ &_19 <- _x ] s10)
+      | s10 = id_ghost_Option_Excl_unit {_19} (fun (_x: t_Id) -> [ &_17 <- _x ] s11)
+      | s11 = new_unit_Option_Excl_unit {_17} (fun (_x: t_Resource_Option_Excl_unit) -> [ &_16 <- _x ] s12)
+      | s12 = [ &_12 <- { atomic_own = _13; data_own = _15; tok = _16 } ] s13
+      | s13 = new_MessagePassingAtomicInv {_12} (fun (_x: t_MessagePassingAtomicInv) -> [ &_11 <- _x ] s14)
+      | s14 = new_MessagePassingAtomicInv'0 {_11} {{ f0'3 = atomic; f1'3 = data; f2'3 = id_Option_Excl_unit excl }}
+          {Namespace_MESSAGE_PASSING 0} (fun (_x: t_AtomicInvariant_MessagePassingAtomicInv) -> [ &inv <- _x ] s15)
+      | s15 = -{resolve_Ghost_AtomicInvariant_MessagePassingAtomicInv inv}- s16
+      | s16 = -{resolve_PermCell_i32 data}- s17
+      | s17 = s18 [ _ck -> (! {[@expl:type invariant] inv_AtomicI32 atomic} any) ]
+      | s18 = -{resolve_AtomicI32 atomic}- s19
+      | s19 = [ &_29 <- { c0 = inv; c1 = data; c2 = atomic; c3 = data_own'0; c4 = excl } ] s20
+      | s20 = scope_closure0 {_29} (fun (_x: ()) -> [ &_28 <- _x ] s21)
+      | s21 = return {_ret} ] ]
+    [ & _ret: () = Any.any_l ()
+    | & atomic: t_AtomicI32 = Any.any_l ()
+    | & atomic_own'0: t_Perm_AtomicI32 = Any.any_l ()
+    | & _3: tup2_AtomicI32_Ghost_Box_Perm_AtomicI32_Global = Any.any_l ()
+    | & data: t_PermCell_i32 = Any.any_l ()
+    | & data_own'0: t_Perm_PermCell_i32 = Any.any_l ()
+    | & _6: tup2_PermCell_i32_Ghost_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & excl: t_Resource_Option_Excl_unit = Any.any_l ()
+    | & inv: t_AtomicInvariant_MessagePassingAtomicInv = Any.any_l ()
+    | & _11: t_MessagePassingAtomicInv = Any.any_l ()
+    | & _12: t_MessagePassingAtomicInv = Any.any_l ()
+    | & _13: t_Perm_AtomicI32 = Any.any_l ()
+    | & _15: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _16: t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _17: t_Id = Any.any_l ()
+    | & _19: t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _28: () = Any.any_l ()
+    | & _29: closure0 = Any.any_l () ]) [ return (result: ()) -> (! return {result}) ]
+end

--- a/examples/message_passing_sc_options.rs
+++ b/examples/message_passing_sc_options.rs
@@ -1,0 +1,109 @@
+extern crate creusot_std;
+
+use creusot_std::{
+    cell::PermCell,
+    ghost::{
+        Committer,
+        invariant::{AtomicInvariant, Protocol, Tokens, declare_namespace},
+        perm::Perm,
+        resource::Resource,
+    },
+    logic::{Id, ra::excl::Excl},
+    prelude::*,
+    std::{
+        sync::atomic_sc::AtomicI32,
+        thread::{self, JoinHandleExt},
+    },
+};
+
+declare_namespace! { MESSAGE_PASSING }
+
+struct MessagePassingAtomicInv {
+    atomic_own: Box<Perm<AtomicI32>>,
+    data_own: Option<Box<Perm<PermCell<i32>>>>,
+    tok: Resource<Option<Excl<()>>>,
+}
+
+impl Protocol for MessagePassingAtomicInv {
+    type Public = (AtomicI32, PermCell<i32>, Id);
+
+    #[logic(inline)]
+    fn protocol(self, data: Self::Public) -> bool {
+        pearlite! {
+            data.0 == *self.atomic_own.ward() && data.2 == self.tok.id() &&
+            (self.atomic_own.val()@ == 0 ||
+             match self.data_own {
+                Some(data_own) => data.1 == *data_own.ward() && self.atomic_own.val()@ == 1 && data_own.val()@ == 1,
+                None => self.tok.val() == Some(Excl(())),
+            })
+        }
+    }
+}
+
+pub fn message_passing() {
+    let (atomic, atomic_own) = AtomicI32::new(0i32);
+    let (data, mut data_own) = PermCell::new(0i32);
+    let mut excl = Resource::alloc(snapshot!(Some(Excl(()))));
+
+    // Initialize our invariant
+    let inv = AtomicInvariant::new(
+        ghost!(MessagePassingAtomicInv {
+            atomic_own: atomic_own.into_inner(),
+            data_own: None,
+            tok: Resource::new_unit(excl.id_ghost())
+        }),
+        snapshot!((atomic, data, excl.id())),
+        snapshot!(MESSAGE_PASSING()),
+    );
+
+    thread::scope(|s| {
+        let inv: Ghost<&_> = inv.borrow();
+        let data = &data;
+        let atomic = &atomic;
+
+        let t1 = s.spawn(move |tokens: Ghost<Tokens>| {
+            unsafe { *data.borrow_mut(ghost!(&mut **data_own)) = 1 }
+
+            atomic.store(
+                1,
+                ghost! { |c: &mut Committer<_>| {
+                    inv.open(tokens.into_inner(), |inv: &mut MessagePassingAtomicInv| {
+                        inv.data_own = Some(data_own.into_inner());
+                        c.shoot(&mut inv.atomic_own);
+                    })
+                }},
+            );
+        });
+
+        let t2 = s.spawn(move |mut tokens: Ghost<Tokens>| {
+            let excl_snap = snapshot!(excl);
+
+            #[invariant(excl == *excl_snap)]
+            #[invariant(tokens.contains(MESSAGE_PASSING()))]
+            loop {
+                let (atomic_res, data_own) = atomic.load(ghost! { |c: &mut Committer<AtomicI32>| {
+                    inv.open(tokens.reborrow(), |inv: &mut MessagePassingAtomicInv| {
+                        excl.valid_op_lemma(&inv.tok);
+                        if snapshot!{ c.old_value() }.into_ghost().into_inner() == 1 {
+                            std::mem::swap(&mut inv.tok, &mut *excl);
+                        }
+                        c.shoot(&mut inv.atomic_own);
+                        inv.data_own.take()
+                    })
+                }});
+
+                if atomic_res != 1 {
+                    continue;
+                }
+
+                let data_own = ghost! { data_own.into_inner().unwrap() };
+                let res = unsafe { data.get(ghost! { &**data_own }) };
+                proof_assert!(res == 1i32);
+                break;
+            }
+        });
+
+        let _ = t1.join_unwrap();
+        let _ = t2.join_unwrap();
+    });
+}

--- a/examples/message_passing_sc_options/proof.json
+++ b/examples/message_passing_sc_options/proof.json
@@ -1,0 +1,147 @@
+{
+  "profile": [],
+  "proofs": {
+    "M_message_passing": {
+      "vc___new_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.031 },
+      "vc___new_closure0'0": { "prover": "alt-ergo@2.6.2", "time": 0.032 },
+      "vc___new_closure0'1": { "prover": "alt-ergo@2.6.2", "time": 0.032 },
+      "vc___new_closure4": { "prover": "alt-ergo@2.6.2", "time": 0.033 },
+      "vc_alloc_Option_Excl_unit": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.047
+      },
+      "vc_borrow_AtomicInvariant_MessagePassingAtomicInv": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.032
+      },
+      "vc_borrow_mut_i32": { "prover": "alt-ergo@2.6.2", "time": 0.031 },
+      "vc_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.032 },
+      "vc_closure0'0": { "prover": "alt-ergo@2.6.2", "time": 0.024 },
+      "vc_closure0'1": { "prover": "alt-ergo@2.6.2", "time": 0.036 },
+      "vc_closure0'2": { "prover": "alt-ergo@2.6.2", "time": 0.023 },
+      "vc_closure0'3": { "prover": "alt-ergo@2.6.2", "time": 0.038 },
+      "vc_closure1": { "prover": "alt-ergo@2.6.2", "time": 0.037 },
+      "vc_closure4": { "prover": "alt-ergo@2.6.2", "time": 0.03 },
+      "vc_deref_Ghost_Box_Perm_PermCell_i32_Global": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.037
+      },
+      "vc_deref_Ghost_Resource_Option_Excl_unit": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.057
+      },
+      "vc_deref_Ghost_ref_AtomicInvariant_MessagePassingAtomicInv": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.025
+      },
+      "vc_deref_mut_Ghost_Box_Perm_PermCell_i32_Global": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.025
+      },
+      "vc_deref_mut_Ghost_Resource_Option_Excl_unit": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.036
+      },
+      "vc_deref_mut_Ghost_Tokens": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.028
+      },
+      "vc_get_i32": { "prover": "alt-ergo@2.6.2", "time": 0.037 },
+      "vc_id_ghost_Option_Excl_unit": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.039
+      },
+      "vc_into_ghost_i32": { "prover": "alt-ergo@2.6.2", "time": 0.028 },
+      "vc_into_inner_Box_Perm_AtomicI32_Global": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.047
+      },
+      "vc_into_inner_Box_Perm_PermCell_i32_Global": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.023
+      },
+      "vc_into_inner_Option_Box_Perm_PermCell_i32_Global": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.031
+      },
+      "vc_into_inner_Tokens": { "prover": "alt-ergo@2.6.2", "time": 0.025 },
+      "vc_into_inner_i32": { "prover": "alt-ergo@2.6.2", "time": 0.028 },
+      "vc_join_unwrap_ScopedJoinHandle_unit": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.032
+      },
+      "vc_load_Option_Box_Perm_PermCell_i32_Global": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.033
+      },
+      "vc_message_passing": {
+        "tactic": "compute_specified",
+        "children": [ { "prover": "cvc4@1.8", "time": 0.81 } ]
+      },
+      "vc_new": { "prover": "alt-ergo@2.6.2", "time": 0.047 },
+      "vc_new_Box_Perm_PermCell_i32_Global": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.031
+      },
+      "vc_new_FnGhostWrapper_closure0": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.032
+      },
+      "vc_new_FnGhostWrapper_closure4": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.033
+      },
+      "vc_new_MessagePassingAtomicInv": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.026
+      },
+      "vc_new_MessagePassingAtomicInv'0": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.042
+      },
+      "vc_new_i32": { "prover": "alt-ergo@2.6.2", "time": 0.044 },
+      "vc_new_ref_Perm_PermCell_i32": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.037
+      },
+      "vc_new_refmut_Perm_PermCell_i32": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.039
+      },
+      "vc_new_unit_Option_Excl_unit": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.036
+      },
+      "vc_open_MessagePassingAtomicInv": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.024
+      },
+      "vc_open_MessagePassingAtomicInv'0": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.029
+      },
+      "vc_reborrow": { "prover": "alt-ergo@2.6.2", "time": 0.028 },
+      "vc_scope_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.029 },
+      "vc_shoot_AtomicI32": { "prover": "alt-ergo@2.6.2", "time": 0.026 },
+      "vc_spawn_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.026 },
+      "vc_spawn_closure1": { "prover": "alt-ergo@2.6.2", "time": 0.035 },
+      "vc_store_unit": { "prover": "alt-ergo@2.6.2", "time": 0.038 },
+      "vc_swap_Resource_Option_Excl_unit": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.028
+      },
+      "vc_take_Box_Perm_PermCell_i32_Global": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.026
+      },
+      "vc_unwrap_Box_Perm_PermCell_i32_Global": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.031
+      },
+      "vc_valid_op_lemma_Option_Excl_unit": {
+        "prover": "alt-ergo@2.6.2",
+        "time": 0.036
+      }
+    }
+  }
+}


### PR DESCRIPTION
I tried an experiment, which made it possible to shorten a bit the proof.

The two main tricks were:
- Use options in the invariant type instead of a sum type
- Use a resource containing an option of an exclusive, instead of an option of an exclusive. This is semantically equivalent, but in the end is slightly simpler to handle.