### PR TITLE
Support aarch64 Linux in creusot-install

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -172,6 +172,45 @@ jobs:
       with:
         path: .why3find
         key: ${{ runner.os }}-why3find-${{ env.TODAY }}-${{ hashFiles('.why3find/**') }}
+  install-aarch64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v4
+    - name: Cache Opam switch
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/share/creusot/_opam
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-${{ hashFiles('creusot-deps.opam') }}
+        restore-keys: ${{ runner.os }}-${{ runner.arch }}-opam-
+    - run: sudo apt update && sudo apt install -y opam libzmq3-dev
+    - name: setup opam
+      run: |
+        opam init --bare --disable-sandboxing --no-setup -y
+        opam --cli=2.1 var --global in-creusot-ci=true
+    # The switch must exist before Alt-Ergo can be installed into it, so the components are taken in
+    # two passes rather than one `./INSTALL`.
+    - name: install why3 (creates the opam switch)
+      run: cargo run --bin creusot-install -- why3
+    - name: install alt-ergo from opam
+      run: opam install -y alt-ergo.2.6.2 --switch "$HOME/.local/share/creusot"
+    - name: install the rest, with alt-ergo supplied externally
+      run: |
+        eval $(opam env --switch "$HOME/.local/share/creusot" --set-switch)
+        cargo run --bin creusot-install -- --external alt-ergo \
+          creusot-rustc prelude cargo-creusot provers why3-conf
+    # Stat the results rather than trusting a zero exit: the point of the job is that the binaries
+    # an aarch64 user needs actually land.
+    - name: the installed toolchain is really there
+      run: |
+        D="$HOME/.local/share/creusot"
+        test -x "$D/bin/z3"
+        test -x "$D/bin/cvc5"
+        test -x "$D/bin/alt-ergo"
+        test -x $(echo "$D"/toolchains/*/bin/creusot-rustc)
+        test -x "$HOME/.cargo/bin/cargo-creusot"
+    - name: Minimize Opam cache
+      run: opam clean --all-switches --download-cache --logs --repo-cache
+
   install:
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -172,6 +172,58 @@ jobs:
       with:
         path: .why3find
         key: ${{ runner.os }}-why3find-${{ env.TODAY }}-${{ hashFiles('.why3find/**') }}
+  # Creusot did not build on aarch64 Linux at all until the linux/aarch64 `URLS` table existed, so
+  # nothing here would have caught a regression in it. This job is deliberately narrow: it proves
+  # the *installation* completes on aarch64 and leaves the translation suite to the jobs above.
+  #
+  # `ubuntu-24.04-arm` is a native arm64 hosted runner, free on public repos — no QEMU, so this
+  # costs about what the x86_64 install job costs rather than many hours.
+  #
+  # Alt-Ergo publishes no aarch64-linux binary, so `creusot-install` skips it and the prover has to
+  # come from opam instead; that is what `--external alt-ergo` is for, and installing it into
+  # Creusot's own switch is what makes it resolvable. CVC4 is likewise absent on this platform
+  # (archived upstream, x86_64 only) and is simply not installed — cvc5 supersedes it.
+  install-aarch64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v4
+    - name: Cache Opam switch
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/share/creusot/_opam
+        # `runner.os` is `Linux` on both x86_64 and arm64 runners, so the arch has to be in the key
+        # or the two would share a cache and restore each other's incompatible switch.
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-${{ hashFiles('creusot-deps.opam') }}
+        restore-keys: ${{ runner.os }}-${{ runner.arch }}-opam-
+    - run: sudo apt update && sudo apt install -y opam libzmq3-dev
+    - name: setup opam
+      run: |
+        opam init --bare --disable-sandboxing --no-setup -y
+        opam --cli=2.1 var --global in-creusot-ci=true
+    # The switch must exist before Alt-Ergo can be installed into it, so the components are taken in
+    # two passes rather than one `./INSTALL`.
+    - name: install why3 (creates the opam switch)
+      run: cargo run --bin creusot-install -- why3
+    - name: install alt-ergo from opam
+      run: opam install -y alt-ergo.2.6.2 --switch "$HOME/.local/share/creusot"
+    - name: install the rest, with alt-ergo supplied externally
+      run: |
+        eval $(opam env --switch "$HOME/.local/share/creusot" --set-switch)
+        cargo run --bin creusot-install -- --external alt-ergo \
+          creusot-rustc prelude cargo-creusot provers why3-conf
+    # Stat the results rather than trusting a zero exit: the point of the job is that the binaries
+    # an aarch64 user needs actually land.
+    - name: the installed toolchain is really there
+      run: |
+        D="$HOME/.local/share/creusot"
+        test -x "$D/bin/z3"
+        test -x "$D/bin/cvc5"
+        test -x "$D/bin/alt-ergo"
+        test -x $(echo "$D"/toolchains/*/bin/creusot-rustc)
+        test -x "$HOME/.cargo/bin/cargo-creusot"
+    - name: Minimize Opam cache
+      run: opam clean --all-switches --download-cache --logs --repo-cache
+
   install:
     strategy:
       matrix:

