### PR TITLE
Implement `SliceIndexSpec` for intervals

### DIFF
--- a/creusot-std/src/std/slice.rs
+++ b/creusot-std/src/std/slice.rs
@@ -277,18 +277,20 @@ impl<T> SliceIndexSpec<[T]> for RangeToInclusive<usize> {
     }
 }
 
-#[logic(open)]
-pub fn to_logic_range(interval: (Bound<usize>, Bound<usize>), len: Int) -> Range<Int> {
-    match interval {
-        (Bound::Included(start), Bound::Included(end)) => start.view()..end.view() + 1,
-        (Bound::Included(start), Bound::Excluded(end)) => start.view()..end.view(),
-        (Bound::Included(start), Bound::Unbounded) => start.view()..len,
-        (Bound::Excluded(start), Bound::Excluded(end)) => start.view() + 1..end.view(),
-        (Bound::Excluded(start), Bound::Included(end)) => start.view() + 1..end.view() + 1,
-        (Bound::Excluded(start), Bound::Unbounded) => start.view() + 1..len,
-        (Bound::Unbounded, Bound::Unbounded) => 0..len,
-        (Bound::Unbounded, Bound::Included(end)) => 0..end.view() + 1,
-        (Bound::Unbounded, Bound::Excluded(end)) => 0..end.view(),
+#[logic(open, inline)]
+pub fn to_logic_range((lo, hi): (Bound<usize>, Bound<usize>), len: Int) -> Range<Int> {
+    pearlite! {
+        let lo = match lo {
+            Bound::Included(i) => i@,
+            Bound::Excluded(i) => i@ + 1,
+            Bound::Unbounded => 0
+        };
+        let hi = match hi {
+            Bound::Included(i) => i@ + 1,
+            Bound::Excluded(i) => i@,
+            Bound::Unbounded => len
+        };
+        lo..hi
     }
 }
 

--- a/creusot-std/src/std/slice.rs
+++ b/creusot-std/src/std/slice.rs
@@ -277,63 +277,40 @@ impl<T> SliceIndexSpec<[T]> for RangeToInclusive<usize> {
     }
 }
 
+#[logic(open)]
+pub fn to_logic_range(interval: (Bound<usize>, Bound<usize>), len: Int) -> Range<Int> {
+    match interval {
+        (Bound::Included(start), Bound::Included(end)) => start.view()..end.view() + 1,
+        (Bound::Included(start), Bound::Excluded(end)) => start.view()..end.view(),
+        (Bound::Included(start), Bound::Unbounded) => start.view()..len,
+        (Bound::Excluded(start), Bound::Excluded(end)) => start.view() + 1..end.view(),
+        (Bound::Excluded(start), Bound::Included(end)) => start.view() + 1..end.view() + 1,
+        (Bound::Excluded(start), Bound::Unbounded) => start.view() + 1..len,
+        (Bound::Unbounded, Bound::Unbounded) => 0..len,
+        (Bound::Unbounded, Bound::Included(end)) => 0..end.view() + 1,
+        (Bound::Unbounded, Bound::Excluded(end)) => 0..end.view(),
+    }
+}
+
 impl<T> SliceIndexSpec<[T]> for (Bound<usize>, Bound<usize>) {
     #[logic(open)]
     fn in_bounds(self, seq: Seq<T>) -> bool {
-        match self {
-            (Bound::Included(start), Bound::Included(end)) => (start..=end).in_bounds(seq),
-            (Bound::Included(start), Bound::Excluded(end)) => (start..end).in_bounds(seq),
-            (Bound::Included(start), Bound::Unbounded) => (start..).in_bounds(seq),
-            (Bound::Excluded(start), Bound::Excluded(end)) => (start + 1usize..end).in_bounds(seq),
-            (Bound::Excluded(start), Bound::Included(end)) => (start + 1usize..=end).in_bounds(seq),
-            (Bound::Excluded(start), Bound::Unbounded) => (start + 1usize..).in_bounds(seq),
-            (Bound::Unbounded, Bound::Unbounded) => (..).in_bounds(seq),
-            (Bound::Unbounded, Bound::Included(end)) => (..=end).in_bounds(seq),
-            (Bound::Unbounded, Bound::Excluded(end)) => (..end).in_bounds(seq),
-        }
+        let range = to_logic_range(self, seq.len());
+        pearlite! { range.start <= range.end && range.end <= seq.len() }
     }
 
     #[logic(open)]
     fn has_value(self, seq: Seq<T>, out: [T]) -> bool {
-        match self {
-            (Bound::Included(start), Bound::Included(end)) => (start..=end).has_value(seq, out),
-            (Bound::Included(start), Bound::Excluded(end)) => (start..end).has_value(seq, out),
-            (Bound::Included(start), Bound::Unbounded) => (start..).has_value(seq, out),
-            (Bound::Excluded(start), Bound::Excluded(end)) => {
-                (start + 1usize..end).has_value(seq, out)
-            }
-            (Bound::Excluded(start), Bound::Included(end)) => {
-                (start + 1usize..=end).has_value(seq, out)
-            }
-            (Bound::Excluded(start), Bound::Unbounded) => (start + 1usize..).has_value(seq, out),
-            (Bound::Unbounded, Bound::Unbounded) => (..).has_value(seq, out),
-            (Bound::Unbounded, Bound::Included(end)) => (..=end).has_value(seq, out),
-            (Bound::Unbounded, Bound::Excluded(end)) => (..end).has_value(seq, out),
-        }
+        let range = to_logic_range(self, seq.len());
+        pearlite! { seq.subsequence(range.start, range.end) == out@ }
     }
 
     #[logic(open)]
     fn resolve_elswhere(self, old: Seq<T>, fin: Seq<T>) -> bool {
-        match self {
-            (Bound::Included(start), Bound::Included(end)) => {
-                (start..=end).resolve_elswhere(old, fin)
-            }
-            (Bound::Included(start), Bound::Excluded(end)) => {
-                (start..end).resolve_elswhere(old, fin)
-            }
-            (Bound::Included(start), Bound::Unbounded) => (start..).resolve_elswhere(old, fin),
-            (Bound::Excluded(start), Bound::Excluded(end)) => {
-                (start + 1usize..end).resolve_elswhere(old, fin)
-            }
-            (Bound::Excluded(start), Bound::Included(end)) => {
-                (start + 1usize..=end).resolve_elswhere(old, fin)
-            }
-            (Bound::Excluded(start), Bound::Unbounded) => {
-                (start + 1usize..).resolve_elswhere(old, fin)
-            }
-            (Bound::Unbounded, Bound::Unbounded) => (..).resolve_elswhere(old, fin),
-            (Bound::Unbounded, Bound::Included(end)) => (..=end).resolve_elswhere(old, fin),
-            (Bound::Unbounded, Bound::Excluded(end)) => (..end).resolve_elswhere(old, fin),
+        let range = to_logic_range(self, old.len());
+        pearlite! {
+            forall<i> 0 <= i && (i < range.start || range.end <= i) && i < old.len()
+            ==> old[i] == fin[i]
         }
     }
 }

--- a/creusot-std/src/std/slice.rs
+++ b/creusot-std/src/std/slice.rs
@@ -4,7 +4,7 @@ use crate::{ghost::perm::Perm, invariant::*, logic::ops::IndexLogic, prelude::*}
 #[cfg(creusot)]
 use core::ops::{Index, IndexMut};
 use core::{
-    ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
+    ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
     slice::*,
 };
 #[cfg(all(creusot, feature = "std"))]
@@ -274,6 +274,67 @@ impl<T> SliceIndexSpec<[T]> for RangeToInclusive<usize> {
     #[logic(open)]
     fn resolve_elswhere(self, old: Seq<T>, fin: Seq<T>) -> bool {
         pearlite! { forall<i> self.end@ < i && i < old.len() ==> old[i] == fin[i] }
+    }
+}
+
+impl<T> SliceIndexSpec<[T]> for (Bound<usize>, Bound<usize>) {
+    #[logic(open)]
+    fn in_bounds(self, seq: Seq<T>) -> bool {
+        match self {
+            (Bound::Included(start), Bound::Included(end)) => (start..=end).in_bounds(seq),
+            (Bound::Included(start), Bound::Excluded(end)) => (start..end).in_bounds(seq),
+            (Bound::Included(start), Bound::Unbounded) => (start..).in_bounds(seq),
+            (Bound::Excluded(start), Bound::Excluded(end)) => (start + 1usize..end).in_bounds(seq),
+            (Bound::Excluded(start), Bound::Included(end)) => (start + 1usize..=end).in_bounds(seq),
+            (Bound::Excluded(start), Bound::Unbounded) => (start + 1usize..).in_bounds(seq),
+            (Bound::Unbounded, Bound::Unbounded) => (..).in_bounds(seq),
+            (Bound::Unbounded, Bound::Included(end)) => (..=end).in_bounds(seq),
+            (Bound::Unbounded, Bound::Excluded(end)) => (..end).in_bounds(seq),
+        }
+    }
+
+    #[logic(open)]
+    fn has_value(self, seq: Seq<T>, out: [T]) -> bool {
+        match self {
+            (Bound::Included(start), Bound::Included(end)) => (start..=end).has_value(seq, out),
+            (Bound::Included(start), Bound::Excluded(end)) => (start..end).has_value(seq, out),
+            (Bound::Included(start), Bound::Unbounded) => (start..).has_value(seq, out),
+            (Bound::Excluded(start), Bound::Excluded(end)) => {
+                (start + 1usize..end).has_value(seq, out)
+            }
+            (Bound::Excluded(start), Bound::Included(end)) => {
+                (start + 1usize..=end).has_value(seq, out)
+            }
+            (Bound::Excluded(start), Bound::Unbounded) => (start + 1usize..).has_value(seq, out),
+            (Bound::Unbounded, Bound::Unbounded) => (..).has_value(seq, out),
+            (Bound::Unbounded, Bound::Included(end)) => (..=end).has_value(seq, out),
+            (Bound::Unbounded, Bound::Excluded(end)) => (..end).has_value(seq, out),
+        }
+    }
+
+    #[logic(open)]
+    fn resolve_elswhere(self, old: Seq<T>, fin: Seq<T>) -> bool {
+        match self {
+            (Bound::Included(start), Bound::Included(end)) => {
+                (start..=end).resolve_elswhere(old, fin)
+            }
+            (Bound::Included(start), Bound::Excluded(end)) => {
+                (start..end).resolve_elswhere(old, fin)
+            }
+            (Bound::Included(start), Bound::Unbounded) => (start..).resolve_elswhere(old, fin),
+            (Bound::Excluded(start), Bound::Excluded(end)) => {
+                (start + 1usize..end).resolve_elswhere(old, fin)
+            }
+            (Bound::Excluded(start), Bound::Included(end)) => {
+                (start + 1usize..=end).resolve_elswhere(old, fin)
+            }
+            (Bound::Excluded(start), Bound::Unbounded) => {
+                (start + 1usize..).resolve_elswhere(old, fin)
+            }
+            (Bound::Unbounded, Bound::Unbounded) => (..).resolve_elswhere(old, fin),
+            (Bound::Unbounded, Bound::Included(end)) => (..=end).resolve_elswhere(old, fin),
+            (Bound::Unbounded, Bound::Excluded(end)) => (..end).resolve_elswhere(old, fin),
+        }
     }
 }
 

--- a/tests/should_succeed/spans.coma
+++ b/tests/should_succeed/spans.coma
@@ -212,7 +212,7 @@ module M_slices [#"spans.rs" 73 0 73 32]
   let%span sspans'5 = "spans.rs" 76 6 76 7
   let%span sspans'6 = "spans.rs" 76 4 76 8
   let%span sspans'7 = "spans.rs" 72 11 72 17
-  let%span sslice = "creusot-std/src/std/slice.rs" 349 18 349 40
+  let%span sslice = "creusot-std/src/std/slice.rs" 326 18 326 40
   
   use creusot.int.UInt64
   use creusot.slice.Slice64

--- a/tests/should_succeed/spans.coma
+++ b/tests/should_succeed/spans.coma
@@ -212,7 +212,7 @@ module M_slices [#"spans.rs" 73 0 73 32]
   let%span sspans'5 = "spans.rs" 76 6 76 7
   let%span sspans'6 = "spans.rs" 76 4 76 8
   let%span sspans'7 = "spans.rs" 72 11 72 17
-  let%span sslice = "creusot-std/src/std/slice.rs" 288 18 288 40
+  let%span sslice = "creusot-std/src/std/slice.rs" 349 18 349 40
   
   use creusot.int.UInt64
   use creusot.slice.Slice64

--- a/tests/should_succeed/spans.coma
+++ b/tests/should_succeed/spans.coma
@@ -212,7 +212,7 @@ module M_slices [#"spans.rs" 73 0 73 32]
   let%span sspans'5 = "spans.rs" 76 6 76 7
   let%span sspans'6 = "spans.rs" 76 4 76 8
   let%span sspans'7 = "spans.rs" 72 11 72 17
-  let%span sslice = "creusot-std/src/std/slice.rs" 326 18 326 40
+  let%span sslice = "creusot-std/src/std/slice.rs" 328 18 328 40
   
   use creusot.int.UInt64
   use creusot.slice.Slice64


### PR DESCRIPTION
The `SliceIndexSpec` trait is not implemented for `(Bound(_), Bound(_))` type but `SliceIndex` is implemented for these types in the standard library. 

I'm concerned about usize overflow in the formula:
```rust
(start + 1usize..end).in_bounds(seq)
```
It seems that the Rust runtime panics on usize overflows, so we don't produce wrong formulae at least.
A solution is to implement `SliceIndexSpec` for ranges on `Int` type and write 
```rust
(start@ + 1..end).in_bounds(seq)
```
You might have a better idea?