### PR TITLE
Use unique identifier for `--package` option of cargo creusot

### DIFF
--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -116,7 +116,7 @@ fn invoke_cargo(
         .env("CARGO_CREUSOT", "1");
 
     for package in packages {
-        cmd.args(["-p", &package.name]);
+        cmd.args(["-p", &package.id.to_string()]);
     }
 
     // Incremental compilation causes Creusot to not see all of a crate's code


### PR DESCRIPTION
The option `--package` of `cargo build` scans all the dependencies of the current crate and features. If there are several matches, it emits an error. For instance, in hashbrown crate:
```console
cargo creusot
```
prints
```
error: specification `hashbrown` is ambiguous
```
as hashbrown appears as a dependency (of creusot-std) and the current crate itself.

This commit prints the unique identifier `packages.id` of Cargo_metadata.