### PR TITLE
Fix version parsing of alt-ergo for the free version

### DIFF
--- a/creusot-setup/src/tools.rs
+++ b/creusot-setup/src/tools.rs
@@ -108,8 +108,8 @@ fn detect_why3find_version(why3find: &Path) -> anyhow::Result<String> {
 
 fn detect_altergo_version(altergo: &Path) -> anyhow::Result<String> {
     let version_full = run(Command::new(&altergo).arg("--version"))?;
-    let version = version_full.trim_end().strip_prefix("v").map(String::from);
-    version.ok_or(anyhow!("bad Altergo version: {}", version_full))
+    let version = version_full.trim_end();
+    Ok(version.strip_prefix("v").unwrap_or(version).into())
 }
 
 // helpers: Z3


### PR DESCRIPTION
The free version of alt-ergo that gets pulled with the example flake setup doesn't start with a `v` which made the version detection fail.
depends on #2129 rn, but i could rebase it onto master