### PR TITLE
Support a constructor used as a function value

### DIFF
--- a/creusot/src/backend/ty_inv.rs
+++ b/creusot/src/backend/ty_inv.rs
@@ -7,7 +7,7 @@ use crate::{
     resolution::TraitResolved,
     translation::{
         pearlite::{Ident, Pattern, Term, TermKind, Trigger},
-        specification::{Condition, PreSignature},
+        specification::{Condition, PreSignature, ctor_term},
     },
 };
 use rustc_abi::{FieldIdx, VariantIdx};
@@ -338,6 +338,16 @@ pub(crate) fn sig_add_type_invariant_spec<'tcx>(
         }
     });
     pre_sig.contract.requires.splice(0..0, new_requires);
+
+    // A constructor has no body, so the result invariant below is a goal nothing else can
+    // discharge: the field invariants above do not imply the built value's. Require it, which
+    // moves the obligation to the call site, where the fields are known.
+    if let Some(built) = ctor_term(ctx, def_id, &pre_sig.inputs, pre_sig.output)
+        && let Some(term) = inv_call(ctx, typing_env, scope_id, built)
+    {
+        let expl = format!("expl:{} result type invariant", fn_name);
+        pre_sig.contract.requires.push(Condition { term: term.span(ctx.def_span(def_id)), expl });
+    }
 
     let ret_ty_span: Option<Span> = try { ctx.hir_get_fn_output(def_id.as_local()?)?.span() };
     if (ctx.def_kind(def_id) == DefKind::ConstParam || !is_open_inv_result(ctx.tcx, def_id))

--- a/creusot/src/backend/ty_inv.rs
+++ b/creusot/src/backend/ty_inv.rs
@@ -7,7 +7,7 @@ use crate::{
     resolution::TraitResolved,
     translation::{
         pearlite::{Ident, Pattern, Term, TermKind, Trigger},
-        specification::{Condition, PreSignature, ctor_term},
+        specification::{Condition, PreSignature},
     },
 };
 use rustc_abi::{FieldIdx, VariantIdx};
@@ -338,16 +338,6 @@ pub(crate) fn sig_add_type_invariant_spec<'tcx>(
         }
     });
     pre_sig.contract.requires.splice(0..0, new_requires);
-
-    // A constructor has no body, so the result invariant below is a goal nothing else can
-    // discharge: the field invariants above do not imply the built value's. Require it, which
-    // moves the obligation to the call site, where the fields are known.
-    if let Some(built) = ctor_term(ctx, def_id, &pre_sig.inputs, pre_sig.output)
-        && let Some(term) = inv_call(ctx, typing_env, scope_id, built)
-    {
-        let expl = format!("expl:{} result type invariant", fn_name);
-        pre_sig.contract.requires.push(Condition { term: term.span(ctx.def_span(def_id)), expl });
-    }
 
     let ret_ty_span: Option<Span> = try { ctx.hir_get_fn_output(def_id.as_local()?)?.span() };
     if (ctx.def_kind(def_id) == DefKind::ConstParam || !is_open_inv_result(ctx.tcx, def_id))

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -569,7 +569,8 @@ impl<'tcx> TranslationCtx<'tcx> {
         param_env: ParamEnv<'tcx>,
     ) -> TypingEnv<'tcx> {
         // FIXME: is it correct to pretend we are doing a non-body analysis?
-        // A constructor has shim MIR, so it passes `is_mir_available`, but it is not a body owner:
+        // `contract_of` calls this for a constructor used as a function value (`o.map(E::A)`). A
+        // constructor has shim MIR, so it passes `is_mir_available`, but it is not a body owner:
         // `post_borrowck_analysis` needs `opaque_types_defined_by`, which rustc refuses for one.
         let mode = if self.is_mir_available(def_id)
             && def_id.is_local()

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -35,7 +35,7 @@ use rustc_data_structures::steal::Steal;
 use rustc_errors::{Diag, DiagMessage, FatalAbort};
 use rustc_hir::{
     HirId,
-    def::DefKind,
+    def::{CtorKind, DefKind},
     def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, ModId},
 };
 use rustc_index::bit_set::DenseBitSet;
@@ -569,7 +569,14 @@ impl<'tcx> TranslationCtx<'tcx> {
         param_env: ParamEnv<'tcx>,
     ) -> TypingEnv<'tcx> {
         // FIXME: is it correct to pretend we are doing a non-body analysis?
