### PR TITLE
cargo-creusot: Pass --no-autodetect-provers to why3find

### DIFF
--- a/cargo-creusot/src/why3find_wrapper.rs
+++ b/cargo-creusot/src/why3find_wrapper.rs
@@ -87,7 +87,7 @@ fn raw_prove(args: ProveArgs, paths: &CreusotPaths, files: &[PathBuf]) -> Result
     if args.why3session || args.ide.ide_always {
         why3find.arg("-s");
     }
-    why3find.arg("--summary");
+    why3find.args(["--summary", "--no-autodetect-provers"]);
     why3find.args(&args.why3find_arg);
     why3find.args(files);
     // Add $XDG_DATA_HOME/creusot/bin to PATH for why3find to find why3


### PR DESCRIPTION
This is to make the behavior stricter, although things already worked because we also set the `PATH` to the Creusot bin directory containing the solvers and Why3.