### PR TITLE
Fixes for verifying a static nostd library:

### DIFF
--- a/cargo-creusot/src/main.rs
+++ b/cargo-creusot/src/main.rs
@@ -107,6 +107,7 @@ impl Runner {
                         let ty = match kind {
                             TargetKind::Lib | TargetKind::RLib => "rlib",
                             TargetKind::Bin => "bin",
+                            TargetKind::StaticLib => "staticlib",
                             _ => return None, // Other types are unsupported at the moment
                         };
                         Some(format!("{}_{}", target.name.replace('-', "_"), ty))

--- a/cargo-creusot/src/why3find_wrapper.rs
+++ b/cargo-creusot/src/why3find_wrapper.rs
@@ -116,7 +116,7 @@ pub fn why3find_prove(args: ProveArgs, root: &Path, targets: Vec<String>) -> Res
         )
     }
     let files = if args.patterns.is_empty() {
-        let verif = PathBuf::from("verif");
+        let verif = PathBuf::from(OUTPUT_PREFIX);
         targets
             .iter()
             .filter_map(|tgt| {
@@ -127,8 +127,7 @@ pub fn why3find_prove(args: ProveArgs, root: &Path, targets: Vec<String>) -> Res
     } else {
         let patterns =
             args.patterns.iter().map(|s| Pattern::parse(root, s)).collect::<Result<Patterns>>()?;
-        let files = match_patterns(&patterns)?;
-        files
+        match_patterns(&patterns)?
     };
     if files.is_empty() {
         // Fail if no files matched the patterns.
@@ -163,10 +162,6 @@ pub struct Patterns {
 }
 
 impl Patterns {
-    fn is_empty(&self) -> bool {
-        self.paths.is_empty() && self.spatterns.is_empty()
-    }
-
     fn matches(&self, path: &Path) -> bool {
         self.path_matches(path) || self.spattern_matches(path)
     }
@@ -316,16 +311,11 @@ fn strip_coma_str(name: &str) -> Option<&str> {
     name.strip_suffix(".coma")
 }
 
-/// If no patterns, return `"verif/"`.
-/// Otherwise, list files under `verif/` that match at least one pattern.
+/// List files under `verif/` that match at least one pattern.
 fn match_patterns(patterns: &Patterns) -> Result<Vec<PathBuf>> {
     let dir = PathBuf::from(OUTPUT_PREFIX);
-    if patterns.is_empty() {
-        Ok(vec![dir])
-    } else if !std::fs::exists(&dir)
-        .context(format!("failed to check directory '{}'", dir.display()))?
-    {
-        return Ok(vec![]);
+    if !std::fs::exists(&dir).context(format!("failed to check directory '{}'", dir.display()))? {
+        Ok(vec![])
     } else {
         let mut dest = vec![];
         match_patterns_from(patterns, &dir, &mut dest)?;

--- a/creusot-std/Cargo.toml
+++ b/creusot-std/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(creusot)'.dependencies]
-num-rational = { version = "0.4", features = ["num-bigint"], default-features = false }
+num-rational = { version = "0.4", optional = true }
 
 [dependencies]
 creusot-std-proc = { path = "../creusot-std-proc", version = "0.12.0-dev" }
@@ -28,7 +28,7 @@ nightly = []
 creusot = ["creusot-std-proc/creusot"]
 sc-drf = []
 default = ["std"]
-std = []
+std = ["dep:num-rational"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(creusot)'] }

--- a/creusot-std/src/logic/real.rs
+++ b/creusot-std/src/logic/real.rs
@@ -5,13 +5,13 @@ use crate::{
     prelude::*,
 };
 use core::cmp::Ordering;
-#[cfg(creusot)]
+#[cfg(all(creusot, feature = "std"))]
 use num_rational::BigRational;
 
 #[builtin("real.Real.real")]
 pub struct Real;
 
-#[cfg(creusot)]
+#[cfg(all(creusot, feature = "std"))]
 impl DeepModel for BigRational {
     type DeepModelTy = Real;
 


### PR DESCRIPTION
- Add staticlib to the list of supported crate types
- Disable support for bigrational in nostd mode (bigrational requires alloc).