### PR TITLE
Use fully qualified syntax with core for unfolding a..=b in Pearlite, to make it compatible with no_std mode and even if the prelude is not loaded.

### DIFF
--- a/creusot-std-proc/src/creusot/pretyping.rs
+++ b/creusot-std-proc/src/creusot/pretyping.rs
@@ -342,7 +342,9 @@ fn encode_term_(term: &Term, locals: &mut Locals) -> Result<EncodingResult, Enco
         }) => {
             let from = encode_term_(from, locals)?.toks();
             let to = encode_term_(to, locals)?.toks();
-            Ok(quote_spanned! {sp=> ::std::ops::RangeInclusive::new_log(#from, #to) }.into())
+            Ok(quote_spanned! {sp=>
+                <::core::ops::RangeInclusive<_> as ::creusot_std::std::ops::RangeInclusiveExt<_>>::new_log(#from, #to)
+            }.into())
         }
         Term::Range(TermRange { from, limits, to }) => {
             let from = match from {


### PR DESCRIPTION
See https://github.com/creusot-rs/creusot/pull/2112#issuecomment-4499543792 .