### PR TITLE
Re-work the API for atomics:

### DIFF
--- a/creusot-std/src/std/sync/atomic_relacq.rs
+++ b/creusot-std/src/std/sync/atomic_relacq.rs
@@ -54,18 +54,15 @@ impl AtomicI32 {
     // TODO: [VL] into_inner
 
     /// Wrapper for [`std::sync::atomic::AtomicI32::load`].
-    #[requires(forall<c: &mut LoadCommitter<i32, Self>> !c.shot() ==> c.ward() == *self ==>
-        f.precondition((c,)) && f.postcondition_once((c,), ()) ==> (^c).shot()
-    )]
-    #[ensures(exists<c: &mut LoadCommitter<i32, Self>>
-        !c.shot() && c.ward() == *self &&
-        c.val() == result && f.postcondition_once((c,), ())
+    #[requires(forall<c: &LoadCommitter<i32, Self>> c.ward() == *self ==> f.precondition((c,)))]
+    #[ensures(exists<c: &LoadCommitter<i32, Self>>
+        c.ward() == *self && c.val() == result && f.postcondition_once((c,), ())
     )]
     #[trusted]
     #[allow(unused_variables)]
-    pub fn load<'a, F>(&'a self, f: Ghost<F>) -> i32
+    pub fn load<F>(&self, f: Ghost<F>) -> i32
     where
-        F: FnGhost + FnOnce(&'a mut LoadCommitter<i32, Self>),
+        F: FnGhost + FnOnce(&LoadCommitter<i32, Self>),
     {
         self.0.load(if cfg!(feature = "sc-drf") {
             ::std::sync::atomic::Ordering::SeqCst
@@ -84,9 +81,9 @@ impl AtomicI32 {
     )]
     #[trusted]
     #[allow(unused_variables)]
-    pub fn store<'a, F>(&'a self, val: i32, f: Ghost<F>)
+    pub fn store<F>(&self, val: i32, f: Ghost<F>)
     where
-        F: FnGhost + FnOnce(&'a mut StoreCommitter<i32, Self>),
+        F: FnGhost + FnOnce(&mut StoreCommitter<i32, Self>),
     {
         self.0.store(
             val,
@@ -101,18 +98,17 @@ impl AtomicI32 {
 
 /// Wrapper around a single atomic load operation, where multiple ghost steps
 /// can be performed.
+///
+/// Note: this committer has no observable effect on ghost ressources. Thus, it is optional to shoot
+/// it, and nothing prevent the user from shooting it several times.
+// This trick is correct for SC accesses under SC-DRF, and for Rel/Acq/Rlx and Rlx accesses, but
+// perhaps not for C20's SC accesses.
 #[opaque]
 pub struct LoadCommitter<T, C: Container<Value = FMap<Timestamp, (T, SyncView)>>>(
     PhantomData<(T, C)>,
 );
 
 impl<T, C: Container<Value = FMap<Timestamp, (T, SyncView)>> + HasTimestamp> LoadCommitter<T, C> {
-    /// Status of the committer
-    #[logic(opaque)]
-    pub fn shot(self) -> bool {
-        dead
-    }
-
     /// Identity of the committer
     ///
     /// This is used so that we can only use the committer with the right [`AtomicOwn`].
@@ -129,21 +125,19 @@ impl<T, C: Container<Value = FMap<Timestamp, (T, SyncView)>> + HasTimestamp> Loa
 
     /// 'Shoot' the committer
     ///
-    /// This does the read on the atomic in ghost code, and can only be called once.
-    #[requires(!(*self).shot())]
-    #[requires(self.ward() == *(*own).ward())]
-    #[ensures((^self).shot())]
+    /// This does the read on the atomic in ghost code.
+    #[requires(self.ward() == *own.ward())]
     #[ensures((*view).le_log(^view))]
-    #[ensures((*self).ward().get_timestamp(*view) <= result)]
-    #[ensures(result <= (*self).ward().get_timestamp(^view))]
+    #[ensures(self.ward().get_timestamp(*view) <= result)]
+    #[ensures(result <= self.ward().get_timestamp(^view))]
     #[ensures(match own.val().get(result) {
-        Some((v, v_view)) => v == (*self).val() && v_view.le_log(^view),
+        Some((v, v_view)) => v == self.val() && v_view.le_log(^view),
         None => false
     })]
     #[check(ghost)]
     #[trusted]
     #[allow(unused_variables)]
-    pub fn shoot(&mut self, own: &Perm<C>, view: &mut SyncView) -> Timestamp {
+    pub fn shoot(&self, own: &Perm<C>, view: &mut SyncView) -> Timestamp {
         panic!("Should not be called outside ghost code")
     }
 }
@@ -182,6 +176,7 @@ impl<T, C: Container<Value = FMap<Timestamp, (T, SyncView)>> + HasTimestamp> Sto
     #[requires(!(*self).shot())]
     #[requires(self.ward() == *(*own).ward())]
     #[ensures((^self).shot())]
+    #[ensures((*self).ward() == (^self).ward() && (*self).val() == (^self).val())]
     #[ensures((*own).ward() == (^own).ward())]
     #[ensures((*view).le_log(^view))]
     #[ensures((*self).ward().get_timestamp(*view) < result)]

--- a/creusot-std/src/std/sync/atomic_sc.rs
+++ b/creusot-std/src/std/sync/atomic_sc.rs
@@ -40,17 +40,15 @@ impl AtomicI32 {
     /// Wrapper for [`std::sync::atomic::AtomicI32::load`].
     ///
     /// The load is always sequentially consistent.
-    #[requires(forall<c: &mut LoadCommitter<Self>> !c.shot() ==> c.ward() == *self ==>
-        f.precondition((c,)) && f.postcondition_once((c,), ()) ==> (^c).shot()
-    )]
-    #[ensures(exists<c: &mut LoadCommitter<Self>>
-        !c.shot() && c.ward() == *self && c.val() == result && f.postcondition_once((c,), ())
+    #[requires(forall<c: &LoadCommitter<Self>> c.ward() == *self ==> f.precondition((c,)))]
+    #[ensures(exists<c: &LoadCommitter<Self>>
+        c.ward() == *self && c.val() == result && f.postcondition_once((c,), ())
     )]
     #[trusted]
     #[allow(unused_variables)]
-    pub fn load<'a, F>(&'a self, f: Ghost<F>) -> i32
+    pub fn load<F>(&self, f: Ghost<F>) -> i32
     where
-        F: FnGhost + FnOnce(&'a mut LoadCommitter<Self>),
+        F: FnGhost + FnOnce(&LoadCommitter<Self>),
     {
         self.0.load(std::sync::atomic::Ordering::SeqCst)
     }
@@ -67,9 +65,9 @@ impl AtomicI32 {
     )]
     #[trusted]
     #[allow(unused_variables)]
-    pub fn store<'a, F>(&'a self, val: i32, f: Ghost<F>)
+    pub fn store<F>(&self, val: i32, f: Ghost<F>)
     where
-        F: FnGhost + FnOnce(&'a mut StoreCommitter<Self>),
+        F: FnGhost + FnOnce(&mut StoreCommitter<Self>),
     {
         self.0.store(val, std::sync::atomic::Ordering::SeqCst)
     }
@@ -86,9 +84,9 @@ impl AtomicI32 {
     )]
     #[trusted]
     #[allow(unused_variables)]
-    pub fn fetch_add<'a, F>(&'a self, val: i32, f: Ghost<F>) -> i32
+    pub fn fetch_add<F>(&self, val: i32, f: Ghost<F>) -> i32
     where
