### PR TITLE
Normalize field types in resolve and ty_inv

### DIFF
--- a/creusot/src/backend/resolve.rs
+++ b/creusot/src/backend/resolve.rs
@@ -60,9 +60,10 @@ pub fn is_resolve_trivial<'tcx>(
                     return false;
                 }
                 AdtKind::Box(ty) | AdtKind::Ghost(ty) => stack.push(ty),
-                AdtKind::Enum | AdtKind::Struct { partially_opaque: false } => {
-                    stack.extend(def.all_fields().map(|f| f.ty(ctx.tcx, subst)))
-                }
+                AdtKind::Enum | AdtKind::Struct { partially_opaque: false } => stack.extend(
+                    def.all_fields()
+                        .map(|f| ctx.normalize_erasing_regions(typing_env, f.ty(ctx.tcx, subst))),
+                ),
             },
             TyKind::Closure(_, subst) => stack.extend(subst.as_closure().upvar_tys()),
             TyKind::Param(_)

--- a/creusot/src/backend/ty_inv.rs
+++ b/creusot/src/backend/ty_inv.rs
@@ -68,9 +68,10 @@ pub(crate) fn is_tyinv_trivial<'tcx>(
                 AdtKind::Struct { partially_opaque: true }
                 | AdtKind::Opaque { always: false }
                 | AdtKind::Empty => return false,
-                AdtKind::Enum | AdtKind::Struct { partially_opaque: false } => {
-                    stack.extend(def.all_fields().map(|f| f.ty(ctx.tcx, subst)))
-                }
+                AdtKind::Enum | AdtKind::Struct { partially_opaque: false } => stack.extend(
+                    def.all_fields()
+                        .map(|f| ctx.normalize_erasing_regions(typing_env, f.ty(ctx.tcx, subst))),
+                ),
                 AdtKind::Ghost(_) | AdtKind::Box(_) => unreachable!(),
             },
             TyKind::Closure(_, subst) => stack.extend(subst.as_closure().upvar_tys()),

--- a/tests/should_succeed/bug/unnormalized_projection.coma
+++ b/tests/should_succeed/bug/unnormalized_projection.coma
@@ -1,0 +1,14 @@
+module M_q
+  use creusot.prelude.Any
+  
+  type t_Vec_B_Global
+  
+  type t_B = { f0: t_Vec_B_Global }
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec q (x: t_B) (return (x'0: ())) = (! bb0
+    [ bb0 = return {_ret} ] [ & _ret: () = Any.any_l () ]) [ return (result: ()) -> (! return {result}) ]
+end

--- a/tests/should_succeed/bug/unnormalized_projection.rs
+++ b/tests/should_succeed/bug/unnormalized_projection.rs
@@ -1,0 +1,17 @@
+extern crate creusot_std;
+#[allow(unused)]
+use creusot_std::prelude::*;
+
+pub trait P {
+    type A;
+}
+
+pub struct B(<B as P>::A);
+
+impl P for B {
+    type A = Vec<B>;
+}
+
+pub fn q(x: B) {
+    let _ = x.0;
+}

--- a/tests/should_succeed/bug/unnormalized_projection/proof.json
+++ b/tests/should_succeed/bug/unnormalized_projection/proof.json
@@ -1,0 +1,6 @@
+{
+  "profile": [],
+  "proofs": {
+    "M_q": { "vc_q": { "prover": "alt-ergo@2.6.2", "time": 0.057 } }
+  }
+}


### PR DESCRIPTION
Make the `unreachable!` calls above in `is_resolve_trivial` and `is_tyinv_trivial` actually unreachable.