### PR TITLE
Fix git repository URL in book

### DIFF
--- a/guide/book.toml
+++ b/guide/book.toml
@@ -5,7 +5,7 @@ src = "src"
 title = "Creusot User Guide"
 
 [output.html]
-git-repository-url = "https://github.com/creusot/creusot-rs/tree/master/guide"
+git-repository-url = "https://github.com/creusot-rs/creusot/tree/master/guide"
 
 [output.html.playground]
 runnable = false


### PR DESCRIPTION
I was having trouble getting back from the book to the repository, Eventually figured out that the book had the wrong link. Thought I would fix it for the next person.