-        F: FnGhost + FnOnce(&'a mut UpdateCommitter<Self>),
+        F: FnGhost + FnOnce(&mut UpdateCommitter<Self>),
     {
         self.0.fetch_add(val, std::sync::atomic::Ordering::SeqCst)
     }
@@ -96,16 +94,15 @@ impl AtomicI32 {
 
 /// Wrapper around a single atomic load operation, where multiple ghost steps
 /// can be performed.
+///
+/// Note: this committer has no observable effect on ghost ressources. Thus, it is optional to shoot
+/// it, and nothing prevent the user from shooting it several times.
+// This trick is correct for SC accesses under SC-DRF, and for Rel/Acq/Rlx and Rlx accesses, but
+// perhaps not for C20's SC accesses.
 #[opaque]
 pub struct LoadCommitter<C: Container<Value: Sized>>(PhantomData<C>);
 
 impl<C: Container<Value: Sized>> LoadCommitter<C> {
-    /// Status of the committer
-    #[logic(opaque)]
-    pub fn shot(self) -> bool {
-        dead
-    }
-
     /// Identity of the committer
     ///
     /// This is used so that we can only use the committer with the right [`AtomicOwn`].
@@ -123,14 +120,12 @@ impl<C: Container<Value: Sized>> LoadCommitter<C> {
     /// 'Shoot' the committer
     ///
     /// This does the read on the atomic in ghost code, and can only be called once.
-    #[requires(!(*self).shot())]
     #[requires(self.ward() == *(*own).ward())]
-    #[ensures((^self).shot())]
-    #[ensures((*self).val() == *own.val())]
+    #[ensures(self.val() == *own.val())]
     #[check(ghost)]
     #[trusted]
     #[allow(unused_variables)]
-    pub fn shoot(&mut self, own: &Perm<C>) {
+    pub fn shoot(&self, own: &Perm<C>) {
         panic!("Should not be called outside ghost code")
     }
 }
@@ -167,6 +162,7 @@ impl<C: Container<Value: Sized>> StoreCommitter<C> {
     #[requires(!(*self).shot())]
     #[requires(self.ward() == *(*own).ward())]
     #[ensures((^self).shot())]
+    #[ensures((*self).ward() == (^self).ward() && (*self).val() == (^self).val())]
     #[ensures((*own).ward() == (^own).ward())]
     #[ensures(*(^own).val() == (*self).val())]
     #[check(ghost)]
@@ -215,6 +211,8 @@ impl<C: Container<Value: Sized>> UpdateCommitter<C> {
     #[requires(!(*self).shot())]
     #[requires(self.ward() == *(*own).ward())]
     #[ensures((^self).shot())]
+    #[ensures((*self).ward() == (^self).ward())]
+    #[ensures((*self).old_val() == (^self).old_val() && (*self).new_val() == (^self).new_val())]
     #[ensures((*own).ward() == (^own).ward())]
     #[ensures(*(*own).val() == (*self).old_val())]
     #[ensures(*(^own).val() == (*self).new_val())]

--- a/examples/message_passing_relacq.coma
+++ b/examples/message_passing_relacq.coma
@@ -511,12 +511,14 @@ module M_message_passing
     any
     [ return (result: int) ->
     {[@stop_split] [@expl:shoot_i32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_i32 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32 own.current = ward_AtomicI32 own.final)
-      /\ ([@stop_split] [@expl:shoot ensures #2] le_log_SyncView view.current view.final)
-      /\ ([@stop_split] [@expl:shoot ensures #3] get_timestamp_AtomicI32 (ward_i32 self.current) view.current < result)
-      /\ ([@stop_split] [@expl:shoot ensures #4] result <= get_timestamp_AtomicI32 (ward_i32 self.current) view.final)
-      /\ ([@stop_split] [@expl:shoot ensures #5] get_Int (val_AtomicI32 own.current) result = None)
-      /\ ([@stop_split] [@expl:shoot ensures #6] val_AtomicI32 own.final
+      /\ ([@stop_split] [@expl:shoot ensures #1] ward_i32 self.current = ward_i32 self.final
+        /\ val_i32 self.current = val_i32 self.final)
+      /\ ([@stop_split] [@expl:shoot ensures #2] ward_AtomicI32 own.current = ward_AtomicI32 own.final)
+      /\ ([@stop_split] [@expl:shoot ensures #3] le_log_SyncView view.current view.final)
+      /\ ([@stop_split] [@expl:shoot ensures #4] get_timestamp_AtomicI32 (ward_i32 self.current) view.current < result)
+      /\ ([@stop_split] [@expl:shoot ensures #5] result <= get_timestamp_AtomicI32 (ward_i32 self.current) view.final)
+      /\ ([@stop_split] [@expl:shoot ensures #6] get_Int (val_AtomicI32 own.current) result = None)
+      /\ ([@stop_split] [@expl:shoot ensures #7] val_AtomicI32 own.final
       = insert_Int (val_AtomicI32 own.current) result { f0'0 = val_i32 self.current; f1'0 = view.current })}
       (! return {result}) ]
   
@@ -916,10 +918,22 @@ module M_message_passing
   
   type t_LoadCommitter_i32_AtomicI32
   
+  function val_i32'0 (self: t_LoadCommitter_i32_AtomicI32) : Int32.t
+  
   type closure0'3 = {
-    c0'5: MutBorrow.t t_Option_Resource_Excl_unit;
-    c1'5: MutBorrow.t (MutBorrow.t t_LoadCommitter_i32_AtomicI32);
+    c0'5: t_LoadCommitter_i32_AtomicI32;
+    c1'5: MutBorrow.t t_Option_Resource_Excl_unit;
     c2'5: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global }
+  
+  let rec into_ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:into_ghost ensures] result = self} (! return {result}) ]
+  
+  let rec deref_Ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:deref ensures] result = self} (! return {result}) ]
+  
+  predicate resolve_refmut_closure0 [@inline:trivial] (_1: MutBorrow.t closure0'3) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_closure0
   
   let rec deref_mut_Ghost_Option_Resource_Excl_unit (self: MutBorrow.t t_Option_Resource_Excl_unit)
     (return (x: MutBorrow.t t_Option_Resource_Excl_unit)) = any
@@ -953,34 +967,20 @@ module M_message_passing
   let rec deref_Ghost_SyncView (self: t_SyncView) (return (x: t_SyncView)) = any
     [ return (result: t_SyncView) -> {[@stop_split] [@expl:deref ensures] result = self} (! return {result}) ]
   
-  function val_i32'0 (self: t_LoadCommitter_i32_AtomicI32) : Int32.t
-  
-  let rec into_ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
-    [ return (result: Int32.t) -> {[@stop_split] [@expl:into_ghost ensures] result = self} (! return {result}) ]
-  
-  predicate shot_i32'0 (self: t_LoadCommitter_i32_AtomicI32)
-  
   function ward_i32'0 (self: t_LoadCommitter_i32_AtomicI32) : t_AtomicI32
   
-  let rec shoot_i32'0 (self: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (own: t_Perm_AtomicI32)
-    (view: MutBorrow.t t_SyncView) (return (x: int)) =
-    {[@stop_split] [@expl:shoot_i32 requires] ([@stop_split] [@expl:shoot requires #0] not shot_i32'0 self.current)
-    /\ ([@stop_split] [@expl:shoot requires #1] ward_i32'0 self.current = ward_AtomicI32 own)}
+  let rec shoot_i32'0 (self: t_LoadCommitter_i32_AtomicI32) (own: t_Perm_AtomicI32) (view: MutBorrow.t t_SyncView)
+    (return (x: int)) = {[@stop_split] [@expl:shoot requires] ward_i32'0 self = ward_AtomicI32 own}
     any
     [ return (result: int) ->
-    {[@stop_split] [@expl:shoot_i32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_i32'0 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] le_log_SyncView view.current view.final)
-      /\ ([@stop_split] [@expl:shoot ensures #2] get_timestamp_AtomicI32 (ward_i32'0 self.current) view.current
-        <= result)
-      /\ ([@stop_split] [@expl:shoot ensures #3] result <= get_timestamp_AtomicI32 (ward_i32'0 self.current) view.final)
-      /\ ([@stop_split] [@expl:shoot ensures #4] match get_Int (val_AtomicI32 own) result with
-        | Some {f0'0 = v; f1'0 = v_view} -> v = val_i32'0 self.current /\ le_log_SyncView v_view view.final
+    {[@stop_split] [@expl:shoot_i32 ensures] ([@stop_split] [@expl:shoot ensures #0] le_log_SyncView view.current view.final)
+      /\ ([@stop_split] [@expl:shoot ensures #1] get_timestamp_AtomicI32 (ward_i32'0 self) view.current <= result)
+      /\ ([@stop_split] [@expl:shoot ensures #2] result <= get_timestamp_AtomicI32 (ward_i32'0 self) view.final)
+      /\ ([@stop_split] [@expl:shoot ensures #3] match get_Int (val_AtomicI32 own) result with
+        | Some {f0'0 = v; f1'0 = v_view} -> v = val_i32'0 self /\ le_log_SyncView v_view view.final
         | None -> false
         end)}
       (! return {result}) ]
-  
-  let rec deref_Ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
-    [ return (result: Int32.t) -> {[@stop_split] [@expl:deref ensures] result = self} (! return {result}) ]
   
   predicate invariant_refmut_State [@inline:trivial] (self: MutBorrow.t t_State) =
     inv_State self.current /\ inv_State self.final
@@ -1004,10 +1004,6 @@ module M_message_passing
   predicate resolve_refmut_State [@inline:trivial] (_1: MutBorrow.t t_State) = _1.final = _1.current
   
   meta "rewrite_def" predicate resolve_refmut_State
-  
-  predicate resolve_refmut_closure0 [@inline:trivial] (_1: MutBorrow.t closure0'3) = _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_closure0
   
   let rec take_Resource_Excl_unit (self_: MutBorrow.t t_Option_Resource_Excl_unit)
     (return (x: t_Option_Resource_Excl_unit)) = any
@@ -1068,11 +1064,6 @@ module M_message_passing
   
   meta "rewrite_def" predicate resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global
   
-  predicate resolve_refmut_refmut_LoadCommitter_i32_AtomicI32 [@inline:trivial] (_1: MutBorrow.t (MutBorrow.t t_LoadCommitter_i32_AtomicI32)) =
-    _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_refmut_LoadCommitter_i32_AtomicI32
-  
   predicate resolve_refmut_Ghost_Option_Resource_Excl_unit [@inline:trivial] (_1: MutBorrow.t t_Option_Resource_Excl_unit) =
     _1.final = _1.current
   
@@ -1080,13 +1071,12 @@ module M_message_passing
   
   predicate resolve_closure0 [@inline:trivial] (_1: closure0'3) =
     resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global _1.c2'5
-    /\ resolve_refmut_refmut_LoadCommitter_i32_AtomicI32 _1.c1'5
-    /\ resolve_refmut_Ghost_Option_Resource_Excl_unit _1.c0'5
+    /\ resolve_refmut_Ghost_Option_Resource_Excl_unit _1.c1'5
   
   meta "rewrite_def" predicate resolve_closure0
   
   predicate hist_inv_closure0 [@inline:trivial] (self: closure0'3) (result_state: closure0'3) =
-    result_state.c0'5.final = self.c0'5.final
+    result_state.c0'5 = self.c0'5
     /\ result_state.c1'5.final = self.c1'5.final /\ result_state.c2'5.final = self.c2'5.final
   
   meta "rewrite_def" predicate hist_inv_closure0
@@ -1095,90 +1085,90 @@ module M_message_passing
     (return (x: ())) = {[@stop_split] [@expl:closure 'inv' type invariant] inv_refmut_MessagePassingAtomicInv inv}
     bb0
     [ bb0 = s0
-      [ s0 = [ &_4 <- inv.current.state ] s1
+      [ s0 = into_ghost_i32 {val_i32'0 self.current.c0'5} (fun (_x: Int32.t) -> [ &_8 <- _x ] s1)
+      | s1 = deref_Ghost_i32 {_8} (fun (_x: Int32.t) -> [ &_6 <- _x ] s2)
+      | s2 = [ &_4 <- _6 <> (1: Int32.t) ] s3
+      | s3 = any [ br0 -> {_4 = false} (! bb5) | br1 -> {_4} (! bb4) ] ]
+    | bb4 = s0
+      [ s0 = s1 [ _ck -> (! {[@expl:type invariant] inv_refmut_MessagePassingAtomicInv inv} any) ]
+      | s1 = -{resolve_refmut_MessagePassingAtomicInv inv}- s2
+      | s2 = -{resolve_refmut_closure0 self}- s3
+      | s3 = return {_ret} ]
+    | bb5 = s0
+      [ s0 = [ &_13 <- inv.current.state ] s1
       | s1 = any
-        [ br0 -> {_4 = NotWrittenYet} (! bb8)
-        | br1 (x0: t_AtView_Box_Perm_PermCell_i32_Global) (x1: t_Resource_Excl_unit) -> {_4 = Synchronisation x0 x1}
-          (! bb8)
-        | br2 (x0: t_Resource_Excl_unit) (x1: t_Resource_Excl_unit) -> {_4 = Readable x0 x1} (! bb2)
-        | br3 -> {_4 = Invalid} (! bb8) ] ]
-    | bb2 = s0
-      [ s0 = elim_Readable {_4} (fun (r0: t_Resource_Excl_unit) (r1: t_Resource_Excl_unit) -> [ &excl_state <- r1 ] s1)
-      | s1 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c0'5.current}
+        [ br0 -> {_13 = NotWrittenYet} (! bb13)
+        | br1 (x0: t_AtView_Box_Perm_PermCell_i32_Global) (x1: t_Resource_Excl_unit) -> {_13 = Synchronisation x0 x1}
+          (! bb13)
+        | br2 (x0: t_Resource_Excl_unit) (x1: t_Resource_Excl_unit) -> {_13 = Readable x0 x1} (! bb7)
+        | br3 -> {_13 = Invalid} (! bb13) ] ]
+    | bb7 = s0
+      [ s0 = elim_Readable {_13} (fun (r0: t_Resource_Excl_unit) (r1: t_Resource_Excl_unit) -> [ &excl_state <- r1 ] s1)
+      | s1 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c1'5.current}
           (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_13 <- _bor ]
-            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
+            [ &_22 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = _bor.final } } } ]
             s2)
-      | s2 = deref_mut_Ghost_Option_Resource_Excl_unit {_13}
-          (fun (_x: MutBorrow.t t_Option_Resource_Excl_unit) -> [ &_12 <- _x ] s3)
-      | s3 = MutBorrow.borrow_final <t_Option_Resource_Excl_unit> {_12.current} {MutBorrow.get_id _12}
+      | s2 = deref_mut_Ghost_Option_Resource_Excl_unit {_22}
+          (fun (_x: MutBorrow.t t_Option_Resource_Excl_unit) -> [ &_21 <- _x ] s3)
+      | s3 = MutBorrow.borrow_final <t_Option_Resource_Excl_unit> {_21.current} {MutBorrow.get_id _21}
           (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_11 <- _bor ] [ &_12 <- { _12 with current = _bor.final } ] s4)
-      | s4 = as_mut_Resource_Excl_unit {_11} (fun (_x: t_Option_refmut_Resource_Excl_unit) -> [ &_10 <- _x ] s5)
-      | s5 = unwrap_refmut_Resource_Excl_unit {_10} (fun (_x: MutBorrow.t t_Resource_Excl_unit) -> [ &_9 <- _x ] s6)
-      | s6 = MutBorrow.borrow_final <t_Resource_Excl_unit> {_9.current} {MutBorrow.get_id _9}
+            [ &_20 <- _bor ] [ &_21 <- { _21 with current = _bor.final } ] s4)
+      | s4 = as_mut_Resource_Excl_unit {_20} (fun (_x: t_Option_refmut_Resource_Excl_unit) -> [ &_19 <- _x ] s5)
+      | s5 = unwrap_refmut_Resource_Excl_unit {_19} (fun (_x: MutBorrow.t t_Resource_Excl_unit) -> [ &_18 <- _x ] s6)
+      | s6 = MutBorrow.borrow_final <t_Resource_Excl_unit> {_18.current} {MutBorrow.get_id _18}
           (fun (_bor: MutBorrow.t t_Resource_Excl_unit) ->
-            [ &_8 <- _bor ] [ &_9 <- { _9 with current = _bor.final } ] s7)
-      | s7 = valid_op_lemma_Excl_unit {_8} {excl_state} (fun (_x: ()) -> [ &_7 <- _x ] s8)
-      | s8 = -{resolve_refmut_Option_Resource_Excl_unit _12}- s9
-      | s9 = -{resolve_refmut_Resource_Excl_unit _9}- s10
-      | s10 = bb8 ]
-    | bb8 = s0
-      [ s0 = new (fun (_x: t_SyncView) -> [ &_18 <- _x ] s1)
-      | s1 = deref_Ghost_SyncView {_18} (fun (_x: t_SyncView) -> [ &_16 <- _x ] s2)
-      | s2 = [ &sync_view <- _16 ] s3
-      | s3 = into_ghost_i32 {val_i32'0 self.current.c1'5.current.current} (fun (_x: Int32.t) -> [ &value <- _x ] s4)
-      | s4 = [ &_26 <- inv.current.atomic_own ] s5
-      | s5 = MutBorrow.borrow_mut <t_SyncView> {sync_view}
-          (fun (_bor: MutBorrow.t t_SyncView) -> [ &_28 <- _bor ] [ &sync_view <- _bor.final ] s6)
-      | s6 = MutBorrow.borrow_mut <t_LoadCommitter_i32_AtomicI32> {self.current.c1'5.current.current}
-          (fun (_bor: MutBorrow.t t_LoadCommitter_i32_AtomicI32) ->
-            [ &_24 <- _bor ]
-            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = { self.current.c1'5.current with current = _bor.final } } } } ]
-            s7)
-      | s7 = MutBorrow.borrow_final <t_SyncView> {_28.current} {MutBorrow.get_id _28}
-          (fun (_bor: MutBorrow.t t_SyncView) -> [ &_27 <- _bor ] [ &_28 <- { _28 with current = _bor.final } ] s8)
-      | s8 = shoot_i32'0 {_24} {_26} {_27} (fun (_x: int) -> [ &_23 <- _x ] s9)
-      | s9 = -{resolve_refmut_SyncView _28}- s10
-      | s10 = deref_Ghost_i32 {value} (fun (_x: Int32.t) -> [ &_31 <- _x ] s11)
-      | s11 = [ &_29 <- _31 = (1: Int32.t) ] s12
-      | s12 = any [ br0 -> {_29 = false} (! bb26) | br1 -> {_29} (! bb15) ] ]
-    | bb15 = s0
-      [ s0 = MutBorrow.borrow_mut <t_State> {inv.current.state}
+            [ &_17 <- _bor ] [ &_18 <- { _18 with current = _bor.final } ] s7)
+      | s7 = valid_op_lemma_Excl_unit {_17} {excl_state} (fun (_x: ()) -> [ &_16 <- _x ] s8)
+      | s8 = -{resolve_refmut_Option_Resource_Excl_unit _21}- s9
+      | s9 = -{resolve_refmut_Resource_Excl_unit _18}- s10
+      | s10 = bb13 ]
+    | bb13 = s0
+      [ s0 = new (fun (_x: t_SyncView) -> [ &_27 <- _x ] s1)
+      | s1 = deref_Ghost_SyncView {_27} (fun (_x: t_SyncView) -> [ &_25 <- _x ] s2)
+      | s2 = [ &sync_view <- _25 ] s3
+      | s3 = [ &_31 <- inv.current.atomic_own ] s4
+      | s4 = MutBorrow.borrow_mut <t_SyncView> {sync_view}
+          (fun (_bor: MutBorrow.t t_SyncView) -> [ &_33 <- _bor ] [ &sync_view <- _bor.final ] s5)
+      | s5 = MutBorrow.borrow_final <t_SyncView> {_33.current} {MutBorrow.get_id _33}
+          (fun (_bor: MutBorrow.t t_SyncView) -> [ &_32 <- _bor ] [ &_33 <- { _33 with current = _bor.final } ] s6)
+      | s6 = shoot_i32'0 {self.current.c0'5} {_31} {_32} (fun (_x: int) -> [ &_28 <- _x ] s7)
+      | s7 = -{resolve_refmut_SyncView _33}- s8
+      | s8 = MutBorrow.borrow_mut <t_State> {inv.current.state}
+          (fun (_bor: MutBorrow.t t_State) ->
+            [ &_40 <- _bor ] -{inv_State _bor.final}-
+            [ &inv <- { inv with current = { inv.current with state = _bor.final } } ] s9)
+        [ _ck -> (! {[@expl:type invariant] inv_State inv.current.state} any) ]
+      | s9 = [ &_41 <- Invalid ] s10
+      | s10 = MutBorrow.borrow_final <t_State> {_40.current} {MutBorrow.get_id _40}
           (fun (_bor: MutBorrow.t t_State) ->
             [ &_39 <- _bor ] -{inv_State _bor.final}-
-            [ &inv <- { inv with current = { inv.current with state = _bor.final } } ] s1)
-        [ _ck -> (! {[@expl:type invariant] inv_State inv.current.state} any) ]
-      | s1 = [ &_40 <- Invalid ] s2
-      | s2 = MutBorrow.borrow_final <t_State> {_39.current} {MutBorrow.get_id _39}
-          (fun (_bor: MutBorrow.t t_State) ->
-            [ &_38 <- _bor ] -{inv_State _bor.final}-
-            [ &_39 <- { _39 with current = _bor.final } ] s3)
-        [ _ck -> (! {[@expl:type invariant] inv_State _39.current} any) ]
-      | s3 = replace_State {_38} {_40} (fun (_x: t_State) -> [ &_37 <- _x ] s4)
-      | s4 = s5 [ _ck -> (! {[@expl:type invariant] inv_refmut_State _39} any) ]
-      | s5 = -{resolve_refmut_State _39}- s6
-      | s6 = s7 [ _ck -> (! {[@expl:type invariant] inv_State _37} any) ]
-      | s7 = -{resolve_State _37}- s8
-      | s8 = any
-        [ br0 -> {_37 = NotWrittenYet} (! bb19)
-        | br1 (x0: t_AtView_Box_Perm_PermCell_i32_Global) (x1: t_Resource_Excl_unit) -> {_37 = Synchronisation x0 x1}
-          (! bb18)
-        | br2 (x0: t_Resource_Excl_unit) (x1: t_Resource_Excl_unit) -> {_37 = Readable x0 x1} (! bb19)
-        | br3 -> {_37 = Invalid} (! bb19) ] ]
-    | bb19 = s0
-      [ s0 = -{match _37 with
+            [ &_40 <- { _40 with current = _bor.final } ] s11)
+        [ _ck -> (! {[@expl:type invariant] inv_State _40.current} any) ]
+      | s11 = replace_State {_39} {_41} (fun (_x: t_State) -> [ &_38 <- _x ] s12)
+      | s12 = s13 [ _ck -> (! {[@expl:type invariant] inv_refmut_State _40} any) ]
+      | s13 = -{resolve_refmut_State _40}- s14
+      | s14 = s15 [ _ck -> (! {[@expl:type invariant] inv_State _38} any) ]
+      | s15 = -{resolve_State _38}- s16
+      | s16 = any
+        [ br0 -> {_38 = NotWrittenYet} (! bb20)
+        | br1 (x0: t_AtView_Box_Perm_PermCell_i32_Global) (x1: t_Resource_Excl_unit) -> {_38 = Synchronisation x0 x1}
+          (! bb19)
+        | br2 (x0: t_Resource_Excl_unit) (x1: t_Resource_Excl_unit) -> {_38 = Readable x0 x1} (! bb20)
+        | br3 -> {_38 = Invalid} (! bb20) ] ]
+    | bb20 = s0
+      [ s0 = -{match _38 with
           | Synchronisation _ x -> resolve_Resource_Excl_unit x
           | _ -> true
           end}-
         s1
       | s1 = s2
-        [ _ck -> (! {[@expl:type invariant] match _37 with
+        [ _ck -> (! {[@expl:type invariant] match _38 with
             | Synchronisation x _ -> inv_AtView_Box_Perm_PermCell_i32_Global x
             | _ -> true
             end}
           any) ]
-      | s2 = -{match _37 with
+      | s2 = -{match _38 with
           | Synchronisation x _ -> resolve_AtView_Box_Perm_PermCell_i32_Global x
           | _ -> true
           end}-
@@ -1187,87 +1177,81 @@ module M_message_passing
       | s4 = -{resolve_refmut_MessagePassingAtomicInv inv}- s5
       | s5 = -{resolve_refmut_closure0 self}- s6
       | s6 = {false} any ]
-    | bb18 = s0
-      [ s0 = elim_Synchronisation {_37}
+    | bb19 = s0
+      [ s0 = elim_Synchronisation {_38}
           (fun (r0: t_AtView_Box_Perm_PermCell_i32_Global) (r1: t_Resource_Excl_unit) -> [ &at_view <- r0 ] s1)
-      | s1 = elim_Synchronisation {_37}
+      | s1 = elim_Synchronisation {_38}
           (fun (r0: t_AtView_Box_Perm_PermCell_i32_Global) (r1: t_Resource_Excl_unit) -> [ &tok_write <- r1 ] s2)
-      | s2 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c0'5.current}
+      | s2 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c1'5.current}
           (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_48 <- _bor ]
-            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
+            [ &_49 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = _bor.final } } } ]
             s3)
-      | s3 = deref_mut_Ghost_Option_Resource_Excl_unit {_48}
-          (fun (_x: MutBorrow.t t_Option_Resource_Excl_unit) -> [ &_47 <- _x ] s4)
-      | s4 = MutBorrow.borrow_final <t_Option_Resource_Excl_unit> {_47.current} {MutBorrow.get_id _47}
+      | s3 = deref_mut_Ghost_Option_Resource_Excl_unit {_49}
+          (fun (_x: MutBorrow.t t_Option_Resource_Excl_unit) -> [ &_48 <- _x ] s4)
+      | s4 = MutBorrow.borrow_final <t_Option_Resource_Excl_unit> {_48.current} {MutBorrow.get_id _48}
           (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_46 <- _bor ] [ &_47 <- { _47 with current = _bor.final } ] s5)
-      | s5 = take_Resource_Excl_unit {_46} (fun (_x: t_Option_Resource_Excl_unit) -> [ &_45 <- _x ] s6)
-      | s6 = -{resolve_refmut_Option_Resource_Excl_unit _47}- s7
-      | s7 = unwrap_Resource_Excl_unit {_45} (fun (_x: t_Resource_Excl_unit) -> [ &_44 <- _x ] s8)
-      | s8 = [ &_42 <- Readable tok_write _44 ] s9
+            [ &_47 <- _bor ] [ &_48 <- { _48 with current = _bor.final } ] s5)
+      | s5 = take_Resource_Excl_unit {_47} (fun (_x: t_Option_Resource_Excl_unit) -> [ &_46 <- _x ] s6)
+      | s6 = -{resolve_refmut_Option_Resource_Excl_unit _48}- s7
+      | s7 = unwrap_Resource_Excl_unit {_46} (fun (_x: t_Resource_Excl_unit) -> [ &_45 <- _x ] s8)
+      | s8 = [ &_43 <- Readable tok_write _45 ] s9
       | s9 = s10 [ _ck -> (! {[@expl:type invariant] inv_State inv.current.state} any) ]
       | s10 = -{resolve_State inv.current.state}- s11
-      | s11 = [ &inv <- { inv with current = { inv.current with state = _42 } } ] s12
+      | s11 = [ &inv <- { inv with current = { inv.current with state = _43 } } ] s12
       | s12 = s13 [ _ck -> (! {[@expl:type invariant] inv_refmut_MessagePassingAtomicInv inv} any) ]
       | s13 = -{resolve_refmut_MessagePassingAtomicInv inv}- s14
       | s14 = into_inner_Box_Perm_PermCell_i32_Global'0 {at_view} {sync_view}
-          (fun (_x: t_Perm_PermCell_i32) -> [ &_51 <- _x ] s15)
-      | s15 = [ &_50 <- Some'2 _51 ] s16
-      | s16 = new_Option_Box_Perm_PermCell_i32_Global {_50}
-          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_49 <- _x ] s17)
+          (fun (_x: t_Perm_PermCell_i32) -> [ &_52 <- _x ] s15)
+      | s15 = [ &_51 <- Some'2 _52 ] s16
+      | s16 = new_Option_Box_Perm_PermCell_i32_Global {_51}
+          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_50 <- _x ] s17)
       | s17 = -{match self with
           | {current = {c2'5 = x}} -> resolve_Ghost_Option_Box_Perm_PermCell_i32_Global x.current
           | _ -> true
           end}-
         s18
-      | s18 = [ &self <- { self with current = { self.current with c2'5 = { self.current.c2'5 with current = _49 } } } ]
+      | s18 = [ &self <- { self with current = { self.current with c2'5 = { self.current.c2'5 with current = _50 } } } ]
         s19
       | s19 = -{resolve_refmut_closure0 self}- s20
-      | s20 = return {_ret} ]
-    | bb26 = s0
-      [ s0 = s1 [ _ck -> (! {[@expl:type invariant] inv_refmut_MessagePassingAtomicInv inv} any) ]
-      | s1 = -{resolve_refmut_MessagePassingAtomicInv inv}- s2
-      | s2 = -{resolve_refmut_closure0 self}- s3
-      | s3 = return {_ret} ] ]
+      | s20 = return {_ret} ] ]
     [ & _ret: () = Any.any_l ()
     | & self: MutBorrow.t closure0'3 = self
     | & inv: MutBorrow.t t_MessagePassingAtomicInv = inv
-    | & _4: t_State = Any.any_l ()
+    | & _4: bool = Any.any_l ()
+    | & _6: Int32.t = Any.any_l ()
+    | & _8: Int32.t = Any.any_l ()
+    | & _13: t_State = Any.any_l ()
     | & excl_state: t_Resource_Excl_unit = Any.any_l ()
-    | & _7: () = Any.any_l ()
-    | & _8: MutBorrow.t t_Resource_Excl_unit = Any.any_l ()
-    | & _9: MutBorrow.t t_Resource_Excl_unit = Any.any_l ()
-    | & _10: t_Option_refmut_Resource_Excl_unit = Any.any_l ()
-    | & _11: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _12: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _13: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _16: () = Any.any_l ()
+    | & _17: MutBorrow.t t_Resource_Excl_unit = Any.any_l ()
+    | & _18: MutBorrow.t t_Resource_Excl_unit = Any.any_l ()
+    | & _19: t_Option_refmut_Resource_Excl_unit = Any.any_l ()
+    | & _20: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _21: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _22: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
     | & sync_view: t_SyncView = Any.any_l ()
-    | & _16: t_SyncView = Any.any_l ()
-    | & _18: t_SyncView = Any.any_l ()
-    | & value: Int32.t = Any.any_l ()
-    | & _23: int = Any.any_l ()
-    | & _24: MutBorrow.t t_LoadCommitter_i32_AtomicI32 = Any.any_l ()
-    | & _26: t_Perm_AtomicI32 = Any.any_l ()
-    | & _27: MutBorrow.t t_SyncView = Any.any_l ()
-    | & _28: MutBorrow.t t_SyncView = Any.any_l ()
-    | & _29: bool = Any.any_l ()
-    | & _31: Int32.t = Any.any_l ()
+    | & _25: t_SyncView = Any.any_l ()
+    | & _27: t_SyncView = Any.any_l ()
+    | & _28: int = Any.any_l ()
+    | & _31: t_Perm_AtomicI32 = Any.any_l ()
+    | & _32: MutBorrow.t t_SyncView = Any.any_l ()
+    | & _33: MutBorrow.t t_SyncView = Any.any_l ()
     | & at_view: t_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
     | & tok_write: t_Resource_Excl_unit = Any.any_l ()
-    | & _37: t_State = Any.any_l ()
-    | & _38: MutBorrow.t t_State = Any.any_l ()
+    | & _38: t_State = Any.any_l ()
     | & _39: MutBorrow.t t_State = Any.any_l ()
-    | & _40: t_State = Any.any_l ()
-    | & _42: t_State = Any.any_l ()
-    | & _44: t_Resource_Excl_unit = Any.any_l ()
-    | & _45: t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _46: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _40: MutBorrow.t t_State = Any.any_l ()
+    | & _41: t_State = Any.any_l ()
+    | & _43: t_State = Any.any_l ()
+    | & _45: t_Resource_Excl_unit = Any.any_l ()
+    | & _46: t_Option_Resource_Excl_unit = Any.any_l ()
     | & _47: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
     | & _48: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _49: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _49: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
     | & _50: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _51: t_Perm_PermCell_i32 = Any.any_l () ]
+    | & _51: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _52: t_Perm_PermCell_i32 = Any.any_l () ]
     [ return (result: ()) -> {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure0 self.current self.final}
       return {result} ]
   
@@ -1350,11 +1334,6 @@ module M_message_passing
   
   meta "rewrite_def" predicate resolve_refmut_Tokens
   
-  predicate resolve_refmut_LoadCommitter_i32_AtomicI32 [@inline:trivial] (_1: MutBorrow.t t_LoadCommitter_i32_AtomicI32) =
-    _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_LoadCommitter_i32_AtomicI32
-  
   predicate resolve_refmut_closure4 [@inline:trivial] (_1: MutBorrow.t closure4) = _1.final = _1.current
   
   meta "rewrite_def" predicate resolve_refmut_closure4
@@ -1376,8 +1355,8 @@ module M_message_passing
   
   meta "rewrite_def" predicate hist_inv_closure4
   
-  let rec closure4 [@coma:extspec] (self: MutBorrow.t closure4) (c: MutBorrow.t t_LoadCommitter_i32_AtomicI32)
-    (return (x: ())) = bb0
+  let rec closure4 [@coma:extspec] (self: MutBorrow.t closure4) (c: t_LoadCommitter_i32_AtomicI32) (return (x: ())) =
+    bb0
     [ bb0 = s0
       [ s0 = deref_Ghost_ref_AtomicInvariant_MessagePassingAtomicInv {self.current.c0'4}
           (fun (_x: t_AtomicInvariant_MessagePassingAtomicInv) -> [ &_4 <- _x ] s1)
@@ -1392,27 +1371,23 @@ module M_message_passing
       | s4 = reborrow {_7} (fun (_x: t_Tokens) -> [ &_6 <- _x ] s5)
       | s5 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c2'4.current}
           (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_12 <- _bor ]
+            [ &_13 <- _bor ]
             [ &self <- { self with current = { self.current with c2'4 = { self.current.c2'4 with current = _bor.final } } } ]
             s6)
-      | s6 = MutBorrow.borrow_mut <MutBorrow.t t_LoadCommitter_i32_AtomicI32> {c}
-          (fun (_bor: MutBorrow.t (MutBorrow.t t_LoadCommitter_i32_AtomicI32)) ->
-            [ &_13 <- _bor ] [ &c <- _bor.final ] s7)
-      | s7 = MutBorrow.borrow_mut <t_Option_Box_Perm_PermCell_i32_Global> {self.current.c3'4.current}
+      | s6 = MutBorrow.borrow_mut <t_Option_Box_Perm_PermCell_i32_Global> {self.current.c3'4.current}
           (fun (_bor: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global) ->
             [ &_14 <- _bor ]
             [ &self <- { self with current = { self.current with c3'4 = { self.current.c3'4 with current = _bor.final } } } ]
-            s8)
-      | s8 = [ &_11 <- { c0'5 = _12; c1'5 = _13; c2'5 = _14 } ] s9
-      | s9 = __new_closure0'1 {_11} (fun (_x: t_FnGhostWrapper_closure0'1) -> [ &_10 <- _x ] s10)
-      | s10 = open_MessagePassingAtomicInv'0 {_4} {_6} {_10} (fun (_x: ()) -> [ &_ret <- _x ] s11)
-      | s11 = -{resolve_refmut_Tokens _8}- s12
-      | s12 = -{resolve_refmut_LoadCommitter_i32_AtomicI32 c}- s13
-      | s13 = -{resolve_refmut_closure4 self}- s14
-      | s14 = return {_ret} ] ]
+            s7)
+      | s7 = [ &_11 <- { c0'5 = c; c1'5 = _13; c2'5 = _14 } ] s8
+      | s8 = __new_closure0'1 {_11} (fun (_x: t_FnGhostWrapper_closure0'1) -> [ &_10 <- _x ] s9)
+      | s9 = open_MessagePassingAtomicInv'0 {_4} {_6} {_10} (fun (_x: ()) -> [ &_ret <- _x ] s10)
+      | s10 = -{resolve_refmut_Tokens _8}- s11
+      | s11 = -{resolve_refmut_closure4 self}- s12
+      | s12 = return {_ret} ] ]
     [ & _ret: () = Any.any_l ()
     | & self: MutBorrow.t closure4 = self
-    | & c: MutBorrow.t t_LoadCommitter_i32_AtomicI32 = c
+    | & c: t_LoadCommitter_i32_AtomicI32 = c
     | & _4: t_AtomicInvariant_MessagePassingAtomicInv = Any.any_l ()
     | & _6: t_Tokens = Any.any_l ()
     | & _7: MutBorrow.t t_Tokens = Any.any_l ()
@@ -1420,8 +1395,7 @@ module M_message_passing
     | & _9: MutBorrow.t t_Tokens = Any.any_l ()
     | & _10: t_FnGhostWrapper_closure0'1 = Any.any_l ()
     | & _11: closure0'3 = Any.any_l ()
-    | & _12: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _13: MutBorrow.t (MutBorrow.t t_LoadCommitter_i32_AtomicI32) = Any.any_l ()
+    | & _13: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
     | & _14: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global = Any.any_l () ]
     [ return (result: ()) -> {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure4 self.current self.final}
       return {result} ]
@@ -1430,23 +1404,23 @@ module M_message_passing
   
   meta "rewrite_def" predicate closure4'post'return
   
-  predicate postcondition_once_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (result: ()) =
+  predicate postcondition_once_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) (result: ()) =
     let c = args in exists e: closure4. (exists bor_self: MutBorrow.t closure4. bor_self.current = self
           /\ bor_self.final = e /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self e)
       /\ resolve_closure4 e
   
   meta "rewrite_def" predicate postcondition_once_closure4
   
-  predicate postcondition_mut_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (result_state: closure4) (result: ()) =
+  predicate postcondition_mut_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) (result_state: closure4) (result: ()) =
     let c = args in exists bor_self: MutBorrow.t closure4. bor_self.current = self
       /\ bor_self.final = result_state /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self result_state
   
   meta "rewrite_def" predicate postcondition_mut_closure4
   
-  function fn_mut_once_closure4 (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (res: ()) : ()
+  function fn_mut_once_closure4 (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) (res: ()) : ()
   
   axiom fn_mut_once_closure4_spec:
-    forall self: closure4, args: MutBorrow.t t_LoadCommitter_i32_AtomicI32, res: (). postcondition_once_closure4 self args res
+    forall self: closure4, args: t_LoadCommitter_i32_AtomicI32, res: (). postcondition_once_closure4 self args res
       = (exists res_state: closure4. postcondition_mut_closure4 self args res_state res /\ resolve_closure4 res_state)
   
   function hist_inv_trans_closure4 (self: closure4) (b: closure4) (c: closure4) : ()
@@ -1458,10 +1432,10 @@ module M_message_passing
   
   axiom hist_inv_refl_closure4_spec: forall self: closure4. hist_inv_closure4 self self
   
-  function postcondition_mut_hist_inv_closure4 (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (res_state: closure4) (res: ()) : ()
+  function postcondition_mut_hist_inv_closure4 (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) (res_state: closure4) (res: ()) : ()
   
   axiom postcondition_mut_hist_inv_closure4_spec:
-    forall self: closure4, args: MutBorrow.t t_LoadCommitter_i32_AtomicI32, res_state: closure4, res: (). postcondition_mut_closure4 self args res_state res
+    forall self: closure4, args: t_LoadCommitter_i32_AtomicI32, res_state: closure4, res: (). postcondition_mut_closure4 self args res_state res
       -> hist_inv_closure4 self res_state
   
   type t_FnGhostWrapper_closure4 = { f0'8: closure4 }
@@ -1473,32 +1447,29 @@ module M_message_passing
   let rec new_FnGhostWrapper_closure4 (x: t_FnGhostWrapper_closure4) (return (x'0: t_FnGhostWrapper_closure4)) = any
     [ return (result: t_FnGhostWrapper_closure4) -> {[@stop_split] [@expl:new ensures] result = x} (! return {result}) ]
   
-  predicate precondition_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) =
+  predicate precondition_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) =
     let c = args in forall bor_self: MutBorrow.t closure4. bor_self.current = self -> closure4'pre bor_self c
   
   meta "rewrite_def" predicate precondition_closure4
   
-  predicate precondition_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) =
+  predicate precondition_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: t_LoadCommitter_i32_AtomicI32) =
     precondition_closure4 self.f0'8 args
   
   meta "rewrite_def" predicate precondition_FnGhostWrapper_closure4
   
-  predicate postcondition_once_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (result: ()) =
+  predicate postcondition_once_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: t_LoadCommitter_i32_AtomicI32) (result: ()) =
     postcondition_once_closure4 self.f0'8 args result
   
   meta "rewrite_def" predicate postcondition_once_FnGhostWrapper_closure4
   
   let rec load_FnGhostWrapper_closure4 (self: t_AtomicI32) (f: t_FnGhostWrapper_closure4) (return (x: Int32.t)) =
     {[@stop_split] [@expl:load_FnGhostWrapper_closure4 requires] ([@stop_split] [@expl:load 'self' type invariant] inv_ref_AtomicI32 self)
-    /\ ([@stop_split] [@expl:load requires] forall c: MutBorrow.t t_LoadCommitter_i32_AtomicI32. not shot_i32'0 c.current
-      -> ward_i32'0 c.current = self
-      -> precondition_FnGhostWrapper_closure4 f c /\ postcondition_once_FnGhostWrapper_closure4 f c ()
-      -> shot_i32'0 c.final)}
+    /\ ([@stop_split] [@expl:load requires] forall c: t_LoadCommitter_i32_AtomicI32. ward_i32'0 c = self
+      -> precondition_FnGhostWrapper_closure4 f c)}
     any
     [ return (result: Int32.t) ->
-    {[@stop_split] [@expl:load ensures] exists c: MutBorrow.t t_LoadCommitter_i32_AtomicI32. not shot_i32'0 c.current
-        /\ ward_i32'0 c.current = self
-        /\ val_i32'0 c.current = result /\ postcondition_once_FnGhostWrapper_closure4 f c ()}
+    {[@stop_split] [@expl:load ensures] exists c: t_LoadCommitter_i32_AtomicI32. ward_i32'0 c = self
+        /\ val_i32'0 c = result /\ postcondition_once_FnGhostWrapper_closure4 f c ()}
       (! return {result}) ]
   
   predicate resolve_Option_Resource_Excl_unit (_1: t_Option_Resource_Excl_unit)

--- a/examples/message_passing_relacq.rs
+++ b/examples/message_passing_relacq.rs
@@ -104,24 +104,23 @@ pub fn message_passing() {
 
             #[invariant(excl == *excl_snap)]
             #[invariant(tokens.contains(MESSAGE_PASSING()))]
-            while atomic.load(ghost! { |c: &mut LoadCommitter<i32, _>| {
+            while atomic.load(ghost! { |c: &LoadCommitter<i32, _>| {
             inv.open(tokens.reborrow(), |inv: &mut MessagePassingAtomicInv| {
-                if let State::Readable(_, excl_state) = &inv.state {
+                if *snapshot!(c.val()).into_ghost() != 1 {
+                    return
+                } else if let State::Readable(_, excl_state) = &inv.state {
                     excl.as_mut().unwrap().valid_op_lemma(excl_state);
                 }
 
                 let mut sync_view = *SyncView::new();
-                let value = snapshot!(c.val()).into_ghost();
-
                 c.shoot(&inv.atomic_own, &mut sync_view);
-
-                if *value == 1 {
-                    let State::Synchronisation(at_view, tok_write) = std::mem::replace(&mut inv.state, State::Invalid) else {
-                        unreachable!();
-                    };
-                    inv.state = State::Readable(tok_write, excl.take().unwrap());
-                    data_own = Ghost::new(Some(at_view.into_inner(sync_view)))
-                }
+                let State::Synchronisation(at_view, tok_write) =
+                    std::mem::replace(&mut inv.state, State::Invalid)
+                else {
+                    unreachable!();
+                };
+                inv.state = State::Readable(tok_write, excl.take().unwrap());
+                data_own = Ghost::new(Some(at_view.into_inner(sync_view)))
             })}})
                 != 1
             {}

--- a/examples/message_passing_relacq/proof.json
+++ b/examples/message_passing_relacq/proof.json
@@ -2,7 +2,7 @@
   "profile": [],
   "proofs": {
     "M_message_passing": {
-      "vc___new_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.023 },
+      "vc___new_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.047 },
       "vc___new_closure0'0": { "prover": "alt-ergo@2.6.2", "time": 0.024 },
       "vc___new_closure0'1": { "prover": "alt-ergo@2.6.2", "time": 0.034 },
       "vc___new_closure4": { "prover": "alt-ergo@2.6.2", "time": 0.035 },
@@ -21,7 +21,7 @@
       },
       "vc_borrow_mut_SyncView": { "prover": "alt-ergo@2.6.2", "time": 0.02 },
       "vc_borrow_mut_i32": { "prover": "alt-ergo@2.6.2", "time": 0.026 },
-      "vc_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.046 },
+      "vc_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.02 },
       "vc_closure0'0": { "prover": "alt-ergo@2.6.2", "time": 0.05 },
       "vc_closure0'1": { "prover": "alt-ergo@2.6.2", "time": 0.026 },
       "vc_closure0'2": { "prover": "alt-ergo@2.6.2", "time": 0.027 },
@@ -57,13 +57,13 @@
         "prover": "alt-ergo@2.6.2",
         "time": 0.025
       },
-      "vc_elim_Readable": { "prover": "alt-ergo@2.6.2", "time": 0.057 },
+      "vc_elim_Readable": { "prover": "alt-ergo@2.6.2", "time": 0.022 },
       "vc_elim_Synchronisation": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.032
       },
       "vc_get_i32": { "prover": "alt-ergo@2.6.2", "time": 0.042 },
-      "vc_into_ghost_i32": { "prover": "alt-ergo@2.6.2", "time": 0.022 },
+      "vc_into_ghost_i32": { "prover": "alt-ergo@2.6.2", "time": 0.056 },
       "vc_into_inner_Box_Perm_AtomicI32_Global": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.031
@@ -99,7 +99,7 @@
           {
             "tactic": "split_vc",
             "children": [
-              { "prover": "alt-ergo@2.6.2", "time": 0.096 },
+              { "prover": "alt-ergo@2.6.2", "time": 0.046 },
               {
                 "tactic": "split_vc",
                 "children": [
@@ -109,7 +109,35 @@
                     "children": [
                       { "prover": "alt-ergo@2.6.2", "time": 0.069 },
                       { "prover": "z3@4.15.3", "time": 0.098 },
-                      { "prover": "cvc5@1.3.1", "time": 0.38 },
+                      {
+                        "tactic": "split_vc",
+                        "children": [
+                          { "prover": "alt-ergo@2.6.2", "time": 0.051 },
+                          { "prover": "alt-ergo@2.6.2", "time": 0.061 },
+                          {
+                            "tactic": "split_vc",
+                            "children": [
+                              { "prover": "alt-ergo@2.6.2", "time": 0.049 },
+                              { "prover": "alt-ergo@2.6.2", "time": 0.072 },
+                              {
+                                "tactic": "split_vc",
+                                "children": [
+                                  {
+                                    "prover": "alt-ergo@2.6.2",
+                                    "time": 0.055
+                                  },
+                                  { "prover": "z3@4.15.3", "time": 1.4 }
+                                ]
+                              },
+                              { "prover": "alt-ergo@2.6.2", "time": 0.097 },
+                              { "prover": "alt-ergo@2.6.2", "time": 0.095 },
+                              { "prover": "z3@4.15.3", "time": 0.068 },
+                              { "prover": "z3@4.15.3", "time": 0.06 },
+                              { "prover": "z3@4.15.3", "time": 0.118 }
+                            ]
+                          }
+                        ]
+                      },
                       { "prover": "alt-ergo@2.6.2", "time": 0.053 },
                       { "prover": "alt-ergo@2.6.2", "time": 0.058 },
                       { "prover": "alt-ergo@2.6.2", "time": 0.059 },
@@ -132,11 +160,11 @@
       },
       "vc_new_Box_Perm_PermCell_i32_Global'0": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.05
+        "time": 0.022
       },
       "vc_new_FnGhostWrapper_closure0": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.046
+        "time": 0.023
       },
       "vc_new_FnGhostWrapper_closure4": {
         "prover": "alt-ergo@2.6.2",

--- a/examples/message_passing_relacq_options.coma
+++ b/examples/message_passing_relacq_options.coma
@@ -428,8 +428,8 @@ module M_message_passing
   type closure0'1 = {
     c0'1: t_AtomicInvariant_MessagePassingAtomicInv;
     c1'1: t_Tokens;
-    c2'1: t_Perm_PermCell_i32;
-    c3'1: MutBorrow.t t_Resource_Option_Excl_unit }
+    c2'1: MutBorrow.t t_Resource_Option_Excl_unit;
+    c3'1: t_Perm_PermCell_i32 }
   
   let rec deref_Ghost_ref_AtomicInvariant_MessagePassingAtomicInv (self: t_AtomicInvariant_MessagePassingAtomicInv)
     (return (x: t_AtomicInvariant_MessagePassingAtomicInv)) = any
@@ -442,9 +442,39 @@ module M_message_passing
   type t_StoreCommitter_i32_AtomicI32
   
   type closure0'2 = {
-    c0'2: t_Perm_PermCell_i32;
-    c1'2: MutBorrow.t t_Resource_Option_Excl_unit;
+    c0'2: MutBorrow.t t_Resource_Option_Excl_unit;
+    c1'2: t_Perm_PermCell_i32;
     c2'2: MutBorrow.t t_StoreCommitter_i32_AtomicI32 }
+  
+  let rec deref_mut_Ghost_Resource_Option_Excl_unit (self: MutBorrow.t t_Resource_Option_Excl_unit)
+    (return (x: MutBorrow.t t_Resource_Option_Excl_unit)) = any
+    [ return (result: MutBorrow.t t_Resource_Option_Excl_unit) -> {[@stop_split] [@expl:deref_mut ensures] result
+      = self}
+      (! return {result}) ]
+  
+  let rec valid_op_lemma_Option_Excl_unit (self: MutBorrow.t t_Resource_Option_Excl_unit)
+    (other: t_Resource_Option_Excl_unit) (return (x: ())) =
+    {[@stop_split] [@expl:valid_op_lemma requires] id_Option_Excl_unit self.current = id_Option_Excl_unit other}
+    any
+    [ return (result: ()) ->
+    {[@stop_split] [@expl:valid_op_lemma_Option_Excl_unit ensures] ([@stop_split] [@expl:valid_op_lemma ensures #0] self.final
+        = self.current)
+      /\ ([@stop_split] [@expl:valid_op_lemma ensures #1] op_Option_Excl_unit (view_Resource_Option_Excl_unit self.current) (view_Resource_Option_Excl_unit other)
+      <> None'2)}
+      (! return {result}) ]
+  
+  predicate resolve_refmut_Resource_Option_Excl_unit [@inline:trivial] (_1: MutBorrow.t t_Resource_Option_Excl_unit) =
+    _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_Resource_Option_Excl_unit
+  
+  let rec swap_Resource_Option_Excl_unit (x: MutBorrow.t t_Resource_Option_Excl_unit)
+    (y: MutBorrow.t t_Resource_Option_Excl_unit) (return (x'0: ())) = any
+    [ return (result: ()) ->
+    {[@stop_split] [@expl:swap_Resource_Option_Excl_unit ensures] ([@stop_split] [@expl:swap ensures #0] x.final
+        = y.current)
+      /\ ([@stop_split] [@expl:swap ensures #1] y.final = x.current)}
+      (! return {result}) ]
   
   let rec into_inner_Box_Perm_PermCell_i32_Global (self: t_Perm_PermCell_i32) (return (x: t_Perm_PermCell_i32)) = any
     [ return (result: t_Perm_PermCell_i32) -> {[@stop_split] [@expl:into_inner ensures] result = self}
@@ -490,36 +520,6 @@ module M_message_passing
       /\ ([@stop_split] [@expl:into_inner ensures] result = self)}
       (! return {result}) ]
   
-  let rec deref_mut_Ghost_Resource_Option_Excl_unit (self: MutBorrow.t t_Resource_Option_Excl_unit)
-    (return (x: MutBorrow.t t_Resource_Option_Excl_unit)) = any
-    [ return (result: MutBorrow.t t_Resource_Option_Excl_unit) -> {[@stop_split] [@expl:deref_mut ensures] result
-      = self}
-      (! return {result}) ]
-  
-  let rec valid_op_lemma_Option_Excl_unit (self: MutBorrow.t t_Resource_Option_Excl_unit)
-    (other: t_Resource_Option_Excl_unit) (return (x: ())) =
-    {[@stop_split] [@expl:valid_op_lemma requires] id_Option_Excl_unit self.current = id_Option_Excl_unit other}
-    any
-    [ return (result: ()) ->
-    {[@stop_split] [@expl:valid_op_lemma_Option_Excl_unit ensures] ([@stop_split] [@expl:valid_op_lemma ensures #0] self.final
-        = self.current)
-      /\ ([@stop_split] [@expl:valid_op_lemma ensures #1] op_Option_Excl_unit (view_Resource_Option_Excl_unit self.current) (view_Resource_Option_Excl_unit other)
-      <> None'2)}
-      (! return {result}) ]
-  
-  predicate resolve_refmut_Resource_Option_Excl_unit [@inline:trivial] (_1: MutBorrow.t t_Resource_Option_Excl_unit) =
-    _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_Resource_Option_Excl_unit
-  
-  let rec swap_Resource_Option_Excl_unit (x: MutBorrow.t t_Resource_Option_Excl_unit)
-    (y: MutBorrow.t t_Resource_Option_Excl_unit) (return (x'0: ())) = any
-    [ return (result: ()) ->
-    {[@stop_split] [@expl:swap_Resource_Option_Excl_unit ensures] ([@stop_split] [@expl:swap ensures #0] x.final
-        = y.current)
-      /\ ([@stop_split] [@expl:swap ensures #1] y.final = x.current)}
-      (! return {result}) ]
-  
   predicate resolve_AtView_Box_Perm_PermCell_i32_Global (_1: t_AtView_Box_Perm_PermCell_i32_Global)
   
   predicate resolve_Option_AtView_Box_Perm_PermCell_i32_Global (_1: t_Option_AtView_Box_Perm_PermCell_i32_Global)
@@ -544,12 +544,14 @@ module M_message_passing
     any
     [ return (result: int) ->
     {[@stop_split] [@expl:shoot_i32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_i32 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32 own.current = ward_AtomicI32 own.final)
-      /\ ([@stop_split] [@expl:shoot ensures #2] le_log_SyncView view.current view.final)
-      /\ ([@stop_split] [@expl:shoot ensures #3] get_timestamp_AtomicI32 (ward_i32 self.current) view.current < result)
-      /\ ([@stop_split] [@expl:shoot ensures #4] result <= get_timestamp_AtomicI32 (ward_i32 self.current) view.final)
-      /\ ([@stop_split] [@expl:shoot ensures #5] get_Int (val_AtomicI32 own.current) result = None)
-      /\ ([@stop_split] [@expl:shoot ensures #6] val_AtomicI32 own.final
+      /\ ([@stop_split] [@expl:shoot ensures #1] ward_i32 self.current = ward_i32 self.final
+        /\ val_i32 self.current = val_i32 self.final)
+      /\ ([@stop_split] [@expl:shoot ensures #2] ward_AtomicI32 own.current = ward_AtomicI32 own.final)
+      /\ ([@stop_split] [@expl:shoot ensures #3] le_log_SyncView view.current view.final)
+      /\ ([@stop_split] [@expl:shoot ensures #4] get_timestamp_AtomicI32 (ward_i32 self.current) view.current < result)
+      /\ ([@stop_split] [@expl:shoot ensures #5] result <= get_timestamp_AtomicI32 (ward_i32 self.current) view.final)
+      /\ ([@stop_split] [@expl:shoot ensures #6] get_Int (val_AtomicI32 own.current) result = None)
+      /\ ([@stop_split] [@expl:shoot ensures #7] val_AtomicI32 own.final
       = insert_Int (val_AtomicI32 own.current) result { f0'0 = val_i32 self.current; f1'0 = view.current })}
       (! return {result}) ]
   
@@ -591,47 +593,47 @@ module M_message_passing
     {[@stop_split] [@expl:closure 'inv' type invariant] inv_refmut_MessagePassingAtomicInv inv}
     bb0
     [ bb0 = s0
-      [ s0 = into_inner_Box_Perm_PermCell_i32_Global {self.c0'2} (fun (_x: t_Perm_PermCell_i32) -> [ &_8 <- _x ] s1)
-      | s1 = new_Box_Perm_PermCell_i32_Global {_8} (fun (_x: t_Perm_PermCell_i32) -> [ &_7 <- _x ] s2)
-      | s2 = new_Box_Perm_PermCell_i32_Global'0 {_7}
-          (fun (_x: tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global) -> [ &_6 <- _x ] s3)
-      | s3 = into_inner_tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global {_6}
-          (fun (_x: tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global) -> [ &_5 <- _x ] s4)
-      | s4 = [ &sync_view <- _5.f0'5 ] s5
-      | s5 = [ &at_view'0 <- _5.f1'5 ] s6
-      | s6 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.c1'2.current}
+      [ s0 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.c0'2.current}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_13 <- _bor ] [ &self <- { self with c1'2 = { self.c1'2 with current = _bor.final } } ] s7)
-      | s7 = deref_mut_Ghost_Resource_Option_Excl_unit {_13}
-          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_12 <- _x ] s8)
-      | s8 = [ &_15 <- inv.current.tok_write ] s9
-      | s9 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_12.current} {MutBorrow.get_id _12}
+            [ &_6 <- _bor ] [ &self <- { self with c0'2 = { self.c0'2 with current = _bor.final } } ] s1)
+      | s1 = deref_mut_Ghost_Resource_Option_Excl_unit {_6}
+          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_5 <- _x ] s2)
+      | s2 = [ &_8 <- inv.current.tok_write ] s3
+      | s3 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_5.current} {MutBorrow.get_id _5}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_11 <- _bor ] [ &_12 <- { _12 with current = _bor.final } ] s10)
-      | s10 = valid_op_lemma_Option_Excl_unit {_11} {_15} (fun (_x: ()) -> [ &_10 <- _x ] s11)
-      | s11 = -{resolve_refmut_Resource_Option_Excl_unit _12}- s12
-      | s12 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {inv.current.tok_write}
+            [ &_4 <- _bor ] [ &_5 <- { _5 with current = _bor.final } ] s4)
+      | s4 = valid_op_lemma_Option_Excl_unit {_4} {_8} (fun (_x: ()) -> [ &_3 <- _x ] s5)
+      | s5 = -{resolve_refmut_Resource_Option_Excl_unit _5}- s6
+      | s6 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {inv.current.tok_write}
           {MutBorrow.inherit_id (MutBorrow.get_id inv) 2}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_18 <- _bor ] [ &inv <- { inv with current = { inv.current with tok_write = _bor.final } } ] s13)
-      | s13 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {self.c1'2.current} {MutBorrow.get_id self.c1'2}
+            [ &_11 <- _bor ] [ &inv <- { inv with current = { inv.current with tok_write = _bor.final } } ] s7)
+      | s7 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {self.c0'2.current} {MutBorrow.get_id self.c0'2}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_22 <- _bor ] [ &self <- { self with c1'2 = { self.c1'2 with current = _bor.final } } ] s14)
-      | s14 = deref_mut_Ghost_Resource_Option_Excl_unit {_22}
-          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_21 <- _x ] s15)
-      | s15 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_21.current} {MutBorrow.get_id _21}
+            [ &_15 <- _bor ] [ &self <- { self with c0'2 = { self.c0'2 with current = _bor.final } } ] s8)
+      | s8 = deref_mut_Ghost_Resource_Option_Excl_unit {_15}
+          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_14 <- _x ] s9)
+      | s9 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_14.current} {MutBorrow.get_id _14}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_20 <- _bor ] [ &_21 <- { _21 with current = _bor.final } ] s16)
-      | s16 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_18.current} {MutBorrow.get_id _18}
+            [ &_13 <- _bor ] [ &_14 <- { _14 with current = _bor.final } ] s10)
+      | s10 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_11.current} {MutBorrow.get_id _11}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_17 <- _bor ] [ &_18 <- { _18 with current = _bor.final } ] s17)
-      | s17 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_20.current} {MutBorrow.get_id _20}
+            [ &_10 <- _bor ] [ &_11 <- { _11 with current = _bor.final } ] s11)
+      | s11 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_13.current} {MutBorrow.get_id _13}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_19 <- _bor ] [ &_20 <- { _20 with current = _bor.final } ] s18)
-      | s18 = swap_Resource_Option_Excl_unit {_17} {_19} (fun (_x: ()) -> [ &_16 <- _x ] s19)
-      | s19 = -{resolve_refmut_Resource_Option_Excl_unit _21}- s20
-      | s20 = -{resolve_refmut_Resource_Option_Excl_unit _20}- s21
-      | s21 = -{resolve_refmut_Resource_Option_Excl_unit _18}- s22
+            [ &_12 <- _bor ] [ &_13 <- { _13 with current = _bor.final } ] s12)
+      | s12 = swap_Resource_Option_Excl_unit {_10} {_12} (fun (_x: ()) -> [ &_9 <- _x ] s13)
+      | s13 = -{resolve_refmut_Resource_Option_Excl_unit _14}- s14
+      | s14 = -{resolve_refmut_Resource_Option_Excl_unit _13}- s15
+      | s15 = -{resolve_refmut_Resource_Option_Excl_unit _11}- s16
+      | s16 = into_inner_Box_Perm_PermCell_i32_Global {self.c1'2} (fun (_x: t_Perm_PermCell_i32) -> [ &_21 <- _x ] s17)
+      | s17 = new_Box_Perm_PermCell_i32_Global {_21} (fun (_x: t_Perm_PermCell_i32) -> [ &_20 <- _x ] s18)
+      | s18 = new_Box_Perm_PermCell_i32_Global'0 {_20}
+          (fun (_x: tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global) -> [ &_19 <- _x ] s19)
+      | s19 = into_inner_tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global {_19}
+          (fun (_x: tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global) -> [ &_18 <- _x ] s20)
+      | s20 = [ &sync_view <- _18.f0'5 ] s21
+      | s21 = [ &at_view'0 <- _18.f1'5 ] s22
       | s22 = [ &_23 <- Some'1 at_view'0 ] s23
       | s23 = s24
         [ _ck -> (! {[@expl:type invariant] inv_Option_AtView_Box_Perm_PermCell_i32_Global inv.current.at_view} any) ]
@@ -662,7 +664,7 @@ module M_message_passing
           end}-
         s37
       | s37 = -{match self with
-          | {c1'2 = x} -> resolve_refmut_Ghost_Resource_Option_Excl_unit x
+          | {c0'2 = x} -> resolve_refmut_Ghost_Resource_Option_Excl_unit x
           | _ -> true
           end}-
         s38
@@ -670,24 +672,24 @@ module M_message_passing
     [ & _ret: () = Any.any_l ()
     | & self: closure0'2 = self
     | & inv: MutBorrow.t t_MessagePassingAtomicInv = inv
-    | & sync_view: t_SyncView = Any.any_l ()
-    | & at_view'0: t_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _5: tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _6: tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _7: t_Perm_PermCell_i32 = Any.any_l ()
-    | & _8: t_Perm_PermCell_i32 = Any.any_l ()
-    | & _10: () = Any.any_l ()
+    | & _3: () = Any.any_l ()
+    | & _4: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _5: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _6: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _8: t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _9: () = Any.any_l ()
+    | & _10: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
     | & _11: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
     | & _12: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
     | & _13: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _15: t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _16: () = Any.any_l ()
-    | & _17: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _18: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _19: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _20: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _21: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _22: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _14: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _15: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & sync_view: t_SyncView = Any.any_l ()
+    | & at_view'0: t_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _18: tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _19: tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _20: t_Perm_PermCell_i32 = Any.any_l ()
+    | & _21: t_Perm_PermCell_i32 = Any.any_l ()
     | & _23: t_Option_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
     | & _25: int = Any.any_l ()
     | & _26: MutBorrow.t t_StoreCommitter_i32_AtomicI32 = Any.any_l ()
@@ -755,18 +757,18 @@ module M_message_passing
       [ s0 = deref_Ghost_ref_AtomicInvariant_MessagePassingAtomicInv {self.c0'1}
           (fun (_x: t_AtomicInvariant_MessagePassingAtomicInv) -> [ &_4 <- _x ] s1)
       | s1 = into_inner_Tokens {self.c1'1} (fun (_x: t_Tokens) -> [ &_6 <- _x ] s2)
-      | s2 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {self.c3'1.current} {MutBorrow.get_id self.c3'1}
+      | s2 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {self.c2'1.current} {MutBorrow.get_id self.c2'1}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_10 <- _bor ] [ &self <- { self with c3'1 = { self.c3'1 with current = _bor.final } } ] s3)
+            [ &_10 <- _bor ] [ &self <- { self with c2'1 = { self.c2'1 with current = _bor.final } } ] s3)
       | s3 = MutBorrow.borrow_final <t_StoreCommitter_i32_AtomicI32> {c.current} {MutBorrow.get_id c}
           (fun (_bor: MutBorrow.t t_StoreCommitter_i32_AtomicI32) ->
             [ &_11 <- _bor ] [ &c <- { c with current = _bor.final } ] s4)
-      | s4 = [ &_9 <- { c0'2 = self.c2'1; c1'2 = _10; c2'2 = _11 } ] s5
+      | s4 = [ &_9 <- { c0'2 = _10; c1'2 = self.c3'1; c2'2 = _11 } ] s5
       | s5 = __new_closure0 {_9} (fun (_x: t_FnGhostWrapper_closure0) -> [ &_8 <- _x ] s6)
       | s6 = open_MessagePassingAtomicInv {_4} {_6} {_8} (fun (_x: ()) -> [ &_ret <- _x ] s7)
       | s7 = -{resolve_refmut_StoreCommitter_i32_AtomicI32 c}- s8
       | s8 = -{match self with
-          | {c3'1 = x} -> resolve_refmut_Ghost_Resource_Option_Excl_unit x
+          | {c2'1 = x} -> resolve_refmut_Ghost_Resource_Option_Excl_unit x
           | _ -> true
           end}-
         s9
@@ -884,7 +886,7 @@ module M_message_passing
       | s16 = -{resolve_refmut_i32 _7}- s17
       | s17 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {excl}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_22 <- _bor ] [ &excl <- _bor.final ] s18)
-      | s18 = [ &_20 <- { c0'1 = self.c4'0; c1'1 = tokens; c2'1 = self.c2'0; c3'1 = _22 } ] s19
+      | s18 = [ &_20 <- { c0'1 = self.c4'0; c1'1 = tokens; c2'1 = _22; c3'1 = self.c2'0 } ] s19
       | s19 = __new_closure0'0 {_20} (fun (_x: t_FnGhostWrapper_closure0'0) -> [ &_19 <- _x ] s20)
       | s20 = new_FnGhostWrapper_closure0 {_19} (fun (_x: t_FnGhostWrapper_closure0'0) -> [ &_18 <- _x ] s21)
       | s21 = store_FnGhostWrapper_closure0 {self.c3'0} {(1: Int32.t)} {_18} (fun (_x: ()) -> [ &_16 <- _x ] s22)
@@ -985,39 +987,37 @@ module M_message_passing
   
   type t_LoadCommitter_i32_AtomicI32
   
-  type closure0'3 = {
-    c0'5: MutBorrow.t t_Resource_Option_Excl_unit;
-    c1'5: MutBorrow.t (MutBorrow.t t_LoadCommitter_i32_AtomicI32);
-    c2'5: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global }
-  
   function val_i32'0 (self: t_LoadCommitter_i32_AtomicI32) : Int32.t
+  
+  type closure0'3 = {
+    c0'5: t_LoadCommitter_i32_AtomicI32;
+    c1'5: MutBorrow.t t_Resource_Option_Excl_unit;
+    c2'5: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global }
   
   let rec into_ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
     [ return (result: Int32.t) -> {[@stop_split] [@expl:into_ghost ensures] result = self} (! return {result}) ]
   
-  let rec into_inner_i32 (self: Int32.t) (return (x: Int32.t)) = any
-    [ return (result: Int32.t) -> {[@stop_split] [@expl:into_inner ensures] result = self} (! return {result}) ]
+  let rec deref_Ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:deref ensures] result = self} (! return {result}) ]
+  
+  predicate resolve_refmut_closure0 [@inline:trivial] (_1: MutBorrow.t closure0'3) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_closure0
   
   let rec deref_Ghost_SyncView (self: t_SyncView) (return (x: t_SyncView)) = any
     [ return (result: t_SyncView) -> {[@stop_split] [@expl:deref ensures] result = self} (! return {result}) ]
   
-  predicate shot_i32'0 (self: t_LoadCommitter_i32_AtomicI32)
-  
   function ward_i32'0 (self: t_LoadCommitter_i32_AtomicI32) : t_AtomicI32
   
-  let rec shoot_i32'0 (self: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (own: t_Perm_AtomicI32)
-    (view: MutBorrow.t t_SyncView) (return (x: int)) =
-    {[@stop_split] [@expl:shoot_i32 requires] ([@stop_split] [@expl:shoot requires #0] not shot_i32'0 self.current)
-    /\ ([@stop_split] [@expl:shoot requires #1] ward_i32'0 self.current = ward_AtomicI32 own)}
+  let rec shoot_i32'0 (self: t_LoadCommitter_i32_AtomicI32) (own: t_Perm_AtomicI32) (view: MutBorrow.t t_SyncView)
+    (return (x: int)) = {[@stop_split] [@expl:shoot requires] ward_i32'0 self = ward_AtomicI32 own}
     any
     [ return (result: int) ->
-    {[@stop_split] [@expl:shoot_i32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_i32'0 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] le_log_SyncView view.current view.final)
-      /\ ([@stop_split] [@expl:shoot ensures #2] get_timestamp_AtomicI32 (ward_i32'0 self.current) view.current
-        <= result)
-      /\ ([@stop_split] [@expl:shoot ensures #3] result <= get_timestamp_AtomicI32 (ward_i32'0 self.current) view.final)
-      /\ ([@stop_split] [@expl:shoot ensures #4] match get_Int (val_AtomicI32 own) result with
-        | Some {f0'0 = v; f1'0 = v_view} -> v = val_i32'0 self.current /\ le_log_SyncView v_view view.final
+    {[@stop_split] [@expl:shoot_i32 ensures] ([@stop_split] [@expl:shoot ensures #0] le_log_SyncView view.current view.final)
+      /\ ([@stop_split] [@expl:shoot ensures #1] get_timestamp_AtomicI32 (ward_i32'0 self) view.current <= result)
+      /\ ([@stop_split] [@expl:shoot ensures #2] result <= get_timestamp_AtomicI32 (ward_i32'0 self) view.final)
+      /\ ([@stop_split] [@expl:shoot ensures #3] match get_Int (val_AtomicI32 own) result with
+        | Some {f0'0 = v; f1'0 = v_view} -> v = val_i32'0 self /\ le_log_SyncView v_view view.final
         | None -> false
         end)}
       (! return {result}) ]
@@ -1094,29 +1094,19 @@ module M_message_passing
   
   meta "rewrite_def" predicate resolve_Ghost_Option_Box_Perm_PermCell_i32_Global
   
-  predicate resolve_refmut_closure0 [@inline:trivial] (_1: MutBorrow.t closure0'3) = _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_closure0
-  
   predicate resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global [@inline:trivial] (_1: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global) =
     _1.final = _1.current
   
   meta "rewrite_def" predicate resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global
   
-  predicate resolve_refmut_refmut_LoadCommitter_i32_AtomicI32 [@inline:trivial] (_1: MutBorrow.t (MutBorrow.t t_LoadCommitter_i32_AtomicI32)) =
-    _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_refmut_LoadCommitter_i32_AtomicI32
-  
   predicate resolve_closure0 [@inline:trivial] (_1: closure0'3) =
     resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global _1.c2'5
-    /\ resolve_refmut_refmut_LoadCommitter_i32_AtomicI32 _1.c1'5
-    /\ resolve_refmut_Ghost_Resource_Option_Excl_unit _1.c0'5
+    /\ resolve_refmut_Ghost_Resource_Option_Excl_unit _1.c1'5
   
   meta "rewrite_def" predicate resolve_closure0
   
   predicate hist_inv_closure0 [@inline:trivial] (self: closure0'3) (result_state: closure0'3) =
-    result_state.c0'5.final = self.c0'5.final
+    result_state.c0'5 = self.c0'5
     /\ result_state.c1'5.final = self.c1'5.final /\ result_state.c2'5.final = self.c2'5.final
   
   meta "rewrite_def" predicate hist_inv_closure0
@@ -1125,126 +1115,120 @@ module M_message_passing
     (return (x: ())) = {[@stop_split] [@expl:closure 'inv' type invariant] inv_refmut_MessagePassingAtomicInv inv}
     bb0
     [ bb0 = s0
-      [ s0 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c0'5.current}
-          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_6 <- _bor ]
-            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
-            s1)
-      | s1 = deref_mut_Ghost_Resource_Option_Excl_unit {_6}
-          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_5 <- _x ] s2)
-      | s2 = [ &_8 <- inv.current.tok_read ] s3
-      | s3 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_5.current} {MutBorrow.get_id _5}
-          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_4 <- _bor ] [ &_5 <- { _5 with current = _bor.final } ] s4)
-      | s4 = valid_op_lemma_Option_Excl_unit {_4} {_8} (fun (_x: ()) -> [ &_3 <- _x ] s5)
-      | s5 = -{resolve_refmut_Resource_Option_Excl_unit _5}- s6
-      | s6 = into_ghost_i32 {val_i32'0 self.current.c1'5.current.current} (fun (_x: Int32.t) -> [ &_10 <- _x ] s7)
-      | s7 = into_inner_i32 {_10} (fun (_x: Int32.t) -> [ &value <- _x ] s8)
-      | s8 = new (fun (_x: t_SyncView) -> [ &_17 <- _x ] s9)
-      | s9 = deref_Ghost_SyncView {_17} (fun (_x: t_SyncView) -> [ &_15 <- _x ] s10)
-      | s10 = [ &sync_view <- _15 ] s11
-      | s11 = [ &_21 <- inv.current.atomic_own ] s12
-      | s12 = MutBorrow.borrow_mut <t_SyncView> {sync_view}
-          (fun (_bor: MutBorrow.t t_SyncView) -> [ &_23 <- _bor ] [ &sync_view <- _bor.final ] s13)
-      | s13 = MutBorrow.borrow_mut <t_LoadCommitter_i32_AtomicI32> {self.current.c1'5.current.current}
-          (fun (_bor: MutBorrow.t t_LoadCommitter_i32_AtomicI32) ->
-            [ &_19 <- _bor ]
-            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = { self.current.c1'5.current with current = _bor.final } } } } ]
-            s14)
-      | s14 = MutBorrow.borrow_final <t_SyncView> {_23.current} {MutBorrow.get_id _23}
-          (fun (_bor: MutBorrow.t t_SyncView) -> [ &_22 <- _bor ] [ &_23 <- { _23 with current = _bor.final } ] s15)
-      | s15 = shoot_i32'0 {_19} {_21} {_22} (fun (_x: int) -> [ &_18 <- _x ] s16)
-      | s16 = -{resolve_refmut_SyncView _23}- s17
-      | s17 = [ &_24 <- value = (1: Int32.t) ] s18
-      | s18 = any [ br0 -> {_24 = false} (! bb17) | br1 -> {_24} (! bb9) ] ]
-    | bb9 = s0
-      [ s0 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {inv.current.tok_read}
-          {MutBorrow.inherit_id (MutBorrow.get_id inv) 3}
-          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_28 <- _bor ] [ &inv <- { inv with current = { inv.current with tok_read = _bor.final } } ] s1)
-      | s1 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c0'5.current}
-          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_32 <- _bor ]
-            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
-            s2)
-      | s2 = deref_mut_Ghost_Resource_Option_Excl_unit {_32}
-          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_31 <- _x ] s3)
-      | s3 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_31.current} {MutBorrow.get_id _31}
-          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_30 <- _bor ] [ &_31 <- { _31 with current = _bor.final } ] s4)
-      | s4 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_28.current} {MutBorrow.get_id _28}
-          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_27 <- _bor ] [ &_28 <- { _28 with current = _bor.final } ] s5)
-      | s5 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_30.current} {MutBorrow.get_id _30}
-          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_29 <- _bor ] [ &_30 <- { _30 with current = _bor.final } ] s6)
-      | s6 = swap_Resource_Option_Excl_unit {_27} {_29} (fun (_x: ()) -> [ &_26 <- _x ] s7)
-      | s7 = -{resolve_refmut_Resource_Option_Excl_unit _31}- s8
-      | s8 = -{resolve_refmut_Resource_Option_Excl_unit _30}- s9
-      | s9 = -{resolve_refmut_Resource_Option_Excl_unit _28}- s10
-      | s10 = MutBorrow.borrow_final <t_Option_AtView_Box_Perm_PermCell_i32_Global> {inv.current.at_view}
-          {MutBorrow.inherit_id (MutBorrow.get_id inv) 1}
-          (fun (_bor: MutBorrow.t t_Option_AtView_Box_Perm_PermCell_i32_Global) ->
-            [ &_38 <- _bor ] -{inv_Option_AtView_Box_Perm_PermCell_i32_Global _bor.final}-
-            [ &inv <- { inv with current = { inv.current with at_view = _bor.final } } ] s11)
-        [ _ck -> (! {[@expl:type invariant] inv_Option_AtView_Box_Perm_PermCell_i32_Global inv.current.at_view} any) ]
-      | s11 = take_AtView_Box_Perm_PermCell_i32_Global {_38}
-          (fun (_x: t_Option_AtView_Box_Perm_PermCell_i32_Global) -> [ &_37 <- _x ] s12)
-      | s12 = s13 [ _ck -> (! {[@expl:type invariant] inv_refmut_MessagePassingAtomicInv inv} any) ]
-      | s13 = -{resolve_refmut_MessagePassingAtomicInv inv}- s14
-      | s14 = unwrap_AtView_Box_Perm_PermCell_i32_Global {_37}
-          (fun (_x: t_AtView_Box_Perm_PermCell_i32_Global) -> [ &_36 <- _x ] s15)
-      | s15 = into_inner_Box_Perm_PermCell_i32_Global'0 {_36} {sync_view}
-          (fun (_x: t_Perm_PermCell_i32) -> [ &_35 <- _x ] s16)
-      | s16 = [ &_34 <- Some'3 _35 ] s17
-      | s17 = new_Option_Box_Perm_PermCell_i32_Global {_34}
-          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_33 <- _x ] s18)
-      | s18 = -{match self with
-          | {current = {c2'5 = x}} -> resolve_Ghost_Option_Box_Perm_PermCell_i32_Global x.current
-          | _ -> true
-          end}-
-        s19
-      | s19 = [ &self <- { self with current = { self.current with c2'5 = { self.current.c2'5 with current = _33 } } } ]
-        s20
-      | s20 = -{resolve_refmut_closure0 self}- s21
-      | s21 = return {_ret} ]
-    | bb17 = s0
+      [ s0 = into_ghost_i32 {val_i32'0 self.current.c0'5} (fun (_x: Int32.t) -> [ &_8 <- _x ] s1)
+      | s1 = deref_Ghost_i32 {_8} (fun (_x: Int32.t) -> [ &_6 <- _x ] s2)
+      | s2 = [ &_4 <- _6 <> (1: Int32.t) ] s3
+      | s3 = any [ br0 -> {_4 = false} (! bb5) | br1 -> {_4} (! bb4) ] ]
+    | bb4 = s0
       [ s0 = s1 [ _ck -> (! {[@expl:type invariant] inv_refmut_MessagePassingAtomicInv inv} any) ]
       | s1 = -{resolve_refmut_MessagePassingAtomicInv inv}- s2
       | s2 = -{resolve_refmut_closure0 self}- s3
-      | s3 = return {_ret} ] ]
+      | s3 = return {_ret} ]
+    | bb5 = s0
+      [ s0 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c1'5.current}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_16 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = _bor.final } } } ]
+            s1)
+      | s1 = deref_mut_Ghost_Resource_Option_Excl_unit {_16}
+          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_15 <- _x ] s2)
+      | s2 = [ &_18 <- inv.current.tok_read ] s3
+      | s3 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_15.current} {MutBorrow.get_id _15}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_14 <- _bor ] [ &_15 <- { _15 with current = _bor.final } ] s4)
+      | s4 = valid_op_lemma_Option_Excl_unit {_14} {_18} (fun (_x: ()) -> [ &_13 <- _x ] s5)
+      | s5 = -{resolve_refmut_Resource_Option_Excl_unit _15}- s6
+      | s6 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {inv.current.tok_read}
+          {MutBorrow.inherit_id (MutBorrow.get_id inv) 3}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_21 <- _bor ] [ &inv <- { inv with current = { inv.current with tok_read = _bor.final } } ] s7)
+      | s7 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c1'5.current}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_25 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = _bor.final } } } ]
+            s8)
+      | s8 = deref_mut_Ghost_Resource_Option_Excl_unit {_25}
+          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_24 <- _x ] s9)
+      | s9 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_24.current} {MutBorrow.get_id _24}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_23 <- _bor ] [ &_24 <- { _24 with current = _bor.final } ] s10)
+      | s10 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_21.current} {MutBorrow.get_id _21}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_20 <- _bor ] [ &_21 <- { _21 with current = _bor.final } ] s11)
+      | s11 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_23.current} {MutBorrow.get_id _23}
+          (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
+            [ &_22 <- _bor ] [ &_23 <- { _23 with current = _bor.final } ] s12)
+      | s12 = swap_Resource_Option_Excl_unit {_20} {_22} (fun (_x: ()) -> [ &_19 <- _x ] s13)
+      | s13 = -{resolve_refmut_Resource_Option_Excl_unit _24}- s14
+      | s14 = -{resolve_refmut_Resource_Option_Excl_unit _23}- s15
+      | s15 = -{resolve_refmut_Resource_Option_Excl_unit _21}- s16
+      | s16 = new (fun (_x: t_SyncView) -> [ &_29 <- _x ] s17)
+      | s17 = deref_Ghost_SyncView {_29} (fun (_x: t_SyncView) -> [ &_27 <- _x ] s18)
+      | s18 = [ &sync_view <- _27 ] s19
+      | s19 = [ &_33 <- inv.current.atomic_own ] s20
+      | s20 = MutBorrow.borrow_mut <t_SyncView> {sync_view}
+          (fun (_bor: MutBorrow.t t_SyncView) -> [ &_35 <- _bor ] [ &sync_view <- _bor.final ] s21)
+      | s21 = MutBorrow.borrow_final <t_SyncView> {_35.current} {MutBorrow.get_id _35}
+          (fun (_bor: MutBorrow.t t_SyncView) -> [ &_34 <- _bor ] [ &_35 <- { _35 with current = _bor.final } ] s22)
+      | s22 = shoot_i32'0 {self.current.c0'5} {_33} {_34} (fun (_x: int) -> [ &_30 <- _x ] s23)
+      | s23 = -{resolve_refmut_SyncView _35}- s24
+      | s24 = MutBorrow.borrow_final <t_Option_AtView_Box_Perm_PermCell_i32_Global> {inv.current.at_view}
+          {MutBorrow.inherit_id (MutBorrow.get_id inv) 1}
+          (fun (_bor: MutBorrow.t t_Option_AtView_Box_Perm_PermCell_i32_Global) ->
+            [ &_41 <- _bor ] -{inv_Option_AtView_Box_Perm_PermCell_i32_Global _bor.final}-
+            [ &inv <- { inv with current = { inv.current with at_view = _bor.final } } ] s25)
+        [ _ck -> (! {[@expl:type invariant] inv_Option_AtView_Box_Perm_PermCell_i32_Global inv.current.at_view} any) ]
+      | s25 = take_AtView_Box_Perm_PermCell_i32_Global {_41}
+          (fun (_x: t_Option_AtView_Box_Perm_PermCell_i32_Global) -> [ &_40 <- _x ] s26)
+      | s26 = s27 [ _ck -> (! {[@expl:type invariant] inv_refmut_MessagePassingAtomicInv inv} any) ]
+      | s27 = -{resolve_refmut_MessagePassingAtomicInv inv}- s28
+      | s28 = unwrap_AtView_Box_Perm_PermCell_i32_Global {_40}
+          (fun (_x: t_AtView_Box_Perm_PermCell_i32_Global) -> [ &_39 <- _x ] s29)
+      | s29 = into_inner_Box_Perm_PermCell_i32_Global'0 {_39} {sync_view}
+          (fun (_x: t_Perm_PermCell_i32) -> [ &_38 <- _x ] s30)
+      | s30 = [ &_37 <- Some'3 _38 ] s31
+      | s31 = new_Option_Box_Perm_PermCell_i32_Global {_37}
+          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_36 <- _x ] s32)
+      | s32 = -{match self with
+          | {current = {c2'5 = x}} -> resolve_Ghost_Option_Box_Perm_PermCell_i32_Global x.current
+          | _ -> true
+          end}-
+        s33
+      | s33 = [ &self <- { self with current = { self.current with c2'5 = { self.current.c2'5 with current = _36 } } } ]
+        s34
+      | s34 = -{resolve_refmut_closure0 self}- s35
+      | s35 = return {_ret} ] ]
     [ & _ret: () = Any.any_l ()
     | & self: MutBorrow.t closure0'3 = self
     | & inv: MutBorrow.t t_MessagePassingAtomicInv = inv
-    | & _3: () = Any.any_l ()
-    | & _4: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _5: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _6: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _8: t_Resource_Option_Excl_unit = Any.any_l ()
-    | & value: Int32.t = Any.any_l ()
-    | & _10: Int32.t = Any.any_l ()
+    | & _4: bool = Any.any_l ()
+    | & _6: Int32.t = Any.any_l ()
+    | & _8: Int32.t = Any.any_l ()
+    | & _13: () = Any.any_l ()
+    | & _14: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _15: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _16: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _18: t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _19: () = Any.any_l ()
+    | & _20: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _21: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _22: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _23: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _24: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _25: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
     | & sync_view: t_SyncView = Any.any_l ()
-    | & _15: t_SyncView = Any.any_l ()
-    | & _17: t_SyncView = Any.any_l ()
-    | & _18: int = Any.any_l ()
-    | & _19: MutBorrow.t t_LoadCommitter_i32_AtomicI32 = Any.any_l ()
-    | & _21: t_Perm_AtomicI32 = Any.any_l ()
-    | & _22: MutBorrow.t t_SyncView = Any.any_l ()
-    | & _23: MutBorrow.t t_SyncView = Any.any_l ()
-    | & _24: bool = Any.any_l ()
-    | & _26: () = Any.any_l ()
-    | & _27: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _28: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _29: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _30: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _31: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _32: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _33: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _34: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _35: t_Perm_PermCell_i32 = Any.any_l ()
-    | & _36: t_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _37: t_Option_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _38: MutBorrow.t t_Option_AtView_Box_Perm_PermCell_i32_Global = Any.any_l () ]
+    | & _27: t_SyncView = Any.any_l ()
+    | & _29: t_SyncView = Any.any_l ()
+    | & _30: int = Any.any_l ()
+    | & _33: t_Perm_AtomicI32 = Any.any_l ()
+    | & _34: MutBorrow.t t_SyncView = Any.any_l ()
+    | & _35: MutBorrow.t t_SyncView = Any.any_l ()
+    | & _36: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _37: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _38: t_Perm_PermCell_i32 = Any.any_l ()
+    | & _39: t_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _40: t_Option_AtView_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _41: MutBorrow.t t_Option_AtView_Box_Perm_PermCell_i32_Global = Any.any_l () ]
     [ return (result: ()) -> {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure0 self.current self.final}
       return {result} ]
   
@@ -1327,11 +1311,6 @@ module M_message_passing
   
   meta "rewrite_def" predicate resolve_refmut_Tokens
   
-  predicate resolve_refmut_LoadCommitter_i32_AtomicI32 [@inline:trivial] (_1: MutBorrow.t t_LoadCommitter_i32_AtomicI32) =
-    _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_LoadCommitter_i32_AtomicI32
-  
   predicate resolve_refmut_closure4 [@inline:trivial] (_1: MutBorrow.t closure4) = _1.final = _1.current
   
   meta "rewrite_def" predicate resolve_refmut_closure4
@@ -1353,8 +1332,8 @@ module M_message_passing
   
   meta "rewrite_def" predicate hist_inv_closure4
   
-  let rec closure4 [@coma:extspec] (self: MutBorrow.t closure4) (c: MutBorrow.t t_LoadCommitter_i32_AtomicI32)
-    (return (x: ())) = bb0
+  let rec closure4 [@coma:extspec] (self: MutBorrow.t closure4) (c: t_LoadCommitter_i32_AtomicI32) (return (x: ())) =
+    bb0
     [ bb0 = s0
       [ s0 = deref_Ghost_ref_AtomicInvariant_MessagePassingAtomicInv {self.current.c0'4}
           (fun (_x: t_AtomicInvariant_MessagePassingAtomicInv) -> [ &_4 <- _x ] s1)
@@ -1369,27 +1348,23 @@ module M_message_passing
       | s4 = reborrow {_7} (fun (_x: t_Tokens) -> [ &_6 <- _x ] s5)
       | s5 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c2'4.current}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_12 <- _bor ]
+            [ &_13 <- _bor ]
             [ &self <- { self with current = { self.current with c2'4 = { self.current.c2'4 with current = _bor.final } } } ]
             s6)
-      | s6 = MutBorrow.borrow_mut <MutBorrow.t t_LoadCommitter_i32_AtomicI32> {c}
-          (fun (_bor: MutBorrow.t (MutBorrow.t t_LoadCommitter_i32_AtomicI32)) ->
-            [ &_13 <- _bor ] [ &c <- _bor.final ] s7)
-      | s7 = MutBorrow.borrow_mut <t_Option_Box_Perm_PermCell_i32_Global> {self.current.c3'4.current}
+      | s6 = MutBorrow.borrow_mut <t_Option_Box_Perm_PermCell_i32_Global> {self.current.c3'4.current}
           (fun (_bor: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global) ->
             [ &_14 <- _bor ]
             [ &self <- { self with current = { self.current with c3'4 = { self.current.c3'4 with current = _bor.final } } } ]
-            s8)
-      | s8 = [ &_11 <- { c0'5 = _12; c1'5 = _13; c2'5 = _14 } ] s9
-      | s9 = __new_closure0'1 {_11} (fun (_x: t_FnGhostWrapper_closure0'1) -> [ &_10 <- _x ] s10)
-      | s10 = open_MessagePassingAtomicInv'0 {_4} {_6} {_10} (fun (_x: ()) -> [ &_ret <- _x ] s11)
-      | s11 = -{resolve_refmut_Tokens _8}- s12
-      | s12 = -{resolve_refmut_LoadCommitter_i32_AtomicI32 c}- s13
-      | s13 = -{resolve_refmut_closure4 self}- s14
-      | s14 = return {_ret} ] ]
+            s7)
+      | s7 = [ &_11 <- { c0'5 = c; c1'5 = _13; c2'5 = _14 } ] s8
+      | s8 = __new_closure0'1 {_11} (fun (_x: t_FnGhostWrapper_closure0'1) -> [ &_10 <- _x ] s9)
+      | s9 = open_MessagePassingAtomicInv'0 {_4} {_6} {_10} (fun (_x: ()) -> [ &_ret <- _x ] s10)
+      | s10 = -{resolve_refmut_Tokens _8}- s11
+      | s11 = -{resolve_refmut_closure4 self}- s12
+      | s12 = return {_ret} ] ]
     [ & _ret: () = Any.any_l ()
     | & self: MutBorrow.t closure4 = self
-    | & c: MutBorrow.t t_LoadCommitter_i32_AtomicI32 = c
+    | & c: t_LoadCommitter_i32_AtomicI32 = c
     | & _4: t_AtomicInvariant_MessagePassingAtomicInv = Any.any_l ()
     | & _6: t_Tokens = Any.any_l ()
     | & _7: MutBorrow.t t_Tokens = Any.any_l ()
@@ -1397,8 +1372,7 @@ module M_message_passing
     | & _9: MutBorrow.t t_Tokens = Any.any_l ()
     | & _10: t_FnGhostWrapper_closure0'1 = Any.any_l ()
     | & _11: closure0'3 = Any.any_l ()
-    | & _12: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _13: MutBorrow.t (MutBorrow.t t_LoadCommitter_i32_AtomicI32) = Any.any_l ()
+    | & _13: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
     | & _14: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global = Any.any_l () ]
     [ return (result: ()) -> {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure4 self.current self.final}
       return {result} ]
@@ -1407,23 +1381,23 @@ module M_message_passing
   
   meta "rewrite_def" predicate closure4'post'return
   
-  predicate postcondition_once_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (result: ()) =
+  predicate postcondition_once_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) (result: ()) =
     let c = args in exists e: closure4. (exists bor_self: MutBorrow.t closure4. bor_self.current = self
           /\ bor_self.final = e /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self e)
       /\ resolve_closure4 e
   
   meta "rewrite_def" predicate postcondition_once_closure4
   
-  predicate postcondition_mut_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (result_state: closure4) (result: ()) =
+  predicate postcondition_mut_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) (result_state: closure4) (result: ()) =
     let c = args in exists bor_self: MutBorrow.t closure4. bor_self.current = self
       /\ bor_self.final = result_state /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self result_state
   
   meta "rewrite_def" predicate postcondition_mut_closure4
   
-  function fn_mut_once_closure4 (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (res: ()) : ()
+  function fn_mut_once_closure4 (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) (res: ()) : ()
   
   axiom fn_mut_once_closure4_spec:
-    forall self: closure4, args: MutBorrow.t t_LoadCommitter_i32_AtomicI32, res: (). postcondition_once_closure4 self args res
+    forall self: closure4, args: t_LoadCommitter_i32_AtomicI32, res: (). postcondition_once_closure4 self args res
       = (exists res_state: closure4. postcondition_mut_closure4 self args res_state res /\ resolve_closure4 res_state)
   
   function hist_inv_trans_closure4 (self: closure4) (b: closure4) (c: closure4) : ()
@@ -1435,10 +1409,10 @@ module M_message_passing
   
   axiom hist_inv_refl_closure4_spec: forall self: closure4. hist_inv_closure4 self self
   
-  function postcondition_mut_hist_inv_closure4 (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (res_state: closure4) (res: ()) : ()
+  function postcondition_mut_hist_inv_closure4 (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) (res_state: closure4) (res: ()) : ()
   
   axiom postcondition_mut_hist_inv_closure4_spec:
-    forall self: closure4, args: MutBorrow.t t_LoadCommitter_i32_AtomicI32, res_state: closure4, res: (). postcondition_mut_closure4 self args res_state res
+    forall self: closure4, args: t_LoadCommitter_i32_AtomicI32, res_state: closure4, res: (). postcondition_mut_closure4 self args res_state res
       -> hist_inv_closure4 self res_state
   
   type t_FnGhostWrapper_closure4 = { f0'9: closure4 }
@@ -1450,32 +1424,29 @@ module M_message_passing
   let rec new_FnGhostWrapper_closure4 (x: t_FnGhostWrapper_closure4) (return (x'0: t_FnGhostWrapper_closure4)) = any
     [ return (result: t_FnGhostWrapper_closure4) -> {[@stop_split] [@expl:new ensures] result = x} (! return {result}) ]
   
-  predicate precondition_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) =
+  predicate precondition_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_i32_AtomicI32) =
     let c = args in forall bor_self: MutBorrow.t closure4. bor_self.current = self -> closure4'pre bor_self c
   
   meta "rewrite_def" predicate precondition_closure4
   
-  predicate precondition_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) =
+  predicate precondition_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: t_LoadCommitter_i32_AtomicI32) =
     precondition_closure4 self.f0'9 args
   
   meta "rewrite_def" predicate precondition_FnGhostWrapper_closure4
   
-  predicate postcondition_once_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_LoadCommitter_i32_AtomicI32) (result: ()) =
+  predicate postcondition_once_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: t_LoadCommitter_i32_AtomicI32) (result: ()) =
     postcondition_once_closure4 self.f0'9 args result
   
   meta "rewrite_def" predicate postcondition_once_FnGhostWrapper_closure4
   
   let rec load_FnGhostWrapper_closure4 (self: t_AtomicI32) (f: t_FnGhostWrapper_closure4) (return (x: Int32.t)) =
     {[@stop_split] [@expl:load_FnGhostWrapper_closure4 requires] ([@stop_split] [@expl:load 'self' type invariant] inv_ref_AtomicI32 self)
-    /\ ([@stop_split] [@expl:load requires] forall c: MutBorrow.t t_LoadCommitter_i32_AtomicI32. not shot_i32'0 c.current
-      -> ward_i32'0 c.current = self
-      -> precondition_FnGhostWrapper_closure4 f c /\ postcondition_once_FnGhostWrapper_closure4 f c ()
-      -> shot_i32'0 c.final)}
+    /\ ([@stop_split] [@expl:load requires] forall c: t_LoadCommitter_i32_AtomicI32. ward_i32'0 c = self
+      -> precondition_FnGhostWrapper_closure4 f c)}
     any
     [ return (result: Int32.t) ->
-    {[@stop_split] [@expl:load ensures] exists c: MutBorrow.t t_LoadCommitter_i32_AtomicI32. not shot_i32'0 c.current
-        /\ ward_i32'0 c.current = self
-        /\ val_i32'0 c.current = result /\ postcondition_once_FnGhostWrapper_closure4 f c ()}
+    {[@stop_split] [@expl:load ensures] exists c: t_LoadCommitter_i32_AtomicI32. ward_i32'0 c = self
+        /\ val_i32'0 c = result /\ postcondition_once_FnGhostWrapper_closure4 f c ()}
       (! return {result}) ]
   
   predicate resolve_Tokens (_1: t_Tokens)

--- a/examples/message_passing_relacq_options.rs
+++ b/examples/message_passing_relacq_options.rs
@@ -83,9 +83,9 @@ pub fn message_passing() {
                 1,
                 ghost! { |c: &mut StoreCommitter<_, _>| {
                     inv.open(tokens.into_inner(), |inv: &mut MessagePassingAtomicInv| {
-                        let (mut sync_view, at_view) = AtView::new(ghost!(data_own.into_inner())).into_inner();
                         excl.valid_op_lemma(&inv.tok_write);
                         std::mem::swap(&mut inv.tok_write, &mut *excl);
+                        let (mut sync_view, at_view) = AtView::new(ghost!(data_own.into_inner())).into_inner();
                         inv.at_view = Some(at_view);
                         c.shoot(&mut inv.atomic_own, &mut sync_view);
                     })
@@ -100,16 +100,16 @@ pub fn message_passing() {
 
             #[invariant(excl == *excl_snap)]
             #[invariant(tokens.contains(MESSAGE_PASSING()))]
-            while atomic.load(ghost! { |c: &mut LoadCommitter<i32, _>| {
+            while atomic.load(ghost! { |c: &LoadCommitter<i32, _>| {
             inv.open(tokens.reborrow(), |inv: &mut MessagePassingAtomicInv| {
+                if *snapshot!{ c.val() }.into_ghost() != 1 {
+                    return
+                }
                 excl.valid_op_lemma(&inv.tok_read);
-                let value = snapshot!{ c.val() }.into_ghost().into_inner();
+                std::mem::swap(&mut inv.tok_read, &mut *excl);
                 let mut sync_view = *SyncView::new();
                 c.shoot(&inv.atomic_own, &mut sync_view);
-                if value == 1 {
-                    std::mem::swap(&mut inv.tok_read, &mut *excl);
-                    data_own = Ghost::new(Some(inv.at_view.take().unwrap().into_inner(sync_view)))
-                }
+                data_own = Ghost::new(Some(inv.at_view.take().unwrap().into_inner(sync_view)))
             })}})
                 != 1
             {}

--- a/examples/message_passing_relacq_options/proof.json
+++ b/examples/message_passing_relacq_options/proof.json
@@ -16,7 +16,7 @@
       },
       "vc_borrow_AtomicInvariant_MessagePassingAtomicInv": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.046
+        "time": 0.023
       },
       "vc_borrow_mut_SyncView": { "prover": "alt-ergo@2.6.2", "time": 0.02 },
       "vc_borrow_mut_i32": { "prover": "alt-ergo@2.6.2", "time": 0.036 },
@@ -33,12 +33,13 @@
       },
       "vc_deref_Ghost_Resource_Option_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.038
+        "time": 0.018
       },
       "vc_deref_Ghost_SyncView": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.034
       },
+      "vc_deref_Ghost_i32": { "prover": "alt-ergo@2.6.2", "time": 0.027 },
       "vc_deref_Ghost_ref_AtomicInvariant_MessagePassingAtomicInv": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.046
@@ -75,10 +76,9 @@
       },
       "vc_into_inner_Resource_Option_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.037
+        "time": 0.018
       },
       "vc_into_inner_Tokens": { "prover": "alt-ergo@2.6.2", "time": 0.043 },
-      "vc_into_inner_i32": { "prover": "alt-ergo@2.6.2", "time": 0.03 },
       "vc_into_inner_tup2_SyncView_AtView_Box_Perm_PermCell_i32_Global": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.041
@@ -98,7 +98,25 @@
             "tactic": "split_vc",
             "children": [
               { "prover": "alt-ergo@2.6.2", "time": 0.085 },
-              { "prover": "z3@4.15.3", "time": 0.853 },
+              {
+                "tactic": "split_vc",
+                "children": [
+                  { "prover": "alt-ergo@2.6.2", "time": 0.036 },
+                  {
+                    "tactic": "split_vc",
+                    "children": [
+                      { "prover": "alt-ergo@2.6.2", "time": 0.044 },
+                      { "prover": "alt-ergo@2.6.2", "time": 0.079 },
+                      { "prover": "cvc4@1.8", "time": 0.929 },
+                      { "prover": "alt-ergo@2.6.2", "time": 0.058 },
+                      { "prover": "alt-ergo@2.6.2", "time": 0.05 },
+                      { "prover": "alt-ergo@2.6.2", "time": 0.055 },
+                      { "prover": "alt-ergo@2.6.2", "time": 0.051 },
+                      { "prover": "alt-ergo@2.6.2", "time": 0.046 }
+                    ]
+                  }
+                ]
+              },
               { "prover": "alt-ergo@2.6.2", "time": 0.027 }
             ]
           }
@@ -136,7 +154,7 @@
       },
       "vc_new_Resource_Option_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.043
+        "time": 0.018
       },
       "vc_new_i32": { "prover": "alt-ergo@2.6.2", "time": 0.027 },
       "vc_new_ref_Perm_PermCell_i32": {
@@ -161,7 +179,7 @@
       },
       "vc_reborrow": { "prover": "alt-ergo@2.6.2", "time": 0.022 },
       "vc_scope_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.042 },
-      "vc_shoot_i32": { "prover": "alt-ergo@2.6.2", "time": 0.043 },
+      "vc_shoot_i32": { "prover": "alt-ergo@2.6.2", "time": 0.02 },
       "vc_shoot_i32'0": { "prover": "alt-ergo@2.6.2", "time": 0.039 },
       "vc_spawn_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.031 },
       "vc_spawn_closure1": { "prover": "alt-ergo@2.6.2", "time": 0.046 },

--- a/examples/message_passing_sc.coma
+++ b/examples/message_passing_sc.coma
@@ -251,8 +251,10 @@ module M_message_passing
     any
     [ return (result: ()) ->
     {[@stop_split] [@expl:shoot_AtomicI32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_AtomicI32 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32 own.current = ward_AtomicI32 own.final)
-      /\ ([@stop_split] [@expl:shoot ensures #2] val_AtomicI32 own.final = val_AtomicI32'0 self.current)}
+      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32'0 self.current = ward_AtomicI32'0 self.final
+        /\ val_AtomicI32'0 self.current = val_AtomicI32'0 self.final)
+      /\ ([@stop_split] [@expl:shoot ensures #2] ward_AtomicI32 own.current = ward_AtomicI32 own.final)
+      /\ ([@stop_split] [@expl:shoot ensures #3] val_AtomicI32 own.final = val_AtomicI32'0 self.current)}
       (! return {result}) ]
   
   predicate resolve_refmut_Box_Perm_AtomicI32_Global [@inline:trivial] (_1: MutBorrow.t t_Perm_AtomicI32) =
@@ -585,6 +587,23 @@ module M_message_passing
   
   type t_LoadCommitter_AtomicI32
   
+  function val_AtomicI32'1 (self: t_LoadCommitter_AtomicI32) : Int32.t
+  
+  type closure0'3 = {
+    c0'5: t_LoadCommitter_AtomicI32;
+    c1'5: MutBorrow.t t_Option_Resource_Excl_unit;
+    c2'5: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global }
+  
+  let rec into_ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:into_ghost ensures] result = self} (! return {result}) ]
+  
+  let rec deref_Ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:deref ensures] result = self} (! return {result}) ]
+  
+  predicate resolve_refmut_closure0 [@inline:trivial] (_1: MutBorrow.t closure0'3) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_closure0
+  
   let rec elim_Readable (_x: t_State) (return (f0'5: t_Resource_Excl_unit)) = any
     [ _k (f0'5: t_Resource_Excl_unit) -> {Readable f0'5 = _x} (! return {f0'5})
     | _chk -> (! {[@expl:elim Readable] match _x with
@@ -592,11 +611,6 @@ module M_message_passing
         | _ -> false
         end}
       any) ]
-  
-  type closure0'3 = {
-    c0'5: MutBorrow.t t_Option_Resource_Excl_unit;
-    c1'5: MutBorrow.t t_LoadCommitter_AtomicI32;
-    c2'5: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global }
   
   let rec deref_mut_Ghost_Option_Resource_Excl_unit (self: MutBorrow.t t_Option_Resource_Excl_unit)
     (return (x: MutBorrow.t t_Option_Resource_Excl_unit)) = any
@@ -650,24 +664,13 @@ module M_message_passing
   
   meta "rewrite_def" predicate resolve_refmut_Resource_Excl_unit
   
-  predicate shot_AtomicI32'0 (self: t_LoadCommitter_AtomicI32)
-  
   function ward_AtomicI32'1 (self: t_LoadCommitter_AtomicI32) : t_AtomicI32
   
-  function val_AtomicI32'1 (self: t_LoadCommitter_AtomicI32) : Int32.t
-  
-  let rec shoot_AtomicI32'0 (self: MutBorrow.t t_LoadCommitter_AtomicI32) (own: t_Perm_AtomicI32) (return (x: ())) =
-    {[@stop_split] [@expl:shoot_AtomicI32 requires] ([@stop_split] [@expl:shoot requires #0] not shot_AtomicI32'0 self.current)
-    /\ ([@stop_split] [@expl:shoot requires #1] ward_AtomicI32'1 self.current = ward_AtomicI32 own)}
+  let rec shoot_AtomicI32'0 (self: t_LoadCommitter_AtomicI32) (own: t_Perm_AtomicI32) (return (x: ())) =
+    {[@stop_split] [@expl:shoot requires] ward_AtomicI32'1 self = ward_AtomicI32 own}
     any
-    [ return (result: ()) ->
-    {[@stop_split] [@expl:shoot_AtomicI32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_AtomicI32'0 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] val_AtomicI32'1 self.current = val_AtomicI32 own)}
+    [ return (result: ()) -> {[@stop_split] [@expl:shoot ensures] val_AtomicI32'1 self = val_AtomicI32 own}
       (! return {result}) ]
-  
-  predicate resolve_refmut_closure0 [@inline:trivial] (_1: MutBorrow.t closure0'3) = _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_closure0
   
   let rec take_Resource_Excl_unit (self_: MutBorrow.t t_Option_Resource_Excl_unit)
     (return (x: t_Option_Resource_Excl_unit)) = any
@@ -718,11 +721,6 @@ module M_message_passing
   
   meta "rewrite_def" predicate resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global
   
-  predicate resolve_refmut_LoadCommitter_AtomicI32 [@inline:trivial] (_1: MutBorrow.t t_LoadCommitter_AtomicI32) =
-    _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_LoadCommitter_AtomicI32
-  
   predicate resolve_refmut_Ghost_Option_Resource_Excl_unit [@inline:trivial] (_1: MutBorrow.t t_Option_Resource_Excl_unit) =
     _1.final = _1.current
   
@@ -730,12 +728,12 @@ module M_message_passing
   
   predicate resolve_closure0 [@inline:trivial] (_1: closure0'3) =
     resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global _1.c2'5
-    /\ resolve_refmut_LoadCommitter_AtomicI32 _1.c1'5 /\ resolve_refmut_Ghost_Option_Resource_Excl_unit _1.c0'5
+    /\ resolve_refmut_Ghost_Option_Resource_Excl_unit _1.c1'5
   
   meta "rewrite_def" predicate resolve_closure0
   
   predicate hist_inv_closure0 [@inline:trivial] (self: closure0'3) (result_state: closure0'3) =
-    result_state.c0'5.final = self.c0'5.final
+    result_state.c0'5 = self.c0'5
     /\ result_state.c1'5.final = self.c1'5.final /\ result_state.c2'5.final = self.c2'5.final
   
   meta "rewrite_def" predicate hist_inv_closure0
@@ -743,127 +741,122 @@ module M_message_passing
   let rec closure0'2 [@coma:extspec] (self: MutBorrow.t closure0'3) (inv: MutBorrow.t t_MessagePassingAtomicInv)
     (return (x: ())) = bb0
     [ bb0 = s0
-      [ s0 = [ &_4 <- inv.current.state ] s1
-      | s1 = any
-        [ br0 -> {_4 = NotWrittenYet} (! bb8)
-        | br1 (x0: t_Perm_PermCell_i32) -> {_4 = Synchronisation x0} (! bb8)
-        | br2 (x0: t_Resource_Excl_unit) -> {_4 = Readable x0} (! bb2) ] ]
-    | bb2 = s0
-      [ s0 = elim_Readable {_4} (fun (r0: t_Resource_Excl_unit) -> [ &excl_state <- r0 ] s1)
-      | s1 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c0'5.current}
-          (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_13 <- _bor ]
-            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
-            s2)
-      | s2 = deref_mut_Ghost_Option_Resource_Excl_unit {_13}
-          (fun (_x: MutBorrow.t t_Option_Resource_Excl_unit) -> [ &_12 <- _x ] s3)
-      | s3 = MutBorrow.borrow_final <t_Option_Resource_Excl_unit> {_12.current} {MutBorrow.get_id _12}
-          (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_11 <- _bor ] [ &_12 <- { _12 with current = _bor.final } ] s4)
-      | s4 = as_mut_Resource_Excl_unit {_11} (fun (_x: t_Option_refmut_Resource_Excl_unit) -> [ &_10 <- _x ] s5)
-      | s5 = unwrap_refmut_Resource_Excl_unit {_10} (fun (_x: MutBorrow.t t_Resource_Excl_unit) -> [ &_9 <- _x ] s6)
-      | s6 = MutBorrow.borrow_final <t_Resource_Excl_unit> {_9.current} {MutBorrow.get_id _9}
-          (fun (_bor: MutBorrow.t t_Resource_Excl_unit) ->
-            [ &_8 <- _bor ] [ &_9 <- { _9 with current = _bor.final } ] s7)
-      | s7 = valid_op_lemma_Excl_unit {_8} {excl_state} (fun (_x: ()) -> [ &_7 <- _x ] s8)
-      | s8 = -{resolve_refmut_Option_Resource_Excl_unit _12}- s9
-      | s9 = -{resolve_refmut_Resource_Excl_unit _9}- s10
-      | s10 = bb8 ]
-    | bb8 = s0
-      [ s0 = [ &_18 <- inv.current.atomic_own ] s1
-      | s1 = MutBorrow.borrow_mut <t_LoadCommitter_AtomicI32> {self.current.c1'5.current}
-          (fun (_bor: MutBorrow.t t_LoadCommitter_AtomicI32) ->
-            [ &_16 <- _bor ]
-            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = _bor.final } } } ]
-            s2)
-      | s2 = shoot_AtomicI32'0 {_16} {_18} (fun (_x: ()) -> [ &_15 <- _x ] s3)
-      | s3 = [ &_19 <- inv.current.state ] s4
-      | s4 = any
-        [ br0 -> {_19 = NotWrittenYet} (! bb24)
-        | br1 (x0: t_Perm_PermCell_i32) -> {_19 = Synchronisation x0} (! bb11)
-        | br2 (x0: t_Resource_Excl_unit) -> {_19 = Readable x0} (! bb24) ] ]
-    | bb24 = s0
+      [ s0 = into_ghost_i32 {val_AtomicI32'1 self.current.c0'5} (fun (_x: Int32.t) -> [ &_8 <- _x ] s1)
+      | s1 = deref_Ghost_i32 {_8} (fun (_x: Int32.t) -> [ &_6 <- _x ] s2)
+      | s2 = [ &_4 <- _6 <> (1: Int32.t) ] s3
+      | s3 = any [ br0 -> {_4 = false} (! bb5) | br1 -> {_4} (! bb4) ] ]
+    | bb4 = s0
       [ s0 = -{resolve_refmut_MessagePassingAtomicInv inv}- s1
       | s1 = -{resolve_refmut_closure0 self}- s2
       | s2 = return {_ret} ]
-    | bb11 = s0
-      [ s0 = MutBorrow.borrow_final <t_State> {inv.current.state} {MutBorrow.inherit_id (MutBorrow.get_id inv) 1}
-          (fun (_bor: MutBorrow.t t_State) ->
-            [ &_26 <- _bor ] [ &inv <- { inv with current = { inv.current with state = _bor.final } } ] s1)
-      | s1 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c0'5.current}
+    | bb5 = s0
+      [ s0 = [ &_13 <- inv.current.state ] s1
+      | s1 = any
+        [ br0 -> {_13 = NotWrittenYet} (! bb13)
+        | br1 (x0: t_Perm_PermCell_i32) -> {_13 = Synchronisation x0} (! bb13)
+        | br2 (x0: t_Resource_Excl_unit) -> {_13 = Readable x0} (! bb7) ] ]
+    | bb7 = s0
+      [ s0 = elim_Readable {_13} (fun (r0: t_Resource_Excl_unit) -> [ &excl_state <- r0 ] s1)
+      | s1 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c1'5.current}
           (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_32 <- _bor ]
-            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
+            [ &_21 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = _bor.final } } } ]
             s2)
-      | s2 = deref_mut_Ghost_Option_Resource_Excl_unit {_32}
-          (fun (_x: MutBorrow.t t_Option_Resource_Excl_unit) -> [ &_31 <- _x ] s3)
-      | s3 = MutBorrow.borrow_final <t_Option_Resource_Excl_unit> {_31.current} {MutBorrow.get_id _31}
+      | s2 = deref_mut_Ghost_Option_Resource_Excl_unit {_21}
+          (fun (_x: MutBorrow.t t_Option_Resource_Excl_unit) -> [ &_20 <- _x ] s3)
+      | s3 = MutBorrow.borrow_final <t_Option_Resource_Excl_unit> {_20.current} {MutBorrow.get_id _20}
           (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_30 <- _bor ] [ &_31 <- { _31 with current = _bor.final } ] s4)
-      | s4 = take_Resource_Excl_unit {_30} (fun (_x: t_Option_Resource_Excl_unit) -> [ &_29 <- _x ] s5)
-      | s5 = -{resolve_refmut_Option_Resource_Excl_unit _31}- s6
-      | s6 = unwrap_Resource_Excl_unit {_29} (fun (_x: t_Resource_Excl_unit) -> [ &_28 <- _x ] s7)
-      | s7 = [ &_27 <- Readable _28 ] s8
-      | s8 = MutBorrow.borrow_final <t_State> {_26.current} {MutBorrow.get_id _26}
-          (fun (_bor: MutBorrow.t t_State) -> [ &_25 <- _bor ] [ &_26 <- { _26 with current = _bor.final } ] s9)
-      | s9 = replace_State {_25} {_27} (fun (_x: t_State) -> [ &_24 <- _x ] s10)
-      | s10 = -{resolve_refmut_State _26}- s11
-      | s11 = -{resolve_refmut_MessagePassingAtomicInv inv}- s12
-      | s12 = -{resolve_State _24}- s13
-      | s13 = any
-        [ br0 -> {_24 = NotWrittenYet} (! bb18)
-        | br1 (x0: t_Perm_PermCell_i32) -> {_24 = Synchronisation x0} (! bb17)
-        | br2 (x0: t_Resource_Excl_unit) -> {_24 = Readable x0} (! bb18) ] ]
-    | bb18 = s0
-      [ s0 = -{match _24 with
+            [ &_19 <- _bor ] [ &_20 <- { _20 with current = _bor.final } ] s4)
+      | s4 = as_mut_Resource_Excl_unit {_19} (fun (_x: t_Option_refmut_Resource_Excl_unit) -> [ &_18 <- _x ] s5)
+      | s5 = unwrap_refmut_Resource_Excl_unit {_18} (fun (_x: MutBorrow.t t_Resource_Excl_unit) -> [ &_17 <- _x ] s6)
+      | s6 = MutBorrow.borrow_final <t_Resource_Excl_unit> {_17.current} {MutBorrow.get_id _17}
+          (fun (_bor: MutBorrow.t t_Resource_Excl_unit) ->
+            [ &_16 <- _bor ] [ &_17 <- { _17 with current = _bor.final } ] s7)
+      | s7 = valid_op_lemma_Excl_unit {_16} {excl_state} (fun (_x: ()) -> [ &_3 <- _x ] s8)
+      | s8 = -{resolve_refmut_Option_Resource_Excl_unit _20}- s9
+      | s9 = -{resolve_refmut_Resource_Excl_unit _17}- s10
+      | s10 = bb13 ]
+    | bb13 = s0
+      [ s0 = [ &_26 <- inv.current.atomic_own ] s1
+      | s1 = shoot_AtomicI32'0 {self.current.c0'5} {_26} (fun (_x: ()) -> [ &_23 <- _x ] s2)
+      | s2 = MutBorrow.borrow_final <t_State> {inv.current.state} {MutBorrow.inherit_id (MutBorrow.get_id inv) 1}
+          (fun (_bor: MutBorrow.t t_State) ->
+            [ &_32 <- _bor ] [ &inv <- { inv with current = { inv.current with state = _bor.final } } ] s3)
+      | s3 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c1'5.current}
+          (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
+            [ &_38 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = _bor.final } } } ]
+            s4)
+      | s4 = deref_mut_Ghost_Option_Resource_Excl_unit {_38}
+          (fun (_x: MutBorrow.t t_Option_Resource_Excl_unit) -> [ &_37 <- _x ] s5)
+      | s5 = MutBorrow.borrow_final <t_Option_Resource_Excl_unit> {_37.current} {MutBorrow.get_id _37}
+          (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
+            [ &_36 <- _bor ] [ &_37 <- { _37 with current = _bor.final } ] s6)
+      | s6 = take_Resource_Excl_unit {_36} (fun (_x: t_Option_Resource_Excl_unit) -> [ &_35 <- _x ] s7)
+      | s7 = -{resolve_refmut_Option_Resource_Excl_unit _37}- s8
+      | s8 = unwrap_Resource_Excl_unit {_35} (fun (_x: t_Resource_Excl_unit) -> [ &_34 <- _x ] s9)
+      | s9 = [ &_33 <- Readable _34 ] s10
+      | s10 = MutBorrow.borrow_final <t_State> {_32.current} {MutBorrow.get_id _32}
+          (fun (_bor: MutBorrow.t t_State) -> [ &_31 <- _bor ] [ &_32 <- { _32 with current = _bor.final } ] s11)
+      | s11 = replace_State {_31} {_33} (fun (_x: t_State) -> [ &_30 <- _x ] s12)
+      | s12 = -{resolve_refmut_State _32}- s13
+      | s13 = -{resolve_refmut_MessagePassingAtomicInv inv}- s14
+      | s14 = -{resolve_State _30}- s15
+      | s15 = any
+        [ br0 -> {_30 = NotWrittenYet} (! bb21)
+        | br1 (x0: t_Perm_PermCell_i32) -> {_30 = Synchronisation x0} (! bb20)
+        | br2 (x0: t_Resource_Excl_unit) -> {_30 = Readable x0} (! bb21) ] ]
+    | bb21 = s0
+      [ s0 = -{match _30 with
           | Synchronisation x -> resolve_Box_Perm_PermCell_i32_Global x
           | _ -> true
           end}-
         s1
       | s1 = -{resolve_refmut_closure0 self}- s2
       | s2 = {false} any ]
-    | bb17 = s0
-      [ s0 = elim_Synchronisation {_24} (fun (r0: t_Perm_PermCell_i32) -> [ &d_own <- r0 ] s1)
-      | s1 = [ &_35 <- Some'0 d_own ] s2
-      | s2 = new_Option_Box_Perm_PermCell_i32_Global {_35}
-          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_34 <- _x ] s3)
+    | bb20 = s0
+      [ s0 = elim_Synchronisation {_30} (fun (r0: t_Perm_PermCell_i32) -> [ &d_own <- r0 ] s1)
+      | s1 = [ &_41 <- Some'0 d_own ] s2
+      | s2 = new_Option_Box_Perm_PermCell_i32_Global {_41}
+          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_40 <- _x ] s3)
       | s3 = -{match self with
           | {current = {c2'5 = x}} -> resolve_Ghost_Option_Box_Perm_PermCell_i32_Global x.current
           | _ -> true
           end}-
         s4
-      | s4 = [ &self <- { self with current = { self.current with c2'5 = { self.current.c2'5 with current = _34 } } } ]
+      | s4 = [ &self <- { self with current = { self.current with c2'5 = { self.current.c2'5 with current = _40 } } } ]
         s5
       | s5 = -{resolve_refmut_closure0 self}- s6
       | s6 = return {_ret} ] ]
     [ & _ret: () = Any.any_l ()
     | & self: MutBorrow.t closure0'3 = self
     | & inv: MutBorrow.t t_MessagePassingAtomicInv = inv
-    | & _4: t_State = Any.any_l ()
+    | & _3: () = Any.any_l ()
+    | & _4: bool = Any.any_l ()
+    | & _6: Int32.t = Any.any_l ()
+    | & _8: Int32.t = Any.any_l ()
+    | & _13: t_State = Any.any_l ()
     | & excl_state: t_Resource_Excl_unit = Any.any_l ()
-    | & _7: () = Any.any_l ()
-    | & _8: MutBorrow.t t_Resource_Excl_unit = Any.any_l ()
-    | & _9: MutBorrow.t t_Resource_Excl_unit = Any.any_l ()
-    | & _10: t_Option_refmut_Resource_Excl_unit = Any.any_l ()
-    | & _11: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _12: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _13: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _15: () = Any.any_l ()
-    | & _16: MutBorrow.t t_LoadCommitter_AtomicI32 = Any.any_l ()
-    | & _18: t_Perm_AtomicI32 = Any.any_l ()
-    | & _19: t_State = Any.any_l ()
+    | & _16: MutBorrow.t t_Resource_Excl_unit = Any.any_l ()
+    | & _17: MutBorrow.t t_Resource_Excl_unit = Any.any_l ()
+    | & _18: t_Option_refmut_Resource_Excl_unit = Any.any_l ()
+    | & _19: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _20: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _21: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _23: () = Any.any_l ()
+    | & _26: t_Perm_AtomicI32 = Any.any_l ()
     | & d_own: t_Perm_PermCell_i32 = Any.any_l ()
-    | & _24: t_State = Any.any_l ()
-    | & _25: MutBorrow.t t_State = Any.any_l ()
-    | & _26: MutBorrow.t t_State = Any.any_l ()
-    | & _27: t_State = Any.any_l ()
-    | & _28: t_Resource_Excl_unit = Any.any_l ()
-    | & _29: t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _30: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _31: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _32: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _34: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _35: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l () ]
+    | & _30: t_State = Any.any_l ()
+    | & _31: MutBorrow.t t_State = Any.any_l ()
+    | & _32: MutBorrow.t t_State = Any.any_l ()
+    | & _33: t_State = Any.any_l ()
+    | & _34: t_Resource_Excl_unit = Any.any_l ()
+    | & _35: t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _36: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _37: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _38: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
+    | & _40: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _41: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l () ]
     [ return (result: ()) -> {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure0 self.current self.final}
       return {result} ]
   
@@ -967,8 +960,7 @@ module M_message_passing
   
   meta "rewrite_def" predicate hist_inv_closure4
   
-  let rec closure4 [@coma:extspec] (self: MutBorrow.t closure4) (c: MutBorrow.t t_LoadCommitter_AtomicI32)
-    (return (x: ())) = bb0
+  let rec closure4 [@coma:extspec] (self: MutBorrow.t closure4) (c: t_LoadCommitter_AtomicI32) (return (x: ())) = bb0
     [ bb0 = s0
       [ s0 = deref_Ghost_ref_AtomicInvariantSC_MessagePassingAtomicInv {self.current.c0'4}
           (fun (_x: t_AtomicInvariantSC_MessagePassingAtomicInv) -> [ &_4 <- _x ] s1)
@@ -983,27 +975,23 @@ module M_message_passing
       | s4 = reborrow {_7} (fun (_x: t_Tokens) -> [ &_6 <- _x ] s5)
       | s5 = MutBorrow.borrow_mut <t_Option_Resource_Excl_unit> {self.current.c2'4.current}
           (fun (_bor: MutBorrow.t t_Option_Resource_Excl_unit) ->
-            [ &_12 <- _bor ]
+            [ &_13 <- _bor ]
             [ &self <- { self with current = { self.current with c2'4 = { self.current.c2'4 with current = _bor.final } } } ]
             s6)
-      | s6 = MutBorrow.borrow_final <t_LoadCommitter_AtomicI32> {c.current} {MutBorrow.get_id c}
-          (fun (_bor: MutBorrow.t t_LoadCommitter_AtomicI32) ->
-            [ &_13 <- _bor ] [ &c <- { c with current = _bor.final } ] s7)
-      | s7 = MutBorrow.borrow_mut <t_Option_Box_Perm_PermCell_i32_Global> {self.current.c3'4.current}
+      | s6 = MutBorrow.borrow_mut <t_Option_Box_Perm_PermCell_i32_Global> {self.current.c3'4.current}
           (fun (_bor: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global) ->
             [ &_14 <- _bor ]
             [ &self <- { self with current = { self.current with c3'4 = { self.current.c3'4 with current = _bor.final } } } ]
-            s8)
-      | s8 = [ &_11 <- { c0'5 = _12; c1'5 = _13; c2'5 = _14 } ] s9
-      | s9 = __new_closure0'1 {_11} (fun (_x: t_FnGhostWrapper_closure0'1) -> [ &_10 <- _x ] s10)
-      | s10 = open_MessagePassingAtomicInv'0 {_4} {_6} {_10} (fun (_x: ()) -> [ &_ret <- _x ] s11)
-      | s11 = -{resolve_refmut_Tokens _8}- s12
-      | s12 = -{resolve_refmut_LoadCommitter_AtomicI32 c}- s13
-      | s13 = -{resolve_refmut_closure4 self}- s14
-      | s14 = return {_ret} ] ]
+            s7)
+      | s7 = [ &_11 <- { c0'5 = c; c1'5 = _13; c2'5 = _14 } ] s8
+      | s8 = __new_closure0'1 {_11} (fun (_x: t_FnGhostWrapper_closure0'1) -> [ &_10 <- _x ] s9)
+      | s9 = open_MessagePassingAtomicInv'0 {_4} {_6} {_10} (fun (_x: ()) -> [ &_ret <- _x ] s10)
+      | s10 = -{resolve_refmut_Tokens _8}- s11
+      | s11 = -{resolve_refmut_closure4 self}- s12
+      | s12 = return {_ret} ] ]
     [ & _ret: () = Any.any_l ()
     | & self: MutBorrow.t closure4 = self
-    | & c: MutBorrow.t t_LoadCommitter_AtomicI32 = c
+    | & c: t_LoadCommitter_AtomicI32 = c
     | & _4: t_AtomicInvariantSC_MessagePassingAtomicInv = Any.any_l ()
     | & _6: t_Tokens = Any.any_l ()
     | & _7: MutBorrow.t t_Tokens = Any.any_l ()
@@ -1011,8 +999,7 @@ module M_message_passing
     | & _9: MutBorrow.t t_Tokens = Any.any_l ()
     | & _10: t_FnGhostWrapper_closure0'1 = Any.any_l ()
     | & _11: closure0'3 = Any.any_l ()
-    | & _12: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
-    | & _13: MutBorrow.t t_LoadCommitter_AtomicI32 = Any.any_l ()
+    | & _13: MutBorrow.t t_Option_Resource_Excl_unit = Any.any_l ()
     | & _14: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global = Any.any_l () ]
     [ return (result: ()) -> {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure4 self.current self.final}
       return {result} ]
@@ -1021,23 +1008,23 @@ module M_message_passing
   
   meta "rewrite_def" predicate closure4'post'return
   
-  predicate postcondition_once_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (result: ()) =
+  predicate postcondition_once_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_AtomicI32) (result: ()) =
     let c = args in exists e: closure4. (exists bor_self: MutBorrow.t closure4. bor_self.current = self
           /\ bor_self.final = e /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self e)
       /\ resolve_closure4 e
   
   meta "rewrite_def" predicate postcondition_once_closure4
   
-  predicate postcondition_mut_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (result_state: closure4) (result: ()) =
+  predicate postcondition_mut_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_AtomicI32) (result_state: closure4) (result: ()) =
     let c = args in exists bor_self: MutBorrow.t closure4. bor_self.current = self
       /\ bor_self.final = result_state /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self result_state
   
   meta "rewrite_def" predicate postcondition_mut_closure4
   
-  function fn_mut_once_closure4 (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (res: ()) : ()
+  function fn_mut_once_closure4 (self: closure4) (args: t_LoadCommitter_AtomicI32) (res: ()) : ()
   
   axiom fn_mut_once_closure4_spec:
-    forall self: closure4, args: MutBorrow.t t_LoadCommitter_AtomicI32, res: (). postcondition_once_closure4 self args res
+    forall self: closure4, args: t_LoadCommitter_AtomicI32, res: (). postcondition_once_closure4 self args res
       = (exists res_state: closure4. postcondition_mut_closure4 self args res_state res /\ resolve_closure4 res_state)
   
   function hist_inv_trans_closure4 (self: closure4) (b: closure4) (c: closure4) : ()
@@ -1049,10 +1036,10 @@ module M_message_passing
   
   axiom hist_inv_refl_closure4_spec: forall self: closure4. hist_inv_closure4 self self
   
-  function postcondition_mut_hist_inv_closure4 (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (res_state: closure4) (res: ()) : ()
+  function postcondition_mut_hist_inv_closure4 (self: closure4) (args: t_LoadCommitter_AtomicI32) (res_state: closure4) (res: ()) : ()
   
   axiom postcondition_mut_hist_inv_closure4_spec:
-    forall self: closure4, args: MutBorrow.t t_LoadCommitter_AtomicI32, res_state: closure4, res: (). postcondition_mut_closure4 self args res_state res
+    forall self: closure4, args: t_LoadCommitter_AtomicI32, res_state: closure4, res: (). postcondition_mut_closure4 self args res_state res
       -> hist_inv_closure4 self res_state
   
   type t_FnGhostWrapper_closure4 = { f0'6: closure4 }
@@ -1064,32 +1051,29 @@ module M_message_passing
   let rec new_FnGhostWrapper_closure4 (x: t_FnGhostWrapper_closure4) (return (x'0: t_FnGhostWrapper_closure4)) = any
     [ return (result: t_FnGhostWrapper_closure4) -> {[@stop_split] [@expl:new ensures] result = x} (! return {result}) ]
   
-  predicate precondition_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) =
+  predicate precondition_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_AtomicI32) =
     let c = args in forall bor_self: MutBorrow.t closure4. bor_self.current = self -> closure4'pre bor_self c
   
   meta "rewrite_def" predicate precondition_closure4
   
-  predicate precondition_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) =
+  predicate precondition_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: t_LoadCommitter_AtomicI32) =
     precondition_closure4 self.f0'6 args
   
   meta "rewrite_def" predicate precondition_FnGhostWrapper_closure4
   
-  predicate postcondition_once_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (result: ()) =
+  predicate postcondition_once_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: t_LoadCommitter_AtomicI32) (result: ()) =
     postcondition_once_closure4 self.f0'6 args result
   
   meta "rewrite_def" predicate postcondition_once_FnGhostWrapper_closure4
   
   let rec load_FnGhostWrapper_closure4 (self: t_AtomicI32) (f: t_FnGhostWrapper_closure4) (return (x: Int32.t)) =
     {[@stop_split] [@expl:load_FnGhostWrapper_closure4 requires] ([@stop_split] [@expl:load 'self' type invariant] inv_ref_AtomicI32 self)
-    /\ ([@stop_split] [@expl:load requires] forall c: MutBorrow.t t_LoadCommitter_AtomicI32. not shot_AtomicI32'0 c.current
-      -> ward_AtomicI32'1 c.current = self
-      -> precondition_FnGhostWrapper_closure4 f c /\ postcondition_once_FnGhostWrapper_closure4 f c ()
-      -> shot_AtomicI32'0 c.final)}
+    /\ ([@stop_split] [@expl:load requires] forall c: t_LoadCommitter_AtomicI32. ward_AtomicI32'1 c = self
+      -> precondition_FnGhostWrapper_closure4 f c)}
     any
     [ return (result: Int32.t) ->
-    {[@stop_split] [@expl:load ensures] exists c: MutBorrow.t t_LoadCommitter_AtomicI32. not shot_AtomicI32'0 c.current
-        /\ ward_AtomicI32'1 c.current = self
-        /\ val_AtomicI32'1 c.current = result /\ postcondition_once_FnGhostWrapper_closure4 f c ()}
+    {[@stop_split] [@expl:load ensures] exists c: t_LoadCommitter_AtomicI32. ward_AtomicI32'1 c = self
+        /\ val_AtomicI32'1 c = result /\ postcondition_once_FnGhostWrapper_closure4 f c ()}
       (! return {result}) ]
   
   predicate resolve_Option_Resource_Excl_unit (_1: t_Option_Resource_Excl_unit)

--- a/examples/message_passing_sc.rs
+++ b/examples/message_passing_sc.rs
@@ -86,20 +86,22 @@ pub fn message_passing() {
 
             #[invariant(excl == *excl_snap)]
             #[invariant(tokens.contains(MESSAGE_PASSING()))]
-            while atomic.load(ghost! { |c: &mut LoadCommitter<_>| {
+            while atomic.load(ghost! { |c: &LoadCommitter<AtomicI32>| {
             inv.open(tokens.reborrow(), |inv: &mut MessagePassingAtomicInv| {
-                if let State::Readable(excl_state) = &inv.state {
-                    excl.as_mut().unwrap().valid_op_lemma(excl_state);
+                if *snapshot!{ c.val() }.into_ghost() != 1 {
+                    return
+                } else if let State::Readable(excl_state) = &inv.state {
+                    excl.as_mut().unwrap().valid_op_lemma(excl_state)
                 }
 
                 c.shoot(&inv.atomic_own);
-
-                if let State::Synchronisation(_) = &inv.state {
-                    let State::Synchronisation(d_own) = std::mem::replace(&mut inv.state, State::Readable(excl.take().unwrap())) else {
-                            unreachable!();
-                    };
-                    data_own = Ghost::new(Some(d_own));
-            }})}})
+                let State::Synchronisation(d_own) =
+                    std::mem::replace(&mut inv.state, State::Readable(excl.take().unwrap()))
+                else {
+                    unreachable!();
+                };
+                data_own = Ghost::new(Some(d_own));
+            })}})
                 != 1
             {}
             let res = unsafe { data.get(ghost! { data_own.as_ref().unwrap() }) };

--- a/examples/message_passing_sc/proof.json
+++ b/examples/message_passing_sc/proof.json
@@ -2,14 +2,14 @@
   "profile": [],
   "proofs": {
     "M_message_passing": {
-      "vc___new_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.025 },
+      "vc___new_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.053 },
       "vc___new_closure0'0": { "prover": "alt-ergo@2.6.2", "time": 0.048 },
       "vc___new_closure0'1": { "prover": "alt-ergo@2.6.2", "time": 0.026 },
-      "vc___new_closure4": { "prover": "alt-ergo@2.6.2", "time": 0.022 },
+      "vc___new_closure4": { "prover": "alt-ergo@2.6.2", "time": 0.047 },
       "vc_alloc_Excl_unit": { "prover": "alt-ergo@2.6.2", "time": 0.038 },
       "vc_as_mut_Resource_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.045
+        "time": 0.022
       },
       "vc_as_ref_Box_Perm_PermCell_i32_Global": {
         "prover": "alt-ergo@2.6.2",
@@ -31,6 +31,7 @@
         "prover": "alt-ergo@2.6.2",
         "time": 0.032
       },
+      "vc_deref_Ghost_i32": { "prover": "alt-ergo@2.6.2", "time": 0.038 },
       "vc_deref_Ghost_ref_AtomicInvariantSC_MessagePassingAtomicInv": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.022
@@ -45,14 +46,15 @@
       },
       "vc_deref_mut_Ghost_Tokens": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.05
+        "time": 0.02
       },
       "vc_elim_Readable": { "prover": "alt-ergo@2.6.2", "time": 0.022 },
       "vc_elim_Synchronisation": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.044
       },
-      "vc_get_i32": { "prover": "alt-ergo@2.6.2", "time": 0.071 },
+      "vc_get_i32": { "prover": "alt-ergo@2.6.2", "time": 0.03 },
+      "vc_into_ghost_i32": { "prover": "alt-ergo@2.6.2", "time": 0.051 },
       "vc_into_inner_Box_Perm_AtomicI32_Global": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.038
@@ -68,7 +70,7 @@
       "vc_into_inner_Tokens": { "prover": "alt-ergo@2.6.2", "time": 0.038 },
       "vc_join_unwrap_ScopedJoinHandle_unit": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.066
+        "time": 0.028
       },
       "vc_load_FnGhostWrapper_closure4": {
         "prover": "alt-ergo@2.6.2",
@@ -76,7 +78,7 @@
       },
       "vc_message_passing": {
         "tactic": "compute_specified",
-        "children": [ { "prover": "cvc4@1.8", "time": 0.759 } ]
+        "children": [ { "prover": "cvc5@1.3.1", "time": 0.281 } ]
       },
       "vc_new": { "prover": "alt-ergo@2.6.2", "time": 0.02 },
       "vc_new_FnGhostWrapper_closure0": {
@@ -85,7 +87,7 @@
       },
       "vc_new_FnGhostWrapper_closure4": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.057
+        "time": 0.026
       },
       "vc_new_MessagePassingAtomicInv": {
         "prover": "alt-ergo@2.6.2",
@@ -97,7 +99,7 @@
       },
       "vc_new_Option_Box_Perm_PermCell_i32_Global": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.05
+        "time": 0.024
       },
       "vc_new_Option_Resource_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
@@ -120,7 +122,7 @@
         "prover": "alt-ergo@2.6.2",
         "time": 0.027
       },
-      "vc_reborrow": { "prover": "alt-ergo@2.6.2", "time": 0.045 },
+      "vc_reborrow": { "prover": "alt-ergo@2.6.2", "time": 0.02 },
       "vc_replace_State": { "prover": "alt-ergo@2.6.2", "time": 0.027 },
       "vc_scope_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.03 },
       "vc_shoot_AtomicI32": { "prover": "alt-ergo@2.6.2", "time": 0.047 },
@@ -145,7 +147,7 @@
       },
       "vc_unwrap_refmut_Resource_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.048
+        "time": 0.022
       },
       "vc_valid_op_lemma_Excl_unit": {
         "prover": "alt-ergo@2.6.2",

--- a/examples/message_passing_sc_options.coma
+++ b/examples/message_passing_sc_options.coma
@@ -307,8 +307,10 @@ module M_message_passing
     any
     [ return (result: ()) ->
     {[@stop_split] [@expl:shoot_AtomicI32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_AtomicI32 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32 own.current = ward_AtomicI32 own.final)
-      /\ ([@stop_split] [@expl:shoot ensures #2] val_AtomicI32 own.final = val_AtomicI32'0 self.current)}
+      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32'0 self.current = ward_AtomicI32'0 self.final
+        /\ val_AtomicI32'0 self.current = val_AtomicI32'0 self.final)
+      /\ ([@stop_split] [@expl:shoot ensures #2] ward_AtomicI32 own.current = ward_AtomicI32 own.final)
+      /\ ([@stop_split] [@expl:shoot ensures #3] val_AtomicI32 own.final = val_AtomicI32'0 self.current)}
       (! return {result}) ]
   
   predicate resolve_refmut_Box_Perm_AtomicI32_Global [@inline:trivial] (_1: MutBorrow.t t_Perm_AtomicI32) =
@@ -628,10 +630,22 @@ module M_message_passing
   
   type t_LoadCommitter_AtomicI32
   
+  function val_AtomicI32'1 (self: t_LoadCommitter_AtomicI32) : Int32.t
+  
   type closure0'3 = {
-    c0'5: MutBorrow.t t_Resource_Option_Excl_unit;
-    c1'5: MutBorrow.t (MutBorrow.t t_LoadCommitter_AtomicI32);
+    c0'5: t_LoadCommitter_AtomicI32;
+    c1'5: MutBorrow.t t_Resource_Option_Excl_unit;
     c2'5: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global }
+  
+  let rec into_ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:into_ghost ensures] result = self} (! return {result}) ]
+  
+  let rec deref_Ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
+    [ return (result: Int32.t) -> {[@stop_split] [@expl:deref ensures] result = self} (! return {result}) ]
+  
+  predicate resolve_refmut_closure0 [@inline:trivial] (_1: MutBorrow.t closure0'3) = _1.final = _1.current
+  
+  meta "rewrite_def" predicate resolve_refmut_closure0
   
   let rec deref_mut_Ghost_Resource_Option_Excl_unit (self: MutBorrow.t t_Resource_Option_Excl_unit)
     (return (x: MutBorrow.t t_Resource_Option_Excl_unit)) = any
@@ -655,14 +669,6 @@ module M_message_passing
   
   meta "rewrite_def" predicate resolve_refmut_Resource_Option_Excl_unit
   
-  function val_AtomicI32'1 (self: t_LoadCommitter_AtomicI32) : Int32.t
-  
-  let rec into_ghost_i32 (self: Int32.t) (return (x: Int32.t)) = any
-    [ return (result: Int32.t) -> {[@stop_split] [@expl:into_ghost ensures] result = self} (! return {result}) ]
-  
-  let rec into_inner_i32 (self: Int32.t) (return (x: Int32.t)) = any
-    [ return (result: Int32.t) -> {[@stop_split] [@expl:into_inner ensures] result = self} (! return {result}) ]
-  
   let rec swap_Resource_Option_Excl_unit (x: MutBorrow.t t_Resource_Option_Excl_unit)
     (y: MutBorrow.t t_Resource_Option_Excl_unit) (return (x'0: ())) = any
     [ return (result: ()) ->
@@ -671,17 +677,12 @@ module M_message_passing
       /\ ([@stop_split] [@expl:swap ensures #1] y.final = x.current)}
       (! return {result}) ]
   
-  predicate shot_AtomicI32'0 (self: t_LoadCommitter_AtomicI32)
-  
   function ward_AtomicI32'1 (self: t_LoadCommitter_AtomicI32) : t_AtomicI32
   
-  let rec shoot_AtomicI32'0 (self: MutBorrow.t t_LoadCommitter_AtomicI32) (own: t_Perm_AtomicI32) (return (x: ())) =
-    {[@stop_split] [@expl:shoot_AtomicI32 requires] ([@stop_split] [@expl:shoot requires #0] not shot_AtomicI32'0 self.current)
-    /\ ([@stop_split] [@expl:shoot requires #1] ward_AtomicI32'1 self.current = ward_AtomicI32 own)}
+  let rec shoot_AtomicI32'0 (self: t_LoadCommitter_AtomicI32) (own: t_Perm_AtomicI32) (return (x: ())) =
+    {[@stop_split] [@expl:shoot requires] ward_AtomicI32'1 self = ward_AtomicI32 own}
     any
-    [ return (result: ()) ->
-    {[@stop_split] [@expl:shoot_AtomicI32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_AtomicI32'0 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] val_AtomicI32'1 self.current = val_AtomicI32 own)}
+    [ return (result: ()) -> {[@stop_split] [@expl:shoot ensures] val_AtomicI32'1 self = val_AtomicI32 own}
       (! return {result}) ]
   
   let rec take_Box_Perm_PermCell_i32_Global (self_: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global)
@@ -696,19 +697,10 @@ module M_message_passing
   
   meta "rewrite_def" predicate resolve_Ghost_Option_Box_Perm_PermCell_i32_Global
   
-  predicate resolve_refmut_closure0 [@inline:trivial] (_1: MutBorrow.t closure0'3) = _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_closure0
-  
   predicate resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global [@inline:trivial] (_1: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global) =
     _1.final = _1.current
   
   meta "rewrite_def" predicate resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global
-  
-  predicate resolve_refmut_refmut_LoadCommitter_AtomicI32 [@inline:trivial] (_1: MutBorrow.t (MutBorrow.t t_LoadCommitter_AtomicI32)) =
-    _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_refmut_LoadCommitter_AtomicI32
   
   predicate resolve_refmut_Ghost_Resource_Option_Excl_unit [@inline:trivial] (_1: MutBorrow.t t_Resource_Option_Excl_unit) =
     _1.final = _1.current
@@ -717,12 +709,12 @@ module M_message_passing
   
   predicate resolve_closure0 [@inline:trivial] (_1: closure0'3) =
     resolve_refmut_Ghost_Option_Box_Perm_PermCell_i32_Global _1.c2'5
-    /\ resolve_refmut_refmut_LoadCommitter_AtomicI32 _1.c1'5 /\ resolve_refmut_Ghost_Resource_Option_Excl_unit _1.c0'5
+    /\ resolve_refmut_Ghost_Resource_Option_Excl_unit _1.c1'5
   
   meta "rewrite_def" predicate resolve_closure0
   
   predicate hist_inv_closure0 [@inline:trivial] (self: closure0'3) (result_state: closure0'3) =
-    result_state.c0'5.final = self.c0'5.final
+    result_state.c0'5 = self.c0'5
     /\ result_state.c1'5.final = self.c1'5.final /\ result_state.c2'5.final = self.c2'5.final
   
   meta "rewrite_def" predicate hist_inv_closure0
@@ -730,103 +722,99 @@ module M_message_passing
   let rec closure0'2 [@coma:extspec] (self: MutBorrow.t closure0'3) (inv: MutBorrow.t t_MessagePassingAtomicInv)
     (return (x: ())) = bb0
     [ bb0 = s0
-      [ s0 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c0'5.current}
+      [ s0 = into_ghost_i32 {val_AtomicI32'1 self.current.c0'5} (fun (_x: Int32.t) -> [ &_8 <- _x ] s1)
+      | s1 = deref_Ghost_i32 {_8} (fun (_x: Int32.t) -> [ &_6 <- _x ] s2)
+      | s2 = [ &_4 <- _6 <> (1: Int32.t) ] s3
+      | s3 = any [ br0 -> {_4 = false} (! bb5) | br1 -> {_4} (! bb4) ] ]
+    | bb4 = s0
+      [ s0 = -{resolve_refmut_MessagePassingAtomicInv inv}- s1
+      | s1 = -{resolve_refmut_closure0 self}- s2
+      | s2 = return {_ret} ]
+    | bb5 = s0
+      [ s0 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c1'5.current}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_6 <- _bor ]
-            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
+            [ &_16 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = _bor.final } } } ]
             s1)
-      | s1 = deref_mut_Ghost_Resource_Option_Excl_unit {_6}
-          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_5 <- _x ] s2)
-      | s2 = [ &_8 <- inv.current.tok ] s3
-      | s3 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_5.current} {MutBorrow.get_id _5}
+      | s1 = deref_mut_Ghost_Resource_Option_Excl_unit {_16}
+          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_15 <- _x ] s2)
+      | s2 = [ &_18 <- inv.current.tok ] s3
+      | s3 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_15.current} {MutBorrow.get_id _15}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_4 <- _bor ] [ &_5 <- { _5 with current = _bor.final } ] s4)
-      | s4 = valid_op_lemma_Option_Excl_unit {_4} {_8} (fun (_x: ()) -> [ &_3 <- _x ] s5)
-      | s5 = -{resolve_refmut_Resource_Option_Excl_unit _5}- s6
-      | s6 = into_ghost_i32 {val_AtomicI32'1 self.current.c1'5.current.current} (fun (_x: Int32.t) -> [ &_12 <- _x ] s7)
-      | s7 = into_inner_i32 {_12} (fun (_x: Int32.t) -> [ &_11 <- _x ] s8)
-      | s8 = [ &_10 <- _11 = (1: Int32.t) ] s9
-      | s9 = any [ br0 -> {_10 = false} (! bb10) | br1 -> {_10} (! bb6) ] ]
-    | bb6 = s0
-      [ s0 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {inv.current.tok}
+            [ &_14 <- _bor ] [ &_15 <- { _15 with current = _bor.final } ] s4)
+      | s4 = valid_op_lemma_Option_Excl_unit {_14} {_18} (fun (_x: ()) -> [ &_13 <- _x ] s5)
+      | s5 = -{resolve_refmut_Resource_Option_Excl_unit _15}- s6
+      | s6 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {inv.current.tok}
           {MutBorrow.inherit_id (MutBorrow.get_id inv) 2}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_18 <- _bor ] [ &inv <- { inv with current = { inv.current with tok = _bor.final } } ] s1)
-      | s1 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c0'5.current}
+            [ &_21 <- _bor ] [ &inv <- { inv with current = { inv.current with tok = _bor.final } } ] s7)
+      | s7 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c1'5.current}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_22 <- _bor ]
-            [ &self <- { self with current = { self.current with c0'5 = { self.current.c0'5 with current = _bor.final } } } ]
-            s2)
-      | s2 = deref_mut_Ghost_Resource_Option_Excl_unit {_22}
-          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_21 <- _x ] s3)
-      | s3 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_21.current} {MutBorrow.get_id _21}
+            [ &_25 <- _bor ]
+            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = _bor.final } } } ]
+            s8)
+      | s8 = deref_mut_Ghost_Resource_Option_Excl_unit {_25}
+          (fun (_x: MutBorrow.t t_Resource_Option_Excl_unit) -> [ &_24 <- _x ] s9)
+      | s9 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_24.current} {MutBorrow.get_id _24}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_20 <- _bor ] [ &_21 <- { _21 with current = _bor.final } ] s4)
-      | s4 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_18.current} {MutBorrow.get_id _18}
+            [ &_23 <- _bor ] [ &_24 <- { _24 with current = _bor.final } ] s10)
+      | s10 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_21.current} {MutBorrow.get_id _21}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_17 <- _bor ] [ &_18 <- { _18 with current = _bor.final } ] s5)
-      | s5 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_20.current} {MutBorrow.get_id _20}
+            [ &_20 <- _bor ] [ &_21 <- { _21 with current = _bor.final } ] s11)
+      | s11 = MutBorrow.borrow_final <t_Resource_Option_Excl_unit> {_23.current} {MutBorrow.get_id _23}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_19 <- _bor ] [ &_20 <- { _20 with current = _bor.final } ] s6)
-      | s6 = swap_Resource_Option_Excl_unit {_17} {_19} (fun (_x: ()) -> [ &_16 <- _x ] s7)
-      | s7 = -{resolve_refmut_Resource_Option_Excl_unit _21}- s8
-      | s8 = -{resolve_refmut_Resource_Option_Excl_unit _20}- s9
-      | s9 = -{resolve_refmut_Resource_Option_Excl_unit _18}- s10
-      | s10 = bb10 ]
-    | bb10 = s0
-      [ s0 = MutBorrow.borrow_final <t_Perm_AtomicI32> {inv.current.atomic_own}
+            [ &_22 <- _bor ] [ &_23 <- { _23 with current = _bor.final } ] s12)
+      | s12 = swap_Resource_Option_Excl_unit {_20} {_22} (fun (_x: ()) -> [ &_19 <- _x ] s13)
+      | s13 = -{resolve_refmut_Resource_Option_Excl_unit _24}- s14
+      | s14 = -{resolve_refmut_Resource_Option_Excl_unit _23}- s15
+      | s15 = -{resolve_refmut_Resource_Option_Excl_unit _21}- s16
+      | s16 = MutBorrow.borrow_final <t_Perm_AtomicI32> {inv.current.atomic_own}
           {MutBorrow.inherit_id (MutBorrow.get_id inv) 0}
           (fun (_bor: MutBorrow.t t_Perm_AtomicI32) ->
-            [ &_26 <- _bor ] [ &inv <- { inv with current = { inv.current with atomic_own = _bor.final } } ] s1)
-      | s1 = -{resolve_refmut_Box_Perm_AtomicI32_Global _26}- s2
-      | s2 = MutBorrow.borrow_mut <t_LoadCommitter_AtomicI32> {self.current.c1'5.current.current}
-          (fun (_bor: MutBorrow.t t_LoadCommitter_AtomicI32) ->
-            [ &_24 <- _bor ]
-            [ &self <- { self with current = { self.current with c1'5 = { self.current.c1'5 with current = { self.current.c1'5.current with current = _bor.final } } } } ]
-            s3)
-      | s3 = shoot_AtomicI32'0 {_24} {_26.current} (fun (_x: ()) -> [ &_23 <- _x ] s4)
-      | s4 = MutBorrow.borrow_final <t_Option_Box_Perm_PermCell_i32_Global> {inv.current.data_own}
+            [ &_29 <- _bor ] [ &inv <- { inv with current = { inv.current with atomic_own = _bor.final } } ] s17)
+      | s17 = -{resolve_refmut_Box_Perm_AtomicI32_Global _29}- s18
+      | s18 = shoot_AtomicI32'0 {self.current.c0'5} {_29.current} (fun (_x: ()) -> [ &_26 <- _x ] s19)
+      | s19 = MutBorrow.borrow_final <t_Option_Box_Perm_PermCell_i32_Global> {inv.current.data_own}
           {MutBorrow.inherit_id (MutBorrow.get_id inv) 1}
           (fun (_bor: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global) ->
-            [ &_29 <- _bor ] [ &inv <- { inv with current = { inv.current with data_own = _bor.final } } ] s5)
-      | s5 = take_Box_Perm_PermCell_i32_Global {_29}
-          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_28 <- _x ] s6)
-      | s6 = -{resolve_refmut_MessagePassingAtomicInv inv}- s7
-      | s7 = new_Option_Box_Perm_PermCell_i32_Global {_28}
-          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_27 <- _x ] s8)
-      | s8 = -{match self with
+            [ &_32 <- _bor ] [ &inv <- { inv with current = { inv.current with data_own = _bor.final } } ] s20)
+      | s20 = take_Box_Perm_PermCell_i32_Global {_32}
+          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_31 <- _x ] s21)
+      | s21 = -{resolve_refmut_MessagePassingAtomicInv inv}- s22
+      | s22 = new_Option_Box_Perm_PermCell_i32_Global {_31}
+          (fun (_x: t_Option_Box_Perm_PermCell_i32_Global) -> [ &_30 <- _x ] s23)
+      | s23 = -{match self with
           | {current = {c2'5 = x}} -> resolve_Ghost_Option_Box_Perm_PermCell_i32_Global x.current
           | _ -> true
           end}-
-        s9
-      | s9 = [ &self <- { self with current = { self.current with c2'5 = { self.current.c2'5 with current = _27 } } } ]
-        s10
-      | s10 = -{resolve_refmut_closure0 self}- s11
-      | s11 = return {_ret} ] ]
+        s24
+      | s24 = [ &self <- { self with current = { self.current with c2'5 = { self.current.c2'5 with current = _30 } } } ]
+        s25
+      | s25 = -{resolve_refmut_closure0 self}- s26
+      | s26 = return {_ret} ] ]
     [ & _ret: () = Any.any_l ()
     | & self: MutBorrow.t closure0'3 = self
     | & inv: MutBorrow.t t_MessagePassingAtomicInv = inv
-    | & _3: () = Any.any_l ()
-    | & _4: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _5: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _6: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _8: t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _10: bool = Any.any_l ()
-    | & _11: Int32.t = Any.any_l ()
-    | & _12: Int32.t = Any.any_l ()
-    | & _16: () = Any.any_l ()
-    | & _17: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _18: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _19: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _4: bool = Any.any_l ()
+    | & _6: Int32.t = Any.any_l ()
+    | & _8: Int32.t = Any.any_l ()
+    | & _13: () = Any.any_l ()
+    | & _14: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _15: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _16: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _18: t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _19: () = Any.any_l ()
     | & _20: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
     | & _21: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
     | & _22: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _23: () = Any.any_l ()
-    | & _24: MutBorrow.t t_LoadCommitter_AtomicI32 = Any.any_l ()
-    | & _26: MutBorrow.t t_Perm_AtomicI32 = Any.any_l ()
-    | & _27: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _28: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
-    | & _29: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global = Any.any_l () ]
+    | & _23: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _24: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _25: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
+    | & _26: () = Any.any_l ()
+    | & _29: MutBorrow.t t_Perm_AtomicI32 = Any.any_l ()
+    | & _30: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _31: t_Option_Box_Perm_PermCell_i32_Global = Any.any_l ()
+    | & _32: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global = Any.any_l () ]
     [ return (result: ()) -> {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure0 self.current self.final}
       return {result} ]
   
