### PR TITLE
Improve error messages using annotate-snippets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +189,7 @@ dependencies = [
  "clap",
  "creusot-args",
  "creusot-setup",
+ "creusot-why3-spans",
  "env_logger",
  "glob",
  "serde",
@@ -417,6 +429,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "creusot-why3-spans"
+version = "0.1.0"
+dependencies = [
+ "annotate-snippets",
+ "cc",
+ "ocaml-interop",
+ "quick-xml",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +447,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "difflib"
@@ -1038,6 +1066,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ocaml-boxroot-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3c2664a427c8046d334bf3a50fc466170a3dc53c65bc926a9be31a8e8debd1"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ocaml-interop"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8de4fb0adf8a103e01b80d769221e37819f59b9b28b30f64eb15cf0dffa8b9"
+dependencies = [
+ "ocaml-boxroot-sys",
+ "ocaml-interop-derive",
+ "ocaml-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "ocaml-interop-derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fa4e369863f0d029abbf61eacc57668db7b3761a6dcec055ea25725af1ddaf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ocaml-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e0db66a4df18164b2318518bea3891b6fd05526253a71023267f8955dbaefa"
+dependencies = [
+ "cc",
+ "cty",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1320,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -1521,6 +1600,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string-interner"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "creusot-install",
   "creusot-metadata",
   "creusot-rustc",
+  "creusot-why3-spans",
   "pearlite-syn",
   "prelude-generator",
   "tests",

--- a/cargo-creusot/Cargo.toml
+++ b/cargo-creusot/Cargo.toml
@@ -14,6 +14,7 @@ env_logger = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 creusot-args = { path = "../creusot-args" }
 creusot-setup = { path = "../creusot-setup" }
+creusot-why3-spans = { path = "../creusot-why3-spans" }
 anyhow = "1.0"
 cargo_metadata = "0.23"
 glob = "0.3"

--- a/cargo-creusot/build.rs
+++ b/cargo-creusot/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // This seems to be ignored when emmitted from dependency and I have no idea why.
+    println!("cargo:rustc-link-arg=-Wl,-export-dynamic");
+}

--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -3,6 +3,7 @@ use cargo_metadata::{Metadata, Package, TargetKind, semver::Version};
 use clap::*;
 use creusot_args::{CREUSOT_RUSTC_ARGS, options::CreusotArgs};
 use creusot_setup as setup;
+use creusot_why3_spans::{get_unproved_goals, generate_reports, display_reports};
 use serde::Deserialize;
 use std::{
     env,
@@ -29,7 +30,23 @@ fn main() -> Result<()> {
         Some(Prove(args)) => {
             let root = workspace_root()?;
             let targets = creusot(None, cargs.args, &root)?;
-            why3find_prove(args, &root, targets)
+            match why3find_prove(args, &root, targets) {
+                Ok(()) => Ok(()),
+                Err(ProveError::FailedToLaunch(error)) => Err(error),
+                Err(ProveError::ErrorStatus(paths)) => {
+                    let conf = setup::creusot_paths().why3_conf();
+                    // split chain to avoid borrowing issues
+                    let conf = conf.to_str().expect("non-UTF-8 paths not supported (yet)");
+                    let goals = get_unproved_goals(conf, paths, false, false);
+                    if goals.is_empty() {
+                        bail!("why3find exited with non-zero status but no goals seem to be unproved");
+                    } else {
+                        let reports = generate_reports(&goals);
+                        display_reports(&reports);
+                        std::process::exit(1);
+                    }
+                },
+            }
         }
         Some(New(args)) => new(args),
         Some(Init(args)) => init(args),

--- a/cargo-creusot/src/why3find_wrapper.rs
+++ b/cargo-creusot/src/why3find_wrapper.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context as _, Result, anyhow, bail};
 use clap::*;
 use creusot_setup::{CreusotPaths, creusot_paths};
 use std::{
@@ -71,7 +71,18 @@ fn check_why3find_json_exists(root: &Path) -> Result<()> {
     }
 }
 
-fn raw_prove(args: ProveArgs, paths: &CreusotPaths, files: &[PathBuf]) -> Result<()> {
+enum RawProveError {
+    FailedToLaunch(anyhow::Error),
+    ErrorStatus,
+}
+
+impl From<anyhow::Error> for RawProveError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::FailedToLaunch(error)
+    }
+}
+
+fn raw_prove(args: ProveArgs, paths: &CreusotPaths, files: &[PathBuf]) -> std::result::Result<(), RawProveError> {
     let mut why3find = Command::new(&paths.why3find());
     why3find.arg("prove");
     if args.ide.ide_on_fail {
@@ -103,19 +114,34 @@ fn raw_prove(args: ProveArgs, paths: &CreusotPaths, files: &[PathBuf]) -> Result
     } else {
         why3find
             .status()
-            .map_err(|e| anyhow::Error::new(e).context("'why3find prove' failed to launch"))
+            .map_err(|e| {
+                let error = anyhow::Error::new(e).context("'why3find prove' failed to launch");
+                RawProveError::FailedToLaunch(error)
+            })
             .and_then(|status| {
-                if status.success() { Ok(()) } else { Err(anyhow!("'why3find prove' failed")) }
+                if status.success() { Ok(()) } else { Err(RawProveError::ErrorStatus) }
             })
     }
 }
 
-pub fn why3find_prove(args: ProveArgs, root: &Path, targets: Vec<String>) -> Result<()> {
+pub enum ProveError {
+    FailedToLaunch(anyhow::Error),
+    ErrorStatus(Vec<PathBuf>),
+}
+
+impl From<anyhow::Error> for ProveError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::FailedToLaunch(error)
+    }
+}
+
+pub fn why3find_prove(args: ProveArgs, root: &Path, targets: Vec<String>) -> std::result::Result<(), ProveError> {
     let paths = creusot_paths();
     check_why3_conf_exists(&paths)?;
     check_why3find_json_exists(root)?;
     // why3find likes relative paths. For that we move back to the root.
-    std::env::set_current_dir(root)?;
+    std::env::set_current_dir(root)
+        .with_context(|| format!("failed to change directory to {}", root.display()))?;
     let files = if args.patterns.is_empty() {
         let verif = PathBuf::from("verif");
         targets
@@ -135,16 +161,16 @@ pub fn why3find_prove(args: ProveArgs, root: &Path, targets: Vec<String>) -> Res
         // Fail if no files matched the patterns.
         // Note: if no patterns is supplied, then `files` will be `["verif/"]`
         // so `why3find` will be successfully called even if there are no coma files under `verif/`.
-        bail!("No files to prove")
+        return Err(anyhow!("No files to prove").into());
     }
     let coma = if args.ide.ide_always {
         // Validate `--ide-always`: it only works with a single Coma file.
         if args.patterns.is_empty() {
-            bail!("--ide-always requires an explicit file or pattern argument")
+            return Err(anyhow!("--ide-always requires an explicit file or pattern argument").into())
         } else if files.len() == 1 && files[0].extension() == Some(OsStr::new("coma")) {
             Some(files[0].clone())
         } else {
-            bail!("The flag --ide-always requires exacly one Coma file argument");
+            return Err(anyhow!("The flag --ide-always requires exacly one Coma file argument").into());
         }
     } else {
         None
@@ -154,7 +180,12 @@ pub fn why3find_prove(args: ProveArgs, root: &Path, targets: Vec<String>) -> Res
     if let Some(coma) = coma {
         why3_launcher::run_why3(Why3Mode::Ide, coma, String::new(), &paths)?;
     }
-    prove_result
+    prove_result.map_err(|error| {
+        match error {
+            RawProveError::FailedToLaunch(error) => ProveError::FailedToLaunch(error),
+            RawProveError::ErrorStatus => ProveError::ErrorStatus(files),
+        }
+    })
 }
 
 #[derive(Debug)]

--- a/creusot-why3-spans/.gitignore
+++ b/creusot-why3-spans/.gitignore
@@ -1,0 +1,4 @@
+target/
+_build
+ocaml-stub/_build
+ocaml-stub/vc_spans_all.o

--- a/creusot-why3-spans/Cargo.toml
+++ b/creusot-why3-spans/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "creusot-why3-spans"
+authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>"]
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Extracts spans produced by creusot from why3"
+publish = false
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+annotate-snippets = "0.12.13"
+quick-xml = "0.36"
+ocaml-interop = "0.12"
+
+[build-dependencies]
+cc = "1"

--- a/creusot-why3-spans/build.rs
+++ b/creusot-why3-spans/build.rs
@@ -1,0 +1,208 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn cmd_output(program: &str, args: &[&str]) -> String {
+    let out = Command::new(program)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run `{program}`: {e}"));
+    assert!(
+        out.status.success(),
+        "`{program} {}` failed:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+fn ocamlfind_query(package: &str) -> String {
+    cmd_output("ocamlfind", &["query", package])
+}
+
+/// Ask ocamlfind for the full `ocamlopt` link command for `why3` (including
+/// all transitive dependencies) and return the argument list — everything
+/// after the leading compiler name token.
+///
+/// Using `-only-show` means ocamlfind prints the command it *would* run
+/// without actually running it.  This gives us the correct `-I` flags and
+/// `.cmxa` paths for all transitive dependencies (including optional ones
+/// such as `camlzip`/`zip` that vary between installations) in the right
+/// order, regardless of OCaml version or switch layout.
+fn ocamlfind_link_args() -> Vec<String> {
+    let line = cmd_output(
+        "ocamlfind",
+        &[
+            "ocamlopt",
+            "-package", "why3",
+            "-linkpkg",
+            "-predicates", "native",
+            "-only-show",
+        ],
+    );
+    // The output is a single line like:
+    //   ocamlopt -I /path/to/foo -I /path/to/bar foo.cmxa bar.cmxa ...
+    // (On some installations the compiler is `ocamlopt.opt` instead of
+    // `ocamlopt`; either way it is exactly one whitespace-separated token.)
+    // We drop that first token and return the rest.
+    line.split_whitespace()
+        .skip(1)
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Scan a directory for `lib*.a` files and emit `cargo:rustc-link-lib=static=<stem>`
+/// for each one found, skipping OCaml runtime archives (handled separately).
+fn emit_static_libs_in_dir(dir: &Path, already_emitted: &mut HashSet<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("lib") && name.ends_with(".a") {
+            // Strip "lib" prefix and ".a" suffix to get the link name.
+            let stem = &name[3..name.len() - 2];
+            // Skip OCaml runtime archives — handled explicitly below.
+            if matches!(
+                stem,
+                "asmrun" | "asmrun_pic" | "asmrund" | "asmruni"
+                | "camlrun" | "camlrun_pic" | "camlrund" | "camlruni"
+                | "threads" | "threadsnat"
+            ) {
+                continue;
+            }
+            if already_emitted.insert(stem.to_owned()) {
+                println!("cargo:rustc-link-lib=static={stem}");
+            }
+        }
+    }
+}
+
+fn main() {
+    let manifest = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let stub_dir = manifest.join("ocaml-stub");
+
+    // ------------------------------------------------------------------
+    // 1. Resolve key paths via ocamlfind / ocamlopt
+    // ------------------------------------------------------------------
+    let why3_dir          = ocamlfind_query("why3");
+    let ocaml_runtime_dir = cmd_output("ocamlopt", &["-where"]);
+
+    // Derive OCAMLPATH for dune: why3 lives at <switch>/lib/why3/, so the
+    // switch lib dir is the parent of why3_dir.
+    let switch_lib_dir = PathBuf::from(&why3_dir)
+        .parent()
+        .expect("why3_dir has no parent")
+        .to_path_buf();
+
+    // ------------------------------------------------------------------
+    // 2. Build the OCaml stub with dune
+    // ------------------------------------------------------------------
+    let status = Command::new("dune")
+        .arg("build")
+        .current_dir(&stub_dir)
+        .env("OCAMLPATH", &switch_lib_dir)
+        .status()
+        .expect("failed to run `dune build`");
+    assert!(status.success(), "`dune build` failed");
+
+    // ------------------------------------------------------------------
+    // 3. Produce the combined OCaml object with ocamlopt -output-obj
+    //
+    //    We ask ocamlfind for the complete, ordered list of -I flags and
+    //    .cmxa archives needed to link why3 and all its transitive
+    //    dependencies (including optional ones like camlzip/zip).  We
+    //    prepend -I for the stub's build directory so ocamlopt can find
+    //    vc_spans_stub.cmi, then append the stub's own .cmx.
+    // ------------------------------------------------------------------
+    let out_obj        = stub_dir.join("vc_spans_all.o");
+    let stub_cmx       = stub_dir
+        .join("_build/default/.vc_spans_stub.objs/native/vc_spans_stub.cmx");
+    let stub_build_dir = stub_dir.join("_build/default");
+
+    let mut link_args = vec![
+        "-output-obj".to_owned(),
+        "-o".to_owned(), out_obj.to_str().unwrap().to_owned(),
+        // The stub's build dir must come first so its .cmi takes precedence.
+        "-I".to_owned(), stub_build_dir.to_str().unwrap().to_owned(),
+    ];
+
+    // Append all -I and .cmxa args from ocamlfind (transitive why3 deps).
+    link_args.extend(ocamlfind_link_args());
+
+    // Finally add the stub .cmx itself.
+    link_args.push(stub_cmx.to_str().unwrap().to_owned());
+
+    let status = Command::new("ocamlopt")
+        .args(&link_args)
+        .status()
+        .expect("failed to run `ocamlopt -output-obj`");
+    assert!(status.success(), "`ocamlopt -output-obj` failed");
+
+    // ------------------------------------------------------------------
+    // 4. Compile the combined object into a static archive for Cargo
+    // ------------------------------------------------------------------
+    cc::Build::new()
+        .object(&out_obj)
+        .compile("vc_spans_ocaml_all");
+
+    // ------------------------------------------------------------------
+    // 5. Link C-level dependencies
+    //
+    //    Strategy: for every unique parent directory of a .cmxa that
+    //    ocamlfind listed, add it as a rustc-link-search path and scan it
+    //    for lib*.a C stub archives.  This automatically handles:
+    //      - libunix.a / libcamlstr.a  (OCaml stdlib, OCaml 4.x flat layout)
+    //      - lib/ocaml/unix/libunix.a  (OCaml 5.x subdirectory layout)
+    //      - libzarith.a               (zarith)
+    //      - libcamlzip.a              (camlzip/zip, if installed)
+    //      - any other optional C stubs
+    //    We also add the OCaml runtime dir for libasmrun.a.
+    // ------------------------------------------------------------------
+
+    // Collect unique .cmxa parent directories from the ocamlfind output.
+    let link_args_for_scan = ocamlfind_link_args();
+    let mut cmxa_dirs: Vec<PathBuf> = Vec::new();
+    let mut seen_dirs: HashSet<PathBuf> = HashSet::new();
+    for arg in &link_args_for_scan {
+        if arg.ends_with(".cmxa") {
+            if let Some(parent) = Path::new(arg).parent() {
+                let p = parent.to_path_buf();
+                if seen_dirs.insert(p.clone()) {
+                    cmxa_dirs.push(p);
+                }
+            }
+        }
+    }
+
+    // Always include the OCaml runtime directory (for libasmrun.a).
+    let runtime_dir = PathBuf::from(&ocaml_runtime_dir);
+    if seen_dirs.insert(runtime_dir.clone()) {
+        cmxa_dirs.push(runtime_dir);
+    }
+
+    // Emit link-search and scan for C stubs.
+    let mut emitted: HashSet<String> = HashSet::new();
+    for dir in &cmxa_dirs {
+        println!("cargo:rustc-link-search=native={}", dir.display());
+        emit_static_libs_in_dir(dir, &mut emitted);
+    }
+
+    // The OCaml native runtime itself.
+    println!("cargo:rustc-link-lib=static=asmrun");
+    println!("cargo:rustc-link-lib=threads");
+
+    // System libraries that OCaml C stubs depend on.
+    println!("cargo:rustc-link-lib=gmp");    // zarith → GMP
+    println!("cargo:rustc-link-lib=z");      // camlzip → zlib
+    println!("cargo:rustc-link-lib=m");
+    println!("cargo:rustc-link-lib=dl");
+    println!("cargo:rustc-link-lib=pthread");
+
+    // Export all symbols so dynamically-loaded OCaml plugins (.cmxs) can
+    // resolve references back into the statically-linked OCaml runtime.
+    println!("cargo:rustc-link-arg=-Wl,-export-dynamic");
+
+    println!("cargo:rerun-if-changed=ocaml-stub/vc_spans_stub.ml");
+    println!("cargo:rerun-if-changed=ocaml-stub/dune");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/creusot-why3-spans/ocaml-stub/creusot-deps.opam.txt
+++ b/creusot-why3-spans/ocaml-stub/creusot-deps.opam.txt
@@ -1,0 +1,22 @@
+name: "creusot-deps"
+synopsis: "Opam dependencies for Creusot"
+opam-version: "2.0"
+maintainer: "Armaël Guéneau <armael.gueneau@inria.fr>"
+authors: "the creusot authors"
+depends: [
+  "ocaml" {= "5.3.0"}
+  "why3" {= "git-2c0f2992"}
+  "why3-ide" {= "git-2c0f2992" & !?in-creusot-ci}
+  "why3find" {= "git-eab37557"} # if these versions change don't forget to update creusot-setup/src/tools_versions_urls.rs
+# optional dependencies of why3
+  "ocamlgraph"
+  "camlzip"
+  "zarith"
+]
+# When updating the hash and git-XXX below, don't forget to update them in the
+# depends: field above!
+pin-depends: [
+  [ "why3.git-2c0f2992" "git+https://gitlab.inria.fr/why3/why3.git#2c0f2992af85f82f3eda0f158dcf10e62e0db875" ]
+  [ "why3-ide.git-2c0f2992" "git+https://gitlab.inria.fr/why3/why3.git#2c0f2992af85f82f3eda0f158dcf10e62e0db875" ]
+  [ "why3find.git-eab37557" "git+https://git.frama-c.com/pub/why3find.git#eab37557d3e24e1913a3c4f44bc5528ef497c6c9" ]
+]

--- a/creusot-why3-spans/ocaml-stub/dune-project
+++ b/creusot-why3-spans/ocaml-stub/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.9)
+(name vc_spans_stub)

--- a/creusot-why3-spans/ocaml-stub/vc_spans_stub.ml
+++ b/creusot-why3-spans/ocaml-stub/vc_spans_stub.ml
@@ -1,0 +1,419 @@
+(* vc_spans_stub.ml — OCaml stub for the vc-spans Rust crate. *)
+
+open Why3
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let is_source_file f =
+  not (String.length f >= 5 &&
+       String.sub f (String.length f - 5) 5 = ".coma")
+
+let all_source_locs (root : Term.term) : Loc.position list =
+  let seen = Hashtbl.create 8 in
+  let result = ref [] in
+  let rec walk t =
+    List.iter (fun loc ->
+      let file, l1, c1, _, _ = Loc.get loc in
+      if is_source_file file then begin
+        let key = (file, l1, c1) in
+        if not (Hashtbl.mem seen key) then begin
+          Hashtbl.add seen key ();
+          result := loc :: !result
+        end
+      end
+    ) t.Term.t_locs;
+    Term.t_iter walk t
+  in
+  walk root;
+  List.rev !result
+
+let first_source_loc (root : Term.term) : Loc.position option =
+  match all_source_locs root with loc :: _ -> Some loc | [] -> None
+
+let second_source_loc (root : Term.term) : Loc.position option =
+  match all_source_locs root with _ :: loc :: _ -> Some loc | _ -> None
+
+(** For precondition VCs, find the call-site location by walking the task's
+    hypothesis chain (task_prev) and returning the first source location that
+    differs from the goal's own location. *)
+let call_site_loc (task : Task.task) (goal_file : string) (goal_l1 : int) : Loc.position option =
+  let result = ref None in
+  let rec walk_task t =
+    match t with
+    | None -> ()
+    | Some { Task.task_decl = td; Task.task_prev = prev; _ } ->
+      (* Walk the term in this declaration looking for a source location
+         that is different from the goal's own location. *)
+      (match td.Theory.td_node with
+       | Theory.Decl { Decl.d_node = Decl.Dprop ((Decl.Paxiom | Decl.Plemma), _, t); _ } ->
+         let rec walk_term tm =
+           List.iter (fun loc ->
+             let file, l1, _, _, _ = Loc.get loc in
+             if is_source_file file && not (file = goal_file && l1 = goal_l1) then
+               (match !result with None -> result := Some loc | Some _ -> ())
+           ) tm.Term.t_locs;
+           Term.t_iter walk_term tm
+         in
+         walk_term t
+       | _ -> ());
+      if !result = None then walk_task prev
+  in
+  walk_task task;
+  !result
+
+(** Walk a term looking for a sub-term whose attributes include a string
+    matching [pred], and return the first source location on that sub-term. *)
+let find_attr_source_loc (pred : string -> bool) (root : Term.term) : Loc.position option =
+  let result = ref None in
+  let rec walk t =
+    if !result <> None then ()
+    else begin
+      let has_match =
+        Ident.Sattr.exists (fun a -> pred a.Ident.attr_string) t.Term.t_attrs
+      in
+      if has_match then
+        (match List.find_opt (fun loc ->
+           let file, _, _, _, _ = Loc.get loc in is_source_file file
+         ) t.Term.t_locs with
+         | Some loc -> result := Some loc
+         | None -> ());
+      Term.t_iter walk t
+    end
+  in
+  walk root;
+  !result
+
+let first_coma_loc (root : Term.term) : Loc.position option =
+  let result = ref None in
+  let rec walk t =
+    List.iter (fun loc ->
+      let file, _, _, _, _ = Loc.get loc in
+      if not (is_source_file file) then
+        (match !result with None -> result := Some loc | Some _ -> ())
+    ) t.Term.t_locs;
+    Term.t_iter walk t
+  in
+  walk root;
+  !result
+
+let loc_fields opt_loc =
+  match opt_loc with
+  | None -> ("", 0, 0, 0, 0)
+  | Some loc ->
+    let file, l1, c1, l2, c2 = Loc.get loc in
+    (file, l1, c1, l2, c2)
+
+(* ------------------------------------------------------------------ *)
+(* Goal kind classification                                            *)
+(* ------------------------------------------------------------------ *)
+
+let contains s sub =
+  let ls = String.length s and lsub = String.length sub in
+  if lsub = 0 then true
+  else if ls < lsub then false
+  else begin
+    let found = ref false in
+    for i = 0 to ls - lsub do
+      if not !found && String.sub s i lsub = sub then found := true
+    done;
+    !found
+  end
+
+let classify_expl (expl : string) : string =
+  let e = String.lowercase_ascii expl in
+  if e = "assertion" then "assertion"
+  else if contains e "ensures" then "postcondition"
+  else if contains e "requires" then "precondition"
+  else if contains e "integer overflow"
+       || contains e "index out of bounds"
+       || contains e "attempt to divide"
+       || contains e "attempt to subtract"
+       || contains e "attempt to add"
+       || contains e "attempt to multiply"
+       || contains e "attempt to shift"
+       || contains e "attempt to negate"
+  then "overflow"
+  else if contains e "unreachable" || contains e "panic" then "panic"
+  else if contains e "refines" then "law"
+  else if contains e "loop invariant" then "loop_invariant"
+  else if contains e "loop variant" then "loop_variant"
+  else if contains e "type invariant" then "type_invariant"
+  else "other"
+
+(* ------------------------------------------------------------------ *)
+(* Global why3 environment                                             *)
+(* ------------------------------------------------------------------ *)
+
+(* Name of the splitting transformation to use. Determined once at init. *)
+let split_trans_name : string ref = ref "split_vc"
+
+let global_env : Env.env option ref = ref None
+
+let init_env (conf_file : string) (extra_loadpath : string) : unit =
+  let conf_arg =
+    if conf_file = "" || not (Sys.file_exists conf_file) then None
+    else Some conf_file
+  in
+  Loc.set_warning_hook (fun ?loc:_ _ -> ());
+  let config =
+    Whyconf.(
+      let base = read_config conf_arg in
+      let main = get_main base in
+      let lp   = loadpath main in
+      let main =
+        if List.mem Config.datadir lp then main
+        else set_loadpath main (Config.datadir :: lp)
+      in
+      set_main base main
+    )
+  in
+  let main   = Whyconf.get_main config in
+  let main   = Whyconf.set_libdir main Config.libdir in
+  let _config = Whyconf.set_main config main in
+  Whyconf.load_plugins main;
+  let base_lp = Whyconf.loadpath main in
+  let home = try Sys.getenv "HOME" with Not_found -> "" in
+  let creusot_auto =
+    List.filter (fun dir -> Sys.file_exists dir && Sys.is_directory dir) [
+      Filename.concat Config.libdir "packages/creusot";
+      Filename.concat home ".local/share/creusot/share/why3find/packages/creusot";
+      Filename.concat
+        (Filename.dirname (Filename.dirname
+          (Filename.dirname (Filename.dirname Config.libdir))))
+        "share/why3find/packages/creusot";
+    ]
+  in
+  let extra_dirs =
+    if extra_loadpath = "" then []
+    else List.filter (fun s -> s <> "") (String.split_on_char ':' extra_loadpath)
+  in
+  let seen = Hashtbl.create 16 in
+  let full_lp =
+    List.filter_map (fun dir ->
+      if Hashtbl.mem seen dir then None
+      else begin Hashtbl.add seen dir (); Some dir end
+    ) (base_lp @ creusot_auto @ extra_dirs)
+  in
+  let env = Env.create_env full_lp in
+  (* Determine which splitting transformation is available. *)
+  let tname =
+    if (try ignore (Trans.lookup_transform_l "split_vc" env); true
+        with Not_found | Trans.UnknownTrans _ -> false)
+    then "split_vc"
+    else if (try ignore (Trans.lookup_transform_l "split_goal_wp" env); true
+             with Not_found | Trans.UnknownTrans _ -> false)
+    then "split_goal_wp"
+    else ""
+  in
+  split_trans_name := tname;
+  global_env := Some env
+
+let get_env () =
+  match !global_env with
+  | Some e -> e
+  | None -> failwith "vc_spans: why3 environment not initialised; call init_env first"
+
+(* ------------------------------------------------------------------ *)
+(* VC span extraction                                                  *)
+(* ------------------------------------------------------------------ *)
+
+let goal_term task =
+  match task with
+  | Some { Task.task_decl = {
+        Theory.td_node = Theory.Decl {
+            Decl.d_node = Decl.Dprop (Decl.Pgoal, _, t) ; _ } ; _ } ; _ } ->
+    Some t
+  | _ -> None
+
+(** Apply [split_vc] recursively, replicating the session's naming scheme.
+    The session names each sub-goal as [parent_name ^ "." ^ string_of_int index].
+    We stop recursing when split_vc produces zero sub-goals or the task is
+    identical to itself (no progress).  Single-child splits are followed
+    because the session records them as a transformation node too. *)
+
+let rec collect_leaf_spans (env : Env.env) (parent_name : string)
+    (task : Task.task)
+    (orig_goal : Term.term option)
+    (fallback_expl : string)
+    (acc : (string * string * string
+                               * string * int * int * int * int
+                               * string * int * int * int * int
+                               * string * int * int * int * int) list)
+    : (string * string * string
+       * string * int * int * int * int
+       * string * int * int * int * int
+       * string * int * int * int * int) list =
+  let tname = !split_trans_name in
+  let orig_term = goal_term task in
+  let sub_tasks =
+    if tname = "" then []
+    else
+      match Trans.apply_transform tname env task with
+      | []       -> []
+      | [single] ->
+        (* Stop if the goal term is unchanged (split made no progress). *)
+        let new_term = goal_term single in
+        let same = match orig_term, new_term with
+          | Some a, Some b -> Term.t_equal a b
+          | None,   None   -> true
+          | _              -> false
+        in
+        if same then [] else [single]
+      | tasks    -> tasks
+      | exception _ -> []
+  in
+  match sub_tasks with
+  | [] ->
+    let _id, expl0, _t2 = Termcode.goal_expl_task ~root:false task in
+    (* When compute_specified strips the [@expl:...] attribute from the goal term,
+       root:false returns "".  Fall back to the top-level expl captured before
+       compute_specified ran. *)
+    let expl =
+      if expl0 <> "" then expl0
+      else fallback_expl
+    in
+    let kind0 = classify_expl expl in
+    let kind =
+      if kind0 = "other" then
+        let base = match String.index_opt parent_name '.' with
+          | None   -> parent_name
+          | Some i -> String.sub parent_name 0 i
+        in
+        if base = "refines" then "refinement" else kind0
+      else kind0
+    in
+    let term = goal_term task in
+    (* For type_invariant VCs, prefer the pre-rewrite location (the return type
+       span) over the post-rewrite location (the invariant definition span),
+       because compute_specified rewrites inv_T away and loses the call-site span.
+       Search the original (pre-compute_specified) goal term for the sub-term
+       whose expl attribute exactly matches this leaf's expl string. *)
+    let primary_loc =
+      if kind = "type_invariant" then
+        let pre_loc =
+          match orig_goal with
+          | None -> None
+          | Some t ->
+            find_attr_source_loc
+              (fun s -> String.lowercase_ascii s = "expl:" ^ String.lowercase_ascii expl)
+              t
+        in
+        (match pre_loc with
+         | Some _ -> pre_loc
+         | None   -> Option.bind term first_source_loc)
+      else
+        Option.bind term first_source_loc
+    in
+    let (file, l1, c1, l2, c2)   = loc_fields primary_loc in
+    let (file2, l1b, c1b, l2b, c2b) =
+      if kind = "precondition" || kind = "refinement" then
+        loc_fields (call_site_loc task file l1)
+      else if kind = "type_invariant" then
+        (* Secondary location: the invariant definition (first_source_loc of the
+           post-rewrite goal, which is the invariant_T predicate declaration). *)
+        loc_fields (Option.bind term first_source_loc)
+      else
+        loc_fields (Option.bind term second_source_loc)
+    in
+    let (coma_ref, cl1, cc1, cl2, cc2) = loc_fields (Option.bind term first_coma_loc) in
+    (parent_name, expl, kind,
+     file, l1, c1, l2, c2,
+     file2, l1b, c1b, l2b, c2b,
+     coma_ref, cl1, cc1, cl2, cc2) :: acc
+  | children ->
+    (* Internal node: recurse into each child with the session naming scheme. *)
+    List.fold_left (fun acc (index, child) ->
+      let child_name = parent_name ^ "." ^ string_of_int index in
+      collect_leaf_spans env child_name child orig_goal fallback_expl acc
+    ) acc (List.mapi (fun i t -> (i, t)) children)
+
+let extract_spans (coma_file : string)
+    : (string * string * string
+       * string * int * int * int * int
+       * string * int * int * int * int
+       * string * int * int * int * int) list =
+  let env = get_env () in
+  let tmap, _format = Env.(read_file ~format:"coma" base_language env coma_file) in
+  let theories = Wstdlib.Mstr.bindings tmap |> List.map snd in
+  List.concat_map (fun theory ->
+    let top_tasks = Task.split_theory theory None None in
+    List.concat_map (fun top_task ->
+      let top_name, _expl, _t = Termcode.goal_expl_task ~root:true top_task in
+      let base_name = top_name.Ident.id_string in
+      (* Capture the original (pre-compute_specified) goal term and expl so that
+         leaf goals can look up their return-type span and kind even after
+         compute_specified strips [@expl:...] attributes from the goal term. *)
+      let orig_goal = goal_term top_task in
+      let _, top_expl, _ = Termcode.goal_expl_task ~root:false top_task in
+      let after_compute =
+        match Trans.apply_transform "compute_specified" env top_task with
+        | [child] -> [(base_name ^ ".0", child)]
+        | children ->
+          List.mapi (fun i t -> (base_name ^ "." ^ string_of_int i, t)) children
+        | exception _ -> [(base_name, top_task)]
+      in
+      List.concat_map (fun (name, task) ->
+        List.rev (collect_leaf_spans env name task orig_goal top_expl [])
+      ) after_compute
+    ) top_tasks
+  ) theories
+
+(* ------------------------------------------------------------------ *)
+(* Exception printing                                                  *)
+(* ------------------------------------------------------------------ *)
+
+let string_of_exn exn =
+  let buf = Buffer.create 64 in
+  let fmt = Format.formatter_of_buffer buf in
+  Exn_printer.exn_printer fmt exn;
+  Format.pp_print_flush fmt ();
+  let s = Buffer.contents buf in
+  if String.length s > 9 && String.sub s 0 9 = "anomaly: "
+  then String.sub s 9 (String.length s - 9)
+  else s
+
+(* ------------------------------------------------------------------ *)
+(* Rust-safe wrappers                                                  *)
+(* ------------------------------------------------------------------ *)
+
+let safe_init_env (args : string) : string =
+  try
+    let conf_file, extra_loadpath =
+      match String.index_opt args ':' with
+      | None   -> (args, "")
+      | Some i ->
+        (String.sub args 0 i,
+         String.sub args (i+1) (String.length args - i - 1))
+    in
+    init_env conf_file extra_loadpath;
+    "ok"
+  with exn -> "error: " ^ string_of_exn exn
+
+let safe_extract_spans (coma_file : string) : string =
+  try
+    let spans = extract_spans coma_file in
+    let buf   = Buffer.create 1024 in
+    let first = ref true in
+    List.iter (fun (name, expl, kind,
+                    file,  l1,  c1,  l2,  c2,
+                    file2, l1b, c1b, l2b, c2b,
+                    coma_ref, cl1, cc1, cl2, cc2) ->
+      if !first then first := false else Buffer.add_string buf "\n---\n";
+      let add s = Buffer.add_string buf s; Buffer.add_char buf '\n' in
+      add name; add expl; add kind;
+      add file;  add (string_of_int l1);  add (string_of_int c1);
+                 add (string_of_int l2);  add (string_of_int c2);
+      add file2; add (string_of_int l1b); add (string_of_int c1b);
+                 add (string_of_int l2b); add (string_of_int c2b);
+      add coma_ref;
+      add (string_of_int cl1); add (string_of_int cc1);
+      add (string_of_int cl2); Buffer.add_string buf (string_of_int cc2)
+    ) spans;
+    Buffer.contents buf
+  with exn -> "error: " ^ string_of_exn exn
+
+let () =
+  Callback.register "vc_spans_init_env" safe_init_env;
+  Callback.register "vc_spans_extract"  safe_extract_spans

--- a/creusot-why3-spans/src/lib.rs
+++ b/creusot-why3-spans/src/lib.rs
@@ -1,0 +1,668 @@
+//! vc-spans — extract source spans of unproved proof goals from why3 .coma files.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use ocaml_interop::{ocaml, OCamlRuntime, ToOCaml};
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Location {
+    pub file: String,
+    pub start_line: usize,
+    pub start_col: usize,
+    pub end_line: usize,
+    pub end_col: usize,
+}
+
+impl Location {
+    fn display(&self) -> String {
+        if self.start_line == self.end_line {
+            format!("{}:{}:{}-{}", self.file, self.start_line, self.start_col, self.end_col)
+        } else {
+            format!("{}:{}:{}-{}:{}", self.file, self.start_line, self.start_col, self.end_line, self.end_col)
+        }
+    }
+}
+
+/// The kind of a proof obligation, with kind-specific data attached.
+#[derive(Debug, Clone)]
+pub enum GoalKind {
+    Assertion,
+    Overflow,
+    Panic,
+    /// Invariant failed to be established before the loop.
+    LoopInvariantEstablish,
+    /// Invariant failed to be preserved by the loop body.
+    LoopInvariantPreserve,
+    LoopVariant,
+    /// `definition` is the location of the `requires` clause.
+    Precondition { definition: Location },
+    Postcondition,
+    /// `definition` is the location where the law is declared.
+    Law { definition: Location },
+    /// Trait contract refinement: the implementation does not satisfy the
+    /// contract declared on the trait. `trait_location` is the span of the
+    /// trait contract that was not satisfied.
+    Refinement { trait_location: Option<Location> },
+    /// A type invariant (from the `Invariant` trait) could not be proved.
+    /// `definition` is the location of the `invariant` method body.
+    TypeInvariant { definition: Option<Location> },
+    Other,
+}
+
+impl GoalKind {
+    fn label(&self) -> &'static str {
+        match self {
+            GoalKind::Assertion               => "assertion",
+            GoalKind::Overflow                => "overflow",
+            GoalKind::Panic                   => "panic",
+            GoalKind::LoopInvariantEstablish  => "loop_invariant",
+            GoalKind::LoopInvariantPreserve   => "loop_invariant",
+            GoalKind::LoopVariant             => "loop_variant",
+            GoalKind::Precondition { .. }     => "precondition",
+            GoalKind::Postcondition           => "postcondition",
+            GoalKind::Law { .. }              => "law",
+            GoalKind::Refinement { .. }        => "refinement",
+            GoalKind::TypeInvariant { .. }       => "type_invariant",
+            GoalKind::Other                    => "other",
+        }
+    }
+}
+
+/// A resolved, display-ready unproved goal.
+///
+/// For `GoalKind::Precondition` and `GoalKind::Law`, `location` is the **call
+/// site** (the most actionable location for the user), and the `definition`
+/// field inside the variant holds the clause/law declaration location.
+#[derive(Debug, Clone)]
+pub struct Goal {
+    /// Human-readable function name (without the `vc_` prefix and index suffix).
+    pub function_name: String,
+    /// The kind of proof obligation, with kind-specific data.
+    pub kind: GoalKind,
+    /// Explanation string from the VC (e.g. "loop invariant #0").
+    pub expl: String,
+    /// Primary location: the call site for preconditions/laws, otherwise the VC location.
+    pub location: Location,
+}
+
+#[derive(Debug, Clone)]
+struct VcSpan {
+    name: String,
+    expl: String,
+    kind: String,
+    file: String,
+    start_line: i64,
+    start_col:  i64,
+    end_line:   i64,
+    end_col:    i64,
+    file2: String,
+    start_line2: i64,
+    start_col2:  i64,
+    end_line2:   i64,
+    end_col2:    i64,
+    coma_ref: String,
+    coma_l1:  i64,
+    coma_c1:  i64,
+    coma_l2:  i64,
+    coma_c2:  i64,
+}
+
+impl VcSpan {
+    fn has_source_location(&self) -> bool { !self.file.is_empty() }
+    fn has_source_location2(&self) -> bool { !self.file2.is_empty() }
+    fn has_coma_ref(&self) -> bool { !self.coma_ref.is_empty() }
+
+    fn function_name(&self) -> &str {
+        let s = self.name.strip_prefix("vc_").unwrap_or(&self.name);
+        if let Some(dot) = s.find('.') { &s[..dot] } else { s }
+    }
+
+    fn location(&self) -> Option<Location> {
+        if !self.has_source_location() { return None; }
+        Some(Location {
+            file:       self.file.clone(),
+            start_line: self.start_line as usize,
+            start_col:  self.start_col as usize,
+            end_line:   self.end_line as usize,
+            end_col:    self.end_col as usize,
+        })
+    }
+
+    fn location2(&self) -> Option<Location> {
+        if !self.has_source_location2() { return None; }
+        Some(Location {
+            file:       self.file2.clone(),
+            start_line: self.start_line2 as usize,
+            start_col:  self.start_col2 as usize,
+            end_line:   self.end_line2 as usize,
+            end_col:    self.end_col2 as usize,
+        })
+    }
+}
+
+fn parse_spans(s: &str) -> Result<Vec<VcSpan>, GoalError> {
+    if s.starts_with("error: ") { return Err(GoalError::Stub(s[7..].to_owned())); }
+    if s.is_empty() { return Ok(Vec::new()); }
+    let mut spans = Vec::new();
+    for record in s.split("\n---\n") {
+        let lines: Vec<&str> = record.splitn(18, '\n').collect();
+        if lines.len() != 18 {
+            return Err(GoalError::MalformedRecord { num_lines: lines.len(), record: record.to_owned() });
+        }
+        let pi = |s: &str| -> Result<i64, GoalError> {
+            s.parse::<i64>().map_err(|e| GoalError::InvalidInt(e))
+        };
+        spans.push(VcSpan {
+            name:        lines[0].to_owned(),
+            expl:        lines[1].to_owned(),
+            kind:        lines[2].to_owned(),
+            file:        lines[3].to_owned(),
+            start_line:  pi(lines[4])?,
+            start_col:   pi(lines[5])?,
+            end_line:    pi(lines[6])?,
+            end_col:     pi(lines[7])?,
+            file2:       lines[8].to_owned(),
+            start_line2: pi(lines[9])?,
+            start_col2:  pi(lines[10])?,
+            end_line2:   pi(lines[11])?,
+            end_col2:    pi(lines[12])?,
+            coma_ref:    lines[13].to_owned(),
+            coma_l1:     pi(lines[14])?,
+            coma_c1:     pi(lines[15])?,
+            coma_l2:     pi(lines[16])?,
+            coma_c2:     pi(lines[17])?,
+        });
+    }
+    Ok(spans)
+}
+
+fn session_path(coma_file: &Path) -> PathBuf {
+    let stem = coma_file.file_stem().unwrap_or_default();
+    let dir  = coma_file.parent().unwrap_or(Path::new("."));
+    dir.join(stem).join("why3session.xml")
+}
+
+fn unproved_leaf_goals(session: PathBuf) -> Result<HashSet<String>, GoalError> {
+    let content = match std::fs::read_to_string(&session) {
+        Ok(content) => content,
+        Err(error) => return Err(GoalError::ReadSessionFile { path: session, error }),
+    };
+
+    let mut reader = Reader::from_str(&content);
+    reader.config_mut().trim_text(true);
+
+    let mut stack: Vec<(String, bool, bool)> = Vec::new();
+    let mut out: HashSet<String> = HashSet::new();
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) if e.name().as_ref() == b"goal" => {
+                let name   = attr_str(&e, b"name").unwrap_or_default();
+                let proved = attr_str(&e, b"proved").map_or(false, |v| v == "true");
+                if let Some(parent) = stack.last_mut() { parent.2 = true; }
+                stack.push((name, proved, false));
+            }
+            Ok(Event::Empty(e)) if e.name().as_ref() == b"goal" => {
+                let name   = attr_str(&e, b"name").unwrap_or_default();
+                let proved = attr_str(&e, b"proved").map_or(false, |v| v == "true");
+                if let Some(parent) = stack.last_mut() { parent.2 = true; }
+                if !proved { out.insert(name); }
+            }
+            Ok(Event::End(e)) if e.name().as_ref() == b"goal" => {
+                if let Some((name, proved, has_sub)) = stack.pop() {
+                    if !proved && !has_sub { out.insert(name); }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(error) => return Err(GoalError::ParseXML { path: session, error }),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(out)
+}
+
+fn attr_str(e: &quick_xml::events::BytesStart, name: &[u8]) -> Option<String> {
+    e.attributes()
+        .filter_map(|a| a.ok())
+        .find(|a| a.key.as_ref() == name)
+        .and_then(|a| String::from_utf8(a.value.into_owned()).ok())
+}
+
+/// Parse the first-line span comment from a coma file:
+/// `(* #"/path/to/file.rs" l1 c1 l2 c2 *)`
+fn coma_header_location(coma_file: &Path) -> Option<Location> {
+    use std::io::{BufRead, BufReader};
+    let f = std::fs::File::open(coma_file).ok()?;
+    let first = BufReader::new(f).lines().next()?.ok()?;
+    // Expected format: (* #"<file>" <l1> <c1> <l2> <c2> *)
+    let inner = first.strip_prefix("(* #\"")?.strip_suffix(" *)")?;
+    let (file, rest) = inner.split_once('"')?;
+    let nums: Vec<i64> = rest.split_whitespace()
+        .filter_map(|s| s.parse().ok())
+        .collect();
+    if nums.len() < 4 { return None; }
+    Some(Location {
+        file:       file.to_string(),
+        start_line: nums[0] as usize,
+        start_col:  nums[1] as usize,
+        end_line:   nums[2] as usize,
+        end_col:    nums[3] as usize,
+    })
+}
+
+type ComaCache = HashMap<String, Vec<VcSpan>>;
+
+fn resolve_cross_ref(cr: &mut OCamlRuntime, span: &VcSpan, cache: &mut ComaCache) -> Option<Location> {
+    if !span.has_coma_ref() { return None; }
+    let coma_ref = &span.coma_ref;
+    let ref_spans = cache.entry(coma_ref.clone()).or_insert_with(|| {
+        let coma_ref = coma_ref.to_boxroot(cr);
+        parse_spans(vc_spans_extract(cr, &coma_ref).get(cr).as_str()).unwrap_or_default()
+    });
+    for rs in &*ref_spans {
+        if rs.has_source_location() && rs.coma_ref == *coma_ref
+            && rs.coma_l1 == span.coma_l1 && rs.coma_c1 == span.coma_c1
+        {
+            return rs.location();
+        }
+    }
+    for rs in &*ref_spans {
+        if rs.has_source_location() && rs.coma_l1 == span.coma_l1 {
+            return rs.location();
+        }
+    }
+    None
+}
+
+fn span_matches_unproved(name: &str, unproved: &HashSet<String>) -> bool {
+    if unproved.contains(name) { return true; }
+    let prefix = format!("{}.", name);
+    if unproved.iter().any(|leaf| leaf.starts_with(&prefix)) { return true; }
+    unproved.iter().any(|leaf| name.starts_with(&format!("{}.", leaf)))
+}
+
+/// Returns the last dot-separated component of a goal name as a usize, if present.
+fn last_name_index(name: &str) -> Option<usize> {
+    name.rsplit_once('.')
+        .and_then(|(_, last)| last.parse::<usize>().ok())
+}
+
+fn parse_kind(span: &VcSpan) -> GoalKind {
+    let fallback_loc = || Location {
+        file:       span.file.clone(),
+        start_line: span.start_line as usize,
+        start_col:  span.start_col as usize,
+        end_line:   span.end_line as usize,
+        end_col:    span.end_col as usize,
+    };
+    match span.kind.as_str() {
+        "assertion"      => GoalKind::Assertion,
+        "overflow"       => GoalKind::Overflow,
+        "panic"          => GoalKind::Panic,
+        "loop_invariant" => {
+            // split_vc always produces two sub-goals for a loop invariant:
+            // index 0 = establish (before the loop), index 1 = preserve (loop body).
+            match last_name_index(&span.name) {
+                Some(0) => GoalKind::LoopInvariantEstablish,
+                Some(1) => GoalKind::LoopInvariantPreserve,
+                // Deeper nesting (e.g. .0.0) — use the grandparent index.
+                _ => match span.name.rsplit_once('.')
+                        .and_then(|(parent, _)| last_name_index(parent))
+                    {
+                        Some(0) => GoalKind::LoopInvariantEstablish,
+                        _       => GoalKind::LoopInvariantPreserve,
+                    }
+            }
+        }
+        "loop_variant"   => GoalKind::LoopVariant,
+        "postcondition"  => GoalKind::Postcondition,
+        "law"            => GoalKind::Law {
+            definition: span.location2().unwrap_or_else(fallback_loc),
+        },
+        "type_invariant" => GoalKind::TypeInvariant {
+            definition: span.location2(),
+        },
+        "refinement"     => GoalKind::Refinement { trait_location: None },
+        "precondition"   => GoalKind::Precondition {
+            definition: span.location().unwrap_or_else(fallback_loc),
+        },
+        _                => GoalKind::Other,
+    }
+}
+
+fn collect_unproved_goals(
+    cr: &mut OCamlRuntime,
+    coma_file: &Path,
+    all_spans: &[VcSpan],
+    show_all: bool,
+    debug: bool,
+    coma_cache: &mut ComaCache,
+    goals: &mut Vec<Result<Goal, GoalError>>,
+) {
+    let unproved_set: Option<HashSet<String>> = if show_all {
+        None
+    } else {
+        let session = session_path(coma_file);
+        match unproved_leaf_goals(session) {
+            Ok(unproved_set) => Some(unproved_set),
+            Err(error) => {
+                goals.push(Err(error));
+                return
+            }
+        }
+    };
+
+    if debug {
+        eprintln!("[debug] span names from stub ({}):", all_spans.len());
+        for s in all_spans {
+            eprintln!("  span: {:?} kind={:?} expl={:?} file2={:?}", s.name, s.kind, s.expl, s.file2);
+        }
+        if let Some(ref set) = unproved_set {
+            let mut v: Vec<_> = set.iter().collect();
+            v.sort();
+            eprintln!("[debug] unproved leaves from session ({}):", v.len());
+            for n in &v { eprintln!("  leaf: {:?}", n); }
+        }
+    }
+
+    let mut seen_display: HashSet<String> = HashSet::new();
+
+    for span in all_spans {
+        let matches = match &unproved_set {
+            None      => true,
+            Some(set) => span_matches_unproved(&span.name, set),
+        };
+        if !matches { continue; }
+
+        let kind = parse_kind(span);
+
+        // For preconditions and laws the primary location is the definition site (file2).
+        // For type invariants and everything else it is the VC location (file).
+        let location = match &kind {
+            GoalKind::Precondition { .. } | GoalKind::Law { .. } => {
+                if let Some(loc2) = span.location2() {
+                    loc2
+                } else if let Some(loc) = span.location() {
+                    loc
+                } else {
+                    continue;
+                }
+            }
+            _ => {
+                if let Some(loc) = span.location() {
+                    loc
+                } else if span.has_coma_ref() {
+                    match resolve_cross_ref(cr, span, coma_cache) {
+                        Some(loc) => loc,
+                        None      => continue,
+                    }
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        // For refinements: primary location is the implementation (coma header),
+        // secondary is the trait contract location (from the VC goal term).
+        let (kind, location) = if let GoalKind::Refinement { .. } = kind {
+            let trait_loc = span.location();
+            let impl_loc  = coma_header_location(coma_file);
+            let primary   = impl_loc.or_else(|| trait_loc.clone()).unwrap_or(location);
+            (GoalKind::Refinement { trait_location: trait_loc }, primary)
+        } else {
+            (kind, location)
+        };
+
+        let display_key = format!("{}|{}|{}|{}|{}",
+            span.expl, location.file, location.start_line, location.start_col, kind.label());
+        if !seen_display.insert(display_key) { continue; }
+
+        goals.push(Ok(Goal {
+            function_name: span.function_name().to_string(),
+            kind,
+            expl: span.expl.clone(),
+            location,
+        }));
+    }
+}
+
+pub fn generate_reports(goals: &[Result<Goal, GoalError>]) -> Vec<annotate_snippets::Group<'_>> {
+    use annotate_snippets::{AnnotationKind, Group, Level, Snippet};
+
+    fn load_snippet(location: &Location) -> String {
+        use std::io::BufRead;
+
+        fn discard_line(reader: &mut impl std::io::BufRead) {
+            loop {
+                let buf = reader.fill_buf().expect("failed to read source file");
+                if let Some(position) = buf.iter().position(|x| *x == b'\n') {
+                    reader.consume(position + 1);
+                    break;
+                } else {
+                    let buf_len = buf.len();
+                    reader.consume(buf_len);
+                }
+            }
+        }
+        let file = std::fs::File::open(&location.file).expect("failed to open the source file");
+        let mut reader = std::io::BufReader::new(file);
+        for _ in 1..location.start_line {
+            discard_line(&mut reader);
+        }
+        let mut buf = String::new();
+        // TODO: adjust end span and return it
+        for _ in location.start_line..=location.end_line {
+            reader.read_line(&mut buf).expect("failed to read source file");
+        }
+        buf
+    }
+
+    let mut unknown_goal_kinds = 0;
+    let mut reports = Vec::new();
+    for goal in goals {
+        let goal = match goal {
+            Ok(goal) => goal,
+            Err(error) => {
+                reports.push(Group::with_title(Level::ERROR.primary_title(error.to_string())));
+                continue;
+            }
+        };
+        let (primary, annotation, definition) = match &goal.kind {
+            GoalKind::Assertion => ("cannot prove assertion", "this assertion could not be proven", None),
+            GoalKind::Overflow => ("cannot prove absence of overflow", "this operation could not be proven to be overflow-free", None),
+            GoalKind::Panic => ("cannot prove absence of panic", "this panic couldn't be proven to not happen", None),
+            GoalKind::LoopInvariantEstablish => ("cannot establish invariant", "this invariant could not be proven to hold when entering the loop", None),
+            GoalKind::LoopInvariantPreserve => ("cannot preserve invariant", "this invariant could not be proven to be preserved by the loop", None),
+            GoalKind::LoopVariant => ("cannot prove loop variant", "this loop variant could not be proven", None),
+            GoalKind::Precondition { definition } => {
+                let snippet = load_snippet(definition);
+                let annotation = AnnotationKind::Context.span(definition.start_col..definition.end_col).label("the precondition was defined here");
+                let definition = Snippet::source(snippet).path(&definition.file).line_start(definition.start_line).annotation(annotation);
+                ("cannot prove precondition", "a precondition of this function call could not be proven", Some(definition))
+            },
+            GoalKind::Postcondition => ("cannot prove postcondition", "this postcondition could not be proven", None),
+            GoalKind::Law { definition } => {
+                let snippet = load_snippet(definition);
+                let annotation = AnnotationKind::Context.span(definition.start_col..definition.end_col).label("the law was defined here");
+                let definition = Snippet::source(snippet).path(&definition.file).line_start(definition.start_line).annotation(annotation);
+                ("cannot prove law", "the law could not be proven here", Some(definition))
+            },
+            GoalKind::Refinement { trait_location } => {
+                let definition = trait_location.as_ref().map(|definition| {
+                    let snippet = load_snippet(definition);
+                    let annotation = AnnotationKind::Context.span(definition.start_col..definition.end_col).label("the refinement was defined here");
+                    Snippet::source(snippet).path(&definition.file).line_start(definition.start_line).annotation(annotation)
+                });
+                ("cannot prove refinement", "the refinement could not be proven here", definition)
+            },
+            GoalKind::TypeInvariant { definition } => {
+                let definition = definition.as_ref().map(|definition| {
+                    let snippet = load_snippet(definition);
+                    let annotation = AnnotationKind::Context.span(definition.start_col..definition.end_col).label("the type invariant is defined here");
+                    Snippet::source(snippet).path(&definition.file).line_start(definition.start_line).annotation(annotation)
+                });
+                ("cannot prove type invariant", "the type invariant of the return value could not be proven here", definition)
+            },
+            GoalKind::Other => {
+                unknown_goal_kinds += 1;
+                ("could not prove unknown VC", "something about this code could not be proven", None)
+            }
+        };
+        let snippet = load_snippet(&goal.location);
+        let mut report = Level::ERROR
+            .primary_title(primary)
+            .element(
+                Snippet::source(snippet)
+                    .line_start(goal.location.start_line)
+                    .path(&goal.location.file)
+                    .annotation(AnnotationKind::Primary.span(goal.location.start_col..goal.location.end_col).label(annotation))
+             );
+        if let Some(definition) = definition {
+            report = report.element(definition);
+        }
+        reports.push(report);
+    }
+    if unknown_goal_kinds > 0 {
+        let unknown_goal_kind_text = if unknown_goal_kinds == 1 {
+            "The file contains a goal of unknown kind, this is a bug in cargo-creusot - please report it."
+        } else {
+            "The file contains goals of unknown kind, this is a bug in cargo-creusot - please report it."
+        };
+        reports.push(Group::with_title(Level::ERROR.primary_title(unknown_goal_kind_text)));
+    }
+    reports
+}
+
+pub fn display_reports(reports: &[annotate_snippets::Group]) {
+    if !reports.is_empty() {
+        let rendered = annotate_snippets::Renderer::styled().render(&reports);
+        println!("{}", rendered);
+    }
+}
+
+ocaml! {
+    fn vc_spans_init_env(conf_v: String);
+    fn vc_spans_extract(path: String) -> String;
+}
+
+pub enum GoalError {
+    /// Currently only UTF-8 paths are supported.
+    UnsupportedPath(PathBuf),
+    Walk(WalkError),
+    ReadSessionFile { path: PathBuf, error: std::io::Error },
+    ParseXML { path: PathBuf, error: quick_xml::Error },
+    InvalidInt(std::num::ParseIntError),
+    Stub(String),
+    MalformedRecord { num_lines: usize, record: String },
+    OCamlRuntime(String),
+}
+
+impl fmt::Display for GoalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use GoalError::*;
+        match self {
+            OCamlRuntime(error) => write!(f, "failed to initialize OCaml runtime: {}", error),
+            UnsupportedPath(path) => write!(f, "non-UTF-8 path: {}", path.display()),
+            Walk(error) => write!(f, "cannot walk directory {}: {}", error.path.display(), error.error),
+            ReadSessionFile { path, error } => write!(f, "couldn't read session file {}: {}", path.display(), error),
+            ParseXML { path, error } => write!(f, "failed to parse session file {}: {}", path.display(), error),
+            InvalidInt(error) => write!(f, "invalid integer returned from stub: {}", error),
+            Stub(error) => fmt::Display::fmt(error, f),
+            MalformedRecord { num_lines, record } => write!(f, "malformed record - expected 18 lines, found {}. Record: {}", num_lines, record),
+        }
+    }
+}
+
+pub struct WalkError {
+    path: PathBuf,
+    error: std::io::Error,
+}
+
+pub fn get_unproved_goals(
+    conf_file: &str,
+    files: Vec<PathBuf>,
+    show_all: bool,
+    debug: bool,
+) -> Vec<Result<Goal, GoalError>> {
+    let _guard = match OCamlRuntime::init() {
+        Ok(guard) => guard,
+        Err(error) => return vec![Err(GoalError::OCamlRuntime(error))],
+    };
+
+    let mut coma_cache = ComaCache::new();
+    OCamlRuntime::with_domain_lock(|cr| {
+        let conf = format!("{conf_file}:").to_boxroot(cr);
+        vc_spans_init_env(cr, &conf);
+
+        // Custom implementation to report errors nicely
+        fn maybe_walk_dir(path: PathBuf) -> Box<dyn Iterator<Item=Result<PathBuf, WalkError>>> {
+            match std::fs::read_dir(&path) {
+                Ok(dir) => Box::new(dir.flat_map(move |result| match result {
+                    // Checking the type here skips a syscall on most OSes and introduces one on
+                    // others. I think it's worth it.
+                    Ok(entry) => {
+                        let path = entry.path();
+                        match entry.file_type() {
+                            Ok(file_type) if file_type.is_dir() => maybe_walk_dir(path),
+                            // we don't know, so let's try to open it as directory anyway
+                            Err(_) => maybe_walk_dir(path),
+                            Ok(file_type) if file_type.is_file() && path.extension() == Some("coma".as_ref()) => {
+                                Box::new(std::iter::once(Ok(entry.path())))
+                            },
+                            Ok(_) => Box::new(std::iter::empty()),
+                        }
+                    },
+                    Err(error) => Box::new(std::iter::once(Err(WalkError { path: path.clone(), error }))),
+                })),
+                Err(error) if error.kind() == std::io::ErrorKind::NotADirectory && path.extension() == Some("coma".as_ref()) => {
+                    Box::new(std::iter::once(Ok(path)))
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotADirectory => {
+                    Box::new(std::iter::empty())
+                },
+                Err(error) => {
+                    Box::new(std::iter::once(Err(WalkError { path, error })))
+                },
+            }
+        }
+
+        let mut goals = Vec::new();
+        for result in files.into_iter().flat_map(maybe_walk_dir) {
+            let coma_file = match result {
+                Ok(coma_file) => coma_file,
+                Err(error) => {
+                    goals.push(Err(GoalError::Walk(error)));
+                    continue
+                },
+            };
+            let path = match coma_file.into_os_string().into_string() {
+                Ok(path) => path,
+                Err(error) => {
+                    goals.push(Err(GoalError::UnsupportedPath(error.into())));
+                    continue;
+                },
+            };
+            let rooted_path = path.to_boxroot(cr);
+
+            let all_spans = match parse_spans(&vc_spans_extract(cr, &rooted_path).get(cr).as_str()) {
+                Ok(s)  => s,
+                Err(error) => {
+                    goals.push(Err(error));
+                    continue;
+                }
+            };
+
+            collect_unproved_goals(
+                cr, path.as_ref(), &all_spans, show_all, debug, &mut coma_cache, &mut goals
+            );
+        }
+        goals
+    })
+}

--- a/creusot/src/backend/clone_map/elaborator.rs
+++ b/creusot/src/backend/clone_map/elaborator.rs
@@ -428,6 +428,8 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
     }
 
     fn expand_ty_inv_axiom(&mut self, ty: Ty<'tcx>) -> Vec<Decl> {
+        use crate::backend::ty_inv::resolve_user_inv;
+
         let root_span = self.root_span;
         let ctx = self.ctx;
         let names = self.namer(Dependency::TyInvAxiom(ty));
@@ -436,7 +438,13 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
             return vec![];
         };
         let name = names.dependency(Dependency::TyInvAxiom(ty)).ident();
-        vec![Decl::Axiom(Axiom { name, rewrite, axiom: lower_pure_weakdep(ctx, &names, &axiom) })]
+        // Use the span of the Invariant impl if available, otherwise root_span
+        let span = match resolve_user_inv(ctx, ty, names.typing_env()) {
+            TraitResolved::Instance { def, .. } => ctx.def_span(def.0),
+            _ => root_span,
+        };
+        let axiom = lower_pure_weakdep(ctx, &names, &axiom.span(span).spanned());
+        vec![Decl::Axiom(Axiom { name, rewrite, axiom })]
     }
 
     fn expand_resolve_axiom(&mut self, ty: Ty<'tcx>) -> Vec<Decl> {

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -1293,11 +1293,13 @@ impl<'tcx> Statement<'tcx> {
                     let inv_did = Intrinsic::Inv.get(lower.ctx);
                     let subst = lower.ctx.tcx.mk_args(&[ty::GenericArg::from(rhs_ty)]);
                     let inv = Exp::var(lower.names.item_ident(inv_did, subst));
-                    istmts.push(IntermediateStmt::Check(
-                        inv.clone()
-                            .app([rhs_rplace.clone()])
-                            .with_attr(Attribute::Attr(format!("expl:type invariant"))),
-                    ));
+                    let mut check_exp = inv.clone()
+                        .app([rhs_rplace.clone()])
+                        .with_attr(Attribute::Attr(format!("expl:type invariant")));
+                    if let Some(attr) = lower.names.span_attr(self.span) {
+                        check_exp = check_exp.with_attr(attr);
+                    }
+                    istmts.push(IntermediateStmt::Check(check_exp));
                     inv_assume = Some(IntermediateStmt::Assume(inv.app([reassign.clone()])))
                 } else {
                     inv_assume = None

--- a/creusot/src/backend/ty_inv.rs
+++ b/creusot/src/backend/ty_inv.rs
@@ -336,7 +336,10 @@ pub(crate) fn sig_add_type_invariant_spec<'tcx>(
     });
     pre_sig.contract.requires.splice(0..0, new_requires);
 
-    let ret_ty_span: Option<Span> = try { ctx.hir_get_fn_output(def_id.as_local()?)?.span() };
+    let ret_ty_span: Option<Span> = try { ctx.hir_get_fn_output(def_id.as_local()?)?.span() }
+    .or_else(|| try { ctx.hir_get_fn_output(scope_id.as_local()?)?.span() })
+    .or_else(|| scope_id.as_local().map(|d| ctx.def_span(d)));
+    let ret_ty_span = Some(ret_ty_span.unwrap());
     if (ctx.def_kind(def_id) == DefKind::ConstParam || !is_open_inv_result(ctx.tcx, def_id))
         && let Some(term) =
             inv_call(ctx, typing_env, scope_id, Term::var(name::result(), pre_sig.output))

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -359,6 +359,7 @@ impl<'body, 'tcx> BodyTranslator<'body, 'tcx> {
             |id| Term::var(*id, self.ctx.types.usize),
             span,
         );
+        let cond = cond.span(span);
         if !res_triv {
             dest.push(fmir::Statement {
                 kind: fmir::StatementKind::Assertion {


### PR DESCRIPTION
**WIP** The code contained a bunch of unsound `unsafe` which I've fixed here but I think some things are still off. At least some spams look weird and there's an unknown VC, so I will need to categorize it.

Whenever a VC failed to prove, the user would have to launch the why3 IDE and click through to find the line where the proof failed. This was quite annoying. It's preferable to have error messages similar to what rustc/cargo emit so that the location is immediately visible.

This change uses the why3 OCaml API to inspect the failures and prints them out in the same style rustc uses using the `annotate-snippets` crate (which is the crate that `rustc` currently uses internally).

Closes #2012 