### PR TITLE
Allow third-parties to use their version of cargo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,12 +101,25 @@
 
           formatter = pkgs.nixfmt-tree;
 
-          packages = {
-            inherit (pkgs.creusot) prelude creusot;
+          packages =
+            let
+              rustShellToolchain = pkgs.creusot.mkRustToolchain [ ];
 
-            default = pkgs.creusot.mkCreusotShell { isFree = false; };
-            free = pkgs.creusot.mkCreusotShell { isFree = true; };
-          };
+              mkCreusot =
+                isFree:
+                (pkgs.creusot.mkCreusotWrapped isFree).override (old: {
+                  paths = old.paths ++ [
+                    pkgs.gcc
+                    rustShellToolchain
+                  ];
+                });
+            in
+            {
+              inherit (pkgs.creusot) prelude creusot;
+
+              default = mkCreusot { isFree = false; };
+              free = mkCreusot { isFree = true; };
+            };
 
           devShells =
             let

--- a/nix/creusot/default.nix
+++ b/nix/creusot/default.nix
@@ -44,8 +44,6 @@ in
     };
 
     mkWhy3Framework = final.callPackage ./mkWhy3Framework.nix { };
-    mkCreusotShell = final.callPackage ./mkCreusotShell.nix {
-      inherit rustToolchain;
-    };
+    mkCreusotWrapped = final.callPackage ./mkCreusotWrapped.nix { };
   };
 }

--- a/nix/creusot/mkCreusotWrapped.nix
+++ b/nix/creusot/mkCreusotWrapped.nix
@@ -6,9 +6,6 @@
 
   # Librairies
   buildEnv,
-
-  # Attributes
-  rustToolchain,
 }:
 
 # Arguments
@@ -20,12 +17,10 @@ let
   why3Framework = creusot.mkWhy3Framework { inherit isFree; };
 in
 buildEnv {
-  name = "creusot-env";
+  name = "creusot-wrapped";
   paths = [
     creusot.prelude
     creusot.creusot
-    gcc
-    rustToolchain
     why3Framework
   ];
 


### PR DESCRIPTION
This is a minor change that relaxes the constraints on the toolchain.

See #2100 for an example.