### PR TITLE
Bump version to 0.11.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-creusot"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "creusot"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "creusot-args",
  "creusot-metadata",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-args"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "clap",
  "serde",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-dev-config"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "anyhow",
  "creusot-setup",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-install"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -354,14 +354,14 @@ dependencies = [
 
 [[package]]
 name = "creusot-metadata"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "creusot-rustc"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "creusot",
  "creusot-args",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-setup"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "anyhow",
  "creusot-args",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-std"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "creusot-std-proc",
  "num-rational",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-std-proc"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "pearlite-syn",
  "proc-macro2",
@@ -1098,7 +1098,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pearlite-syn"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "prelude-generator"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "anyhow",
  "creusot-setup",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "why3"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "indexmap",
  "itertools",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "why3tests"
-version = "0.10.0"
+version = "0.11.0-dev"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0-dev"
 documentation = "https://creusot-rs.github.io/creusot/doc/creusot_std/"
 readme = "README.md"
 keywords = ["verification"]

--- a/creusot-args/Cargo.toml
+++ b/creusot-args/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-args"
-version = "0.10.0"
+version = "0.11.0-dev"
 edition = "2024"
 publish = false
 

--- a/creusot-rustc/Cargo.toml
+++ b/creusot-rustc/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 serde_json = { version = "1.0" }
-creusot = { path = "../creusot", version = "0.10.0" }
+creusot = { path = "../creusot", version = "0.11.0-dev" }
 env_logger = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 creusot-args = { path = "../creusot-args" }

--- a/creusot-setup/Cargo.toml
+++ b/creusot-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-setup"
-version = "0.10.0"
+version = "0.11.0-dev"
 edition = "2024"
 publish = false
 

--- a/creusot-std-proc/Cargo.toml
+++ b/creusot-std-proc/Cargo.toml
@@ -27,7 +27,7 @@ creusot = ["dep:uuid", "dep:pearlite-syn", "proc-macro2/span-locations"]
 [dependencies]
 quote = "1.0"
 uuid = { version = "1.12", features = ["v4"], optional = true }
-pearlite-syn = { version = "0.10.0", path = "../pearlite-syn", features = ["full"], optional = true }
+pearlite-syn = { version = "0.11.0-dev", path = "../pearlite-syn", features = ["full"], optional = true }
 syn = { version = "2.0", features = ["full", "visit", "visit-mut"] }
 proc-macro2 = { version = "1.0" }
 

--- a/creusot-std/Cargo.toml
+++ b/creusot-std/Cargo.toml
@@ -18,7 +18,7 @@ categories.workspace = true
 num-rational = { version = "0.4", features = ["num-bigint"], default-features = false }
 
 [dependencies]
-creusot-std-proc = { path = "../creusot-std-proc", version = "0.10.0" }
+creusot-std-proc = { path = "../creusot-std-proc", version = "0.11.0-dev" }
 
 [features]
 # Enabled by creusot.


### PR DESCRIPTION
Creusot can no longer compile creusot-std 0.10.0 since the termination checker fix. I should add a job to check this some day.