-        let mode = if self.is_mir_available(def_id) && def_id.is_local() {
+        // A tuple-struct/tuple-variant constructor has shim MIR, so it passes `is_mir_available`,
+        // but it is not a body owner: rustc refuses to compute `opaque_types_defined_by` for one,
+        // which `post_borrowck_analysis` needs. It defines no opaque types, so the non-body mode is
+        // both correct and the only one available (#2223).
+        let mode = if self.is_mir_available(def_id)
+            && def_id.is_local()
+            && !matches!(self.def_kind(def_id), DefKind::Ctor(..))
+        {
             TypingMode::post_borrowck_analysis(self.tcx, def_id.as_local().unwrap())
         } else {
             TypingMode::non_body_analysis()
@@ -761,6 +768,10 @@ impl<'tcx> TranslationCtx<'tcx> {
             DefKind::AssocTy => ItemType::AssocTy,
             DefKind::Field => ItemType::Field,
             DefKind::Variant => ItemType::Variant,
+            // A tuple-struct/tuple-variant constructor used as a *function value* (`o.map(E::A)`)
+            // reaches us as an item of its own. It behaves like a program function whose contract
+            // is trivial, so it is translated as one (#2223).
+            DefKind::Ctor(_, CtorKind::Fn) => ItemType::Program,
             dk => ItemType::Unsupported(dk),
         }
     }

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -569,10 +569,8 @@ impl<'tcx> TranslationCtx<'tcx> {
         param_env: ParamEnv<'tcx>,
     ) -> TypingEnv<'tcx> {
         // FIXME: is it correct to pretend we are doing a non-body analysis?
-        // A tuple-struct/tuple-variant constructor has shim MIR, so it passes `is_mir_available`,
-        // but it is not a body owner: rustc refuses to compute `opaque_types_defined_by` for one,
-        // which `post_borrowck_analysis` needs. It defines no opaque types, so the non-body mode is
-        // both correct and the only one available (#2223).
+        // A constructor has shim MIR, so it passes `is_mir_available`, but it is not a body owner:
+        // `post_borrowck_analysis` needs `opaque_types_defined_by`, which rustc refuses for one.
         let mode = if self.is_mir_available(def_id)
             && def_id.is_local()
             && !matches!(self.def_kind(def_id), DefKind::Ctor(..))
@@ -768,9 +766,10 @@ impl<'tcx> TranslationCtx<'tcx> {
             DefKind::AssocTy => ItemType::AssocTy,
             DefKind::Field => ItemType::Field,
             DefKind::Variant => ItemType::Variant,
-            // A tuple-struct/tuple-variant constructor used as a *function value* (`o.map(E::A)`)
-            // reaches us as an item of its own. It behaves like a program function whose contract
-            // is trivial, so it is translated as one (#2223).
+            // Reached only for a constructor used as a function value (`o.map(E::A)`): applying
+            // one (`E::A(x)`) is an aggregate in MIR and never asks for its item type. Such a
+            // constructor is called like any program function, and is translated as one; its
+            // contract is synthesized in `contract_of`.
             DefKind::Ctor(_, CtorKind::Fn) => ItemType::Program,
             dk => ItemType::Unsupported(dk),
         }

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -9,11 +9,15 @@ use crate::{
     naming::{lowercase_prefix, name},
     translation::{
         external::ExternSpec,
-        pearlite::{Ident, PIdent, Term, TermWithTriggers, Trigger, normalize},
+        pearlite::{Ident, PIdent, Term, TermKind, TermWithTriggers, Trigger, normalize},
     },
     util::erased_identity_for_item,
 };
-use rustc_hir::{AttrArgs, HirId, Safety, def::DefKind, def_id::DefId};
+use rustc_hir::{
+    AttrArgs, HirId, Safety,
+    def::{CtorKind, CtorOf, DefKind},
+    def_id::DefId,
+};
 use rustc_macros::{TyDecodable, TyEncodable, TypeFoldable, TypeVisitable};
 use rustc_middle::{
     thir::{BodyTy, Pat, PatKind, Thir},
@@ -368,6 +372,32 @@ pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pr
                 expl: format!("expl:{} requires false", fn_name),
             });
         }
