### PR TITLE
Fix bounds of `Int$bits_count$BW` in Coma prelude

### DIFF
--- a/prelude-generator/int.in.coma
+++ b/prelude-generator/int.in.coma
@@ -246,9 +246,9 @@ module Int$bits_count$BW
   use bv.BVConverter_$bits_count$_256
   use mach.int.Int
 
-  constant min_sint_as_BV256 : BV256.t = $min_signed_value$
+  constant min_sint_as_BV256 : BV256.t = BV256.neg ($min_signed_value$ : BV256.t)
   constant max_sint_as_BV256 : BV256.t = $max_signed_value$
-  predicate in_bounds [@inline:trivial] (n:int) = - $min_signed_value$ <= n <= $max_unsigned_value$
+  predicate in_bounds [@inline:trivial] (n:int) = - $min_signed_value$ <= n <= $max_signed_value$
 
   function to_BV256 (x: t) : BV256.t = stoBig x
   function of_BV256 (x: BV256.t) : t = toSmall x


### PR DESCRIPTION
`Int$bits_count$BW` was using the unsigned max value instead of the signed one in predicate `in_bounds`. Moreover `min_sint_as_BV256` was missing a minus sign.

The fixes were verified by regenerating the prelude and reading `target/creusot/packages/creusot/creusot/int.coma`.

Before:

    constant min_sint_as_BV256 : BV256.t = 0x80
    constant max_sint_as_BV256 : BV256.t = 0x7F
    predicate in_bounds [@inline:trivial] (n:int) = - 0x80 <= n <= 0xFF

After:

    constant min_sint_as_BV256 : BV256.t = BV256.neg (0x80 : BV256.t)
    constant max_sint_as_BV256 : BV256.t = 0x7F
    predicate in_bounds [@inline:trivial] (n:int) = - 0x80 <= n <= 0x7F

In practice, these errors did not seem to have any impact on Creusot, because:

- `min_sint_as_BV256` is used in expressions which also checked the right bounds. For example for `add`, the second part of the expression was always false, and the first part (with `to_int`) computed the right expression to ensure there was no overflow:

      { [@expl:arithmetic overflow]
      - two_power_sizem1 <= to_int a + to_int b < two_power_sizem1 \/
      let r = BV256.add (to_BV256 a) (to_BV256 b) in
        (BV256.sle min_sint_as_BV256 r /\ BV256.sle r max_sint_as_BV256) }

- `in_bounds` is only used by functions `add_with_overflow`, `sub_with_overflow` and `mul_with_overflow`. For these functions to be used in the generated Coma files, the Rust file has to use intrisics with the same name, which are in practice only exposed in the standard library, under feature flag `core_intrinsics`. And Creusot directly models Rust functions `i8::overflowing_add`, `i8::overflowing_sub`... without using these intrinsics. So the fact that `Int8BW.in_bounds 0xFF` incorrectly returned `true` does not seem to have any consequence on the soundness of any Rust code using Creusot.

_Disclaimer of AI usage:_ This error was found by Claude Code running model Sonnet 4.6 while reviewing another PR I did (#2185). I prompted "There was an error in prelude.coma. I am fixing it. What other errors?". I wrote the fix myself, and asked Claude Code to write a test. It failed to write a test which failed with the current version of Creusot, and understanding why it failed led me to write the explanation above. I did not use an AI tool to write this description.