### PR TITLE
Reduce repetition of version numbers

### DIFF
--- a/creusot-args/Cargo.toml
+++ b/creusot-args/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-args"
-version = "0.13.0-dev"
+version.workspace = true
 edition = "2024"
 publish = false
 

--- a/creusot-rustc/Cargo.toml
+++ b/creusot-rustc/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 serde_json = { version = "1.0" }
-creusot = { path = "../creusot", version = "0.13.0-dev" }
+creusot = { path = "../creusot" }
 env_logger = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 creusot-args = { path = "../creusot-args" }

--- a/creusot-setup/Cargo.toml
+++ b/creusot-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "creusot-setup"
-version = "0.13.0-dev"
+version.workspace = true
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
There are two left in the dependencies of creusot-std and creusot-std-proc, but those need to be explicit for `cargo release` to work.