### PR TITLE
Upgrade toolchain to 2026-08-03 and adapt tests to new Cargo build dir layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "glob",
  "libc",
  "regex",
+ "serde_json",
  "similar",
  "termcolor",
 ]
@@ -1237,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",

--- a/creusot-args/src/options.rs
+++ b/creusot-args/src/options.rs
@@ -30,8 +30,8 @@ pub struct CreusotArgs {
     #[clap(group = "output", long, env)]
     pub output_dir: Option<PathBuf>,
     /// Disable output.
-    #[clap(group = "output", long, default_value_t = false, action = clap::ArgAction::SetTrue)]
-    pub check: bool,
+    #[clap(group = "output", long)]
+    pub no_output: bool,
     /// Output the generated code in a single file in output_dir.
     #[clap(long, default_value_t = false, action = clap::ArgAction::SetTrue)]
     pub monolithic: bool,
@@ -147,13 +147,15 @@ impl CreusotArgs {
         let cargo_creusot = std::env::var("CARGO_CREUSOT").is_ok();
         let should_output = !cargo_creusot || std::env::var("CARGO_PRIMARY_PACKAGE").is_ok();
 
-        let output = match (self.stdout, self.output_file, self.output_dir, self.check) {
+        let output = match (self.stdout, self.output_file, self.output_dir, self.no_output) {
             (true, None, None, false) => Ok(Output::Stdout),
             (false, Some(f), None, false) => Ok(Output::File(f)),
             (false, None, Some(d), false) => Ok(Output::Directory(d)),
             (false, None, None, true) => Ok(Output::None),
             (false, None, None, false) => Ok(Output::Directory(PathBuf::from("."))), // default --output-dir=.
-            _ => Err("--stdout, --output-file, --output-dir, and --check are mutually exclusive"), // This should already be enforced by clap
+            _ => {
+                Err("--stdout, --output-file, --output-dir, and --no-output are mutually exclusive")
+            } // This should already be enforced by clap
         }?;
 
         let span_mode = match (&self.span_mode, &output, &self.spans_relative_to) {

--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -203,7 +203,8 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                 | CastKind::FnPtrToPtr
                 | CastKind::FloatToFloat
                 | CastKind::Subtype
-                | CastKind::Transmute,
+                | CastKind::Transmute
+                | CastKind::BoxDerefTransmute,
                 _,
                 _,
             ) => self.ctx.crash_and_error(si.span, format!("Unsupported pointer cast: {rvalue:?}")),

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785476452,
-        "narHash": "sha256-/CXwCFPS41rb/JI2VitKCgVK6V5E6/sfw5ke3B9zyVQ=",
+        "lastModified": 1785736145,
+        "narHash": "sha256-DauSP0ACycrq3MEEmDz/Scsxhs9TPBTexwKbTuE8Bw8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6ef009bf4c4873cdc1a621826722bdea7c03e62c",
+        "rev": "292249772330735cb32b90dedf44feddec40e7d0",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-07-29"
+channel = "nightly-2026-08-03"
 components = [ "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,6 +15,7 @@ termcolor = "1.4"
 libc = "0.2"
 creusot-std = { path = "../creusot-std", features = ["nightly"] }
 creusot-setup = { path = "../creusot-setup" }
+serde_json = "1.0.151"
 
 [[test]]
 name = "ui"

--- a/tests/should_fail/terminates/invalid_variant_type.stderr
+++ b/tests/should_fail/terminates/invalid_variant_type.stderr
@@ -12,12 +12,12 @@ help: the trait `creusot_std::logic::WellFounded` is not implemented for `S`
   = help: the following other types implement trait `creusot_std::logic::WellFounded`:
             &T
             ()
+            (T0,)
             (T0, T1)
             (T0, T1, T2)
             (T0, T1, T2, T3)
             (T0, T1, T2, T3, T4)
             (T0, T1, T2, T3, T4, T5)
-            (T0, T1, T2, T3, T4, T5, T6)
           and 16 others
 note: required by a bound in `creusot_std::__stubs::variant_check`
  --> creusot-std/src/stubs.rs:59:0

--- a/tests/should_fail/terminates/trait_def_and_impl_disagree.stderr
+++ b/tests/should_fail/terminates/trait_def_and_impl_disagree.stderr
@@ -1,13 +1,13 @@
-error: Expected `h` to be `#[check(ghost)]` as specified by the trait declaration
-  --> trait_def_and_impl_disagree.rs:22:5
-   |
-22 |     fn h() {}
-   |     ^^^^^^
-
 error: Expected `f` to be `#[check(terminates)]` as specified by the trait declaration
   --> trait_def_and_impl_disagree.rs:17:5
    |
 17 |     fn f() {}
+   |     ^^^^^^
+
+error: Expected `h` to be `#[check(ghost)]` as specified by the trait declaration
+  --> trait_def_and_impl_disagree.rs:22:5
+   |
+22 |     fn h() {}
    |     ^^^^^^
 
 error: Expected `g` to be `#[check(ghost)]` as specified by the trait declaration

--- a/tests/tests/diff.rs
+++ b/tests/tests/diff.rs
@@ -15,8 +15,9 @@ pub fn normalize_file_path(input: impl Into<String>) -> String {
 }
 
 pub fn differ(
-    output: std::process::Output,
-    stdout: &Path,
+    output: &std::process::Output,
+    actual: &str,
+    expect: &Path,
     stderr: Option<&Path>,
     should_succeed: bool,
     enable_color: bool,
@@ -24,9 +25,8 @@ pub fn differ(
     let mut buf = if enable_color { Buffer::ansi() } else { Buffer::no_color() };
     match output.clone().ok() {
         Ok(output) => {
-            let expect_out = &std::fs::read(stdout).unwrap_or_else(|_| Vec::new());
-            let success_out =
-                compare_str(&mut buf, from_utf8(&output.stdout)?, from_utf8(expect_out)?);
+            let expect_out = std::fs::read(expect).unwrap_or_else(|_| Vec::new());
+            let success_out = compare_str(&mut buf, actual, from_utf8(&expect_out)?);
 
             let success_err = if let Some(stderr) = stderr {
                 let expect_err = &std::fs::read(stderr).unwrap_or_else(|_| Vec::new());

--- a/tests/tests/ui.rs
+++ b/tests/tests/ui.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use libc::{STDOUT_FILENO, TIOCGWINSZ, c_ushort, ioctl};
+use serde_json;
 use std::{
     env,
     fs::{self, File},
@@ -79,7 +80,7 @@ fn main() {
     build_cargo_creusot(args.force_color);
 
     let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let paths = CreusotPaths::new(base_path.parent().unwrap());
+    let mut paths = CreusotPaths::new(base_path.parent().unwrap());
 
     if args.erasure_check {
         erasure_check(&paths);
@@ -92,10 +93,10 @@ fn main() {
     {
         test_creusot_std = false;
     }
-    let contracts_success = translate_creusot_std(&args, &paths, test_creusot_std);
+    let creusot_std_success = translate_creusot_std(&args, &mut paths, test_creusot_std);
 
     let (mut failed, mut total) =
-        (if contracts_success { 0 } else { 1 }, if test_creusot_std { 1 } else { 0 });
+        (if creusot_std_success { 0 } else { 1 }, if test_creusot_std { 1 } else { 0 });
     let (fail1, total1) = should_fail(&["tests/should_fail/**/*.rs"], &args, |p| {
         run_creusot(p, &paths, args.with_spans)
     });
@@ -143,9 +144,9 @@ fn cargo_build(target: &str, force_color: bool) {
 
 struct CreusotPaths {
     creusot_rustc: PathBuf,
-    deps: PathBuf,
     rlib: PathBuf,
     cmeta: PathBuf,
+    libs: Vec<PathBuf>,
 }
 
 impl CreusotPaths {
@@ -153,17 +154,19 @@ impl CreusotPaths {
         let creusot = base.join("target/creusot/debug");
         Self {
             creusot_rustc: base.join(CREUSOT_RUSTC),
-            deps: creusot.join("deps"),
             rlib: creusot.join("libcreusot_std.rlib"),
             cmeta: creusot.join("libcreusot_std.cmeta"),
+            libs: vec![],
         }
     }
 }
 
-/// Returns `false` if the translation changed
+/// Run cargo creusot on creusot-std, output to `/tmp/creusot-std.coma`,
+/// and record compiled artifacts in `paths` (for invoking creusot-rustc ourselves, without cargo).
 ///
+/// Returns `false` if the translation changed.
 /// This will only check the output of `creusot-std` if `test_creusot_std` is true.
-fn translate_creusot_std(args: &Args, paths: &CreusotPaths, test_creusot_std: bool) -> bool {
+fn translate_creusot_std(args: &Args, paths: &mut CreusotPaths, test_creusot_std: bool) -> bool {
     print!("Translating creusot-std... ");
     std::io::stdout().flush().unwrap();
     if test_creusot_std {
@@ -171,8 +174,21 @@ fn translate_creusot_std(args: &Args, paths: &CreusotPaths, test_creusot_std: bo
     }
 
     let mut out = args.stream();
-    let output = build_creusot_std(paths, true, ErasureCheck::No, args.with_spans)
-        .expect("could not translate `creusot_std`");
+    let tmpfile = if test_creusot_std {
+        let mut tmpfile = std::env::temp_dir();
+        tmpfile.push("creusot-std.coma");
+        Some(tmpfile)
+    } else {
+        None
+    };
+    let output = build_creusot_std(
+        paths,
+        tmpfile.as_ref().map(|p| p.as_path()),
+        true,
+        ErasureCheck::No,
+        args.with_spans,
+    )
+    .expect("could not translate `creusot_std`");
     if !output.status.success() {
         writeln_color!(out, Color::Red, "could not translate");
         out.flush().unwrap();
@@ -180,14 +196,42 @@ fn translate_creusot_std(args: &Args, paths: &CreusotPaths, test_creusot_std: bo
         std::process::exit(1);
     }
 
-    if !test_creusot_std {
-        println!();
-        return true;
+    use serde_json::Value;
+    for line in output.stdout.lines() {
+        let line: Value = serde_json::from_str(&line.unwrap()).unwrap();
+        let Some(object) = line.as_object() else {
+            continue;
+        };
+        let Some(filenames) = object.get("filenames") else {
+            continue;
+        };
+        let Some(filename) = filenames
+            .as_array()
+            .iter()
+            .flat_map(|array| array.iter())
+            .filter_map(|name| {
+                name.as_str().and_then(|name| {
+                    if name.ends_with(".rlib") || name.ends_with(".so") { Some(name) } else { None }
+                })
+            })
+            .next()
+        else {
+            continue;
+        };
+        let mut path = PathBuf::from(filename);
+        path.pop();
+        paths.libs.push(path);
     }
 
+    let Some(tmpfile) = tmpfile else {
+        println!();
+        return true;
+    };
+
+    let actual = std::fs::read_to_string(tmpfile).unwrap();
     let expect = PathBuf::from("tests/creusot-std/creusot-std.coma");
     let mut succeeded = true;
-    let (success, buf) = differ(output.clone(), &expect, None, true, args.force_color).unwrap();
+    let (success, buf) = differ(&output, &actual, &expect, None, true, args.force_color).unwrap();
 
     // Warnings in creusot-std will be counted as an error at the end,
     // but we still allow --bless so we can experiment without resolving warnings immediately.
@@ -233,6 +277,7 @@ enum ErasureCheck {
 
 fn build_creusot_std(
     paths: &CreusotPaths,
+    outfile: Option<&Path>,
     output_cmeta: bool,
     erasure_check: ErasureCheck,
     with_spans: bool,
@@ -259,12 +304,16 @@ fn build_creusot_std(
         "--package",
         "creusot-std",
         "--no-check-version",
-        "--stdout",
         "--spans-relative-to=tests/creusot-std",
     ]);
+    if let Some(outfile) = outfile {
+        build.arg("--output-file").arg(outfile);
+    } else {
+        build.arg("--no-output");
+    }
     build.arg("--creusot-rustc").arg(&paths.creusot_rustc);
     build
-        .args(["--", "--package", "creusot-std", "--quiet", "-Fsc-drf"])
+        .args(["--", "--package", "creusot-std", "--quiet", "-Fsc-drf", "--message-format=json"])
         .env("CREUSOT_CONTINUE", "true");
     if matches!(erasure_check, ErasureCheck::Warn | ErasureCheck::Error) {
         build.arg("-Zbuild-std=core,std");
@@ -298,8 +347,11 @@ fn run_creusot(
     cmd.args(["--diagnostic-width=100", "-Zwrite-long-types-to-disk=no"]);
     cmd.args(["--edition=2024", "-Zno-codegen", "--crate-type=lib"]);
     cmd.args(["--extern", &format!("creusot_std={}", paths.rlib.display())]);
-    cmd.arg(format!("-Ldependency={}/", paths.deps.display()));
     cmd.arg(file.file_name().unwrap());
+
+    for path in paths.libs.iter() {
+        cmd.arg("-L").arg(format!("dependency={}", path.display()));
+    }
 
     if header_line.contains("SHORT_ERROR") {
         cmd.arg("--error-format=short");
@@ -419,7 +471,7 @@ where
 
                 let entry_name = entry.file_stem().unwrap().to_str().unwrap();
 
-                let output = match command_builder(&entry) {
+                let mut output = match command_builder(&entry) {
                     None => continue,
                     Some(mut c) => {
                         if !args.quiet {
@@ -438,9 +490,11 @@ where
 
                 let stderr = entry.with_extension("stderr");
                 let stdout = entry.with_extension("coma");
+                let actual = String::from_utf8(std::mem::take(&mut output.stdout)).unwrap();
 
                 let (success, buf) = differ(
-                    output.clone(),
+                    &output,
+                    &actual,
                     &stdout,
                     Some(&stderr),
                     should_succeed,
@@ -458,10 +512,10 @@ where
                 }
 
                 if args.bless && !(should_succeed && !output.status.success()) {
-                    if output.stdout.is_empty() {
+                    if actual.is_empty() {
                         let _ = std::fs::remove_file(stdout);
                     } else {
-                        std::fs::write(stdout, &output.stdout).unwrap();
+                        std::fs::write(stdout, &actual).unwrap();
                     }
 
                     let no_warn = output.stderr.is_empty();
@@ -520,7 +574,7 @@ fn erasure_check(paths: &CreusotPaths) {
     let build_once = |erasure_check, msg: &str| {
         print!("{msg}");
         std::io::stdout().flush().unwrap();
-        let output = build_creusot_std(paths, false, erasure_check, false).unwrap();
+        let output = build_creusot_std(paths, None, false, erasure_check, false).unwrap();
         if !output.status.success() {
             println!("failed");
             if !output.stderr.is_empty() {


### PR DESCRIPTION
Cargo is changing where it outputs its artifacts. Previously, artifacts were dumped in `deps/`. Now, they are placed in crate-specific directories that we have to find. They can't be guessed because they contain hashes. Cargo officially doesn't provide an API to query this because the layout details are considered internal to Cargo, but we can recover the paths from the output of `--message-format=json`.