@@ -909,11 +897,6 @@ module M_message_passing
   
   meta "rewrite_def" predicate resolve_refmut_Tokens
   
-  predicate resolve_refmut_LoadCommitter_AtomicI32 [@inline:trivial] (_1: MutBorrow.t t_LoadCommitter_AtomicI32) =
-    _1.final = _1.current
-  
-  meta "rewrite_def" predicate resolve_refmut_LoadCommitter_AtomicI32
-  
   predicate resolve_refmut_closure4 [@inline:trivial] (_1: MutBorrow.t closure4) = _1.final = _1.current
   
   meta "rewrite_def" predicate resolve_refmut_closure4
@@ -935,8 +918,7 @@ module M_message_passing
   
   meta "rewrite_def" predicate hist_inv_closure4
   
-  let rec closure4 [@coma:extspec] (self: MutBorrow.t closure4) (c: MutBorrow.t t_LoadCommitter_AtomicI32)
-    (return (x: ())) = bb0
+  let rec closure4 [@coma:extspec] (self: MutBorrow.t closure4) (c: t_LoadCommitter_AtomicI32) (return (x: ())) = bb0
     [ bb0 = s0
       [ s0 = deref_Ghost_ref_AtomicInvariantSC_MessagePassingAtomicInv {self.current.c0'4}
           (fun (_x: t_AtomicInvariantSC_MessagePassingAtomicInv) -> [ &_4 <- _x ] s1)
@@ -951,26 +933,23 @@ module M_message_passing
       | s4 = reborrow {_7} (fun (_x: t_Tokens) -> [ &_6 <- _x ] s5)
       | s5 = MutBorrow.borrow_mut <t_Resource_Option_Excl_unit> {self.current.c2'4.current}
           (fun (_bor: MutBorrow.t t_Resource_Option_Excl_unit) ->
-            [ &_12 <- _bor ]
+            [ &_13 <- _bor ]
             [ &self <- { self with current = { self.current with c2'4 = { self.current.c2'4 with current = _bor.final } } } ]
             s6)
-      | s6 = MutBorrow.borrow_mut <MutBorrow.t t_LoadCommitter_AtomicI32> {c}
-          (fun (_bor: MutBorrow.t (MutBorrow.t t_LoadCommitter_AtomicI32)) -> [ &_13 <- _bor ] [ &c <- _bor.final ] s7)
-      | s7 = MutBorrow.borrow_mut <t_Option_Box_Perm_PermCell_i32_Global> {self.current.c3'4.current}
+      | s6 = MutBorrow.borrow_mut <t_Option_Box_Perm_PermCell_i32_Global> {self.current.c3'4.current}
           (fun (_bor: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global) ->
             [ &_14 <- _bor ]
             [ &self <- { self with current = { self.current with c3'4 = { self.current.c3'4 with current = _bor.final } } } ]
-            s8)
-      | s8 = [ &_11 <- { c0'5 = _12; c1'5 = _13; c2'5 = _14 } ] s9
-      | s9 = __new_closure0'1 {_11} (fun (_x: t_FnGhostWrapper_closure0'1) -> [ &_10 <- _x ] s10)
-      | s10 = open_MessagePassingAtomicInv'0 {_4} {_6} {_10} (fun (_x: ()) -> [ &_ret <- _x ] s11)
-      | s11 = -{resolve_refmut_Tokens _8}- s12
-      | s12 = -{resolve_refmut_LoadCommitter_AtomicI32 c}- s13
-      | s13 = -{resolve_refmut_closure4 self}- s14
-      | s14 = return {_ret} ] ]
+            s7)
+      | s7 = [ &_11 <- { c0'5 = c; c1'5 = _13; c2'5 = _14 } ] s8
+      | s8 = __new_closure0'1 {_11} (fun (_x: t_FnGhostWrapper_closure0'1) -> [ &_10 <- _x ] s9)
+      | s9 = open_MessagePassingAtomicInv'0 {_4} {_6} {_10} (fun (_x: ()) -> [ &_ret <- _x ] s10)
+      | s10 = -{resolve_refmut_Tokens _8}- s11
+      | s11 = -{resolve_refmut_closure4 self}- s12
+      | s12 = return {_ret} ] ]
     [ & _ret: () = Any.any_l ()
     | & self: MutBorrow.t closure4 = self
-    | & c: MutBorrow.t t_LoadCommitter_AtomicI32 = c
+    | & c: t_LoadCommitter_AtomicI32 = c
     | & _4: t_AtomicInvariantSC_MessagePassingAtomicInv = Any.any_l ()
     | & _6: t_Tokens = Any.any_l ()
     | & _7: MutBorrow.t t_Tokens = Any.any_l ()
@@ -978,8 +957,7 @@ module M_message_passing
     | & _9: MutBorrow.t t_Tokens = Any.any_l ()
     | & _10: t_FnGhostWrapper_closure0'1 = Any.any_l ()
     | & _11: closure0'3 = Any.any_l ()
-    | & _12: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
-    | & _13: MutBorrow.t (MutBorrow.t t_LoadCommitter_AtomicI32) = Any.any_l ()
+    | & _13: MutBorrow.t t_Resource_Option_Excl_unit = Any.any_l ()
     | & _14: MutBorrow.t t_Option_Box_Perm_PermCell_i32_Global = Any.any_l () ]
     [ return (result: ()) -> {[@stop_split] [@expl:closure hist_inv post] hist_inv_closure4 self.current self.final}
       return {result} ]
