### PR TITLE
Add version numbers in creusot_why3.conf

### DIFF
--- a/creusot-install/creusot_why3.conf
+++ b/creusot-install/creusot_why3.conf
@@ -1,20 +1,24 @@
 [prover]
 name = "Alt-Ergo"
+version = "2.6.2"
 command = "alt-ergo --timelimit %.t %f"
 driver = "alt_ergo_26"
 
 [prover]
 name = "Z3"
+version = "4.15.3"
 command = "z3 -smt2 -T:%t sat.random_seed=42 nlsat.randomize=false smt.random_seed=42 -st %f"
 driver = "z3_4_12"
 
 [prover]
 name = "CVC5"
+version = "1.3.1"
 command = "cvc5 --stats-internal --tlimit=%T %f"
 driver = "cvc5"
 
 [prover]
 name = "CVC4"
+version = "1.8"
 command = "cvc4 --stats --tlimit=%T --lang=smt2 %f"
 driver = "cvc4_17"
 

--- a/examples/iterators/06_map_precond/why3session.xml
+++ b/examples/iterators/06_map_precond/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="2" name="Z3" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="4" name="CVC5" version="" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="2" name="Z3" version="4.15.3" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="4" name="CVC5" version="1.3.1" timelimit="5" steplimit="0" memlimit="1000"/>
 <file format="coma" proved="true">
 <path name=".."/><path name="06_map_precond.coma"/>
 <theory name="M_common__trait_ExactSizeIterator__is_empty" proved="true">

--- a/examples/iterators/07_fuse/why3session.xml
+++ b/examples/iterators/07_fuse/why3session.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC5" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="0.2" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC5" version="1.3.1" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="0.2" steplimit="0" memlimit="1000"/>
 <file format="coma" proved="true">
 <path name=".."/><path name="07_fuse.coma"/>
 <theory name="M_common__trait_ExactSizeIterator__is_empty" proved="true">

--- a/examples/iterators/17_filter/why3session.xml
+++ b/examples/iterators/17_filter/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Alt-Ergo" version="" timelimit="0.2" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC4" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="3" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Alt-Ergo" version="2.6.2" timelimit="0.2" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC4" version="1.8" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="3" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma" proved="true">
 <path name=".."/><path name="17_filter.coma"/>
 <theory name="M_common__trait_ExactSizeIterator__is_empty" proved="true">

--- a/tests/creusot-std/creusot-std/why3session.xml
+++ b/tests/creusot-std/creusot-std/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="0.2" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="0.2" steplimit="0" memlimit="1000"/>
 <file format="coma" proved="true">
 <path name=".."/><path name="creusot-std.coma"/>
 <theory name="M_cell__permcell__impl_PermCell_T__take" proved="true">

--- a/tests/should_fail/bug/01_resolve_unsoundness/why3session.xml
+++ b/tests/should_fail/bug/01_resolve_unsoundness/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="4" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="6" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="4" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="6" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="01_resolve_unsoundness.coma"/>
 <theory name="M_make_vec_of_size">

--- a/tests/should_fail/bug/1204/why3session.xml
+++ b/tests/should_fail/bug/1204/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="5" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="1204.coma"/>
 <theory name="M_evil" proved="true">

--- a/tests/should_fail/bug/2054-b/why3session.xml
+++ b/tests/should_fail/bug/2054-b/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Alt-Ergo" version="" timelimit="5" steplimit="0" memlimit="1000"/>
-<prover id="2" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Alt-Ergo" version="2.6.2" timelimit="5" steplimit="0" memlimit="1000"/>
+<prover id="2" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="2054-b.coma"/>
 <theory name="M_g">

--- a/tests/should_fail/bug/222/why3session.xml
+++ b/tests/should_fail/bug/222/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="6" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="6" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="222.coma"/>
 <theory name="M_trait_A__is_true">

--- a/tests/should_fail/bug/492/why3session.xml
+++ b/tests/should_fail/bug/492/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="5" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="5" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="492.coma"/>
 <theory name="M_reborrow_tuple" proved="true">

--- a/tests/should_fail/bug/692/why3session.xml
+++ b/tests/should_fail/bug/692/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="6" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="6" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="692.coma"/>
 <theory name="M_incorrect">

--- a/tests/should_fail/bug/695/why3session.xml
+++ b/tests/should_fail/bug/695/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="4" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="6" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="4" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="6" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="695.coma"/>
 <theory name="M_inversed_if" proved="true">

