### PR TITLE
Add regression test for a constructor used as a function value

### DIFF
--- a/tests/should_fail/constructor_as_value.rs
+++ b/tests/should_fail/constructor_as_value.rs
@@ -1,0 +1,14 @@
+extern crate creusot_std;
+
+pub enum E {
+    A(u32),
+}
+
+// A tuple-variant constructor used as a function value, rather than applied
+// directly, reaches Creusot as an item of kind `Ctor`, which it does not
+// translate. Creusot must reject it with a diagnostic: asking rustc for the
+// argument idents of the synthesized `{constructor#0}` item instead ICEs,
+// as it did in 0.12.0 (creusot-rs/creusot#2223).
+pub fn g(o: Option<u32>) -> Option<E> {
+    o.map(E::A)
+}

--- a/tests/should_fail/constructor_as_value.stderr
+++ b/tests/should_fail/constructor_as_value.stderr
@@ -1,0 +1,8 @@
+error: expanding "E::A" failed because of unexpected kind Unsupported(Ctor(Variant, Fn)) while translating "g"
+  --> constructor_as_value.rs:12:1
+   |
+12 | pub fn g(o: Option<u32>) -> Option<E> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This is the regression test I offered in
[#2223](https://github.com/creusot-rs/creusot/issues/2223#issuecomment-5249418140). Test-only — no
translation changes.

I filed #2223 as an ICE against 0.12.0: using a tuple-variant constructor as a *function value*
rather than applying it directly reached rustc's `fn_arg_idents`, which has no entry for the
synthesized `{constructor#0}` item, so it hit the `span_bug!`:

```text
error: internal compiler error: rustc_middle/src/hir/mod.rs:499:13: fn_arg_idents:
unexpected item DefId(0:6 ~ ctorprobe[a00c]::E::A::{constructor#0})
```

On `master` it is already refused with a proper diagnostic, so there is nothing to fix — but nothing
pins the behaviour either, and the crashing path is one `item_type` arm away. This adds a
`should_fail` test recording the refusal:

```text
error: expanding "E::A" failed because of unexpected kind Unsupported(Ctor(Variant, Fn)) while translating "g"
```

Checked on `master` @ 7c3d1e83: `./t ui` 472/472, `./t fmt --fmt-check` clean.

Close this without ceremony if you'd rather not carry the extra test — I won't be offended, and #2223
can just be closed as fixed either way.
