### PR TITLE
Improve UX for newcomers

### DIFF
--- a/cargo-creusot/src/new.rs
+++ b/cargo-creusot/src/new.rs
@@ -3,7 +3,7 @@ use cargo_metadata::semver::Version;
 use clap::Parser;
 use creusot_setup::creusot_paths;
 use std::{
-    fs,
+    fs::{self, remove_file},
     io::Write,
     path::{Path, PathBuf},
 };
@@ -34,30 +34,14 @@ pub struct NewInitArgs {
     #[clap(long)]
     pub tests: bool,
     /// Path to local creusot-std relative to the generated Cargo.toml
-    #[clap(long, env = "CREUSOT_STD")]
-    pub creusot_std: Option<String>,
+    #[clap(long, env = "CREUSOT_PATH")]
+    pub creusot_path: Option<PathBuf>,
     /// Disable standard library
     #[clap(long)]
     pub no_std: bool,
 }
 
-fn cargo_template(name: &str, creusot_std: Option<String>, no_std: bool) -> String {
-    let patch = if let Some(creusot_std) = creusot_std {
-        format!(
-            r#"
-[patch.crates-io]
-creusot-std = {{ path = "{}" }}
-"#,
-            creusot_std
-        )
-    } else {
-        if !Version::parse(CREUSOT_STD_VERSION).unwrap().pre.is_empty() {
-            eprintln!(
-                "Warning: using dev version of Creusot ({CREUSOT_STD_VERSION}), you should set a local path to creusot-std.\nSuggestion: cargo creusot init --creusot-std <PATH>"
-            )
-        }
-        "".into()
-    };
+fn cargo_template(name: &str, no_std: bool) -> String {
     let creusot_std = if no_std {
         format!("{{ version = \"{CREUSOT_STD_VERSION}\", default-features = false }}")
     } else {
@@ -74,7 +58,7 @@ creusot-std = {creusot_std}
 
 [lints.rust]
 unexpected_cfgs = {{ level = "warn", check-cfg = ['cfg(creusot)'] }}
-{patch}"#
+"#
     )
 }
 
@@ -149,10 +133,17 @@ pub fn init(args: InitArgs) -> Result<()> {
 pub fn create_project(name: String, args: NewInitArgs) -> Result<()> {
     let paths = creusot_paths();
     let cargo_toml = Path::new("Cargo.toml");
-    if cargo_toml.exists() {
-        patch_dep(cargo_toml, args.creusot_std)?;
+    let self_version = Version::parse(CREUSOT_STD_VERSION)?;
+    let creusot_path = if self_version.pre.is_empty() {
+        None
     } else {
-        write(cargo_toml, &cargo_template(&name, args.creusot_std, args.no_std));
+        args.creusot_path.or_else(|| Some(creusot_source_path()))
+    };
+    if cargo_toml.exists() {
+        patch_dep(cargo_toml)?;
+    } else {
+        // Rust files are only generated if there wasn't already a Cargo.toml
+        write(cargo_toml, &cargo_template(&name, args.no_std));
         if args.tests {
             fs::create_dir_all("tests")?;
             write("tests/test.rs", TEST_TEMPLATE);
@@ -167,15 +158,17 @@ pub fn create_project(name: String, args: NewInitArgs) -> Result<()> {
             write("src/lib.rs", LIB_TEMPLATE);
         }
     }
-    if let Some(parent_cargo_toml) = find_parent_cargo_toml() {
-        eprintln!(
-            "Info: It seems that you are in a workspace (found {}), so no why3find.json will be created in the current directory.",
-            parent_cargo_toml.display()
-        );
+    let root = if let Some(mut parent) = find_parent_cargo_toml() {
+        eprintln!("Info: It seems that you are in a workspace (found {}).", parent.display());
+        parent.pop();
+        parent
     } else {
-        let why3find_json = paths.why3find_json();
-        copy(&why3find_json, "why3find.json");
-    }
+        PathBuf::new()
+    };
+    write_cargo_config(&root, &creusot_path)?;
+    let why3find_json = paths.why3find_json();
+    copy(&why3find_json, root.join("why3find.json"));
+    write(root.join(".gitignore"), "target\ncreusot\n_creusot_erasure\n*.coma\n.why3find");
     Ok(())
 }
 
@@ -188,6 +181,58 @@ fn find_parent_cargo_toml() -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// For a dev version (`creusot_path` is `Some`), create `.cargo/config.toml`:
+///
+/// ```toml
+/// [patch.crates-io]
+/// creusot-std = { path = "creusot/creusot-std" }
+/// ```
+///
+/// And create a symlink `creusot` to the parent of `creusot_path` (this allows
+/// Cargo to also find `creusot-std-proc` and `pearlite-syn`).
+///
+/// For a released version (`creusot_path` is `None`), remove `.cargo/config.toml`
+/// if it only contains the above patch.
+fn write_cargo_config(root: &Path, creusot_path: &Option<PathBuf>) -> Result<()> {
+    let cargo = root.join(".cargo");
+    let cargo_config = cargo.join("config.toml");
+    if let Some(creusot_path) = creusot_path {
+        fs::create_dir_all(&cargo)?;
+        write(
+            cargo_config,
+            "[patch.crates-io]\ncreusot-std = { path = \"creusot/creusot-std\" }\n",
+        );
+        let creusot = root.join("creusot");
+        let _ = std::os::unix::fs::symlink(creusot_path, creusot);
+    } else {
+        if only_patch_creusot_std(&cargo_config) {
+            // Remove only if there is only a patch for creusot-std
+            if let Ok(_) = remove_file(&cargo_config) {
+                eprintln!("Removed '{}'", cargo_config.display());
+            }
+        }
+        let _ = fs::remove_dir(cargo); // Try remove empty directory
+    }
+    Ok(())
+}
+
+fn only_patch_creusot_std(cargo_config: &Path) -> bool {
+    use std::io::{self, BufRead};
+    let Ok(file) = fs::File::open(cargo_config) else {
+        return false;
+    };
+    let mut lines = io::BufReader::new(file).lines();
+    let Some(Ok(line0)) = lines.next() else {
+        return false;
+    };
+    let Some(Ok(line1)) = lines.next() else {
+        return false;
+    };
+    matches!(lines.next(), None)
+        && line0.trim() == "[patch.crates-io]"
+        && line1.trim_start().starts_with("creusot-std =")
 }
 
 fn validate_name(name: &str) -> Result<()> {
@@ -214,13 +259,13 @@ fn write(path: impl AsRef<Path>, contents: &str) {
         });
 }
 
-/// Do not overwrite existing file.
+/// Do nothing if the target exists.
 fn copy(src: impl AsRef<Path>, dst: impl AsRef<Path>) {
-    let src = src.as_ref();
     let dst = dst.as_ref();
     if dst.exists() {
         return;
     }
+    let src = src.as_ref();
     if let Err(err) = fs::copy(src, dst) {
         panic!("Error copying {} to {}: {err}", src.display(), dst.display());
     }
@@ -231,23 +276,26 @@ fn copy(src: impl AsRef<Path>, dst: impl AsRef<Path>) {
 /// ```toml
 /// [dependencies]
 /// creusot-std = "X.Y.Z"
-///
-/// [patch.crates-io]
-/// creusot-std = { path = "/path/to/creusot-std" }  # Only for dev versions
 /// ```
-fn patch_dep(cargo_toml_path: impl AsRef<Path>, creusot_std: Option<String>) -> Result<()> {
+fn patch_dep(cargo_toml_path: impl AsRef<Path>) -> Result<()> {
     let cargo_toml_path = cargo_toml_path.as_ref();
-    let self_version = Version::parse(CREUSOT_STD_VERSION)?;
     let cargo_toml = std::fs::read_to_string(cargo_toml_path)?;
     let mut cargo_toml = cargo_toml.parse::<toml_edit::DocumentMut>()?;
-    let creusot_std = creusot_std.unwrap_or(creusot_std_path().display().to_string());
     if cargo_toml.contains_key("package") {
         implicit_table(&mut cargo_toml, "dependencies")["creusot-std"] =
             toml_edit::value(CREUSOT_STD_VERSION);
-        if !self_version.pre.is_empty() {
-            let patch = implicit_table(&mut cargo_toml, "patch");
-            implicit_table(patch.as_table_mut().unwrap(), "crates-io")["creusot-std"]["path"] =
-                toml_edit::value(creusot_std);
+        // Remove legacy [patch.crates-io]
+        // FIXME: remove after 0.12
+        if let Some(toml_edit::Item::Table(patch)) = cargo_toml.get_mut("patch")
+            && let toml_edit::Item::Table(ref mut crates_io) = patch["crates-io"]
+        {
+            crates_io.remove("creusot-std");
+            if crates_io.is_empty() {
+                patch.remove("crates-io");
+                if patch.is_empty() {
+                    cargo_toml.remove("patch");
+                }
+            }
         }
     } else {
         eprintln!(
@@ -277,12 +325,14 @@ fn implicit_table<'a>(toml: &'a mut toml_edit::Table, key: &'a str) -> &'a mut t
 /// Only remember the version string at compile-time
 pub const CREUSOT_STD_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-fn creusot_std_path() -> PathBuf {
+/// The hard-coded path to the source of creusot-std
+/// Note: this is meaningless in nix. The nix config will set CREUSOT_PATH
+/// so this should not be reachable.
+fn creusot_source_path() -> PathBuf {
     // This must be the dev version of `cargo-creusot`.
     // It should have been installed from source and `creusot-std`
     // should be available next to its source.
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.pop();
-    path.push("creusot-std");
     path
 }

--- a/guide/src/command_line_interface.md
+++ b/guide/src/command_line_interface.md
@@ -131,7 +131,7 @@ which ensures that the Coma artifacts are always up to date.
 ### `new`
 
 ```
-cargo creusot new <NAME> [--main] [--creusot-std <PATH>]
+cargo creusot new <NAME> [--main] [--tests] [--no-std] [--creusot-path <PATH>]
 ```
 
 Create or update package named `<NAME>`.
@@ -141,7 +141,16 @@ Create directory `<NAME>` if it doesn't already exist, and run `cargo creusot in
 #### Options
 
 - `--main`: Create `main.rs` for an executable crate. (By default, only a library crate `lib.rs` is created.)
-- `--creusot-std <PATH>`: Path to local `creusot-std` used to set the `[patch.crates-io]` section of `Cargo.toml`.
+- `--creusot-path <PATH>`: Path to local `creusot` repository, used to find dev
+    versions of `creusot-std`, `creusot-std-proc`, and `pearlite-syn`.
+    - This creates a symlink `creusot` pointing to `<PATH>` in the newly created project,
+      and a file `.cargo/config.toml` that points to `creusot/creusot-std`,
+      going through that symlink to find `creusot-std` (and thus the other crates as well).
+    - This option has a default value so you shouldn't need to set this normally.
+        + For non-Nix installations, this defaults to a path hard-coded during the
+          compilation of `cargo-creusot`, so it should work as long as you didn't move it.
+        + In a Nix shell, this option is set via the environment variable `CREUSOT_PATH`.
+    - This option is ignored in released versions of Creusot.
 
 ### `init`
 
@@ -159,14 +168,17 @@ If `Cargo.toml` exists, update an existing package for verification with Creusot
 
     For released versions of Creusot, this is equivalent to `cargo add creusot-std@<VERSION>` just with the right version.
 
-    For a development version of Creusot (prerelease version `-dev`), this also adds the following lines:
+    For a development version of Creusot (prerelease version `-dev`), this also creates
+    `.cargo/config.toml` with these contents:
 
     ```
     [patch.crates-io]
-    creusot-std = { path = "/path/to/creusot-std" }
+    creusot-std = { path = "creusot/creusot-std" }
     ```
 
-    This setting is documented in [The Cargo Book: Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html).
+    and a `creusot` symlink to the Creusot repository.
+
+    The `[patch.crates-io]` setting is documented in [The Cargo Book: Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html).
 
 - add `why3find.json` if it doesn't exist.
 
@@ -174,7 +186,7 @@ If `Cargo.toml` exists, update an existing package for verification with Creusot
 
 - `<NAME>`: Name of the package. (By default, it is the name of the directory.)
 - `--main`: Create `main.rs` for an executable crate. (By default, only a library crate `lib.rs` is created.)
-- `--creusot-std <PATH>`: Path to local `creusot-std` used to set the `[patch.crates-io]` section of `Cargo.toml`.
+- `--creusot-path <PATH>`: Path to local `creusot` repository.
 
 ## Configuration
 

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -5,7 +5,8 @@ and some configuration options.
 
 ## Quick installation (using custom script)
 
-The `INSTALL` script installs Creusot and its accompanying tools.
+The `INSTALL` script in the Creusot repository installs Creusot and its
+accompanying tools.
 
 Requirements to run the `INSTALL` script:
 
@@ -14,6 +15,8 @@ Requirements to run the `INSTALL` script:
 - `curl` to download provers: `alt-ergo`, `z3`, `cvc4`, `cvc5`.
 
 ```sh
+git clone https://github.com/creusot-rs/creusot
+cd creusot
 ./INSTALL
 ```
 
@@ -191,3 +194,20 @@ Nevertheless, you may like to experiment with some of these options:
   For example: `compute_in_goal` and `inline_goal` are tactics; `apply H`, `exists X` are not tactics.
 
 See [the Why3find README](https://git.frama-c.com/pub/why3find#why3find) for more information.
+
+## Creusot versions
+
+If you are just getting started with Creusot, we recommend that you install Creusot
+from the default `master` branch.
+This is the "dev version" `X.Y.Z-dev` where `X.Y.Z` is the upcoming version number.
+The main benefit is to allow you to get fixes quicker if you run into issues.
+The drawback is that your projects must then depend on the dev version of
+the `creusot-std` crate. In particular, you cannot get it from crates.io,
+and you have to apply "patches" in the Cargo config.
+`cargo creusot new` handles this automatically in simple cases,
+but some intervention may be necessary when switching between a dev version
+and a released version of Creusot.
+
+We make a new release of Creusot every month, providing a clearly defined version
+for your projects to depend on (as opposed to having to remember a specific commit hash).
+This also enables getting the `creusot-std` crate from crates.io.

--- a/guide/src/quickstart.md
+++ b/guide/src/quickstart.md
@@ -12,15 +12,6 @@ Create a new project with this command:
 cargo creusot new project-name
 ```
 
-> [!NOTE]
-> If you are using the development version of Creusot (`master` branch), you
-> should also point your project to your local copy of `creusot-std`,
-> using the `--creusot-std` option (otherwise the default is to use the
-> released version on crates.io). To avoid hard-coding local paths in your
-> configuration, one approach is to set `--creusot-std creusot-std`,
-> and make a symbolic link `creusot-std` pointing to your local
-> `creusot-std`.
-
 That command creates a directory `package-name` containing the basic elements of a Rust project verified with Creusot. The file `src/lib.rs` is initialized with an example function annotated with a contract:
 
 ```rust

--- a/nix/creusot/creusot.nix
+++ b/nix/creusot/creusot.nix
@@ -45,7 +45,7 @@ rustBuilder.buildPackage rec {
     cp -r {creusot-std,creusot-std-proc,pearlite-syn} $out/share/.
 
     wrapProgram $out/bin/cargo-creusot \
-      --set CREUSOT_STD $out/share/creusot-std \
+      --set CREUSOT_PATH $out/share/ \
       --set CREUSOT_RUSTC $out/bin/creusot-rustc \
 
     wrapProgram $out/bin/creusot-rustc \

--- a/t
+++ b/t
@@ -160,7 +160,7 @@ if [ "$TEST_BUILD_NEW" ] || [ "$TEST_ALL" ] ; then
   pushd $TMP
   DIR=creusot-test-please-ignore
   rm -rf $DIR
-  cargo_creusot new $DIR --main --creusot-std $CREUSOT_DIR/creusot-std
+  cargo_creusot new $DIR --main --creusot-path $CREUSOT_DIR
   cd $DIR
   cargo fmt --check
   cargo build
@@ -178,7 +178,7 @@ if [ "$TEST_BUILD_NO_STD" ] || [ "$TEST_ALL" ] ; then
   pushd $TMP
   DIR=creusot-test-please-ignore
   rm -rf $DIR
-  cargo_creusot new $DIR --no-std --creusot-std $CREUSOT_DIR/creusot-std
+  cargo_creusot new $DIR --no-std --creusot-path $CREUSOT_DIR
   cd $DIR
   echo "$TLC" > rust-toolchain
   cargo fmt --check


### PR DESCRIPTION
- Document that `INSTALL` is part of the creusot repository.
- Document versioning process. Recommend sticking to `master` for now.
- Fix `cargo creusot new` for dev version of Creusot to automatically set the path to `creusot-std` (instead of emitting a warning to tell you to do it).
    - Create `.cargo/config.toml` with `[patch.crates-io]\ncreusot-std = { path = "creusot/creusot-std" }`
    - Create a symlink `creusot` to the `creusot` repository
    - Remove the now obsolete `[patch.crates-io]` section from `Cargo.toml`.

This addresses feedback from [this Zulip thread](https://why3.zulipchat.com/#narrow/channel/304503-general/topic/Having.20trouble.20installing.20creusot/with/595164015) from user Eh2406.