### PR TITLE
pearlite-syn: Fix printing of TermSeq

### DIFF
--- a/pearlite-syn/src/term.rs
+++ b/pearlite-syn/src/term.rs
@@ -2099,7 +2099,7 @@ pub(crate) mod printing {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             self.seq_token.to_tokens(tokens);
             self.bang_token.to_tokens(tokens);
-            self.terms.to_tokens(tokens);
+            self.bracket_token.surround(tokens, |tokens| self.terms.to_tokens(tokens));
         }
     }
 


### PR DESCRIPTION
This broke using `seq!` in extern specs. Example upcoming in another PR.