@@ -988,23 +966,23 @@ module M_message_passing
   
   meta "rewrite_def" predicate closure4'post'return
   
-  predicate postcondition_once_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (result: ()) =
+  predicate postcondition_once_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_AtomicI32) (result: ()) =
     let c = args in exists e: closure4. (exists bor_self: MutBorrow.t closure4. bor_self.current = self
           /\ bor_self.final = e /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self e)
       /\ resolve_closure4 e
   
   meta "rewrite_def" predicate postcondition_once_closure4
   
-  predicate postcondition_mut_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (result_state: closure4) (result: ()) =
+  predicate postcondition_mut_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_AtomicI32) (result_state: closure4) (result: ()) =
     let c = args in exists bor_self: MutBorrow.t closure4. bor_self.current = self
       /\ bor_self.final = result_state /\ closure4'post'return bor_self c result /\ hist_inv_closure4 self result_state
   
   meta "rewrite_def" predicate postcondition_mut_closure4
   
-  function fn_mut_once_closure4 (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (res: ()) : ()
+  function fn_mut_once_closure4 (self: closure4) (args: t_LoadCommitter_AtomicI32) (res: ()) : ()
   
   axiom fn_mut_once_closure4_spec:
-    forall self: closure4, args: MutBorrow.t t_LoadCommitter_AtomicI32, res: (). postcondition_once_closure4 self args res
+    forall self: closure4, args: t_LoadCommitter_AtomicI32, res: (). postcondition_once_closure4 self args res
       = (exists res_state: closure4. postcondition_mut_closure4 self args res_state res /\ resolve_closure4 res_state)
   
   function hist_inv_trans_closure4 (self: closure4) (b: closure4) (c: closure4) : ()
@@ -1016,10 +994,10 @@ module M_message_passing
   
   axiom hist_inv_refl_closure4_spec: forall self: closure4. hist_inv_closure4 self self
   
-  function postcondition_mut_hist_inv_closure4 (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (res_state: closure4) (res: ()) : ()
+  function postcondition_mut_hist_inv_closure4 (self: closure4) (args: t_LoadCommitter_AtomicI32) (res_state: closure4) (res: ()) : ()
   
   axiom postcondition_mut_hist_inv_closure4_spec:
-    forall self: closure4, args: MutBorrow.t t_LoadCommitter_AtomicI32, res_state: closure4, res: (). postcondition_mut_closure4 self args res_state res
+    forall self: closure4, args: t_LoadCommitter_AtomicI32, res_state: closure4, res: (). postcondition_mut_closure4 self args res_state res
       -> hist_inv_closure4 self res_state
   
   type t_FnGhostWrapper_closure4 = { f0'7: closure4 }
@@ -1031,32 +1009,29 @@ module M_message_passing
   let rec new_FnGhostWrapper_closure4 (x: t_FnGhostWrapper_closure4) (return (x'0: t_FnGhostWrapper_closure4)) = any
     [ return (result: t_FnGhostWrapper_closure4) -> {[@stop_split] [@expl:new ensures] result = x} (! return {result}) ]
   
-  predicate precondition_closure4 [@inline:trivial] (self: closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) =
+  predicate precondition_closure4 [@inline:trivial] (self: closure4) (args: t_LoadCommitter_AtomicI32) =
     let c = args in forall bor_self: MutBorrow.t closure4. bor_self.current = self -> closure4'pre bor_self c
   
   meta "rewrite_def" predicate precondition_closure4
   
-  predicate precondition_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) =
+  predicate precondition_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: t_LoadCommitter_AtomicI32) =
     precondition_closure4 self.f0'7 args
   
   meta "rewrite_def" predicate precondition_FnGhostWrapper_closure4
   
-  predicate postcondition_once_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: MutBorrow.t t_LoadCommitter_AtomicI32) (result: ()) =
+  predicate postcondition_once_FnGhostWrapper_closure4 [@inline:trivial] (self: t_FnGhostWrapper_closure4) (args: t_LoadCommitter_AtomicI32) (result: ()) =
     postcondition_once_closure4 self.f0'7 args result
   
   meta "rewrite_def" predicate postcondition_once_FnGhostWrapper_closure4
   
   let rec load_FnGhostWrapper_closure4 (self: t_AtomicI32) (f: t_FnGhostWrapper_closure4) (return (x: Int32.t)) =
     {[@stop_split] [@expl:load_FnGhostWrapper_closure4 requires] ([@stop_split] [@expl:load 'self' type invariant] inv_ref_AtomicI32 self)
-    /\ ([@stop_split] [@expl:load requires] forall c: MutBorrow.t t_LoadCommitter_AtomicI32. not shot_AtomicI32'0 c.current
-      -> ward_AtomicI32'1 c.current = self
-      -> precondition_FnGhostWrapper_closure4 f c /\ postcondition_once_FnGhostWrapper_closure4 f c ()
-      -> shot_AtomicI32'0 c.final)}
+    /\ ([@stop_split] [@expl:load requires] forall c: t_LoadCommitter_AtomicI32. ward_AtomicI32'1 c = self
+      -> precondition_FnGhostWrapper_closure4 f c)}
     any
     [ return (result: Int32.t) ->
-    {[@stop_split] [@expl:load ensures] exists c: MutBorrow.t t_LoadCommitter_AtomicI32. not shot_AtomicI32'0 c.current
-        /\ ward_AtomicI32'1 c.current = self
-        /\ val_AtomicI32'1 c.current = result /\ postcondition_once_FnGhostWrapper_closure4 f c ()}
+    {[@stop_split] [@expl:load ensures] exists c: t_LoadCommitter_AtomicI32. ward_AtomicI32'1 c = self
+        /\ val_AtomicI32'1 c = result /\ postcondition_once_FnGhostWrapper_closure4 f c ()}
       (! return {result}) ]
   
   predicate inv_closure1 [@inline:trivial] (_1: closure1) =

--- a/examples/message_passing_sc_options.rs
+++ b/examples/message_passing_sc_options.rs
@@ -80,12 +80,13 @@ pub fn message_passing() {
 
             #[invariant(excl == *excl_snap)]
             #[invariant(tokens.contains(MESSAGE_PASSING()))]
-            while atomic.load(ghost! { |c: &mut LoadCommitter<AtomicI32>| {
+            while atomic.load(ghost! { |c: &LoadCommitter<AtomicI32>| {
             inv.open(tokens.reborrow(), |inv: &mut MessagePassingAtomicInv| {
-                excl.valid_op_lemma(&inv.tok);
-                if snapshot!{ c.val() }.into_ghost().into_inner() == 1 {
-                    std::mem::swap(&mut inv.tok, &mut *excl);
+                if *snapshot!{ c.val() }.into_ghost() != 1 {
+                    return
                 }
+                excl.valid_op_lemma(&inv.tok);
+                std::mem::swap(&mut inv.tok, &mut *excl);
                 c.shoot(&mut inv.atomic_own);
                 data_own = Ghost::new(inv.data_own.take())
             })}})

--- a/examples/message_passing_sc_options/proof.json
+++ b/examples/message_passing_sc_options/proof.json
@@ -5,14 +5,14 @@
       "vc___new_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.031 },
       "vc___new_closure0'0": { "prover": "alt-ergo@2.6.2", "time": 0.032 },
       "vc___new_closure0'1": { "prover": "alt-ergo@2.6.2", "time": 0.032 },
-      "vc___new_closure4": { "prover": "alt-ergo@2.6.2", "time": 0.066 },
+      "vc___new_closure4": { "prover": "alt-ergo@2.6.2", "time": 0.033 },
       "vc_alloc_Option_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.047
       },
       "vc_as_ref_Box_Perm_PermCell_i32_Global": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.073
+        "time": 0.028
       },
       "vc_borrow_AtomicInvariantSC_MessagePassingAtomicInv": {
         "prover": "alt-ergo@2.6.2",
@@ -23,17 +23,18 @@
       "vc_closure0'0": { "prover": "alt-ergo@2.6.2", "time": 0.06 },
       "vc_closure0'1": { "prover": "alt-ergo@2.6.2", "time": 0.036 },
       "vc_closure0'2": { "prover": "alt-ergo@2.6.2", "time": 0.023 },
-      "vc_closure0'3": { "prover": "alt-ergo@2.6.2", "time": 0.062 },
-      "vc_closure1": { "prover": "alt-ergo@2.6.2", "time": 0.078 },
-      "vc_closure4": { "prover": "alt-ergo@2.6.2", "time": 0.063 },
+      "vc_closure0'3": { "prover": "alt-ergo@2.6.2", "time": 0.03 },
+      "vc_closure1": { "prover": "alt-ergo@2.6.2", "time": 0.038 },
+      "vc_closure4": { "prover": "alt-ergo@2.6.2", "time": 0.028 },
       "vc_deref_Ghost_Option_Box_Perm_PermCell_i32_Global": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.057
+        "time": 0.027
       },
       "vc_deref_Ghost_Resource_Option_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.057
+        "time": 0.028
       },
+      "vc_deref_Ghost_i32": { "prover": "alt-ergo@2.6.2", "time": 0.029 },
       "vc_deref_Ghost_ref_AtomicInvariantSC_MessagePassingAtomicInv": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.025
@@ -48,14 +49,14 @@
       },
       "vc_deref_mut_Ghost_Tokens": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.061
+        "time": 0.028
       },
-      "vc_get_i32": { "prover": "alt-ergo@2.6.2", "time": 0.078 },
+      "vc_get_i32": { "prover": "alt-ergo@2.6.2", "time": 0.038 },
       "vc_id_ghost_Option_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.039
       },
-      "vc_into_ghost_i32": { "prover": "alt-ergo@2.6.2", "time": 0.059 },
+      "vc_into_ghost_i32": { "prover": "alt-ergo@2.6.2", "time": 0.029 },
       "vc_into_inner_Box_Perm_AtomicI32_Global": {
         "prover": "alt-ergo@2.6.2",
         "time": 0.047
@@ -65,18 +66,17 @@
         "time": 0.046
       },
       "vc_into_inner_Tokens": { "prover": "alt-ergo@2.6.2", "time": 0.05 },
-      "vc_into_inner_i32": { "prover": "alt-ergo@2.6.2", "time": 0.059 },
       "vc_join_unwrap_ScopedJoinHandle_unit": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.074
+        "time": 0.03
       },
       "vc_load_FnGhostWrapper_closure4": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.061
+        "time": 0.026
       },
       "vc_message_passing": {
         "tactic": "compute_specified",
-        "children": [ { "prover": "z3@4.15.3", "time": 0.84 } ]
+        "children": [ { "prover": "cvc4@1.8", "time": 0.911 } ]
       },
       "vc_new": { "prover": "alt-ergo@2.6.2", "time": 0.047 },
       "vc_new_FnGhostWrapper_closure0": {
@@ -85,7 +85,7 @@
       },
       "vc_new_FnGhostWrapper_closure4": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.066
+        "time": 0.033
       },
       "vc_new_MessagePassingAtomicInv": {
         "prover": "alt-ergo@2.6.2",
@@ -97,12 +97,12 @@
       },
       "vc_new_Option_Box_Perm_PermCell_i32_Global": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.055
+        "time": 0.022
       },
       "vc_new_i32": { "prover": "alt-ergo@2.6.2", "time": 0.044 },
       "vc_new_ref_Perm_PermCell_i32": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.074
