### PR TITLE
Disjointness of shared permissions

### DIFF
--- a/creusot-std/src/cell/permcell.rs
+++ b/creusot-std/src/cell/permcell.rs
@@ -4,10 +4,7 @@
 //! track of the logical value.
 
 use crate::{
-    ghost::{
-        NotObjective,
-        perm::{Perm, PermTarget},
-    },
+    ghost::{NotObjective, Perm, perm::PermTarget},
     prelude::*,
 };
 use core::{cell::UnsafeCell, marker::PhantomData};

--- a/creusot-std/src/ghost.rs
+++ b/creusot-std/src/ghost.rs
@@ -24,7 +24,7 @@ mod shared;
 
 pub use self::{
     fn_ghost::{FnGhost, FnGhostWrapper},
-    perm::PermTarget,
+    perm::Perm,
     shared::GhostShared,
 };
 

--- a/creusot-std/src/ghost/perm.rs
+++ b/creusot-std/src/ghost/perm.rs
@@ -5,12 +5,27 @@ use crate::prelude::*;
 #[cfg(creusot)]
 use crate::resolve::structural_resolve;
 
+/// Trait for the types that can be used in a [`Perm`].
 pub trait PermTarget {
+    /// Value managed by the type.
+    ///
+    /// For example, a pointer `*const T` manages a value of type `T`.
+    ///
+    /// In practice, you will use a borrow `&'a T` here, to allow for unsized
+    /// types.
     type Value<'a>
     where
         Self: 'a;
+
+    /// Variance, objectiveness and sizeness parametrization for the [`Perm`].
+    ///
+    /// This type is used to force certain auto-traits to be
+    /// implemented on the [`Perm`] object (or not!). See [this trait
+    /// implementation](crate::cell::PermCell::PermPayload) for `PermCell` for
+    /// an example. You may also add a type like `[bool]` to force unsizeness.
     type PermPayload: ?Sized;
 
+    /// Logical function that describes the behavior of [`Perm::disjoint_lemma`].
     #[logic(open, inline)]
     fn is_disjoint(
         &self,

--- a/creusot-std/src/ghost/perm.rs
+++ b/creusot-std/src/ghost/perm.rs
@@ -83,6 +83,49 @@ impl<C: ?Sized + PermTarget> Perm<C> {
         dead
     }
 
+    /// If two permissions have different values, then they must be disjoint.
+    ///
+    /// This is a ghost lemma: calling it has no operational effects, but allows
+    /// Creusot to deduce things based on the ownership of the arguments.
+    ///
+    /// Note that disjointness is defined with the `is_disjoint` logical
+    /// function. In particular, pointers to ZST are always disjoint, and may
+    /// indeed have different pointed-to values (for example, [`Snapshot`] or
+    /// [`Ghost`] values).
+    ///
+    /// If you have a mutable borrow to one of the permissions, you should use
+    /// [`Self::disjoint_lemma`] instead.
+    ///
+    /// This lemma can also be used the other way: if you have two pointer
+    /// permissions (with non-ZST values) with the same ward, then their values
+    /// are equal.
+    ///
+    /// # Example
+    ///
+    /// ```rust,creusot
+    /// use creusot_std::prelude::*;
+    /// use creusot_std::ghost::perm::Perm;
+    ///
+    /// #[requires(*perm1.ward() == p1 && *perm2.ward() == p2)]
+    /// fn foo(
+    ///     (p1, perm1): (*const i32, Ghost<&Perm<*const i32>>),
+    ///     (p2, perm2): (*const i32, Ghost<&Perm<*const i32>>)) {
+    ///     if p1 == p2 {
+    ///         let v1 = *unsafe { Perm::as_ref(p1, perm1) };
+    ///         let v2 = *unsafe { Perm::as_ref(p1, perm2) };
+    ///         // If both pointers are equal, it does not matter which permission
+    ///         // we read the value from
+    ///         ghost! { perm1.disjoint_lemma_shared(*perm2) };
+    ///         assert!(v1 == v2);
+    ///     }
+    /// }
+    /// ```
+    #[trusted]
+    #[check(ghost)]
+    #[ensures(self.val() != other.val() ==> self.ward().is_disjoint(self.val(), other.ward(), other.val()))]
+    #[allow(unused_variables)]
+    pub fn disjoint_lemma_shared(&self, other: &Self) {}
+
     /// If one owns two permissions in ghost code, then they correspond to different containers.
     #[trusted]
     #[check(ghost)]

--- a/creusot-std/src/std/ptr.rs
+++ b/creusot-std/src/std/ptr.rs
@@ -526,6 +526,10 @@ impl<T: ?Sized> PermTarget for *const T {
         Self: 'a;
     type PermPayload = (NotObjective, PhantomData<T>, [bool]);
 
+    /// Two pointers to distinct non-empty allocations are disjoint.
+    ///
+    /// Note that this definition also implies that a pointer to a ZST is
+    /// disjoint with itself.
     #[logic(open, inline)]
     fn is_disjoint(&self, self_val: &T, other: &Self, other_val: &T) -> bool {
         pearlite! {

--- a/creusot-std/src/std/ptr.rs
+++ b/creusot-std/src/std/ptr.rs
@@ -4,10 +4,7 @@ pub use self::nonnull::NonNullExt;
 #[cfg(creusot)]
 use crate::std::mem::{align_of_logic, size_of_logic, size_of_val_logic};
 use crate::{
-    ghost::{
-        NotObjective,
-        perm::{Perm, PermTarget},
-    },
+    ghost::{NotObjective, Perm, perm::PermTarget},
     prelude::*,
 };
 use core::marker::PhantomData;

--- a/creusot-std/src/std/sync/atomic.rs
+++ b/creusot-std/src/std/sync/atomic.rs
@@ -1,8 +1,5 @@
 use crate::{
-    ghost::{
-        FnGhost,
-        perm::{Perm, PermTarget},
-    },
+    ghost::{FnGhost, Perm, perm::PermTarget},
     logic::FMap,
     prelude::*,
     std::sync::{

--- a/creusot-std/src/std/sync/atomic_sc.rs
+++ b/creusot-std/src/std/sync/atomic_sc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ghost::{FnGhost, PermTarget, perm::Perm},
+    ghost::{FnGhost, Perm, perm::PermTarget},
     prelude::*,
     std::sync::committer::Committer,
 };

--- a/creusot-std/src/std/sync/committer.rs
+++ b/creusot-std/src/std/sync/committer.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "sc-drf")]
 use crate::std::sync::atomic_sc::ordering::SeqCst;
 use crate::{
-    ghost::{PermTarget, perm::Perm},
+    ghost::{Perm, perm::PermTarget},
     logic::FMap,
     prelude::*,
     std::sync::{


### PR DESCRIPTION
Also reexport `Perm` in the `ghost` module rather than `PermTarget`, as the former is massively more used.