### PR TITLE
creusot-std: Use the same dependencies in Rust builds as in Creusot builds by default

### DIFF
--- a/creusot-std-proc/Cargo.toml
+++ b/creusot-std-proc/Cargo.toml
@@ -22,7 +22,8 @@ proc-macro = true
 # rustc flag `cfg(creusot)`, which is a different thing from crate features).
 # This feature is enabled by `cargo creusot`,
 # and also by rust-analyzer during development (see `.vscode/settings.json`).
-creusot = ["dep:uuid", "dep:pearlite-syn", "proc-macro2/span-locations"]
+creusot = ["creusot-deps", "proc-macro2/span-locations"]
+creusot-deps = ["dep:uuid", "dep:pearlite-syn"]
 
 [dependencies]
 quote = "1.0"

--- a/creusot-std/Cargo.toml
+++ b/creusot-std/Cargo.toml
@@ -25,9 +25,10 @@ creusot-std-proc = { path = "../creusot-std-proc", version = "0.12.0-dev" }
 # Must be disabled to build with stable Rust.
 # May be enabled to build with nightly Rust.
 nightly = []
-creusot = ["creusot-std-proc/creusot"]
+creusot = ["creusot-deps", "creusot-std-proc/creusot"]
+creusot-deps = ["creusot-std-proc/creusot-deps"]
 sc-drf = []
-default = ["std"]
+default = ["std", "creusot-deps"]
 std = ["dep:num-rational"]
 
 [lints.rust]


### PR DESCRIPTION
Fix #2134 by including the same dependencies in `cargo build` as in `cargo creusot`.

I am still looking for a fix that lets `cargo build` not build useless things.

To recover the old behavior, set `default-features = false`

```toml
[dependencies]
creusot-std = { version = "0.12.0-dev", default-features = false, features = ["std"] }
```