### PR TITLE
Exit when additional predicates from extern specs cannot be fulfilled

### DIFF
--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -88,7 +88,7 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                             span,
                         );
                         if let Err(errs) = res {
-                            infcx.err_ctxt().report_fulfillment_errors(errs);
+                            infcx.err_ctxt().report_fulfillment_errors(errs).raise_fatal();
                         }
 
                         let tr_res = TraitResolved::resolve_item(

--- a/tests/should_fail/bug/1610-crash.rs
+++ b/tests/should_fail/bug/1610-crash.rs
@@ -1,9 +1,8 @@
 // Test a crash when trying to implement collect
 // This test may become should_succeed in the future.
 extern crate creusot_std;
-use creusot_std::prelude::*;
 
-struct P();
+pub struct P();
 
 impl ::std::iter::Iterator for P {
     type Item = ();

--- a/tests/should_fail/bug/1610-crash.stderr
+++ b/tests/should_fail/bug/1610-crash.stderr
@@ -1,28 +1,9 @@
-warning: unused import: `creusot_std::prelude::*`
- --> 1610-crash.rs:4:5
-  |
-4 | use creusot_std::prelude::*;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
-
-warning: struct `P` is never constructed
- --> 1610-crash.rs:6:8
-  |
-6 | struct P();
-  |        ^
-  |
-  = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
-
 error[E0277]: the trait bound `B: creusot_std::prelude::FromIteratorSpec<()>` is not satisfied
-  --> 1610-crash.rs:15:9
+  --> 1610-crash.rs:14:9
    |
-15 |         std::iter::empty().collect()
+14 |         std::iter::empty().collect()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `creusot_std::prelude::FromIteratorSpec<()>` is not implemented for `B`
 
-error: could not resolve trait instance for creusot_std::prelude::FromIteratorSpec::from_iter_post[B, <std::iter::Empty<()> as std::iter::Iterator>::Item]
- --> creusot-std/src/std/iter.rs:173:88
-
-error: aborting due to 2 previous errors; 2 warnings emitted
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/should_fail/bug/2040.rs
+++ b/tests/should_fail/bug/2040.rs
@@ -1,0 +1,5 @@
+extern crate creusot_std;
+
+pub fn f<T: Eq>(x: T) -> bool {
+    x == x
+}

--- a/tests/should_fail/bug/2040.stderr
+++ b/tests/should_fail/bug/2040.stderr
@@ -1,0 +1,9 @@
+error[E0277]: the trait bound `T: creusot_std::model::DeepModel` is not satisfied
+ --> 2040.rs:4:5
+  |
+4 |     x == x
+  |     ^^^^^^ the trait `creusot_std::model::DeepModel` is not implemented for `T`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Close #2040

This fixes the ICE but ultimately I'd like to rework the handling of extern specs. If the additional predicates cannot be fulfilled then that should be equivalent to having no specs.