### PR TITLE
Pull why3find from creusot-rs mirror

### DIFF
--- a/creusot-deps.opam
+++ b/creusot-deps.opam
@@ -18,5 +18,5 @@ depends: [
 pin-depends: [
   [ "why3.git-2c0f2992" "git+https://gitlab.inria.fr/why3/why3.git#2c0f2992af85f82f3eda0f158dcf10e62e0db875" ]
   [ "why3-ide.git-2c0f2992" "git+https://gitlab.inria.fr/why3/why3.git#2c0f2992af85f82f3eda0f158dcf10e62e0db875" ]
-  [ "why3find.git-eab37557" "git+https://git.frama-c.com/pub/why3find.git#eab37557d3e24e1913a3c4f44bc5528ef497c6c9" ]
+  [ "why3find.git-eab37557" "git+https://github.com/creusot-rs/why3find.git#eab37557d3e24e1913a3c4f44bc5528ef497c6c9" ]
 ]

--- a/nix/why3find.nix
+++ b/nix/why3find.nix
@@ -12,7 +12,7 @@ with ocamlPackages;
     pname = "why3find";
 
     src = pkgs.fetchurl {
-      url = "https://git.frama-c.com/pub/why3find/-/archive/${version}/why3find-${version}.tar.gz";
+      url = "https://github.com/creusot-rs/why3find/archive/${version}.tar.gz";
       hash = sha256;
     };
 


### PR DESCRIPTION
We need a special branch of why3find to depend on why3 master. The why3find authors kindly added a why3-master branch, but it is still too unstable for releases to rely on it.

On the long term it would be nice to be able to only depend on released why3 versions.