### PR TITLE
Force why3find to only use solvers that are mentionned in why3.conf

### DIFF
--- a/why3tests/tests/why3.rs
+++ b/why3tests/tests/why3.rs
@@ -250,6 +250,7 @@ fn main() {
             why3find.env("WHY3CONFIG", paths.why3_conf());
             why3find.env("DUNE_DIR_LOCATIONS", &format!("why3find:lib:{}", library.display()));
             why3find.arg("prove").arg(file.canonicalize().unwrap());
+            why3find.arg("--no-autodetect-provers");
             if let Some(tactic) = tactic_re.captures_iter(&header_line).next() {
                 why3find.args(["--tactic", tactic.get(1).unwrap().as_str()]);
             }


### PR DESCRIPTION
This should avoid problems when running the testsuite in an environment where other solvers we don't care about are installed.