+        "time": 0.028
       },
       "vc_new_refmut_Perm_PermCell_i32": {
         "prover": "alt-ergo@2.6.2",
@@ -118,13 +118,13 @@
       },
       "vc_open_MessagePassingAtomicInv'0": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.062
+        "time": 0.025
       },
-      "vc_reborrow": { "prover": "alt-ergo@2.6.2", "time": 0.061 },
-      "vc_scope_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.068 },
+      "vc_reborrow": { "prover": "alt-ergo@2.6.2", "time": 0.028 },
+      "vc_scope_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.029 },
       "vc_shoot_AtomicI32": { "prover": "alt-ergo@2.6.2", "time": 0.032 },
-      "vc_shoot_AtomicI32'0": { "prover": "alt-ergo@2.6.2", "time": 0.043 },
-      "vc_spawn_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.06 },
+      "vc_shoot_AtomicI32'0": { "prover": "alt-ergo@2.6.2", "time": 0.019 },
+      "vc_spawn_closure0": { "prover": "alt-ergo@2.6.2", "time": 0.025 },
       "vc_spawn_closure1": { "prover": "alt-ergo@2.6.2", "time": 0.035 },
       "vc_store_FnGhostWrapper_closure0": {
         "prover": "alt-ergo@2.6.2",
@@ -132,7 +132,7 @@
       },
       "vc_swap_Resource_Option_Excl_unit": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.059