+        // A tuple-struct/tuple-variant constructor used as a function value has no body to
+        // translate, but its meaning is exact and trivially expressible: it returns precisely the
+        // variant built from its arguments. Without this the constructor would translate with a
+        // vacuous `true` postcondition, so `o.map(E::A)` would compile and prove nothing about the
+        // result — worse than refusing it, because the vacuity is silent (#2223).
+        if let DefKind::Ctor(ctor_of, CtorKind::Fn) = ctx.def_kind(def_id) {
+            let variant = match ctor_of {
+                CtorOf::Struct => rustc_abi::FIRST_VARIANT,
+                CtorOf::Variant => {
+                    let variant_did = ctx.parent(def_id);
+                    ctx.adt_def(ctx.parent(variant_did)).variant_index_with_id(variant_did)
+                }
+            };
+            let fields =
+                inputs.iter().map(|(ident, _, ty)| Term::var(ident.0, *ty)).collect::<Box<[_]>>();
+            let built = Term {
+                ty: output,
+                kind: TermKind::Constructor { variant, fields },
+                span: ctx.def_span(def_id),
+            };
+            let term = Term::var(name::result(), output).eq(ctx.tcx, built);
+            contract
+                .ensures
+                .push((Box::new([]), Condition { term, expl: format!("expl:{fn_name} result") }));
+        }
+
         if !matches!(ctx.item_type(def_id), ItemType::Logic { .. }) {
             contract.check_ensures_no_trigger(ctx);
         }
@@ -566,10 +596,18 @@ pub fn inputs_and_output<'tcx>(
                 typing_env,
                 tcx.fn_sig(def_id).instantiate_identity().skip_normalization(),
             );
