### PR TITLE
Update toolchain to nightly-2026-07-29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-creusot"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "creusot"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "creusot-args",
  "creusot-metadata",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-args"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "clap",
  "serde",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-dev-config"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "anyhow",
  "creusot-setup",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-install"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -339,14 +339,14 @@ dependencies = [
 
 [[package]]
 name = "creusot-metadata"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "creusot-rustc"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "creusot",
  "creusot-args",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-setup"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "anyhow",
  "creusot-args",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-std"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "creusot-std-proc",
  "num-rational",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "creusot-std-proc"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "pearlite-syn",
  "proc-macro2",
@@ -889,7 +889,7 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pearlite-syn"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "prelude-generator"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "anyhow",
  "creusot-setup",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "why3"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "indexmap",
  "itertools",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "why3tests"
-version = "0.13.0"
+version = "0.14.0-dev"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0-dev"
 documentation = "https://doc.creusot.rs/creusot_std/"
 readme = "README.md"
 keywords = ["verification"]

--- a/creusot-metadata/src/decoder.rs
+++ b/creusot-metadata/src/decoder.rs
@@ -6,7 +6,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::{CrateNum, DefId, DefIndex, DefPathHash, StableCrateId};
 use rustc_middle::{
     implement_ty_decoder,
-    ty::{Ty, TyCtxt, codec::TyDecoder},
+    ty::{InternerDecoder, Ty, TyCtxt, codec::TyDecoder},
 };
 use rustc_serialize::{
     Decodable, Decoder,
@@ -166,10 +166,6 @@ impl<'a, 'tcx> TyDecoder<'tcx> for MetadataDecoder<'a, 'tcx> {
     // Whether crate-local information can be cleared while encoding
     const CLEAR_CROSS_CRATE: bool = true;
 
-    fn interner(&self) -> TyCtxt<'tcx> {
-        self.tcx
-    }
-
     fn cached_ty_for_shorthand<F>(&mut self, shorthand: usize, or_insert_with: F) -> Ty<'tcx>
     where
         F: FnOnce(&mut Self) -> Ty<'tcx>,
@@ -196,6 +192,14 @@ impl<'a, 'tcx> TyDecoder<'tcx> for MetadataDecoder<'a, 'tcx> {
 
     fn decode_alloc_id(&mut self) -> rustc_middle::mir::interpret::AllocId {
         unimplemented!("decode_alloc_id")
+    }
+}
+
+impl<'a, 'tcx> InternerDecoder for MetadataDecoder<'a, 'tcx> {
+    type Interner = TyCtxt<'tcx>;
+
+    fn interner(&self) -> TyCtxt<'tcx> {
+        self.tcx
     }
 }
 

--- a/creusot-std-proc/Cargo.toml
+++ b/creusot-std-proc/Cargo.toml
@@ -28,7 +28,7 @@ creusot-deps = ["dep:uuid", "dep:pearlite-syn"]
 [dependencies]
 quote = "1.0"
 uuid = { version = "1.12", features = ["v4"], optional = true }
-pearlite-syn = { version = "0.13.0", path = "../pearlite-syn", features = ["full"], optional = true }
+pearlite-syn = { version = "0.14.0-dev", path = "../pearlite-syn", features = ["full"], optional = true }
 syn = { version = "2.0", features = ["parsing", "full", "visit", "visit-mut"] }
 proc-macro2 = { version = "1.0" }
 

--- a/creusot-std-proc/src/creusot/extern_spec.rs
+++ b/creusot-std-proc/src/creusot/extern_spec.rs
@@ -222,6 +222,19 @@ impl FlatSpec {
             paren_token: Paren::default(),
             args,
         });
+        // Rust intrinsics marked with `#[rustc_comptime]` can only be used in `const` blocks
+        let call = if has_comptime(&attrs) {
+            Expr::Const(ExprConst {
+                attrs: Vec::new(),
+                const_token: Token![const](self.span),
+                block: Block {
+                    brace_token: Default::default(),
+                    stmts: vec![Stmt::Expr(call, None)],
+                },
+            })
+        } else {
+            call
+        };
 
         match self.kind {
             FlatSpecKind::Fn { body, doc_item_name, .. } => {
@@ -415,6 +428,10 @@ fn filter_erasure(attrs: &[Attribute]) -> Vec<Attribute> {
         })
         .cloned()
         .collect::<Vec<_>>()
+}
+
+fn has_comptime(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| attr.path().is_ident("rustc_comptime"))
 }
 
 enum SelfTypeKind {

--- a/creusot-std/Cargo.toml
+++ b/creusot-std/Cargo.toml
@@ -18,7 +18,7 @@ categories.workspace = true
 num-rational = { version = "0.4", optional = true }
 
 [dependencies]
-creusot-std-proc = { path = "../creusot-std-proc", version = "0.13.0" }
+creusot-std-proc = { path = "../creusot-std-proc", version = "0.14.0-dev" }
 
 [features]
 # Enabled by creusot.

--- a/creusot-std/src/std/intrinsics.rs
+++ b/creusot-std/src/std/intrinsics.rs
@@ -24,11 +24,13 @@ extern_spec! {
             // This intrinsic is used by the constant `SizedTypeProperties::SIZE`
             #[check(terminates)]
             #[ensures(result@ == size_of_logic::<T>())]
+            #[rustc_comptime]
             fn size_of<T>() -> usize;
 
             // This intrinsic is used by the constant `SizedTypeProperties::ALIGN`
             #[check(terminates)]
             #[ensures(result == align_of_logic::<T>())]
+            #[rustc_comptime]
             fn align_of<T>() -> usize;
         }
     }

--- a/creusot/src/analysis.rs
+++ b/creusot/src/analysis.rs
@@ -12,7 +12,7 @@ use borrows::*;
 use liveness_no_drop::*;
 use not_final_places::NotFinalPlaces;
 use rustc_abi::{FieldIdx, VariantIdx};