+        "time": 0.029
       },
       "vc_take_Box_Perm_PermCell_i32_Global": {
         "prover": "alt-ergo@2.6.2",
@@ -140,7 +140,7 @@
       },
       "vc_unwrap_ref_Box_Perm_PermCell_i32_Global": {
         "prover": "alt-ergo@2.6.2",
-        "time": 0.059
+        "time": 0.028
       },
       "vc_valid_op_lemma_Option_Excl_unit": {
         "prover": "alt-ergo@2.6.2",

--- a/examples/parallel_add.coma
+++ b/examples/parallel_add.coma
@@ -491,9 +491,12 @@ module M_parallel_add
     any
     [ return (result: ()) ->
     {[@stop_split] [@expl:shoot_AtomicI32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_AtomicI32 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32 own'0.current = ward_AtomicI32 own'0.final)
-      /\ ([@stop_split] [@expl:shoot ensures #2] val_AtomicI32 own'0.current = old_val_AtomicI32 self.current)
-      /\ ([@stop_split] [@expl:shoot ensures #3] val_AtomicI32 own'0.final = new_val_AtomicI32 self.current)}
+      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32'0 self.current = ward_AtomicI32'0 self.final)
+      /\ ([@stop_split] [@expl:shoot ensures #2] old_val_AtomicI32 self.current = old_val_AtomicI32 self.final
+        /\ new_val_AtomicI32 self.current = new_val_AtomicI32 self.final)
+      /\ ([@stop_split] [@expl:shoot ensures #3] ward_AtomicI32 own'0.current = ward_AtomicI32 own'0.final)
+      /\ ([@stop_split] [@expl:shoot ensures #4] val_AtomicI32 own'0.current = old_val_AtomicI32 self.current)
+      /\ ([@stop_split] [@expl:shoot ensures #5] val_AtomicI32 own'0.final = new_val_AtomicI32 self.current)}
       (! return {result}) ]
   
   predicate resolve_refmut_Box_Perm_AtomicI32_Global [@inline:trivial] (_1: MutBorrow.t t_Perm_AtomicI32) =

--- a/examples/parallel_add_n.coma
+++ b/examples/parallel_add_n.coma
@@ -1115,9 +1115,12 @@ module M_parallel_add
     any
     [ return (result: ()) ->
     {[@stop_split] [@expl:shoot_AtomicI32 ensures] ([@stop_split] [@expl:shoot ensures #0] shot_AtomicI32 self.final)
-      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32 own'0.current = ward_AtomicI32 own'0.final)
-      /\ ([@stop_split] [@expl:shoot ensures #2] val_AtomicI32 own'0.current = old_val_AtomicI32 self.current)
-      /\ ([@stop_split] [@expl:shoot ensures #3] val_AtomicI32 own'0.final = new_val_AtomicI32 self.current)}
+      /\ ([@stop_split] [@expl:shoot ensures #1] ward_AtomicI32'0 self.current = ward_AtomicI32'0 self.final)
+      /\ ([@stop_split] [@expl:shoot ensures #2] old_val_AtomicI32 self.current = old_val_AtomicI32 self.final
+        /\ new_val_AtomicI32 self.current = new_val_AtomicI32 self.final)
+      /\ ([@stop_split] [@expl:shoot ensures #3] ward_AtomicI32 own'0.current = ward_AtomicI32 own'0.final)
+      /\ ([@stop_split] [@expl:shoot ensures #4] val_AtomicI32 own'0.current = old_val_AtomicI32 self.current)
+      /\ ([@stop_split] [@expl:shoot ensures #5] val_AtomicI32 own'0.final = new_val_AtomicI32 self.current)}
       (! return {result}) ]
   
   predicate resolve_refmut_Box_Perm_AtomicI32_Global [@inline:trivial] (_1: MutBorrow.t t_Perm_AtomicI32) =


### PR DESCRIPTION
- Loads can be shot 0, 1 or mor times
- Load committers are passed as shared borrows
- Lifetimes for comitter are set to be the duration of the ghost closure instead of polymorphic at the atomic level. The previous API was probably sound, but weird.