### PR TITLE
Restore patch #1829

### DIFF
--- a/creusot/src/contracts_items/intrinsics.rs
+++ b/creusot/src/contracts_items/intrinsics.rs
@@ -26,7 +26,6 @@ macro_rules! contracts_items {
                 .iter_local_def_id()
                 .filter_map(|did| {
                     let mut did = did.to_def_id();
-                    let intrinsic = get_intrinsic(tcx, did)?;
                     match tcx.def_kind(did) {
                         DefKind::Ctor(..) => did = tcx.parent(did),
                         // Some definitions are not associated to HirIds and cannot have attributes
@@ -43,7 +42,7 @@ macro_rules! contracts_items {
                         _ => return None
                     }
 
-                    Some((intrinsic, did))
+                    Some((get_intrinsic(tcx, did)?, did))
                 })
                 .collect();
             let mut int2did = HashMap::new();

--- a/tests/should_succeed/bug/1828.coma
+++ b/tests/should_succeed/bug/1828.coma
@@ -1,0 +1,33 @@
+module M_foo
+  use creusot.int.UInt64
+  use creusot.prelude.Any
+  
+  let rec closure0 [@coma:extspec] (self: ()) (return (x: UInt64.t)) = bb0
+    [ bb0 = s0 [ s0 = [ &_ret <- (0: UInt64.t) ] s1 | s1 = return {_ret} ] ] [ & _ret: UInt64.t = Any.any_l () ]
+    [ return (result: UInt64.t) -> return {result} ]
+  
+  meta "rewrite_def" predicate closure0'pre
+  
+  meta "rewrite_def" predicate closure0'post'return
+  
+  type t_S
+  
+  predicate inv_S (_1: t_S)
+  
+  predicate invariant_ref_S [@inline:trivial] (self: t_S) = inv_S self
+  
+  meta "rewrite_def" predicate invariant_ref_S
+  
+  predicate inv_ref_S [@inline:trivial] (_1: t_S) = invariant_ref_S _1
+  
+  meta "rewrite_def" predicate inv_ref_S
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let rec foo_S (_1: t_S) (return (x: ())) = {[@stop_split] [@expl:foo '_1' type invariant] inv_ref_S _1}
+    (! bb0
+    [ bb0 = s0 [ s0 = [ &_ret <- () ] s1 | s1 = return {_ret} ] ] [ & _ret: () = Any.any_l () ])
+    [ return (result: ()) -> (! return {result}) ]
+end

--- a/tests/should_succeed/bug/1828.rs
+++ b/tests/should_succeed/bug/1828.rs
@@ -1,0 +1,7 @@
+extern crate creusot_std;
+
+// Prevent reintroducing bug described in issue:
+// https://github.com/creusot-rs/creusot/issues/1828
+pub fn foo<S>(_: &S) -> impl Fn() -> u64 {
+    move || 0
+}

--- a/tests/should_succeed/bug/1828/proof.json
+++ b/tests/should_succeed/bug/1828/proof.json
@@ -1,0 +1,9 @@
+{
+  "profile": [],
+  "proofs": {
+    "M_foo": {
+      "vc_closure0": { "prover": "alt-ergo", "time": 0.025 },
+      "vc_foo_S": { "prover": "alt-ergo", "time": 0.019 }
+    }
+  }
+}


### PR DESCRIPTION
As explained in PR #1829, some nodes of the HIR have no HirIds. We should ignore them in `gather_intrinsics`.

The bug is reintroduced in #2023. This commit restores #1829.