--- a/tests/should_fail/bug/869/why3session.xml
+++ b/tests/should_fail/bug/869/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="869.coma"/>
 <theory name="M_unsound">

--- a/tests/should_fail/bug/878/why3session.xml
+++ b/tests/should_fail/bug/878/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="878.coma"/>
 <theory name="M_test">

--- a/tests/should_fail/bug/specialize/why3session.xml
+++ b/tests/should_fail/bug/specialize/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="5" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="7" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="5" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="7" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="specialize.coma"/>
 <theory name="M_f">

--- a/tests/should_fail/bug/subregion/why3session.xml
+++ b/tests/should_fail/bug/subregion/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="5" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="5" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="subregion.coma"/>
 <theory name="M_list_reversal_h">

--- a/tests/should_fail/const_default/why3session.xml
+++ b/tests/should_fail/const_default/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="const_default.coma"/>
 <theory name="M_nat">

--- a/tests/should_fail/final_borrows/why3session.xml
+++ b/tests/should_fail/final_borrows/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="0.5" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="0.5" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="final_borrows.coma"/>
 <theory name="M_call_changes_prophecy">

--- a/tests/should_fail/generic_deref_ghost/why3session.xml
+++ b/tests/should_fail/generic_deref_ghost/why3session.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="generic_deref_ghost.coma"/>
 <theory name="M_bad">

--- a/tests/should_fail/generic_deref_snap/why3session.xml
+++ b/tests/should_fail/generic_deref_snap/why3session.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="generic_deref_snap.coma"/>
 <theory name="M_bad">

--- a/tests/should_fail/ignore_overflow/why3session.xml
+++ b/tests/should_fail/ignore_overflow/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="ignore_overflow.coma"/>
 <theory name="M_f">

--- a/tests/should_fail/impl_trait/why3session.xml
+++ b/tests/should_fail/impl_trait/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="impl_trait.coma"/>
 <theory name="M_main">

--- a/tests/should_fail/opaque_unproveable/why3session.xml
+++ b/tests/should_fail/opaque_unproveable/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="4" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="6" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="4" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="6" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="opaque_unproveable.coma"/>
 <theory name="M_test">

--- a/tests/should_fail/terminates/incorrect_variant/why3session.xml
+++ b/tests/should_fail/terminates/incorrect_variant/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="0.5" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="0.5" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="incorrect_variant.coma"/>
 <theory name="M_incorrect_loop_variant">

--- a/tests/should_fail/traits/17_impl_refinement/why3session.xml
+++ b/tests/should_fail/traits/17_impl_refinement/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="4" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="4" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="17_impl_refinement.coma"/>
 <theory name="M_impl_ReqFalse_for_unit__need_false" proved="true">

--- a/tests/should_fail/type_invariants/borrows/why3session.xml
+++ b/tests/should_fail/type_invariants/borrows/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="borrows.coma"/>
 <theory name="M_dec" proved="true">

--- a/tests/should_fail/type_invariants/partial_instance/why3session.xml
+++ b/tests/should_fail/type_invariants/partial_instance/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="partial_instance.coma"/>
 <theory name="M_evil" proved="true">

--- a/tests/should_fail/unsupported/hash_map/why3session.xml
+++ b/tests/should_fail/unsupported/hash_map/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="hash_map.coma"/>
 <theory name="M_impl_Foo__add">

--- a/tests/should_fail/wrong_permissions/why3session.xml
+++ b/tests/should_fail/wrong_permissions/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="wrong_permissions.coma"/>
 <theory name="M_unknown_permcell_permission">

--- a/tests/should_fail/zst/why3session.xml
+++ b/tests/should_fail/zst/why3session.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "https://www.why3.org/why3session.dtd">
 <why3session shape_version="6">
-<prover id="0" name="CVC4" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="1" name="Alt-Ergo" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="2" name="Z3" version="" timelimit="1" steplimit="0" memlimit="1000"/>
-<prover id="3" name="CVC5" version="" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="0" name="CVC4" version="1.8" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="1" name="Alt-Ergo" version="2.6.2" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="2" name="Z3" version="4.15.3" timelimit="1" steplimit="0" memlimit="1000"/>
+<prover id="3" name="CVC5" version="1.3.1" timelimit="1" steplimit="0" memlimit="1000"/>
 <file format="coma">
 <path name=".."/><path name="zst.coma"/>
 <theory name="M_zst_pointers_may_be_equal">


### PR DESCRIPTION
Temporary fix for Why3 IDE to be reverted when empty version strings are allowed (#2141).

Fix #2136 