-            let inputs = tcx
-                .fn_arg_idents(def_id)
-                .iter()
-                .cloned()
+            // A tuple-struct/tuple-variant constructor is a synthesized item with no HIR
+            // parameters, so asking rustc for its argument idents would ICE (#2223). Its arguments
+            // are anonymous by construction — the fields are positional — so name them like any
+            // other unnamed parameter.
+            let arg_idents: Vec<Option<rustc_span::Ident>> =
+                if matches!(tcx.def_kind(def_id), DefKind::Ctor(..)) {
+                    vec![None; sig.inputs().len()]
+                } else {
+                    tcx.fn_arg_idents(def_id).to_vec()
+                };
+            let inputs = arg_idents
+                .into_iter()
                 .zip(sig.inputs().iter().cloned())
                 .zip(1..) // We start numbering from 1 to match locals numbering (_0 is the return value)
                 .map(|((ident, ty), ix)| match ident {

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::closures::ClosSubst,
+    backend::{closures::ClosSubst, ty_inv::inv_call},
     contracts_items::{
         Intrinsic, creusot_clause_attrs, is_check_ghost, is_check_terminates, is_trusted_ghost,
         is_trusted_terminates,
@@ -301,34 +301,6 @@ pub(crate) fn inherited_extern_spec<'tcx, 'a>(
     Some((spec, subst))
 }
 
-/// The term `C(args)` built by a tuple-struct or tuple-variant constructor, or `None` if `def_id`
-/// is not one.
-///
-/// Both halves of a constructor's contract are stated in terms of the value it builds: the
-/// postcondition says the result is that value, and the type invariant it must establish is that
-/// value's (see `sig_add_type_invariant_spec`). They have to agree, so they share this.
-pub(crate) fn ctor_term<'tcx>(
-    ctx: &TranslationCtx<'tcx>,
-    def_id: DefId,
-    inputs: &[(PIdent, Span, Ty<'tcx>)],
-    output: Ty<'tcx>,
-) -> Option<Term<'tcx>> {
-    let DefKind::Ctor(ctor_of, CtorKind::Fn) = ctx.def_kind(def_id) else { return None };
-    let variant = match ctor_of {
-        CtorOf::Struct => rustc_abi::FIRST_VARIANT,
-        CtorOf::Variant => {
-            let variant_did = ctx.parent(def_id);
-            ctx.adt_def(ctx.parent(variant_did)).variant_index_with_id(variant_did)
-        }
-    };
-    let fields = inputs.iter().map(|(ident, _, ty)| Term::var(ident.0, *ty)).collect::<Box<[_]>>();
-    Some(Term {
-        ty: output,
-        kind: TermKind::Constructor { variant, fields },
-        span: ctx.def_span(def_id),
-    })
-}
-
 pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> PreSignature<'tcx> {
     let fn_name = ctx.opt_item_name(def_id);
     let fn_name = match &fn_name {
@@ -391,7 +363,10 @@ pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pr
             contract,
         }
     } else {
-        let ctor = ctor_term(ctx, def_id, &inputs, output);
+        let ctor = match ctx.def_kind(def_id) {
+            DefKind::Ctor(ctor_of, CtorKind::Fn) => Some(ctor_of),
+            _ => None,
+        };
         // A constructor needs no written spec, so it is not "extern without one": its contract is
         // the same whichever crate it comes from. Poisoning it would leave `o.map(Some)` unusable.
         if ctx.non_creusot_crate(def_id.krate) && ctor.is_none() {
@@ -403,9 +378,24 @@ pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pr
                 expl: format!("expl:{} requires false", fn_name),
             });
         }
-        // A constructor has no body, so without a postcondition it would translate with a vacuous
-        // `true` one: `o.map(E::A)` would compile and prove nothing about the result.
-        if let Some(built) = ctor {
+        // A constructor has no body: without these, it would translate with a vacuous `true`
+        // postcondition, and its result's type invariant would be a goal nothing can discharge.
+        if let Some(ctor_of) = ctor {
+            let span = ctx.def_span(def_id);
+            let variant = match ctor_of {
+                CtorOf::Struct => rustc_abi::FIRST_VARIANT,
+                CtorOf::Variant => {
+                    let variant_did = ctx.parent(def_id);
+                    ctx.adt_def(ctx.parent(variant_did)).variant_index_with_id(variant_did)
+                }
+            };
+            let fields =
+                inputs.iter().map(|(ident, _, ty)| Term::var(ident.0, *ty)).collect::<Box<[_]>>();
+            let built = Term { ty: output, kind: TermKind::Constructor { variant, fields }, span };
+            if let Some(term) = inv_call(ctx, ctx.typing_env(def_id), def_id, built.clone()) {
+                let expl = format!("expl:{fn_name} result type invariant");
+                contract.requires.push(Condition { term: term.span(span), expl });
+            }
             let term = Term::var(name::result(), output).eq(ctx.tcx, built);
             contract
                 .ensures
@@ -610,9 +600,6 @@ pub fn inputs_and_output<'tcx>(
                 typing_env,
                 tcx.fn_sig(def_id).instantiate_identity().skip_normalization(),
             );
-            // A constructor has no HIR parameters, so `fn_arg_idents` raises `unexpected item` for
-            // one. Its fields are positional, so they are unnamed like any other anonymous
-            // parameter.
             let arg_idents = if matches!(tcx.def_kind(def_id), DefKind::Ctor(..)) {
                 &vec![None; sig.inputs().len()]
             } else {

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -301,6 +301,34 @@ pub(crate) fn inherited_extern_spec<'tcx, 'a>(
     Some((spec, subst))
 }
 
+/// The term `C(args)` built by a tuple-struct or tuple-variant constructor, or `None` if `def_id`
+/// is not one.
+///
+/// Both halves of a constructor's contract are stated in terms of the value it builds: the
+/// postcondition says the result is that value, and the type invariant it must establish is that
+/// value's (see `sig_add_type_invariant_spec`). They have to agree, so they share this.
+pub(crate) fn ctor_term<'tcx>(
+    ctx: &TranslationCtx<'tcx>,
+    def_id: DefId,
+    inputs: &[(PIdent, Span, Ty<'tcx>)],
+    output: Ty<'tcx>,
+) -> Option<Term<'tcx>> {
+    let DefKind::Ctor(ctor_of, CtorKind::Fn) = ctx.def_kind(def_id) else { return None };
+    let variant = match ctor_of {
+        CtorOf::Struct => rustc_abi::FIRST_VARIANT,
+        CtorOf::Variant => {
+            let variant_did = ctx.parent(def_id);
+            ctx.adt_def(ctx.parent(variant_did)).variant_index_with_id(variant_did)
+        }
+    };
+    let fields = inputs.iter().map(|(ident, _, ty)| Term::var(ident.0, *ty)).collect::<Box<[_]>>();
+    Some(Term {
+        ty: output,
+        kind: TermKind::Constructor { variant, fields },
+        span: ctx.def_span(def_id),
+    })
+}
+
 pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> PreSignature<'tcx> {
     let fn_name = ctx.opt_item_name(def_id);
     let fn_name = match &fn_name {
@@ -363,7 +391,10 @@ pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pr
             contract,
         }
     } else {
-        if ctx.non_creusot_crate(def_id.krate) {
+        let ctor = ctor_term(ctx, def_id, &inputs, output);
+        // A constructor needs no written spec, so it is not "extern without one": its contract is
+        // the same whichever crate it comes from. Poisoning it would leave `o.map(Some)` unusable.
+        if ctx.non_creusot_crate(def_id.krate) && ctor.is_none() {
             assert!(contract.is_empty());
             assert_matches!(ctx.item_type(def_id), ItemType::Program | ItemType::Constant);
             contract.extern_no_spec = true;
@@ -372,26 +403,9 @@ pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pr
                 expl: format!("expl:{} requires false", fn_name),
             });
         }
-        // A tuple-struct/tuple-variant constructor used as a function value has no body to
-        // translate, but its meaning is exact and trivially expressible: it returns precisely the
-        // variant built from its arguments. Without this the constructor would translate with a
-        // vacuous `true` postcondition, so `o.map(E::A)` would compile and prove nothing about the
-        // result — worse than refusing it, because the vacuity is silent (#2223).
-        if let DefKind::Ctor(ctor_of, CtorKind::Fn) = ctx.def_kind(def_id) {
-            let variant = match ctor_of {
-                CtorOf::Struct => rustc_abi::FIRST_VARIANT,
-                CtorOf::Variant => {
-                    let variant_did = ctx.parent(def_id);
-                    ctx.adt_def(ctx.parent(variant_did)).variant_index_with_id(variant_did)
-                }
-            };
-            let fields =
-                inputs.iter().map(|(ident, _, ty)| Term::var(ident.0, *ty)).collect::<Box<[_]>>();
-            let built = Term {
-                ty: output,
-                kind: TermKind::Constructor { variant, fields },
-                span: ctx.def_span(def_id),
-            };
+        // A constructor has no body, so without a postcondition it would translate with a vacuous
+        // `true` one: `o.map(E::A)` would compile and prove nothing about the result.
+        if let Some(built) = ctor {
             let term = Term::var(name::result(), output).eq(ctx.tcx, built);
             contract
                 .ensures
@@ -596,18 +610,17 @@ pub fn inputs_and_output<'tcx>(
                 typing_env,
                 tcx.fn_sig(def_id).instantiate_identity().skip_normalization(),
             );
-            // A tuple-struct/tuple-variant constructor is a synthesized item with no HIR
-            // parameters, so asking rustc for its argument idents would ICE (#2223). Its arguments
-            // are anonymous by construction — the fields are positional — so name them like any
-            // other unnamed parameter.
-            let arg_idents: Vec<Option<rustc_span::Ident>> =
-                if matches!(tcx.def_kind(def_id), DefKind::Ctor(..)) {
-                    vec![None; sig.inputs().len()]
-                } else {
-                    tcx.fn_arg_idents(def_id).to_vec()
-                };
+            // A constructor has no HIR parameters, so `fn_arg_idents` raises `unexpected item` for
+            // one. Its fields are positional, so they are unnamed like any other anonymous
+            // parameter.
+            let arg_idents = if matches!(tcx.def_kind(def_id), DefKind::Ctor(..)) {
+                &vec![None; sig.inputs().len()]
+            } else {
+                tcx.fn_arg_idents(def_id)
+            };
             let inputs = arg_idents
-                .into_iter()
+                .iter()
+                .cloned()
                 .zip(sig.inputs().iter().cloned())
                 .zip(1..) // We start numbering from 1 to match locals numbering (_0 is the return value)
                 .map(|((ident, ty), ix)| match ident {

--- a/tests/should_succeed/constructor_as_value.coma
+++ b/tests/should_succeed/constructor_as_value.coma
@@ -52,3 +52,127 @@ module M_g
       /\ ([@stop_split] [@expl:g ensures #1] o = None -> result = None'0)}
       (! return {result}) ]
 end
+module M_g_extern
+  use creusot.prelude.Any
+  use map.Map
+  
+  type t_A
+  
+  type t_Option_A = None | Some t_A
+  
+  predicate inv_A (_1: t_A)
+  
+  predicate inv_Option_A (_1: t_Option_A)
+  
+  axiom inv_axiom [@rewrite]: forall x: t_Option_A [inv_Option_A x]. inv_Option_A x
+      = match x with
+        | None -> true
+        | Some f0 -> inv_A f0
+        end
+  
+  let f_Some_A (_1: t_A) (return (x: t_Option_A)) =
+  {[@stop_split] [@expl:f_Some_A requires] ([@stop_split] [@expl:Some '_1' type invariant] inv_A _1)
+    /\ ([@stop_split] [@expl:Some result type invariant] inv_Option_A (Some _1))}
+    any
+    [ return (result: t_Option_A) ->
+    {[@stop_split] [@expl:f_Some_A ensures] ([@stop_split] [@expl:Some result type invariant] inv_Option_A result)
+      /\ ([@stop_split] [@expl:Some result] result = Some _1)}
+      (! return {result}) ]
+  
+  type t_Option_Option_A = None'0 | Some'0 t_Option_A
+  
+  predicate precondition_Some (self: ()) (args: t_A) = let _1 = args in inv_A _1 /\ inv_Option_A (Some _1)
+  
+  meta "rewrite_def" predicate precondition_Some
+  
+  predicate inv_Option_Option_A (_1: t_Option_Option_A)
+  
+  axiom inv_axiom'0 [@rewrite]: forall x: t_Option_Option_A [inv_Option_Option_A x]. inv_Option_Option_A x
+      = match x with
+        | None'0 -> true
+        | Some'0 f0 -> inv_Option_A f0
+        end
+  
+  predicate resolve_Some [@inline:trivial] (_1: ()) = true
+  
+  meta "rewrite_def" predicate resolve_Some
+  
+  predicate postcondition_Some (self: ()) (args: t_A) (result: t_Option_A) =
+    let _1 = args in inv_Option_A result /\ result = Some _1
+  
+  meta "rewrite_def" predicate postcondition_Some
+  
+  predicate postcondition_once_Some (self: ()) (args: t_A) (result: t_Option_A) = postcondition_Some self args result
+  
+  meta "rewrite_def" predicate postcondition_once_Some
+  
+  let map_A (self_: t_Option_A) (f: ()) (return (x: t_Option_Option_A)) =
+  {[@stop_split] [@expl:map_A requires] ([@stop_split] [@expl:map 'self_' type invariant] inv_Option_A self_)
+    /\ ([@stop_split] [@expl:map requires] match self_ with
+      | None -> true
+      | Some t -> precondition_Some f t
+      end)}
+    any
+    [ return (result: t_Option_Option_A) ->
+    {[@stop_split] [@expl:map_A ensures] ([@stop_split] [@expl:map result type invariant] inv_Option_Option_A result)
+      /\ ([@stop_split] [@expl:map ensures] match self_ with
+        | None -> resolve_Some f /\ result = None'0
+        | Some t -> exists r: t_Option_A. result = Some'0 r /\ postcondition_once_Some f t r
+        end)}
+      (! return {result}) ]
+  
+  function map_Option_A (self: t_Option_A) (f: Map.map t_A t_Option_A) : t_Option_Option_A = match self with
+      | None -> None'0
+      | Some x -> Some'0 (Map.get f x)
+      end
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let g_extern_A (o: t_Option_A) (return (x: t_Option_Option_A)) =
+  {[@stop_split] [@expl:g_extern 'o' type invariant] inv_Option_A o}
+    (! bb0
+    [ bb0 = s0 [ s0 = map_A {o} {()} (fun (_x: t_Option_Option_A) -> [ &_ret <- _x ] s1) | s1 = return {_ret} ] ]
+    [ & _ret: t_Option_Option_A = Any.any_l () | & o: t_Option_A = o ])
+    [ return (result: t_Option_Option_A) ->
+    {[@stop_split] [@expl:g_extern_A ensures] ([@stop_split] [@expl:g_extern result type invariant] inv_Option_Option_A result)
+      /\ ([@stop_split] [@expl:g_extern ensures] result = map_Option_A o (fun (x: t_A) -> Some x))}
+      (! return {result}) ]
+end
+module M_h
+  use creusot.prelude.Any
+  
+  let f_T0 (return (x: ())) = any
+    [ return (result: ()) -> {[@stop_split] [@expl:T0 result] result = ()} (! return {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let h (return (x: ())) = (! bb0
+    [ bb0 = s0 [ s0 = [ &t <- () ] s1 | s1 = f_T0 (fun (_x: ()) -> [ &_ret <- _x ] s2) | s2 = return {_ret} ] ]
+    [ & _ret: () = Any.any_l () | & t: () = Any.any_l () ])
+    [ return (result: ()) -> {[@stop_split] [@expl:h ensures] result = ()} (! return {result}) ]
+end
+module M_i
+  use creusot.int.UInt32
+  use creusot.prelude.Any
+  
+  type t_T2 = { f0: UInt32.t; f1: UInt32.t }
+  
+  let f_T2 (_1: UInt32.t) (_2: UInt32.t) (return (x: t_T2)) = any
+    [ return (result: t_T2) -> {[@stop_split] [@expl:T2 result] result = { f0 = _1; f1 = _2 }} (! return {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let i (return (x: t_T2)) = (! bb0
+    [ bb0 = s0
+      [ s0 = [ &t <- () ] s1
+      | s1 = f_T2 {(0: UInt32.t)} {(1: UInt32.t)} (fun (_x: t_T2) -> [ &_ret <- _x ] s2)
+      | s2 = return {_ret} ] ] [ & _ret: t_T2 = Any.any_l () | & t: () = Any.any_l () ])
+    [ return (result: t_T2) -> {[@stop_split] [@expl:i ensures] result = { f0 = (0: UInt32.t); f1 = (1: UInt32.t) }}
+      (! return {result}) ]
+end

--- a/tests/should_succeed/constructor_as_value.coma
+++ b/tests/should_succeed/constructor_as_value.coma
@@ -1,0 +1,54 @@
+module M_g
+  use creusot.int.UInt32
+  use creusot.prelude.Any
+  
+  type t_Option_u32 = None | Some UInt32.t
+  
+  type t_E = A UInt32.t
+  
+  let f_A (_1: UInt32.t) (return (x: t_E)) = any
+    [ return (result: t_E) -> {[@stop_split] [@expl:A result] result = A _1} (! return {result}) ]
+  
+  type t_Option_E = None'0 | Some'0 t_E
+  
+  predicate precondition_A (self: ()) (args: UInt32.t) = let _1 = args in true
+  
+  meta "rewrite_def" predicate precondition_A
+  
+  predicate resolve_A [@inline:trivial] (_1: ()) = true
+  
+  meta "rewrite_def" predicate resolve_A
+  
+  predicate postcondition_A (self: ()) (args: UInt32.t) (result: t_E) = let _1 = args in result = A _1
+  
+  meta "rewrite_def" predicate postcondition_A
+  
+  predicate postcondition_once_A (self: ()) (args: UInt32.t) (result: t_E) = postcondition_A self args result
+  
+  meta "rewrite_def" predicate postcondition_once_A
+  
+  let map_u32 (self_: t_Option_u32) (f: ()) (return (x: t_Option_E)) =
+  {[@stop_split] [@expl:map requires] match self_ with
+      | None -> true
+      | Some t -> precondition_A f t
+      end}
+    any
+    [ return (result: t_Option_E) -> {[@stop_split] [@expl:map ensures] match self_ with
+        | None -> resolve_A f /\ result = None'0
+        | Some t -> exists r: t_E. result = Some'0 r /\ postcondition_once_A f t r
+        end}
+      (! return {result}) ]
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let g (o: t_Option_u32) (return (x: t_Option_E)) = (! bb0
+    [ bb0 = s0 [ s0 = map_u32 {o} {()} (fun (_x: t_Option_E) -> [ &_ret <- _x ] s1) | s1 = return {_ret} ] ]
+    [ & _ret: t_Option_E = Any.any_l () | & o: t_Option_u32 = o ])
+    [ return (result: t_Option_E) ->
+    {[@stop_split] [@expl:g ensures] ([@stop_split] [@expl:g ensures #0] forall x: UInt32.t. o = Some x
+          -> result = Some'0 (A x))
+      /\ ([@stop_split] [@expl:g ensures #1] o = None -> result = None'0)}
+      (! return {result}) ]
+end

--- a/tests/should_succeed/constructor_as_value.rs
+++ b/tests/should_succeed/constructor_as_value.rs
@@ -1,0 +1,14 @@
+extern crate creusot_std;
+use creusot_std::prelude::*;
+
+pub enum E {
+    A(u32),
+}
+
+/// A tuple-variant constructor used as a function value. The postcondition is only provable if the
+/// constructor carries its meaning — `result = A x` — rather than an opaque one.
+#[ensures(forall<x: u32> o == Some(x) ==> result == Some(E::A(x)))]
+#[ensures(o == None ==> result == None)]
+pub fn g(o: Option<u32>) -> Option<E> {
+    o.map(E::A)
+}

--- a/tests/should_succeed/constructor_as_value.rs
+++ b/tests/should_succeed/constructor_as_value.rs
@@ -12,3 +12,29 @@ pub enum E {
 pub fn g(o: Option<u32>) -> Option<E> {
     o.map(E::A)
 }
+
+/// A constructor from another crate. It needs no written spec, so it must not be poisoned the way
+/// an unspecified extern function is.
+#[ensures(result == o.map_logic(|x| Some(x)))]
+pub fn g_extern<A>(o: Option<A>) -> Option<Option<A>> {
+    o.map(Some)
+}
+
+pub struct T0();
+
+/// Zero arity.
+#[ensures(result == T0())]
+pub fn h() -> T0 {
+    let t = T0;
+    t()
+}
+
+#[allow(dead_code)]
+pub struct T2(u32, u32);
+
+/// More than one argument, so the fields must stay in order.
+#[ensures(result == T2(0u32, 1u32))]
+pub fn i() -> T2 {
+    let t = T2;
+    t(0, 1)
+}

--- a/tests/should_succeed/constructor_as_value/proof.json
+++ b/tests/should_succeed/constructor_as_value/proof.json
@@ -2,9 +2,22 @@
   "profile": [],
   "proofs": {
     "M_g": {
-      "vc_f_A": { "prover": "alt-ergo", "time": 0.035 },
+      "vc_f_A": { "prover": "alt-ergo", "time": 0.014 },
       "vc_g": { "prover": "alt-ergo", "time": 0.029 },
       "vc_map_u32": { "prover": "alt-ergo", "time": 0.02 }
+    },
+    "M_g_extern": {
+      "vc_f_Some_A": { "prover": "alt-ergo", "time": 0.036 },
+      "vc_g_extern_A": { "prover": "alt-ergo", "time": 0.038 },
+      "vc_map_A": { "prover": "alt-ergo", "time": 0.034 }
+    },
+    "M_h": {
+      "vc_f_T0": { "prover": "alt-ergo", "time": 0.034 },
+      "vc_h": { "prover": "alt-ergo", "time": 0.028 }
+    },
+    "M_i": {
+      "vc_f_T2": { "prover": "alt-ergo", "time": 0.027 },
+      "vc_i": { "prover": "alt-ergo", "time": 0.03 }
     }
   }
 }

--- a/tests/should_succeed/constructor_as_value/proof.json
+++ b/tests/should_succeed/constructor_as_value/proof.json
@@ -1,0 +1,10 @@
+{
+  "profile": [],
+  "proofs": {
+    "M_g": {
+      "vc_f_A": { "prover": "alt-ergo", "time": 0.035 },
+      "vc_g": { "prover": "alt-ergo", "time": 0.029 },
+      "vc_map_u32": { "prover": "alt-ergo", "time": 0.02 }
+    }
+  }
+}


### PR DESCRIPTION
Implements the feature request in #2223, taking the second of the two suggestions there — generating
the pre/post for the constructor directly, since they are very simple logical terms.

`o.map(E::A)` — a tuple-struct or tuple-variant constructor passed as a function value rather than
applied — was refused with `unexpected kind Unsupported(Ctor(Variant, Fn))`, and before 0.13.0 it
ICEd in `fn_arg_idents`.

## What was in the way

Three things, each fixed where every caller routes through rather than at the use site:

- **`item_type`** did not classify a constructor at all, so the elaborator took its `Unsupported`
  arm. A constructor behaves like a program function with a trivial contract, so it is classified
  as one.
- **`inputs_and_output`** asked rustc for the constructor's argument idents. A constructor is
  synthesized and has no HIR parameters, so that query raises `fn_arg_idents: unexpected item` —
  the original ICE. Its arguments are positional and therefore anonymous, which the existing
  unnamed-parameter path already handles.
- **`typing_env_with`** chose `post_borrowck_analysis`, because a constructor has shim MIR and so
  passes `is_mir_available`. That mode needs `opaque_types_defined_by`, which rustc refuses for a
  constructor. A constructor defines no opaque types, so the non-body mode is both correct and the
  only one available.

## Why that alone wasn't enough

With just the above it translates, but with a `true` postcondition:

```
predicate postcondition_A (self: ()) (args: UInt32.t) (result: t_E) = let _1 = args in true
```

It would compile and prove nothing about the result, which seemed worse than refusing it — the
vacuity is silent. So `contract_of` now gives a constructor the postcondition it obviously has:

```
predicate postcondition_A (self: ()) (args: UInt32.t) (result: t_E) = let _1 = args in result = A _1
```

## Test

Written so it cannot pass unless that postcondition is really there:

```rust
#[ensures(forall<x: u32> o == Some(x) ==> result == Some(E::A(x)))]
#[ensures(o == None ==> result == None)]
pub fn g(o: Option<u32>) -> Option<E> {
    o.map(E::A)
}
```

- `./t ui` — 473/473. Worth noting: the UI tests compare exact generated Coma, and no other
  baseline moved, so nothing outside constructors-as-values changed translation.
- `./t why3` — `tests/should_succeed/constructor_as_value.coma ... proved`.
- `./t fmt --fmt-check` — clean.
- Also run on x86_64 in my fork before sending: the full workflow is green, including `why3`
  proving the new test. One earlier attempt on the same commit failed `why3` on
  `examples/insertion_sort.coma` and `examples/parallel_add/sc_generic.coma`; re-running the same
  commit passed. Different examples fail on different runs there, including on an unmodified
  `master`, so I read it as prover timeouts on those runners rather than anything here — but you
  will see it against your own CI, so flagging it rather than leaving you to wonder.

## One edge I did not fix

`contract_of` pushes `requires false` for items from a non-Creusot crate, so a constructor imported
from another crate should still be poisoned. I have not tested that, it is not covered by the new
test, and I did not want to claim behaviour I have not measured. Happy to extend this to cover it if
you would like it in the same PR.

Closes #2223.