--- a/creusot-install/src/main.rs
+++ b/creusot-install/src/main.rs
@@ -10,7 +10,9 @@ use std::{
 #[derive(Clone, Copy)]
 pub struct ManagedBinary {
     pub bin: setup::Binary,
-    url: &'static Url,
+    /// `None` if no binary release exists for this platform; the tool must then
+    /// be supplied with `--external`.
+    url: &'static Option<Url>,
     download: fn(&Url, &Path, &Path, &Args) -> anyhow::Result<()>,
 }
 
@@ -255,9 +257,16 @@ fn install_provers(paths: &setup::CreusotPaths, args: &Args) -> anyhow::Result<(
         if args.external.contains(&tool) {
             // create symbolic links for external tools
             args.symlink_file(get_path(bin.bin, args)?, paths.bin().join(bin.bin.binary_name))?;
-        } else {
+        } else if let Some(url) = bin.url {
             // download binaries for builtins
-            download(bin, &paths.cache_dir(), &paths.bin(), args)?;
+            download(bin, url, &paths.cache_dir(), &paths.bin(), args)?;
+        } else {
+            eprintln!(
+                "Skipping {}: no binary release for this platform. \
+                 Install it separately and re-run with `--external {}`.",
+                bin.bin.display_name,
+                format!("{tool:?}").to_lowercase(),
+            );
         }
     }
     Ok(())
@@ -381,6 +390,7 @@ fn download_from_url_with_cache(
 
 fn download(
     bin: ManagedBinary,
+    url: &Url,
     cache_dir: &Path,
     dest_dir: &Path,
     args: &Args,
@@ -392,7 +402,7 @@ fn download(
     }
     let path = dest_dir.join(bin.bin.binary_name);
     let dl = bin.download;
-    dl(bin.url, cache_dir, &path, args)?;
+    dl(url, cache_dir, &path, args)?;
     set_executable(&path)
 }
 

--- a/creusot-setup/src/tools_versions_urls.rs
+++ b/creusot-setup/src/tools_versions_urls.rs
@@ -17,50 +17,71 @@ pub const CVC5_VERSION: &'static str = "1.3.1";
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 pub const URLS: Urls = Urls {
-    altergo: Url {
+    altergo: Some(Url {
         url: "https://github.com/OCamlPro/alt-ergo/releases/download/v2.6.2/alt-ergo-v2.6.2-x86_64-linux-musl",
         sha256: "bdc4e487f2bdfd421011c82f545df3f50530aee6d6e406b1e847d433650ca3c1",
-    },
-    z3: Url {
+    }),
+    z3: Some(Url {
         url: "https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-x64-glibc-2.39.zip",
         sha256: "94549c5e31a75b9c543fe6eea8f32927054765c2e92e696d2d6dde0eedf348a1",
-    },
-    cvc4: Url {
+    }),
+    cvc4: Some(Url {
         url: "https://github.com/CVC4/CVC4-archived/releases/download/1.8/cvc4-1.8-x86_64-linux-opt",
         sha256: "d38a79cf984592785eda41ec888d94ca107ac1f13058740238041e28c8472e51",
-    },
-    cvc5: Url {
+    }),
+    cvc5: Some(Url {
         url: "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.1/cvc5-Linux-x86_64-static-gpl.zip",
         sha256: "dcad9de0827509e8517f60da87f0c4292652627641dbcad8012644b6a982a183",
-    },
+    }),
+};
+
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+pub const URLS: Urls = Urls {
+    // Alt-Ergo publishes no aarch64-linux binary; it is an OCaml program, so
+    // `opam install alt-ergo` plus `--external alt-ergo` covers it.
+    altergo: None,
+    z3: Some(Url {
+        url: "https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-arm64-glibc-2.34.zip",
+        sha256: "78b383374905a20af7f38cb3e8e9e8e38c5cb3d23a8c2fbf8f54ff4b41a9c605",
+    }),
+    // CVC4 is archived upstream (last release 2020) and never shipped an
+    // aarch64-linux binary. CVC5 supersedes it.
+    cvc4: None,
+    cvc5: Some(Url {
+        url: "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.1/cvc5-Linux-arm64-static-gpl.zip",
+        sha256: "a3673b5f91aa71f11939494498ae7f8b89a035c7e0993f5a2f81728e6f9bcc43",
+    }),
 };
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub const URLS: Urls = Urls {
-    altergo: Url {
+    altergo: Some(Url {
         url: "https://github.com/OCamlPro/alt-ergo/releases/download/v2.6.2/alt-ergo-v2.6.2-aarch64-macos",
         sha256: "bfec57500243a3cf1d3b613662f5814492d49152453409a9a46d0dfeacf61b31",
-    },
-    z3: Url {
+    }),
+    z3: Some(Url {
         url: "https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-arm64-osx-13.7.6.zip",
         sha256: "941659417b5464a361c49089658509f3118a0c3e8d4f8a1dc999f8b5cd1f3c71",
-    },
+    }),
     // CVC4 only has a macos x86_64 binary; we rely on rosetta for compatibility
-    cvc4: Url {
+    cvc4: Some(Url {
         url: "https://github.com/CVC4/CVC4-archived/releases/download/1.8/cvc4-1.8-macos-opt",
         sha256: "b8a0b8714dd947aa46182402d9caba27d3d696041e17704884bc3d8510066527",
-    },
-    cvc5: Url {
+    }),
+    cvc5: Some(Url {
         url: "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.1/cvc5-macOS-arm64-static-gpl.zip",
         sha256: "e28df7104ebac5ca0953a0e9aadd016c2c63b00ec6edc3d25820fd888e7e22c3",
-    },
+    }),
 };
 
+/// A `None` field means: no binary release of that prover exists for this
+/// platform. `creusot-install` skips it with a message; install it by other
+/// means (opam, distro package, from source) and pass `--external <TOOL>`.
 pub struct Urls {
-    pub altergo: Url,
-    pub z3: Url,
-    pub cvc4: Url,
-    pub cvc5: Url,
+    pub altergo: Option<Url>,
+    pub z3: Option<Url>,
+    pub cvc4: Option<Url>,
+    pub cvc5: Option<Url>,
 }
 
 pub struct Url {


### PR DESCRIPTION
On aarch64 Linux, `creusot-install` does not compile — `URLS` is `#[cfg]`-gated to linux/x86_64 and
macos/aarch64 only, so there is no definition for the platform:

```text
error[E0425]: cannot find value `URLS` in this scope
```

This adds the missing linux/aarch64 table. Z3 and cvc5 both publish aarch64 Linux binaries, so those
are wired up directly. Alt-Ergo and CVC4 do not, so the per-tool URLs become `Option<Url>` and
`install_provers` skips a `None` tool with a message pointing at `--external <TOOL>`:

```text
Skipping Alt-Ergo: no binary release for this platform. Install it separately and re-run with `--external altergo`.
```

Alt-Ergo is an OCaml program, so `opam install alt-ergo` + `--external alt-ergo` covers it. CVC4 is
archived upstream (last release 2020) and never shipped an aarch64 binary; cvc5 supersedes it.

The x86_64 Linux and aarch64 macOS tables are unchanged apart from being wrapped in `Some`, and I've
deliberately left the `PROVERS` list and the `why3find.json` template alone — see the caveat below.

### Checks

- `cargo build -p creusot-install` on aarch64 Linux: succeeds (it did not compile before this).
- `cargo check -p creusot-setup --target x86_64-unknown-linux-gnu`: clean.
- `cargo check -p creusot-setup --target aarch64-apple-darwin`: clean.
- `./t fmt --fmt-check`: clean.
- Both new SHA256s verified by fresh download of the release archives, not copied from anywhere.
- This has been running in anger: I've built and used Creusot on aarch64 Linux with this change for
  about three weeks (`creusot-install why3` / `creusot-rustc` / `prelude cargo-creusot provers
  why3-conf`, with `--external alt-ergo`), and Z3 + cvc5 install and discharge goals normally.

### One caveat, deliberately not fixed here

`CVC4` stays in `PROVERS` and in the `why3find.json` template, so on a platform where it is skipped,
`why3find` can still try to *calibrate* it and report `can not calibrate prover cvc4` on a goal it
cannot discharge quickly — which reads as an error rather than a clean unproved result. Locally I
drop CVC4 from both, but that is a prover-policy change affecting every platform, and it seemed
wrong to smuggle it into a PR about aarch64 support. Happy to send it separately, or to scope the
prover list per-platform instead, whichever you'd prefer.