-use rustc_borrowck::consumers::{BodyWithBorrowckFacts, TwoPhaseActivation};
+use rustc_borrowck::consumers::{BodyWithBorrowckFacts, TwoPhaseActivation::ActivatedAt};
 use rustc_hir::{
     HirId,
     def_id::{DefId, LocalDefId},
@@ -21,7 +21,7 @@ use rustc_index::{Idx as _, bit_set::MixedBitSet};
 use rustc_macros::{TyDecodable, TyEncodable};
 use rustc_middle::{
     mir::{self, BasicBlock, Local, Location, Place, traversal},
-    ty::{self, TyCtxt, TypingEnv, Unnormalized},
+    ty::{self, TyCtxt, TypingEnv},
 };
 use rustc_mir_dataflow::{
     Analysis as _, ResultsCursor,
@@ -81,12 +81,32 @@ pub struct BorrowData<'tcx> {
 }
 
 impl<'tcx> BorrowData<'tcx> {
-    pub fn new() -> Self {
+    pub fn new(borrow_set: &rustc_borrowck::consumers::BorrowSet<'tcx>) -> Self {
+        // Collect two-phase borrows
+        let mut two_phases_created = HashSet::new();
+        let mut two_phases_activated: HashMap<
+            Orphan<Location>,
+            Vec<(Place<'tcx>, Place<'tcx>, BorrowKind)>,
+        > = HashMap::new();
+
+        for borrow in borrow_set.iter() {
+            let ActivatedAt(activated) = borrow.activation_location() else {
+                continue;
+            };
+            two_phases_created.insert(Orphan(borrow.reserve_location()));
+            // The `BorrowKind` (third component of the triple) is a dummy value to be set by the analysis.
+            two_phases_activated.entry(Orphan(activated)).or_default().push((
+                borrow.assigned_place(),
+                borrow.borrowed_place(),
+                BorrowKind::Mut,
+            ));
+        }
+
         BorrowData {
             resolved_at: HashMap::new(),
             resolved_between_blocks: HashMap::new(),
-            two_phases_created: HashSet::new(),
-            two_phases_activated: HashMap::new(),
+            two_phases_created,
+            two_phases_activated,
             final_borrows: HashMap::new(),
         }
     }
@@ -300,7 +320,7 @@ impl<'a, 'tcx> Analysis<'a, 'tcx> {
             not_final_places: NotFinalPlaces::new(tcx, &body.body)
                 .iterate_to_fixpoint(tcx, &body.body, None)
                 .into_results_cursor(&body.body),
-            data: BorrowData::new(),
+            data: BorrowData::new(&body.borrow_set),
             body_specs,
         }
     }
@@ -447,7 +467,6 @@ impl<'a, 'tcx> Analysis<'a, 'tcx> {
             }
             let tcx = self.tcx();
             let ty = pl.ty(&self.body().local_decls, tcx);
-            let ty = tcx.normalize_erasing_regions(self.typing_env, Unnormalized::new(ty));
             use TyKind::*;
             match ty.ty.kind() {
                 Adt(adt_def, subst) => {
@@ -514,7 +533,7 @@ impl<'a, 'tcx> Analysis<'a, 'tcx> {
                 | Foreign(_)
                 | Str
                 | RawPtr(_, _)
-                | Alias(_)
+                | Alias(_, _)
                 | Param(_)
                 | Bound(_, _)
                 | Placeholder(_)
@@ -678,7 +697,7 @@ impl<'a, 'tcx> Analysis<'a, 'tcx> {
     }
 
     fn analyze_statement(&mut self, statement: &mir::Statement<'tcx>, loc: Location) {
-        self.activate_two_phases(loc);
+        self.update_final_two_phases(loc);
         use mir::StatementKind::*;
         match statement.kind {
             Assign(box (pl, ref rvalue)) => {
@@ -757,7 +776,7 @@ impl<'a, 'tcx> Analysis<'a, 'tcx> {
     }
 
     fn analyze_terminator(&mut self, terminator: &mir::Terminator<'tcx>, mut loc: Location) {
-        self.activate_two_phases(loc);
+        self.update_final_two_phases(loc);
         use mir::TerminatorKind::*;
         match terminator.kind {
             Return => {
@@ -781,7 +800,7 @@ impl<'a, 'tcx> Analysis<'a, 'tcx> {
                 else {
                     self.fatal_error(fn_span, "unsupported function call type").emit()
                 };
-                if let Some(ty) = subst.get(1)
+                if let Some(ty) = subst.no_bound_vars().unwrap().get(1)
                     && let ty::GenericArgKind::Type(ty) = ty.kind()
                     && let &ty::TyKind::Closure(def_id, _) = ty.kind()
                     && is_snapshot_closure(self.tcx(), def_id)
@@ -835,31 +854,21 @@ impl<'a, 'tcx> Analysis<'a, 'tcx> {
         self.store_resolved_before(loc);
     }
 
-    /// Store the location if it is a two-phase borrow creation.
-    fn is_two_phases(&mut self, loc: Location) -> bool {
-        let borrows = self.resolver.borrow_set();
-        let is_two_phases = borrows.location_map().get(&loc).iter().any(|borrow| {
-            matches!(borrow.activation_location(), TwoPhaseActivation::ActivatedAt(_))
-        });
-        if is_two_phases {
-            self.data.two_phases_created.insert(Orphan(loc));
-        }
-        is_two_phases
+    fn is_two_phases(&self, loc: Location) -> bool {
+        self.data.two_phases_created.contains(&Orphan(loc))
     }
 
-    /// Collect two-phase borrows activated at this location.
-    fn activate_two_phases(&mut self, loc: Location) {
+    /// Record which two-phase borrows activated at this location are final.
+    fn update_final_two_phases(&mut self, loc: Location) {
         let not_final_places = &mut self.not_final_places;
-        let borrows = self.resolver.borrow_set();
-        let mut activations = Vec::new();
-        for i in borrows.activation_map().get(&loc).iter().flat_map(|is| is.iter()) {
-            let borrow = &borrows[*i];
-            let borrowed = borrow.borrowed_place();
-            let is_final = NotFinalPlaces::is_final_at(not_final_places, &borrowed, loc);
-            activations.push((borrow.assigned_place(), borrowed, is_final))
-        }
-        if !activations.is_empty() {
-            self.data.two_phases_activated.insert(Orphan(loc), activations);
+        for (_, borrowed, is_final) in self
+            .data
+            .two_phases_activated
+            .get_mut(&Orphan(loc))
+            .iter_mut()
+            .flat_map(|is| is.iter_mut())
+        {
+            *is_final = NotFinalPlaces::is_final_at(not_final_places, borrowed, loc);
         }
     }
 
@@ -911,18 +920,20 @@ pub(crate) fn run_with_specs<'tcx>(
     let tree = fmir::ScopeTree::build(&body.body, &body_locals.locals);
     let clos_subst = tcx.is_closure_like(def_id).then(|| {
         let loc = body_locals.vars.get_index(1).unwrap();
-        let ty_env = tcx.type_of(def_id).instantiate_identity().skip_normalization();
-        let TyKind::Closure(_, subst) = ty_env.kind() else { unreachable!() };
+        let closure_kind = {
+            let TyKind::Closure(_, subst) =
+                tcx.type_of(def_id).instantiate_identity().skip_normalization().kind()
+            else {
+                unreachable!()
+            };
+            subst.as_closure().kind()
+        };
         let self_ = Term::var(*loc.0, loc.1.ty);
-        let self_ = match subst.as_closure().kind() {
+        let self_ = match closure_kind {
             ClosureKind::Fn => self_.clone().shr_deref(),
             ClosureKind::FnMut => self_.clone().cur(),
             ClosureKind::FnOnce => self_.clone(),
         };
-        assert_eq!(
-            ctx.erase_and_anonymize_regions(self_.ty),
-            ctx.erase_and_anonymize_regions(ty_env)
-        );
         ClosSubst::pre_or_cur(tcx, def_id.expect_local(), self_)
     });
     let analysis_env = AnalysisEnv::new(tree, corenamer, &body_locals.locals, clos_subst);

--- a/creusot/src/analysis/borrows.rs
+++ b/creusot/src/analysis/borrows.rs
@@ -72,8 +72,7 @@ impl<'a, 'mir, 'tcx> Borrows<'a, 'mir, 'tcx> {
     fn kill_borrows_on_place(&self, trans: &mut impl GenKill<BorrowIndex>, place: Place<'tcx>) {
         let other_borrows_of_local = self
             .borrow_set
-            .local_map()
-            .get(&place.local)
+            .borrows_on_local(place.local)
             .into_iter()
             .flat_map(|bs| bs.iter())
             .copied();
@@ -113,7 +112,7 @@ impl<'tcx> Analysis<'tcx> for Borrows<'_, '_, 'tcx> {
 
     fn bottom_value(&self, _: &mir::Body<'tcx>) -> Self::Domain {
         // bottom = nothing is reserved or activated yet;
-        MixedBitSet::new_empty(self.borrow_set.location_map().len())
+        MixedBitSet::new_empty(self.borrow_set.len())
     }
 
     fn initialize_start_block(&self, _: &mir::Body<'tcx>, _: &mut Self::Domain) {
@@ -137,16 +136,13 @@ impl<'tcx> Analysis<'tcx> for Borrows<'_, '_, 'tcx> {
                         self.body,
                         &self.borrow_set.locals_state_at_exit(),
                     ) {
-                        let index = self
-                            .borrow_set
-                            .location_map()
-                            .get_index_of(&location)
-                            .map(BorrowIndex::from)
-                            .unwrap_or_else(|| {
+                        for &index in
+                            self.borrow_set.borrows_at_location(&location).unwrap_or_else(|| {
                                 panic!("could not find BorrowIndex for location {:?}", location);
-                            });
-
-                        trans.gen_(index);
+                            })
+                        {
+                            trans.gen_(index);
+                        }
                     }
                 }
 

--- a/creusot/src/analysis/resolve.rs
+++ b/creusot/src/analysis/resolve.rs
@@ -87,10 +87,6 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         Resolver { live, uninit, borrows, borrow_set, move_data, body, tcx }
     }
 
-    pub(super) fn borrow_set(&self) -> &BorrowSet<'tcx> {
-        self.borrow_set
-    }
-
     /// Get the set of frozen move paths corresponding to the given set of borrows.
     /// If both components of a tuple are borrowed, then each component is
     /// considered frozen independently, and not the parent move path.
@@ -151,7 +147,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 // and factor what can be factored.
                 self.uninit.seek_before_primary_effect(loc);
                 uninit = self.uninit.get().clone();
-                for mi in &self.move_data().loc_map[loc] {
+                for mi in &self.move_data().move_out_loc_map[loc] {
                     let path = mi.move_path_index(self.move_data());
                     on_all_children_bits(self.move_data(), path, |mpi| {
                         uninit.insert(mpi);
@@ -195,10 +191,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         self.body,
                         &self.borrow_set.locals_state_at_exit(),
                     ) {
-                        let index = BorrowIndex::from(
-                            self.borrow_set.location_map().get_index_of(&loc).unwrap(),
-                        );
-                        borrows.insert(index);
+                        for &index in self.borrow_set.borrows_at_location(&loc).unwrap() {
+                            borrows.insert(index);
+                        }
                     }
                 }
             }

--- a/creusot/src/backend/clone_map.rs
+++ b/creusot/src/backend/clone_map.rs
@@ -25,6 +25,7 @@ use rustc_middle::ty::{
     Unnormalized,
 };
 use rustc_span::Span;
+use rustc_type_ir::IsRigid;
 use why3::{
     Exp, Ident, Name, QName, Symbol,
     coma::{Defn, Expr, Param, Prototype},
@@ -67,17 +68,20 @@ pub(crate) trait Namer<'tcx> {
         self.dependency(Dependency::Item(def_id, subst)).ident()
     }
 
-    fn def_ty(&self, def_id: DefId, subst: GenericArgsRef<'tcx>) -> Name {
-        let ty = match self.tcx().def_kind(def_id) {
-            DefKind::Enum | DefKind::Struct | DefKind::Union => {
-                Ty::new_adt(self.tcx(), self.tcx().adt_def(def_id), subst)
-            }
-            DefKind::AssocTy => Ty::new_projection(self.tcx(), def_id, subst),
-            DefKind::Closure => Ty::new_closure(self.tcx(), def_id, subst),
-            DefKind::OpaqueTy => Ty::new_opaque(self.tcx(), def_id, subst),
-            k => unreachable!("{k:?}"),
-        };
-        self.ty(ty)
+    fn ty_adt(&self, def_id: DefId, subst: GenericArgsRef<'tcx>) -> Name {
+        self.ty(Ty::new_adt(self.tcx(), self.tcx().adt_def(def_id), subst))
+    }
+
+    fn ty_projection(&self, rigid: IsRigid, def_id: DefId, subst: GenericArgsRef<'tcx>) -> Name {
+        self.ty(Ty::new_projection(self.tcx(), rigid, def_id, subst))
+    }
+
+    fn ty_closure(&self, def_id: DefId, subst: GenericArgsRef<'tcx>) -> Name {
+        self.ty(Ty::new_closure(self.tcx(), def_id, subst))
+    }
+
+    fn ty_opaque(&self, rigid: IsRigid, def_id: DefId, subst: GenericArgsRef<'tcx>) -> Name {
+        self.ty(Ty::new_opaque(self.tcx(), rigid, def_id, subst))
     }
 
     fn ty(&self, ty: Ty<'tcx>) -> Name {
@@ -93,7 +97,7 @@ pub(crate) trait Namer<'tcx> {
     fn field(&self, def_id: DefId, subst: GenericArgsRef<'tcx>, ix: FieldIdx) -> Ident {
         let node = match self.tcx().def_kind(def_id) {
             DefKind::Closure => {
-                self.def_ty(def_id, subst);
+                self.ty_closure(def_id, subst);
                 Dependency::ClosureAccessor(def_id, subst, ix.as_u32())
             }
             DefKind::Struct => {
@@ -433,7 +437,7 @@ impl<'a, 'tcx> Dependencies<'a, 'tcx> {
 
     /// Get a name for the `Namespace` type, _without_ adding it to the list of dependencies.
     pub(crate) fn namespace_ty(&self) -> Name {
-        self.names.def_ty(Intrinsic::Namespace.get(self.names.ctx), GenericArgsRef::default())
+        self.names.ty_adt(Intrinsic::Namespace.get(self.names.ctx), GenericArgsRef::default())
     }
 
     pub(crate) fn provide_deps(mut self, ctx: &Why3Generator<'tcx>) -> (Vec<Decl>, Setters) {

--- a/creusot/src/backend/clone_map/elaborator.rs
+++ b/creusot/src/backend/clone_map/elaborator.rs
@@ -127,10 +127,11 @@ fn builtin_clone_posts<'tcx>(
         .map(|(i, field_ty)| {
             let self_i = self_val.clone().proj(i.into(), field_ty);
             let result_i = result_val.clone().proj(i.into(), field_ty);
-            let fndef_ty = Ty::new_fn_def(
-                ctx.tcx,
-                ctx.lang_items().clone_fn().unwrap(),
-                ctx.mk_args(&[GenericArg::from(field_ty)]),
+            let fndef_ty = ctx.tcx.normalize_erasing_regions(
+                typing_env,
+                ctx.tcx
+                    .type_of(ctx.lang_items().clone_fn().unwrap())
+                    .instantiate(ctx.tcx, ctx.mk_args(&[GenericArg::from(field_ty)])),
             );
             let args = Term::tuple(ctx.tcx, [self_i.shr_ref(ctx.tcx)]);
             let subst = ctx.mk_args(&[args.ty, fndef_ty].map(GenericArg::from));
@@ -187,7 +188,10 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
                     ctx.tcx,
                     pre_sig.inputs.iter().map(|&(nm, _, ty)| Term::var(nm, ty)),
                 );
-                let fndef_ty = Ty::new_fn_def(ctx.tcx, def_id, subst);
+                let fndef_ty = ctx.tcx.normalize_erasing_regions(
+                    typing_env,
+                    ctx.tcx.type_of(def_id).instantiate(ctx.tcx, subst),
+                );
 
                 let pre_post_subst = ctx.mk_args(&[args.ty, fndef_ty].map(GenericArg::from));
 
@@ -309,6 +313,7 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
                     | Intrinsic::PostconditionOnce
             ) && let &TyKind::FnDef(did_f, subst_f) = subst.type_at(1).kind()
             {
+                let subst_f = subst_f.skip_binder();
                 // No definite instance if found for this method, so `term` has returned `None`
                 // However, we still emit an axiom telling that the specification should be a refinement.
                 let args_id = Ident::fresh_local("args").into();
@@ -465,7 +470,7 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
             let output = ctx.instantiate_and_normalize_erasing_regions(
                 subst,
                 typing_env,
-                EarlyBinder::bind(ctx.sig(def_id).output),
+                EarlyBinder::bind(ctx.tcx, ctx.sig(def_id).output),
             );
             let ty = translate_ty(ctx, &mut names, ctx.def_span(def_id), output);
             let inner_def = Defn {
@@ -518,15 +523,21 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
                 ty_name: names.ty(ty).to_ident(),
                 ty_params: Box::new([]),
             })],
-            &TyKind::Alias(AliasTy {
-                kind: AliasTyKind::Opaque { def_id } | AliasTyKind::Projection { def_id },
-                args,
-                ..
-            }) => {
-                vec![Decl::TyDecl(TyDecl::Opaque {
-                    ty_name: names.def_ty(def_id, args).to_ident(),
-                    ty_params: Box::new([]),
-                })]
+            &TyKind::Alias(
+                rigid,
+                AliasTy {
+                    kind:
+                        kind @ (AliasTyKind::Opaque { def_id } | AliasTyKind::Projection { def_id }),
+                    args,
+                    ..
+                },
+            ) => {
+                let ty_name = if let AliasTyKind::Opaque { .. } = kind {
+                    names.ty_opaque(rigid, def_id, args).to_ident()
+                } else {
+                    names.ty_projection(rigid, def_id, args).to_ident()
+                };
+                vec![Decl::TyDecl(TyDecl::Opaque { ty_name, ty_params: Box::new([]) })]
             }
             TyKind::Closure(did, subst) => translate_closure_ty(ctx, &names, *did, subst),
             TyKind::Adt(_, _) => translate_adtdecl(ctx, &names, ty),
@@ -646,7 +657,7 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
                 ItemType::Logic { .. } => self.expand_logic(def_id, subst),
                 ItemType::Constant => self.expand_constant(def_id, subst),
                 ItemType::Field | ItemType::Variant => {
-                    self.namer(dep).def_ty(ctx.parent(def_id), subst);
+                    self.namer(dep).ty_adt(ctx.parent(def_id), subst);
                     vec![]
                 }
                 ItemType::Program | ItemType::Closure => self.expand_program(def_id, subst),
@@ -786,7 +797,7 @@ fn postcondition_once_term<'tcx>(
     let ty_res = ctx.instantiate_and_normalize_erasing_regions(
         subst,
         typing_env,
-        EarlyBinder::bind(ctx.sig(Intrinsic::PostconditionOnce.get(ctx)).inputs[2].2),
+        EarlyBinder::bind(ctx.tcx, ctx.sig(Intrinsic::PostconditionOnce.get(ctx)).inputs[2].2),
     );
     let res = Term::var(result, ty_res);
     match ty_self.kind() {
@@ -858,7 +869,7 @@ fn postcondition_mut_term<'tcx>(
     let ty_res = ctx.instantiate_and_normalize_erasing_regions(
         subst,
         typing_env,
-        EarlyBinder::bind(ctx.sig(Intrinsic::PostconditionMut.get(ctx)).inputs[3].2),
+        EarlyBinder::bind(ctx.tcx, ctx.sig(Intrinsic::PostconditionMut.get(ctx)).inputs[3].2),
     );
     let res = Term::var(result, ty_res);
     match ty_self.kind() {
@@ -947,7 +958,7 @@ fn postcondition_term<'tcx>(
     let ty_res = ctx.instantiate_and_normalize_erasing_regions(
         subst,
         typing_env,
-        EarlyBinder::bind(ctx.sig(Intrinsic::Postcondition.get(ctx)).inputs[2].2),
+        EarlyBinder::bind(ctx.tcx, ctx.sig(Intrinsic::Postcondition.get(ctx)).inputs[2].2),
     );
     let res = Term::var(result, ty_res);
     match ty_self.kind() {
@@ -984,7 +995,9 @@ fn postcondition_term<'tcx>(
             let post_fn = Intrinsic::Postcondition.get(ctx);
             Some(Term::call(ctx.tcx, typing_env, post_fn, subst_postcond, post_args))
         }
-        &TyKind::FnDef(did, subst) => post_fndef(ctx, names, did, subst, args, res, true),
+        &TyKind::FnDef(did, subst) => {
+            post_fndef(ctx, names, did, subst.skip_binder(), args, res, true)
+        }
         _ => None,
     }
 }
@@ -1077,7 +1090,7 @@ fn precondition_term<'tcx>(
             let pre_args = [self_.proj(0usize.into(), closure_ty), args];
             Some(Term::call(ctx.tcx, typing_env, pre_fn, subst_postcond, pre_args))
         }
-        &TyKind::FnDef(did, subst) => pre_fndef(ctx, names, did, subst, args, true),
+        &TyKind::FnDef(did, subst) => pre_fndef(ctx, names, did, subst.skip_binder(), args, true),
         _ => None,
     }
 }
@@ -1349,7 +1362,7 @@ fn term<'tcx>(
         Intrinsic::IsAlignedLogic => is_aligned_logic_term(ctx, names, subst.type_at(0), bound),
         Intrinsic::MetadataMatches => metadata_matches_term(ctx, names, subst, bound),
         _ => {
-            let term = EarlyBinder::bind(ctx.term(def_id).unwrap().rename(bound));
+            let term = EarlyBinder::bind(ctx.tcx, ctx.term(def_id).unwrap().rename(bound));
             Some(normalize(ctx, typing_env, term.instantiate(ctx.tcx, subst).skip_normalization()))
         }
     }

--- a/creusot/src/backend/dependency.rs
+++ b/creusot/src/backend/dependency.rs
@@ -38,11 +38,14 @@ impl<'tcx> Dependency<'tcx> {
             Dependency::Type(t) => match t.kind() {
                 TyKind::Adt(def, substs) => Some((def.did(), substs)),
                 TyKind::Closure(id, substs) => Some((*id, substs)),
-                &TyKind::Alias(AliasTy {
-                    kind: AliasTyKind::Opaque { def_id } | AliasTyKind::Projection { def_id },
-                    args,
-                    ..
-                }) => Some((def_id, args)),
+                &TyKind::Alias(
+                    _,
+                    AliasTy {
+                        kind: AliasTyKind::Opaque { def_id } | AliasTyKind::Projection { def_id },
+                        args,
+                        ..
+                    },
+                ) => Some((def_id, args)),
                 _ => None,
             },
             _ => None,

--- a/creusot/src/backend/logic/vcgen.rs
+++ b/creusot/src/backend/logic/vcgen.rs
@@ -162,7 +162,7 @@ impl<'tcx> VCGen<'_, 'tcx> {
             //  pre(f)(a0..an) /\ variant(f)(a0..an) /\ (post(f)(a0..an, F(a0..an)) -> Q(F a0..an))
             // ))
             &TermKind::Call { id, subst, ref args } => self.build_wp_slice(args, &|args| {
-                let pre_sig = EarlyBinder::bind(self.ctx.sig(id).clone())
+                let pre_sig = EarlyBinder::bind(self.ctx.tcx, self.ctx.sig(id).clone())
                     .instantiate(self.ctx.tcx, subst)
                     .skip_normalization().normalize_contract(self.ctx, self.typing_env);
 

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -43,7 +43,7 @@ use rustc_abi::VariantIdx;
 use rustc_hir::{Safety, def::DefKind, def_id::DefId};
 use rustc_middle::{
     mir::{BasicBlock, BinOp, PlaceTy, ProjectionElem, START_BLOCK, UnOp},
-    ty::{self, AdtDef, GenericArgs, GenericArgsRef, Ty, TyCtxt, TyKind, Unnormalized},
+    ty::{self, AdtDef, GenericArgs, GenericArgsRef, Ty, TyCtxt, TyKind},
 };
 use rustc_span::{DUMMY_SP, Span};
 use rustc_type_ir::IntTy;
@@ -80,7 +80,7 @@ pub(crate) fn translate_function<'tcx>(
             }
             Some(names.source_ident())
         }
-        InlineConst { .. } => return None,
+        AnonConst { .. } => return None,
         _ => None,
     };
 
@@ -172,8 +172,11 @@ pub(crate) fn to_why_body<'tcx>(
         why_body(ctx, names, body_id, None, &args, name::return_(), &mut recursive_calls);
     let (mut sig, variant) = {
         let mut sig = sig.clone();
+        sig.inputs =
+            names.normalize(ty::EarlyBinder::bind(ctx.tcx, sig.inputs).instantiate_identity());
         // normalize any RPITs away
-        sig.output = names.normalize(Unnormalized::new(sig.output));
+        sig.output =
+            names.normalize(ty::EarlyBinder::bind(ctx.tcx, sig.output).instantiate_identity());
         let variant = sig.contract.variant.clone();
         sig_add_type_invariant_spec(ctx, names.typing_env(), names.source_id(), &mut sig, def_id);
         (lower_program_sig(ctx, names, name, sig, def_id, name::return_()), variant)
@@ -319,7 +322,7 @@ pub fn why_body<'tcx>(
     body = if let Some(subst) = subst {
         ctx.tcx.normalize_erasing_regions(
             names.typing_env(),
-            ty::EarlyBinder::bind(body).instantiate(ctx.tcx, subst),
+            ty::EarlyBinder::bind(ctx.tcx, body).instantiate(ctx.tcx, subst),
         )
     } else {
         body

--- a/creusot/src/backend/resolve.rs
+++ b/creusot/src/backend/resolve.rs
@@ -67,7 +67,7 @@ pub fn is_resolve_trivial<'tcx>(
             },
             TyKind::Closure(_, subst) => stack.extend(subst.as_closure().upvar_tys()),
             TyKind::Param(_)
-            | TyKind::Alias(_)
+            | TyKind::Alias(_, _)
             | TyKind::Dynamic(..)
             | TyKind::Ref(_, _, Mutability::Mut) => return false,
             TyKind::Bool

--- a/creusot/src/backend/term.rs
+++ b/creusot/src/backend/term.rs
@@ -565,6 +565,7 @@ impl<'tcx, N: Namer<'tcx>> Lower<'_, 'tcx, N> {
             }
             Literal::ZST => {
                 if let &TyKind::FnDef(id, subst) = ty.kind() {
+                    let subst = subst.skip_binder();
                     let (id, subst) =
                         TraitResolved::resolve_item(self.tcx(), self.names.typing_env(), id, subst)
                             .to_opt(id, subst)
@@ -637,7 +638,7 @@ pub(crate) fn tyconst_to_term_final<'tcx>(
     use rustc_type_ir::ConstKind::*;
     match c.kind() {
         Value(ty::Value { ty, valtree }) => valtree_to_term(valtree, ctx, ty, env, span),
-        Unevaluated(ty::UnevaluatedConst { kind, args, .. }) => {
+        Alias(_, ty::AliasConst { kind, args, .. }) => {
             Some(Term::const_item(kind.opt_def_id().unwrap(), args, ty))
         }
         Param(p) => {

--- a/creusot/src/backend/ty.rs
+++ b/creusot/src/backend/ty.rs
@@ -137,7 +137,7 @@ pub(crate) fn translate_ty<'tcx>(
         Foreign(_) => MlT::qconstructor(names.in_pre(PreMod::Opaque, "foreign")),
         Error(_) => MlT::unit(),
         Closure(..) | Tuple(_) | Param(_) | Dynamic(_, _) => MlT::TConstructor(names.ty(ty)),
-        Alias(t)
+        Alias(_, t)
             if matches!(t.kind, AliasTyKind::Opaque { .. } | AliasTyKind::Projection { .. }) =>
         {
             MlT::TConstructor(names.ty(ty))
@@ -152,7 +152,7 @@ pub(crate) fn translate_closure_ty<'tcx>(
     did: DefId,
     subst: GenericArgsRef<'tcx>,
 ) -> Vec<Decl> {
-    let ty_name = names.def_ty(did, subst).to_ident();
+    let ty_name = names.ty_closure(did, subst).to_ident();
     let closure_subst = subst.as_closure();
     let fields: Box<[_]> = closure_subst
         .upvar_tys()
@@ -237,11 +237,11 @@ pub(crate) fn translate_adtdecl<'tcx>(
             vec![]
         }
         AdtKind::Opaque { .. } => {
-            let ty_name = names.def_ty(def.did(), subst).to_ident();
+            let ty_name = names.ty_adt(def.did(), subst).to_ident();
             vec![Decl::TyDecl(TyDecl::Opaque { ty_name, ty_params: Box::new([]) })]
         }
         AdtKind::Enum => {
-            let ty_name = names.def_ty(def.did(), subst).to_ident();
+            let ty_name = names.ty_adt(def.did(), subst).to_ident();
             let sumrecord = SumRecord::Sum(
                 def.variants()
                     .iter()
@@ -263,7 +263,7 @@ pub(crate) fn translate_adtdecl<'tcx>(
             })]
         }
         AdtKind::Struct { partially_opaque } => {
-            let ty_name = names.def_ty(def.did(), subst).to_ident();
+            let ty_name = names.ty_adt(def.did(), subst).to_ident();
 
             let fields: Box<[_]> = def
                 .non_enum_variant()

--- a/creusot/src/backend/ty_inv.rs
+++ b/creusot/src/backend/ty_inv.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use rustc_abi::{FieldIdx, VariantIdx};
 use rustc_hir::{def::DefKind, def_id::DefId};
-use rustc_middle::ty::{GenericArg, Ty, TyKind, TypingEnv, Unnormalized};
+use rustc_middle::ty::{EarlyBinder, GenericArg, Ty, TyKind, TypingEnv};
 use rustc_span::{DUMMY_SP, Span};
 use std::collections::HashSet;
 
@@ -76,7 +76,7 @@ pub(crate) fn is_tyinv_trivial<'tcx>(
                 AdtKind::Box(_) => unreachable!(),
             },
             TyKind::Closure(_, subst) => stack.extend(subst.as_closure().upvar_tys()),
-            TyKind::Param(_) | TyKind::Alias(_) | TyKind::Never => return false,
+            TyKind::Param(_) | TyKind::Alias(_, _) | TyKind::Never => return false,
             TyKind::Bool
             | TyKind::Char
             | TyKind::Int(_)
@@ -266,7 +266,10 @@ pub(crate) fn inv_call<'tcx>(
     scope_id: DefId,
     term: Term<'tcx>,
 ) -> Option<Term<'tcx>> {
-    let ty = ctx.normalize_erasing_regions(typing_env, Unnormalized::new(term.ty));
+    let ty = ctx.normalize_erasing_regions(
+        typing_env,
+        EarlyBinder::bind(ctx.tcx, term.ty).instantiate_identity(),
+    );
     if is_tyinv_trivial(&ctx, scope_id, typing_env, ty, term.span) {
         return None;
     }

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -36,7 +36,7 @@ use rustc_errors::{Diag, DiagMessage, FatalAbort};
 use rustc_hir::{
     HirId,
     def::DefKind,
-    def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId},
+    def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, ModId},
 };
 use rustc_index::bit_set::DenseBitSet;
 use rustc_infer::traits::ObligationCause;
@@ -80,7 +80,7 @@ impl BodyId {
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum Opacity {
     Opaque,
-    Transparent(Visibility<DefId>),
+    Transparent(Visibility<ModId>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -471,7 +471,7 @@ impl<'tcx> TranslationCtx<'tcx> {
             ItemType::Logic { .. } => {
                 let vis = opacity_witness_name(self.tcx, item).map_or_else(
                     || Visibility::Restricted(parent_module(self.tcx, item)),
-                    |nm| self.visibility(self.creusot_item(nm).unwrap()),
+                    |nm| self.visibility(ModId::new_unchecked(self.creusot_item(nm).unwrap())),
                 );
                 Opacity::Transparent(vis)
             }
@@ -754,7 +754,7 @@ impl<'tcx> TranslationCtx<'tcx> {
             }
             DefKind::AssocConst { .. }
             | DefKind::Const { .. }
-            | DefKind::InlineConst
+            | DefKind::AnonConst
             | DefKind::ConstParam => ItemType::Constant,
             DefKind::Closure => ItemType::Closure,
             DefKind::Struct | DefKind::Enum | DefKind::Union => ItemType::Type,

--- a/creusot/src/lints.rs
+++ b/creusot/src/lints.rs
@@ -48,7 +48,7 @@ pub fn register_lints(_sess: &Session, store: &mut LintStore) {
         trusted::TRUSTED_CODE,
         result_param::RESULT_PARAM,
     ]);
-    store.register_late_pass(move |_| Box::new(validate::GhostValidate {}));
-    store.register_late_pass(move |_| Box::new(experimental_types::Experimental {}));
-    store.register_late_pass(move |_| Box::new(trusted::TrustedCode {}));
+    store.register_late_lint_pass(Box::new(move |_| Box::new(validate::GhostValidate {})));
+    store.register_late_lint_pass(Box::new(move |_| Box::new(experimental_types::Experimental {})));
+    store.register_late_lint_pass(Box::new(move |_| Box::new(trusted::TrustedCode {})));
 }

--- a/creusot/src/naming.rs
+++ b/creusot/src/naming.rs
@@ -276,14 +276,17 @@ fn type_string_walk(tcx: TyCtxt, prefix: &mut String, ty: Ty) {
                 type_string_walk(tcx, prefix, ty)
             }
         }
-        &Alias(AliasTy {
-            kind:
-                AliasTyKind::Projection { def_id }
-                | AliasTyKind::Inherent { def_id }
-                | AliasTyKind::Free { def_id }
-                | AliasTyKind::Opaque { def_id },
-            ..
-        }) => match tcx.def_key(def_id).get_opt_name() {
+        &Alias(
+            _,
+            AliasTy {
+                kind:
+                    AliasTyKind::Projection { def_id }
+                    | AliasTyKind::Inherent { def_id }
+                    | AliasTyKind::Free { def_id }
+                    | AliasTyKind::Opaque { def_id },
+                ..
+            },
+        ) => match tcx.def_key(def_id).get_opt_name() {
             None => push_(prefix, "opaque"),
             Some(name) => push_(prefix, &to_alphanumeric(name.as_str())),
         },

--- a/creusot/src/resolution.rs
+++ b/creusot/src/resolution.rs
@@ -6,8 +6,8 @@ use rustc_infer::{
     traits::{CodegenObligationError, ObligationCause, specialization_graph::Graph},
 };
 use rustc_middle::ty::{
-    self, Const, ConstKind, GenericArgsRef, ParamConst, ParamEnv, ParamEnvAnd, ParamTy, TraitRef,
-    Ty, TyCtxt, TyKind, TypeFoldable, TypeFolder, TypingEnv, TypingMode, Unnormalized,
+    self, Const, ConstKind, EarlyBinder, GenericArgsRef, ParamConst, ParamEnv, ParamEnvAnd,
+    ParamTy, TraitRef, Ty, TyCtxt, TyKind, TypeFoldable, TypeFolder, TypingEnv, TypingMode,
 };
 use rustc_span::{DUMMY_SP, ErrorGuaranteed};
 use rustc_trait_selection::traits::{ImplSource, InCrate, orphan_check_trait_ref};
@@ -219,7 +219,10 @@ impl<'tcx> TraitResolved<'tcx> {
         } else {
             return TraitResolved::NotATraitItem;
         };
-        let trait_ref = tcx.normalize_erasing_regions(typing_env, Unnormalized::new(trait_ref));
+        let trait_ref = tcx.normalize_erasing_regions(
+            typing_env,
+            EarlyBinder::bind(tcx, trait_ref).instantiate_identity(),
+        );
 
         let source = match select_trait_impl(tcx, typing_env, trait_ref) {
             ImplSelection::Found(source) => source,

--- a/creusot/src/translation/constant.rs
+++ b/creusot/src/translation/constant.rs
@@ -6,7 +6,7 @@ use rustc_abi::Size;
 use rustc_hir::{def::DefKind, def_id::DefId};
 use rustc_middle::{
     mir::{self, ConstOperand, ConstValue, TerminatorKind, interpret::AllocRange},
-    ty::{self, ConstKind, Ty, TyCtxt, TypingEnv, UnevaluatedConstKind},
+    ty::{self, AliasConstKind, ConstKind, Ty, TyCtxt, TypingEnv},
 };
 use rustc_span::Span;
 
@@ -29,7 +29,7 @@ pub(crate) fn mirconst_to_operand<'tcx>(
         Unevaluated(u, ty) => {
             if let Some(promoted) = u.promoted {
                 Operand::promoted(caller_id, promoted, ty)
-            } else if matches!(ctx.def_kind(u.def), DefKind::InlineConst) {
+            } else if matches!(ctx.def_kind(u.def), DefKind::AnonConst) {
                 Operand::inline_const(u.def, u.args, ty)
             } else {
                 Operand::term(Term::const_item(u.def, u.args, ty).span(c.span))
@@ -177,8 +177,8 @@ pub fn try_const_to_term<'tcx>(
         let ty = ctx.type_of(def_id).instantiate(ctx.tcx, subst);
         let ty = ctx.tcx.normalize_erasing_regions(typing_env, ty);
         let span = ctx.def_span(def_id);
-        let kind = ty::UnevaluatedConstKind::new_from_def_id(ctx.tcx, def_id);
-        let uneval = ty::UnevaluatedConst::new(ctx.tcx, kind, subst);
+        let kind = ty::AliasConstKind::new_from_def_id(ctx.tcx, def_id);
+        let uneval = ty::AliasConst::new(ctx.tcx, kind, subst);
         if let Ok(Ok(val)) = ctx.const_eval_resolve_for_typeck(typing_env, uneval, span) {
             return valtree_to_term(val, ctx, ty, typing_env, span);
         }
@@ -203,14 +203,14 @@ pub fn try_const_to_term<'tcx>(
             let c = args.const_at(p.index as usize);
             Some(Term::const_(c, ty, span))
         }
-        ConstKind::Unevaluated(u)
-            if let UnevaluatedConstKind::Projection { def_id }
-            | UnevaluatedConstKind::Free { def_id }
-            | UnevaluatedConstKind::Inherent { def_id } = u.kind =>
+        ConstKind::Alias(_, u)
+            if let AliasConstKind::Projection { def_id }
+            | AliasConstKind::Free { def_id }
+            | AliasConstKind::Inherent { def_id } = u.kind =>
         {
             let (u, ty) = ctx.tcx.normalize_erasing_regions(
                 typing_env,
-                ty::EarlyBinder::bind((u, ty)).instantiate(ctx.tcx, args),
+                ty::EarlyBinder::bind(ctx.tcx, (u, ty)).instantiate(ctx.tcx, args),
             );
             Some(Term::const_item(def_id, u.args, ty).span(span))
         }
@@ -282,7 +282,7 @@ fn simple_body_const<'tcx>(
     match rhs.const_ {
         mir::Const::Ty(ty, c) => Some((c.kind(), ty, rhs.span)),
         mir::Const::Unevaluated(u, ty) => {
-            Some((rustc_type_ir::ConstKind::Unevaluated(u.shrink(tcx)), ty, rhs.span))
+            Some((rustc_type_ir::ConstKind::Alias(ty::IsRigid::No, u.shrink(tcx)), ty, rhs.span))
         }
         _ => return None,
     }

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -47,7 +47,7 @@ impl<'tcx> ExternSpec<'tcx> {
         sub: GenericArgsRef<'tcx>,
     ) -> Vec<Predicate<'tcx>> {
         // skip normalization: the instantiation should just be a renaming
-        EarlyBinder::bind(self.additional_predicates.clone())
+        EarlyBinder::bind(tcx, self.additional_predicates.clone())
             .instantiate(tcx, sub)
             .skip_normalization()
     }
@@ -89,7 +89,7 @@ pub(crate) fn extract_extern_specs_from_item<'tcx>(
         let id = ctx.lang_items().into_try_type_fn().unwrap();
         (id, erased_identity_for_item(ctx.tcx, id), ItemKind::Fn)
     } else {
-        extract_extern_item(thir, expr)
+        extract_extern_item(ctx.tcx, thir, expr)
     };
     let (id, inner_subst) =
         TraitResolved::resolve_item(ctx.tcx, ctx.typing_env(def_id), id, subst).to_opt(id, subst).unwrap_or_else(|| {
@@ -158,9 +158,9 @@ pub(crate) fn extract_extern_specs_from_item<'tcx>(
     let subst = ctx.mk_args(&subst);
 
     let additional_predicates = ctx
-        .predicates_of(local_def_id)
+        .clauses_of(local_def_id)
         .instantiate(ctx.tcx, subst)
-        .predicates
+        .clauses
         .into_iter()
         // skip normalization: the instantiation was only renaming
         .map(|clause| clause.skip_normalization().as_predicate())
@@ -177,8 +177,12 @@ pub(crate) fn extract_extern_specs_from_item<'tcx>(
 
 /// Extract a target item for `extern_spec!` or `#[erasure]`.
 /// The visited body should be just a function call.
-fn extract_extern_item<'tcx>(thir: &Thir<'tcx>, expr_id: thir::ExprId) -> ExternItem<'tcx> {
-    let mut visitor = ExtractExternItem::new(thir);
+fn extract_extern_item<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    thir: &Thir<'tcx>,
+    expr_id: thir::ExprId,
+) -> ExternItem<'tcx> {
+    let mut visitor = ExtractExternItem::new(tcx, thir);
     visitor.visit_expr(&thir[expr_id]);
     visitor.item.unwrap()
 }
@@ -186,13 +190,14 @@ fn extract_extern_item<'tcx>(thir: &Thir<'tcx>, expr_id: thir::ExprId) -> Extern
 type ExternItem<'tcx> = (DefId, GenericArgsRef<'tcx>, ItemKind);
 
 struct ExtractExternItem<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
     thir: &'a Thir<'tcx>,
     item: Option<ExternItem<'tcx>>,
 }
 
 impl<'a, 'tcx> ExtractExternItem<'a, 'tcx> {
-    pub fn new(thir: &'a Thir<'tcx>) -> Self {
-        ExtractExternItem { thir, item: None }
+    pub fn new(tcx: TyCtxt<'tcx>, thir: &'a Thir<'tcx>) -> Self {
+        ExtractExternItem { tcx, thir, item: None }
     }
 }
 
@@ -207,14 +212,26 @@ impl<'a, 'tcx> thir::visit::Visitor<'a, 'tcx> for ExtractExternItem<'a, 'tcx> {
     }
 
     fn visit_expr(&mut self, expr: &'a Expr<'tcx>) {
-        if let ExprKind::Call { ty, .. } = expr.kind {
-            if let TyKind::FnDef(id, subst) = ty.kind() {
-                self.item = Some((*id, subst, ItemKind::Fn));
+        match expr.kind {
+            ExprKind::Call { ty, .. } => {
+                if let TyKind::FnDef(id, subst) = ty.kind() {
+                    self.item = Some((*id, subst.skip_binder(), ItemKind::Fn));
+                }
             }
-        } else if let ExprKind::NamedConst { def_id, args, .. } = expr.kind {
-            self.item = Some((def_id, args, ItemKind::Const))
-        } else {
-            thir::visit::walk_expr(self, expr);
+            ExprKind::NamedConst { def_id, args, .. } => {
+                self.item = Some((def_id, args, ItemKind::Const))
+            }
+            ExprKind::ConstBlock { did, args } => {
+                let (thir, expr) =
+                    self.tcx.thir_body(did.expect_local()).unwrap_or_else(|e| e.raise_fatal());
+                let thir = &thir.borrow();
+                let mut item = extract_extern_item(self.tcx, thir, expr);
+                item.1 = EarlyBinder::bind(self.tcx, item.1)
+                    .instantiate(self.tcx, args)
+                    .skip_normalization();
+                self.item = Some(item);
+            }
+            _ => thir::visit::walk_expr(self, expr),
         }
     }
 }
@@ -236,7 +253,8 @@ pub(crate) fn extract_erasure_from_item<'tcx>(
         None => return None,
         Some(ErasureKind::Parent) => {
             let parent = ctx.tcx.parent(def_id);
-            let (id_erased, subst_erased, kind) = extract_extern_item(&thir.borrow(), expr);
+            let (id_erased, subst_erased, kind) =
+                extract_extern_item(ctx.tcx, &thir.borrow(), expr);
             let ItemKind::Fn = kind else {
                 ctx.crash_and_error(ctx.def_span(def_id), "erasure for const is not implemented")
             };

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -20,7 +20,7 @@ use rustc_hir::def_id::DefId;
 use rustc_index::bit_set::MixedBitSet;
 use rustc_middle::{
     mir::{self, BasicBlock, Body, Local, Location, Operand, Place, traversal::reverse_postorder},
-    ty::{Ty, TyCtxt, TyKind, TypingEnv, Unnormalized},
+    ty::{EarlyBinder, Ty, TyCtxt, TyKind, TypingEnv},
 };
 use rustc_span::{DUMMY_SP, Span};
 use std::{assert_matches, collections::HashMap, ops::FnOnce};
@@ -266,7 +266,10 @@ impl<'body, 'tcx> BodyTranslator<'body, 'tcx> {
 
     /// These types cannot contain mutable borrows and thus do not need to be resolved.
     fn skip_resolve_type(&self, ty: Ty<'tcx>) -> bool {
-        let ty = self.ctx.normalize_erasing_regions(self.typing_env(), Unnormalized::new(ty));
+        let ty = self.ctx.normalize_erasing_regions(
+            self.typing_env(),
+            EarlyBinder::bind(self.ctx.tcx, ty).instantiate_identity(),
+        );
         self.tcx().type_is_copy_modulo_regions(self.typing_env(), ty)
         // The following is unsound because it does not take into account aliases.
         // It can be made technically sound, but anyway seems much less predictable than "we resolve

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -54,6 +54,7 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                 else {
                     self.fatal_error(fn_span, "unsupported function call type").emit()
                 };
+                let subst = subst.skip_binder();
                 if Intrinsic::SnapshotFromFn.is(self.ctx, fun_def_id) {
                     let GenericArgKind::Type(ty) = subst.get(1).unwrap().kind() else {
                         unreachable!()

--- a/creusot/src/translation/pearlite.rs
+++ b/creusot/src/translation/pearlite.rs
@@ -6,8 +6,8 @@ use rustc_macros::{TyDecodable, TyEncodable, TypeFoldable, TypeVisitable};
 use rustc_middle::{
     mir::{Mutability::*, ProjectionElem},
     ty::{
-        Const, GenericArgsRef, ParamConst, Ty, TyCtxt, TyKind, TypeFoldable, TypeVisitable,
-        TypingEnv, Unnormalized,
+        Const, EarlyBinder, GenericArgsRef, ParamConst, Ty, TyCtxt, TyKind, TypeFoldable,
+        TypeVisitable, TypingEnv,
     },
 };
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -529,7 +529,10 @@ impl<'tcx> Term<'tcx> {
         args: impl IntoIterator<Item = Term<'tcx>>,
     ) -> Self {
         let mut res = Self::call_no_normalize(tcx, def_id, subst, args);
-        res.ty = tcx.normalize_erasing_regions(typing_env, Unnormalized::new(res.ty));
+        res.ty = tcx.normalize_erasing_regions(
+            typing_env,
+            EarlyBinder::bind(tcx, res.ty).instantiate_identity(),
+        );
         res
     }
 

--- a/creusot/src/translation/pearlite/from_thir.rs
+++ b/creusot/src/translation/pearlite/from_thir.rs
@@ -335,6 +335,7 @@ impl<'tcx> ThirTerm<'_, 'tcx> {
                 let TyKind::FnDef(id, subst) = *f_ty.kind() else {
                     unreachable!("Call on non-function type");
                 };
+                let subst = subst.skip_binder();
                 match self.ctx.intrinsic(id) {
                     s @ (Intrinsic::Forall | Intrinsic::Exists) => {
                         let kind = if let Intrinsic::Forall = s {
@@ -503,7 +504,7 @@ impl<'tcx> ThirTerm<'_, 'tcx> {
             {
                 // We have just detected `*deref_mut(&mut x)`, which can happen only for Ghost and Snapshot
                 assert_matches!(borrow_kind, BorrowKind::Mut { .. });
-                assert_matches!(subst.type_at(0).kind(),
+                assert_matches!(subst.skip_binder().type_at(0).kind(),
                     TyKind::Adt(adt, _) if matches!(self.ctx.intrinsic(adt.did()), Intrinsic::Snapshot | Intrinsic::Ghost));
                 Ok(self.expr_term(arg)?.coerce(ty).span(span))
             }
@@ -784,6 +785,7 @@ impl<'tcx> ThirTerm<'_, 'tcx> {
                         && self.ctx.is_diagnostic_item(sym::deref_method, f_did)
                         && let ExprKind::Borrow { borrow_kind, arg } = self.head(args[0]).kind =>
                 {
+                    let subst = subst.skip_binder();
                     assert_matches!(borrow_kind, BorrowKind::Shared);
                     assert_matches!(subst.type_at(0).kind(),
                         TyKind::Adt(adt, _) if matches!(self.ctx.intrinsic(adt.did()), Intrinsic::Snapshot | Intrinsic::Ghost));

--- a/creusot/src/translation/pearlite/normalize.rs
+++ b/creusot/src/translation/pearlite/normalize.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::{GenericArgsRef, TypingEnv, Unnormalized};
+use rustc_middle::ty::{EarlyBinder, GenericArgsRef, TypingEnv};
 use rustc_span::sym;
 
 pub(crate) fn normalize<'tcx>(
@@ -17,7 +17,10 @@ pub(crate) fn normalize<'tcx>(
     mut term: Term<'tcx>,
 ) -> Term<'tcx> {
     NormalizeTerm { typing_env, ctx }.visit_mut_term(&mut term);
-    let term = ctx.normalize_erasing_regions(typing_env, Unnormalized::new(term));
+    let term = ctx.normalize_erasing_regions(
+        typing_env,
+        EarlyBinder::bind(ctx.tcx, term).instantiate_identity(),
+    );
     term
 }
 

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -217,14 +217,17 @@ impl ContractClauses {
             ctx.term(var_id).unwrap().rename(bound)
         });
         log::trace!("purity: {}", self.purity);
-        EarlyBinder::bind(PreContract {
-            variant,
-            requires,
-            ensures,
-            purity: self.purity,
-            extern_no_spec: false,
-            has_user_contract,
-        })
+        EarlyBinder::bind(
+            ctx.tcx,
+            PreContract {
+                variant,
+                requires,
+                ensures,
+                purity: self.purity,
+                extern_no_spec: false,
+                has_user_contract,
+            },
+        )
     }
 }
 
@@ -324,10 +327,10 @@ pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pr
             .skip_normalization();
         contract.check_ensures_no_trigger(ctx);
         PreSignature {
-            inputs: EarlyBinder::bind(spec.inputs)
+            inputs: EarlyBinder::bind(ctx.tcx, spec.inputs)
                 .instantiate(ctx.tcx, spec.subst)
                 .skip_normalization(),
-            output: EarlyBinder::bind(spec.output)
+            output: EarlyBinder::bind(ctx.tcx, spec.output)
                 .instantiate(ctx.tcx, spec.subst)
                 .skip_normalization(),
             contract,
@@ -347,10 +350,10 @@ pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pr
             .skip_normalization();
         contract.check_ensures_no_trigger(ctx);
         PreSignature {
-            inputs: EarlyBinder::bind(spec.inputs.clone())
+            inputs: EarlyBinder::bind(ctx.tcx, spec.inputs.clone())
                 .instantiate(ctx.tcx, subst)
                 .skip_normalization(),
-            output: EarlyBinder::bind(spec.output.clone())
+            output: EarlyBinder::bind(ctx.tcx, spec.output.clone())
                 .instantiate(ctx.tcx, subst)
                 .skip_normalization(),
             contract,
@@ -397,7 +400,8 @@ impl<'tcx> PreSignature<'tcx> {
         subst: GenericArgsRef<'tcx>,
         typing_env: TypingEnv<'tcx>,
     ) -> Self {
-        let mut sig = EarlyBinder::bind(self).instantiate(ctx.tcx, subst).skip_normalization();
+        let mut sig =
+            EarlyBinder::bind(ctx.tcx, self).instantiate(ctx.tcx, subst).skip_normalization();
         sig.contract = sig.contract.normalize(ctx, typing_env);
         (sig.inputs, sig.output) = ctx
             .tcx
@@ -406,6 +410,8 @@ impl<'tcx> PreSignature<'tcx> {
     }
 }
 
+// Note: the result contains unnormalized types: all `TyKind::Alias` have their first field set to `IsRigid::No`.
+// We cannot normalize them under the `TypingEnv` of `def_id` because we don't want to unfold RPITs.
 pub(crate) fn pre_sig_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> PreSignature<'tcx> {
     if ctx.def_kind(def_id) == DefKind::ConstParam {
         let contract = PreContract {
@@ -423,7 +429,8 @@ pub(crate) fn pre_sig_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pre
     let mut presig = contract_of(ctx, def_id);
 
     if ctx.def_kind(def_id) == DefKind::Closure {
-        let fn_ty = ctx.type_of(def_id).instantiate_identity().skip_normalization();
+        let fn_ty = ctx.type_of(def_id).instantiate_identity();
+        let fn_ty = ctx.normalize_erasing_regions(ctx.typing_env(def_id), fn_ty);
         let TyKind::Closure(_, subst) = fn_ty.kind() else { unreachable!() };
 
         let kind = subst.as_closure().kind();

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -125,7 +125,7 @@ fn logic_refinement_term<'tcx>(
     let typing_env = TypingEnv::non_body_analysis(ctx.tcx, impl_item_id);
 
     // Get the contract of the trait version
-    let mut trait_sig = EarlyBinder::bind(ctx.sig(trait_item_id).clone())
+    let mut trait_sig = EarlyBinder::bind(ctx.tcx, ctx.sig(trait_item_id).clone())
         .instantiate(ctx.tcx, refn_subst)
         .skip_normalization()
         .normalize_contract(ctx, typing_env);

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -2,7 +2,7 @@ use std::{hash::Hash as _, path::Path};
 
 use rustc_hir::{
     def::DefKind,
-    def_id::{DefId, DefPathHash, LOCAL_CRATE},
+    def_id::{DefId, DefPathHash, LOCAL_CRATE, ModId},
     definitions::{DefKey, DefPathData, DisambiguatedDefPathData},
 };
 use rustc_index::IndexVec;
@@ -21,11 +21,11 @@ pub(crate) fn erased_identity_for_item(tcx: TyCtxt, did: DefId) -> GenericArgsRe
     tcx.erase_and_anonymize_regions(GenericArgs::identity_for_item(tcx, did))
 }
 
-pub(crate) fn parent_module(tcx: TyCtxt, mut id: DefId) -> DefId {
+pub(crate) fn parent_module(tcx: TyCtxt, mut id: DefId) -> ModId {
     while tcx.def_kind(id) != DefKind::Mod {
         id = tcx.parent(id);
     }
-    id
+    ModId::new_unchecked(id)
 }
 
 pub(crate) fn path_of_span(tcx: TyCtxt, span: Span, span_mode: &SpanMode) -> Option<Box<Path>> {
@@ -203,7 +203,9 @@ fn equal_types<'tcx>(t1: &ty::Ty<'tcx>, t2: &ty::Ty<'tcx>) -> bool {
             mutable1 == mutable2 && equal_types(ty1, ty2)
         }
         (FnDef(def_id1, subst1), FnDef(def_id2, subst2)) => {
-            def_id1 == def_id2 && NamelessGenericArgs(*subst1) == NamelessGenericArgs(*subst2)
+            def_id1 == def_id2
+                && NamelessGenericArgs(subst1.skip_binder())
+                    == NamelessGenericArgs(subst2.skip_binder())
         }
         (Param(p1), Param(p2)) => p1.index == p2.index, // Ignore `name`
         _ => t1 == t2,

--- a/creusot/src/validate/erasure.rs
+++ b/creusot/src/validate/erasure.rs
@@ -132,7 +132,7 @@ fn check_erasure<'tcx>(
     };
     let right = ctx.tcx.normalize_erasing_regions(
         typing_env,
-        ty::EarlyBinder::bind(right_anf.into_owned()).instantiate(ctx.tcx, right.def.1),
+        ty::EarlyBinder::bind(ctx.tcx, right_anf.into_owned()).instantiate(ctx.tcx, right.def.1),
     );
     Ok(equate_anf(ctx, left_local, &left, &right, level).map_err(|_| None)?)
 }
@@ -855,6 +855,7 @@ impl<'a, 'tcx> AnfBuilder<'a, 'tcx> {
             }
             ZstLiteral { .. } => match expr.ty.kind() {
                 &ty::TyKind::FnDef(fun_id, subst) => {
+                    let subst = subst.no_bound_vars().unwrap();
                     let (mut fun_id, mut subst) =
                         TraitResolved::resolve_item(self.tcx, self.typing_env, fun_id, subst)
                             .to_opt(fun_id, subst)
@@ -872,7 +873,7 @@ impl<'a, 'tcx> AnfBuilder<'a, 'tcx> {
                                 fun_id = erasure.def.0;
                                 subst = self.tcx.normalize_erasing_regions(
                                     self.typing_env,
-                                    ty::EarlyBinder::bind(erasure.def.1)
+                                    ty::EarlyBinder::bind(ctx.tcx, erasure.def.1)
                                         .instantiate(self.tcx, subst),
                                 );
                                 erasure_info =
@@ -1364,12 +1365,13 @@ fn erase_types<'tcx, T: TypeFoldable<TyCtxt<'tcx>>>(
                     if let Some(Some(erasure)) = self.ctx.erasure(fun_id) =>
                 {
                     let tcx = self.cx();
-                    ty::Ty::new_fn_def(
-                        tcx,
-                        erasure.def.0,
-                        self.cx().normalize_erasing_regions(
-                            self.typing_env,
-                            ty::EarlyBinder::bind(erasure.def.1).instantiate(tcx, args),
+                    self.cx().normalize_erasing_regions(
+                        self.typing_env,
+                        tcx.type_of(erasure.def.0).instantiate(
+                            tcx,
+                            ty::EarlyBinder::bind(self.cx(), erasure.def.1)
+                                .instantiate(tcx, args.skip_binder())
+                                .skip_normalization(),
                         ),
                     )
                 }

--- a/creusot/src/validate/opacity.rs
+++ b/creusot/src/validate/opacity.rs
@@ -195,7 +195,7 @@ impl<'thir, 'tcx> Visitor<'thir, 'tcx> for OpacityVisitor<'thir, 'tcx> {
 
 /// Validates that a private function is not made visible in a public *open* logic function or in a public const.
 pub(crate) fn validate_opacity<'tcx>(ctx: &TranslationCtx<'tcx>, item: DefId) {
-    if matches!(ctx.tcx.def_kind(item), DefKind::Closure | DefKind::InlineConst) {
+    if matches!(ctx.tcx.def_kind(item), DefKind::Closure | DefKind::AnonConst) {
         return;
     }
     let is_logic = is_logic(ctx.tcx, item);

--- a/creusot/src/validate/purity.rs
+++ b/creusot/src/validate/purity.rs
@@ -264,7 +264,8 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for PurityVisitor<'a, 'tcx> {
             ExprKind::Call { fun, ref args, .. } => {
                 if let &FnDef(func_did, subst) = self.thir[fun].ty.kind() {
                     // try to specialize the called function if it is a trait method.
-                    let subst = self.ctx.erase_and_anonymize_regions(subst);
+                    let subst =
+                        self.ctx.erase_and_anonymize_regions(subst.no_bound_vars().unwrap());
                     let (func_did, _) =
                         TraitResolved::resolve_item(self.ctx.tcx, self.typing_env, func_did, subst)
                             .to_opt(func_did, subst)

--- a/creusot/src/validate/recursive_types.rs
+++ b/creusot/src/validate/recursive_types.rs
@@ -7,7 +7,7 @@ use crate::{
 use petgraph::{algo::tarjan_scc, graph};
 use rustc_hir::def_id::DefId;
 use rustc_index::bit_set::DenseBitSet;
-use rustc_middle::ty::{self, AliasTyKind, AssocKind, EarlyBinder, Unnormalized};
+use rustc_middle::ty::{self, AliasTyKind, AssocKind, EarlyBinder};
 use rustc_span::Span;
 use std::collections::{HashMap, HashSet};
 
@@ -184,7 +184,7 @@ fn forbid_recursion<'tcx>(
         // recursion through arrays and slices is not yet supported
         Array(_, _) => Err(Other("array".into())),
         Slice(_) => Err(Other("slice".into())),
-        Alias(alias) => {
+        Alias(_, alias) => {
             let (AliasTyKind::Projection { def_id }
             | AliasTyKind::Inherent { def_id }
             | AliasTyKind::Opaque { def_id }
@@ -389,9 +389,7 @@ fn add_trait(ctx: &TranslationCtx, def_id: DefId, graph: &mut TypeGraph) {
     }
     let node = graph.node(TypeNode::Trait(def_id));
 
-    for &(clause, span) in
-        ctx.trait_explicit_predicates_and_bounds(def_id.expect_local()).predicates
-    {
+    for &(clause, span) in ctx.trait_explicit_clauses_and_bounds(def_id.expect_local()).clauses {
         if let ty::ClauseKind::Trait(predicate) = clause.kind().skip_binder() {
             graph.add_edge(
                 node,
@@ -409,7 +407,7 @@ fn add_trait(ctx: &TranslationCtx, def_id: DefId, graph: &mut TypeGraph) {
         match item.kind {
             AssocKind::Const { .. } => continue,
             AssocKind::Fn { .. } => {
-                for &(clause, span) in ctx.predicates_of(item.def_id.expect_local()).predicates {
+                for &(clause, span) in ctx.clauses_of(item.def_id.expect_local()).clauses {
                     if let ty::ClauseKind::Trait(predicate) = clause.kind().skip_binder() {
                         graph.add_edge(
                             node,
@@ -441,7 +439,7 @@ fn add_trait_impl(ctx: &TranslationCtx, def_id: DefId, graph: &mut TypeGraph) {
             let typing_env = ctx.typing_env(item.def_id);
             let ty = ctx.normalize_erasing_regions(
                 typing_env,
-                Unnormalized::new(ctx.type_of(item.def_id).skip_binder()),
+                ctx.type_of(item.def_id).instantiate_identity(),
             );
             let mut path = Vec::new();
             walk_type(ctx, typing_env, ty, &mut path, &mut |tgt, _| {
@@ -488,10 +486,10 @@ fn walk_type<'tcx, E>(
         &Adt(adt, args) => {
             f(TypeNode::Type(adt.did()), path)?;
             // Add edges to impls used to resolve bounds on this ADT's generic arguments
-            let clauses = ctx.predicates_of(adt.did()).predicates.iter().map(|&(clause, _)| {
+            let clauses = ctx.clauses_of(adt.did()).clauses.iter().map(|&(clause, _)| {
                 ctx.normalize_erasing_regions(
                     typing_env,
-                    EarlyBinder::bind(clause).instantiate(ctx.tcx, args),
+                    EarlyBinder::bind(ctx.tcx, clause).instantiate(ctx.tcx, args),
                 )
             });
             path.push((ty, None)); // Pass the current type to f (for more precise errors)
@@ -517,7 +515,7 @@ fn walk_type<'tcx, E>(
         &Tuple(args) => {
             args.iter().try_for_each(|arg| walk_type(ctx, typing_env, arg, path, f))?;
         }
-        Alias(alias) => {
+        Alias(_, alias) => {
             // Types are normalized, so the only case left should be unresolved associated types.
             // Nothing to do then: an associated type is like an extra type parameter, and we will track
             // the subsequent dependency via the instantiation of the surrounding type with a trait impl.

--- a/creusot/src/validate/terminates.rs
+++ b/creusot/src/validate/terminates.rs
@@ -60,7 +60,7 @@ use rustc_middle::{
     thir::{self, visit::Visitor},
     ty::{
         self, ClauseKind, Clauses, EarlyBinder, FnDef, GenericArgs, GenericArgsRef, ParamEnv,
-        PredicateKind, TraitRef, TyCtxt, TyKind, TypingEnv, TypingMode, Unnormalized,
+        PredicateKind, TraitRef, TyCtxt, TyKind, TypingEnv, TypingMode,
     },
 };
 use rustc_span::Span;
@@ -353,7 +353,7 @@ impl<'tcx> BuildFunctionsGraph<'tcx> {
 
         let called_node: Option<graph::NodeIndex>;
         let mut bounds: Box<dyn Iterator<Item = ty::Clause<'tcx>>> = Box::new(
-            EarlyBinder::bind(ctx.param_env(fun_id).caller_bounds())
+            EarlyBinder::bind(ctx.tcx, ctx.param_env(fun_id).caller_bounds())
                 .instantiate(ctx.tcx, subst)
                 .skip_normalization()
                 .iter(),
@@ -371,7 +371,7 @@ impl<'tcx> BuildFunctionsGraph<'tcx> {
                 let (node, bnds) = self.visit_specialized_default_function(ctx, impl_ldid, fun_id);
                 called_node = Some(node);
                 bounds = Box::new(
-                    EarlyBinder::bind(bnds)
+                    EarlyBinder::bind(ctx.tcx, bnds)
                         .instantiate(
                             ctx.tcx,
                             subst.rebase_onto(ctx.tcx, ctx.parent(fun_id), impl_args),
@@ -485,7 +485,7 @@ impl<'tcx> BuildFunctionsGraph<'tcx> {
             item_bounds.iter().filter(|b| !defimpl_bounds.contains(b)).map(|b| {
                 ctx.tcx.normalize_erasing_regions(
                     typing_env_for_bounds,
-                    EarlyBinder::bind(b).instantiate(ctx.tcx, func_impl_args),
+                    EarlyBinder::bind(ctx.tcx, b).instantiate(ctx.tcx, func_impl_args),
                 )
             }),
         );
@@ -501,7 +501,7 @@ impl<'tcx> BuildFunctionsGraph<'tcx> {
         visitor.visit_term(&ctx.term(item_id).unwrap().1);
         for (called_id, generic_args, call_span) in visitor.results {
             // Instantiate the args for the call with the context we just built up.
-            let actual_args = EarlyBinder::bind(generic_args)
+            let actual_args = EarlyBinder::bind(ctx.tcx, generic_args)
                 .instantiate(ctx.tcx, func_impl_args)
                 .skip_normalization();
             self.function_dep(ctx, node, typing_env, called_id, actual_args, call_span, true);
@@ -612,14 +612,14 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for FunctionDeps<'a, 'tcx> {
         use thir::ExprKind::*;
         match expr.kind {
             ZstLiteral { .. } if let &FnDef(def_id, generic_args) = expr.ty.kind() => {
-                self.deps.push((def_id, generic_args, expr.span, false));
+                self.deps.push((def_id, generic_args.no_bound_vars().unwrap(), expr.span, false));
             }
             Call { ty, fun, ref args, .. }
                 if let fun = &self.thir[fun]
                     && self.is_trivial_fun(fun)
                     && let &FnDef(def_id, generic_args) = ty.kind() =>
             {
-                self.deps.push((def_id, generic_args, fun.span, true));
+                self.deps.push((def_id, generic_args.no_bound_vars().unwrap(), fun.span, true));
                 for &arg in &**args {
                     self.visit_expr(&self.thir()[arg]);
                 }
@@ -764,7 +764,7 @@ impl<'tcx> TermVisitor<'tcx> for TermCalls<'tcx> {
                 self.results.insert((id, subst, term.span));
             }
             TermKind::Lit(Literal::ZST) if let &TyKind::FnDef(id, subst) = term.ty.kind() => {
-                self.results.insert((id, subst, term.span));
+                self.results.insert((id, subst.no_bound_vars().unwrap(), term.span));
             }
             _ => (),
         }
@@ -908,16 +908,20 @@ pub(crate) fn proof_tree_nodes<'tcx>(
     let mut nodes = Vec::new();
     let mut predicates: Vec<_> = trait_refs_of_clauses(tcx, clauses).collect();
     while let Some(trait_ref) = predicates.pop() {
-        let trait_ref = tcx.normalize_erasing_regions(typing_env, Unnormalized::new(trait_ref));
+        let trait_ref = tcx.normalize_erasing_regions(
+            typing_env,
+            EarlyBinder::bind(tcx, trait_ref).instantiate_identity(),
+        );
         let ImplSelection::Found(source) = select_trait_impl(tcx, typing_env, trait_ref) else {
             continue;
         };
         match source {
             ImplSource::UserDefined(source) => {
                 nodes.push(source.impl_def_id);
-                let bounds = EarlyBinder::bind(tcx.param_env(source.impl_def_id).caller_bounds())
-                    .instantiate(tcx, source.args)
-                    .skip_normalization();
+                let bounds =
+                    EarlyBinder::bind(tcx, tcx.param_env(source.impl_def_id).caller_bounds())
+                        .instantiate(tcx, source.args)
+                        .skip_normalization();
                 predicates.extend(trait_refs_of_clauses(tcx, bounds));
             }
             ImplSource::Param(_) => (),
@@ -956,12 +960,12 @@ fn param_env_for_termination(tcx: TyCtxt, trait_item_id: DefId, impl_item_id: De
     let args = impl_item_args.rebase_onto(tcx, impl_id, trait_ref.args);
 
     // Reverse engineered from `GenericPredicates::instantiate_into`
-    let predicates = tcx.predicates_of(impl_id).instantiate_identity(tcx).predicates.into_iter();
+    let predicates = tcx.clauses_of(impl_id).instantiate_identity(tcx).clauses.into_iter();
     let predicates = predicates.chain(
-        tcx.predicates_of(trait_item_id)
-            .predicates
+        tcx.clauses_of(trait_item_id)
+            .clauses
             .iter()
-            .map(|(p, _)| EarlyBinder::bind(*p).instantiate(tcx, args)),
+            .map(|(p, _)| EarlyBinder::bind(tcx, *p).instantiate(tcx, args)),
     );
     let predicates: Vec<_> = predicates.map(|p| p.skip_normalization()).collect();
     let unnormalized_env = ty::ParamEnv::new(tcx.mk_clauses(&predicates));

--- a/creusot/src/validate/traits.rs
+++ b/creusot/src/validate/traits.rs
@@ -16,7 +16,7 @@ pub(crate) fn validate_traits(ctx: &TranslationCtx) {
         let trait_item = ctx.hir_trait_item(trait_item_id);
 
         if is_law(ctx.tcx, trait_item.owner_id.def_id.to_def_id())
-            && !(ctx.predicates_of(trait_item.owner_id.def_id).predicates.is_empty()
+            && !(ctx.clauses_of(trait_item.owner_id.def_id).clauses.is_empty()
                 && ctx.generics_of(trait_item.owner_id.def_id).own_params.is_empty())
         {
             law_violations.push((trait_item.owner_id.def_id, trait_item.span))

--- a/examples/iterators/04_skip.coma
+++ b/examples/iterators/04_skip.coma
@@ -652,6 +652,14 @@ module M_impl_Iterator_for_Skip_I__next (* <Skip<I> as common::Iterator> *)
   
   meta "rewrite_def" predicate resolve_refmut_Skip_I
   
+  predicate resolve_Option_Item (_1: t_Option_Item)
+  
+  axiom resolve_axiom [@rewrite]: forall x: t_Option_Item [resolve_Option_Item x]. resolve_Option_Item x
+      = match x with
+        | None -> true
+        | Some x0 -> resolve_Item x0
+        end
+  
   predicate completed_Skip_I (self: MutBorrow.t t_Skip_I) =
     UInt64.t'int self.final.n = 0
     /\ (exists s: Seq.seq t_Item, i: MutBorrow.t t_I. Seq.length s <= UInt64.t'int self.current.n
@@ -721,10 +729,12 @@ module M_impl_Iterator_for_Skip_I__next (* <Skip<I> as common::Iterator> *)
       | s2 = [ &_ret <- r ] s3
       | s3 = return {_ret} ]
     | bb9 = s0
-      [ s0 = s1 [ _ck -> (! {[@expl:type invariant] inv_refmut_Skip_I self} any) ]
-      | s1 = -{resolve_refmut_Skip_I self}- s2
-      | s2 = [ &_ret <- r ] s3
-      | s3 = return {_ret} ] ]
+      [ s0 = s1 [ _ck -> (! {[@expl:type invariant] inv_Option_Item r} any) ]
+      | s1 = -{resolve_Option_Item r}- s2
+      | s2 = s3 [ _ck -> (! {[@expl:type invariant] inv_refmut_Skip_I self} any) ]
+      | s3 = -{resolve_refmut_Skip_I self}- s4
+      | s4 = [ &_ret <- r ] s5
+      | s5 = return {_ret} ] ]
     [ & _ret: t_Option_Item = Any.any_l ()
     | & self: MutBorrow.t t_Skip_I = self
     | & old_self: MutBorrow.t t_Skip_I = Any.any_l ()

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784004965,
-        "narHash": "sha256-5Dk8H/H9fqjr7kS4MKqdBOzVsTK5r1/PMjC6eQuXd54=",
+        "lastModified": 1785476452,
+        "narHash": "sha256-/CXwCFPS41rb/JI2VitKCgVK6V5E6/sfw5ke3B9zyVQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a794b72f1297136a654424de0348d32e76a9f14e",
+        "rev": "6ef009bf4c4873cdc1a621826722bdea7c03e62c",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-06-22"
+channel = "nightly-2026-07-29"
 components = [ "rustfmt", "rustc-dev", "llvm-tools" ]


### PR DESCRIPTION
Main changes

- Some Rust intrinsics can only be used in `const` blocks and this is now strictly enforced. This affects us because we have extern specs on them (because these intrinsics are exposed in constants; otherwise users are not supposed to use these intrinsics directly), so the generated wrapper must now wrap its body in a `const` block. I have added an attribute to that effect.
- `TyKind::Alias` now has a `IsRigid` field that indicates whether the alias is "rigid". If I understand correctly, normalization either unfolds the alias (when possible) or sets that flag to `IsRigid::Yes`, whereas instantiation (`EarlyBinder::bind` + `instantiate`) sets that flag everywhere to `IsRigid::No`. Basically this means we have to call normalization more consistently than before to correctly identify types (we should never try to translate an alias with `IsRigid::No`).
- Only one test changed: `examples/iterators/04_skip.coma` has an extra resolve statement which looks like it should have been there from the beginning, so I deduce that was a bugfix in Rust's borrowchecker.