### PR TITLE
Mapping should be contravariant.

### DIFF
--- a/creusot-std/src/logic/mapping.rs
+++ b/creusot-std/src/logic/mapping.rs
@@ -17,7 +17,7 @@ use core::marker::PhantomData;
 /// proof_assert!(map.get(1) == 4);
 /// ```
 #[builtin("map.Map.map")]
-pub struct Mapping<A: ?Sized, B>(PhantomData<A>, PhantomData<B>);
+pub struct Mapping<A: ?Sized, B>(PhantomData<fn(&A) -> B>);
 
 impl<A: ?Sized, B> Mapping<A, B> {
     /// Get the value associated with `a` in the map.


### PR DESCRIPTION
Note that I don't think that this is currently unsound, and maybe this would have never caused unsoundness, but at least on principles, it should be contravariant on the first parameter.