### PR TITLE
Support constructor closures

### DIFF
--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -91,6 +91,7 @@ impl<'tcx> Why3Generator<'tcx> {
                 format!("unsupported definition kind {:?} {:?}", def_id, dk),
             ),
             ItemType::Closure
+            | ItemType::CtorFn
             | ItemType::Trait
             | ItemType::Type
             | ItemType::AssocTy

--- a/creusot/src/backend/clone_map/elaborator.rs
+++ b/creusot/src/backend/clone_map/elaborator.rs
@@ -2,16 +2,17 @@ use crate::{
     backend::{
         self, Why3Generator,
         clone_map::{CloneNames, DepGraphBuilder, Dependency, Kind, Namer},
-        closures::{closure_hist_inv, closure_post, closure_pre},
+        closures::{closure_hist_inv, closure_post, closure_pre, ctor_post, ctor_pre},
         logic::{lower_logical_defn, spec_axioms},
         program,
         resolve::{ResolveDef, elaborate_resolve_def, structural_resolve},
         signature::{LogicSignature, lower_logic_sig, lower_program_sig},
         term::{lower_pure, lower_pure_weakdep},
         ty::{
-            eliminator, translate_adtdecl, translate_closure_ty, translate_tuple_ty, translate_ty,
+            constructor, eliminator, translate_adtdecl, translate_closure_ty, translate_tuple_ty,
+            translate_ty,
         },
-        ty_inv::{TyInvDef, elaborate_tyinv_def, sig_add_type_invariant_spec},
+        ty_inv::{TyInvDef, elaborate_tyinv_def, inv_call, sig_add_type_invariant_spec},
     },
     contracts_items::{Intrinsic, get_builtin, is_law, is_logic, why3_metas},
     ctx::{BodyId, HasTyCtxt, ItemType},
@@ -252,6 +253,50 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
             }))
         }
         decls
+    }
+
+    // Generate a body for a constructor closure, of the form
+    //
+    // ```
+    // let c_Some (_1: a) (return (x: option_a)) =
+    //   {inv (Some x)} return {Some x}
+    // ```
+    //
+    // We duplicate the constructor application because it's usually shorter
+    // than writing out the let binding (most constructors used this way have
+    // few fields, and the assertion even goes away if it's trivial).
+    fn expand_ctor(&mut self, def_id: DefId, subst: GenericArgsRef<'tcx>) -> Vec<Decl> {
+        let dep = Dependency::Item(def_id, subst);
+        let typing_env = self.typing_env;
+        let ctx = self.ctx;
+        let names = self.namer(dep);
+        let name = names.dependency(dep).ident();
+        let pre_sig = ctx.sig(def_id).clone().instantiate_and_normalize(ctx, subst, typing_env);
+
+        use why3::{coma::Arg, declaration::Attribute};
+        let fields = pre_sig.inputs.iter().map(|(arg, _, _)| Exp::var(arg.0)).collect();
+        let ctor = constructor(&names, fields, ctx.parent(def_id), subst);
+        let body = Expr::App(Expr::var(name::return_()).boxed(), Arg::Term(ctor.clone()).into());
+        // Placeholder for the argument of `inv_call`, to be substituted after lowering.
+        let result = name::result();
+        let invariant =
+            inv_call(ctx, typing_env, names.source_id(), Term::var(result, pre_sig.output));
+        let body = match invariant {
+            None => body,
+            Some(invariant) => {
+                let mut invariant = lower_pure(ctx, &names, &invariant);
+                invariant.subst(&[(result, ctor)].into());
+                let expl = format!("expl:{} type invariant", ctx.item_name(def_id).as_str());
+                let invariant = Exp::Attr(Attribute::Attr(expl), invariant.boxed());
+                Expr::Assert(invariant.boxed(), body.boxed())
+            }
+        };
+
+        let sig = lower_program_sig(ctx, &names, name, pre_sig, def_id, name::return_());
+        let prototype =
+            Prototype { attrs: vec![Attribute::Attr("coma:extspec".into())], ..sig.prototype };
+
+        vec![Decl::Coma(Defn { prototype, body })]
     }
 
     /// Expand a logical item
@@ -671,6 +716,7 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
                 }
                 ItemType::Program => self.expand_program(def_id, subst),
                 ItemType::Closure => self.expand_closure(def_id, subst),
+                ItemType::CtorFn => self.expand_ctor(def_id, subst),
                 item_type => {
                     let path = ctx.def_path_str(def_id);
                     let self_path = ctx.def_path_str(self.namer.source_id());
@@ -1005,6 +1051,9 @@ fn postcondition_term<'tcx>(
             let post_fn = Intrinsic::Postcondition.get(ctx);
             Some(Term::call(ctx.tcx, typing_env, post_fn, subst_postcond, post_args))
         }
+        &TyKind::FnDef(did, subst) if let DefKind::Ctor(..) = ctx.def_kind(did) => {
+            Some(ctor_post(ctx, names.source_id(), did, subst.skip_binder(), args, res))
+        }
         &TyKind::FnDef(did, subst) => {
             post_fndef(ctx, names, did, subst.skip_binder(), args, res, true)
         }
@@ -1053,7 +1102,7 @@ fn post_fndef<'tcx>(
     Some(Term::let_(pattern, args, post).span(ctx.def_span(did)))
 }
 
-/// Generate body of `precondition_once` for `FnOnce` closures.
+/// Generate body of `precondition` for `FnOnce` closures.
 fn precondition_term<'tcx>(
     ctx: &Why3Generator<'tcx>,
     names: &impl Namer<'tcx>,
@@ -1062,7 +1111,7 @@ fn precondition_term<'tcx>(
 ) -> Option<Term<'tcx>> {
     let typing_env = names.typing_env();
     let &[self_, args] = bound else {
-        panic!("precondition_once must have 2 arguments. This should not happen. Found: {bound:?}")
+        panic!("precondition must have 2 arguments. This should not happen. Found: {bound:?}")
     };
     let ty_self = subst.type_at(1);
     let self_ = Term::var(self_, ty_self);
@@ -1099,6 +1148,9 @@ fn precondition_term<'tcx>(
             let pre_fn = Intrinsic::Precondition.get(ctx);
             let pre_args = [self_.proj(0usize.into(), closure_ty), args];
             Some(Term::call(ctx.tcx, typing_env, pre_fn, subst_postcond, pre_args))
+        }
+        &TyKind::FnDef(did, subst) if let DefKind::Ctor(..) = ctx.def_kind(did) => {
+            Some(ctor_pre(ctx, names.source_id(), did, subst.skip_binder(), args))
         }
         &TyKind::FnDef(did, subst) => pre_fndef(ctx, names, did, subst.skip_binder(), args, true),
         _ => None,

--- a/creusot/src/backend/clone_map/elaborator.rs
+++ b/creusot/src/backend/clone_map/elaborator.rs
@@ -152,23 +152,6 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
 
         let mut pre_sig = ctx.sig(def_id).clone().instantiate_and_normalize(ctx, subst, typing_env);
 
-        if ctx.def_kind(def_id) == DefKind::Closure {
-            // Inline the body of closures
-            let mut decls = vec![Decl::Coma(program::to_why(ctx, &names, name, def_id))];
-            if !pre_sig.contract.has_user_contract {
-                decls.extend(["'pre", "'post'return"].map(|s| {
-                    Decl::Meta(Meta {
-                        name: MetaIdent("rewrite_def".into()),
-                        args: Box::new([
-                            MetaArg::Keyword("predicate".into()),
-                            MetaArg::Name(Name::Local(name, Some(why3::Symbol::intern(s)))),
-                        ]),
-                    })
-                }))
-            }
-            return decls;
-        }
-
         if matches!(ctx.intrinsic(def_id), Intrinsic::GhostDeref | Intrinsic::GhostDerefMut) {
             // If `Ghost::deref`` or `Ghost::deref_mut` are called direclty, then
             // the validation pass has checked that the call is in the right context.
@@ -243,6 +226,32 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
 
         let sig = lower_program_sig(ctx, &names, name, pre_sig, def_id, name::return_());
         vec![program::val(sig.prototype, sig.contract, sig.return_ty)]
+    }
+
+    fn expand_closure(&mut self, def_id: DefId, subst: GenericArgsRef<'tcx>) -> Vec<Decl> {
+        let dep = Dependency::Item(def_id, subst);
+        let typing_env = self.typing_env;
+        let ctx = self.ctx;
+        let names = self.namer(dep);
+
+        let name = names.dependency(dep).ident();
+
+        let pre_sig = ctx.sig(def_id).clone().instantiate_and_normalize(ctx, subst, typing_env);
+
+        // Inline the body of closures
+        let mut decls = vec![Decl::Coma(program::to_why(ctx, &names, name, def_id))];
+        if !pre_sig.contract.has_user_contract {
+            decls.extend(["'pre", "'post'return"].map(|s| {
+                Decl::Meta(Meta {
+                    name: MetaIdent("rewrite_def".into()),
+                    args: Box::new([
+                        MetaArg::Keyword("predicate".into()),
+                        MetaArg::Name(Name::Local(name, Some(why3::Symbol::intern(s)))),
+                    ]),
+                })
+            }))
+        }
+        decls
     }
 
     /// Expand a logical item
@@ -660,7 +669,8 @@ impl<'a, 'ctx, 'tcx> Expander<'a, 'ctx, 'tcx> {
                     self.namer(dep).ty_adt(ctx.parent(def_id), subst);
                     vec![]
                 }
-                ItemType::Program | ItemType::Closure => self.expand_program(def_id, subst),
+                ItemType::Program => self.expand_program(def_id, subst),
+                ItemType::Closure => self.expand_closure(def_id, subst),
                 item_type => {
                     let path = ctx.def_path_str(def_id);
                     let self_path = ctx.def_path_str(self.namer.source_id());

--- a/creusot/src/backend/closures.rs
+++ b/creusot/src/backend/closures.rs
@@ -8,7 +8,7 @@ use crate::{
             Ident, Pattern, Term, TermKind, normalize,
             visit::{TermVisitorMut, super_visit_mut_term},
         },
-        specification::{PreSignature, contract_of},
+        specification::{PreSignature, contract_of, inputs_and_output},
     },
 };
 use itertools::Itertools;
@@ -17,7 +17,10 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::IndexVec;
 use rustc_middle::{
     mir::Mutability,
-    ty::{BorrowKind, CapturedPlace, ClosureKind, GenericArg, Ty, TyCtxt, TyKind, UpvarCapture},
+    ty::{
+        BorrowKind, CapturedPlace, ClosureKind, EarlyBinder, GenericArg, GenericArgsRef, Ty,
+        TyCtxt, TyKind, UpvarCapture,
+    },
 };
 use std::{assert_matches, iter::once};
 
@@ -313,6 +316,59 @@ pub(crate) fn closure_post<'tcx>(
     }
 
     normalize(ctx, typing_env, post)
+}
+
+pub(crate) fn ctor_pre<'tcx>(
+    ctx: &TranslationCtx<'tcx>,
+    scope: DefId,
+    def_id: DefId,
+    subst: GenericArgsRef<'tcx>,
+    args: Term<'tcx>,
+) -> Term<'tcx> {
+    let typing_env = ctx.typing_env(scope);
+    let inputs = ctx.normalize_erasing_regions(
+        typing_env,
+        EarlyBinder::bind(ctx.tcx, inputs_and_output(ctx, def_id.into()).0)
+            .instantiate(ctx.tcx, subst),
+    );
+    let params = inputs.iter().map(|&(nm, _, ty)| Term::var(nm, ty)).collect();
+    let pre = Term {
+        kind: TermKind::Precondition { item: def_id, subst, params },
+        ty: ctx.types.bool,
+        span: ctx.def_span(def_id),
+    };
+    let pattern = Pattern::tuple(
+        inputs.iter().map(|&(nm, span, ty)| Pattern::binder_sp(nm, span, ty)),
+        args.ty,
+    );
+    Term::let_(pattern, args, pre).span(ctx.def_span(def_id))
+}
+
+pub(crate) fn ctor_post<'tcx>(
+    ctx: &TranslationCtx<'tcx>,
+    scope: DefId,
+    def_id: DefId,
+    subst: GenericArgsRef<'tcx>,
+    args: Term<'tcx>,
+    res: Term<'tcx>,
+) -> Term<'tcx> {
+    let typing_env = ctx.typing_env(scope);
+    let inputs = ctx.normalize_erasing_regions(
+        typing_env,
+        EarlyBinder::bind(ctx.tcx, inputs_and_output(ctx, def_id.into()).0)
+            .instantiate(ctx.tcx, subst),
+    );
+    let params = inputs.iter().map(|&(nm, _, ty)| Term::var(nm, ty)).chain(once(res)).collect();
+    let pre = Term {
+        kind: TermKind::Postcondition { item: def_id, subst, params },
+        ty: ctx.types.bool,
+        span: ctx.def_span(def_id),
+    };
+    let pattern = Pattern::tuple(
+        inputs.iter().map(|&(nm, span, ty)| Pattern::binder_sp(nm, span, ty)),
+        args.ty,
+    );
+    Term::let_(pattern, args, pre).span(ctx.def_span(def_id))
 }
 
 // Responsible for replacing occurences of captured variables with projections from the closure environment.

--- a/creusot/src/backend/dependency.rs
+++ b/creusot/src/backend/dependency.rs
@@ -78,6 +78,9 @@ impl<'tcx> Dependency<'tcx> {
                 DefKind::Variant => {
                     Some(Symbol::intern(&uppercase_prefix("C_", ctx.item_name(did).as_str())))
                 }
+                DefKind::Ctor(..) => {
+                    Some(Symbol::intern(&lowercase_prefix("c_", ctx.item_name(did).as_str())))
+                }
                 _ if Intrinsic::SizeOfLogic.is(ctx, did) => {
                     Some(Symbol::intern(&type_string(ctx.tcx, "size_of".into(), subst.type_at(0))))
                 }

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -35,7 +35,7 @@ use rustc_data_structures::steal::Steal;
 use rustc_errors::{Diag, DiagMessage, FatalAbort};
 use rustc_hir::{
     HirId,
-    def::DefKind,
+    def::{CtorKind, DefKind},
     def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, ModId},
 };
 use rustc_index::bit_set::DenseBitSet;
@@ -94,8 +94,9 @@ pub enum ItemType {
     AssocTy,
     Constant,
     Variant,
-    Unsupported(DefKind),
+    CtorFn,
     Field,
+    Unsupported(DefKind),
 }
 
 impl ItemType {
@@ -110,9 +111,10 @@ impl ItemType {
             ItemType::Type => "type declaration",
             ItemType::AssocTy => "associated type",
             ItemType::Constant => "constant",
+            ItemType::Variant => "constructor",
+            ItemType::CtorFn => "constructor function",
             ItemType::Field => "field",
             ItemType::Unsupported(_) => "[OTHER]",
-            ItemType::Variant => "constructor",
         }
     }
 
@@ -761,6 +763,7 @@ impl<'tcx> TranslationCtx<'tcx> {
             DefKind::AssocTy => ItemType::AssocTy,
             DefKind::Field => ItemType::Field,
             DefKind::Variant => ItemType::Variant,
+            DefKind::Ctor(_, CtorKind::Fn) => ItemType::CtorFn,
             dk => ItemType::Unsupported(dk),
         }
     }

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -358,6 +358,9 @@ pub(crate) fn contract_of<'tcx>(ctx: &TranslationCtx<'tcx>, def_id: DefId) -> Pr
                 .skip_normalization(),
             contract,
         }
+    } else if matches!(ctx.def_kind(def_id), DefKind::Ctor(..)) {
+        contract.purity = ProgramPurity::Ghost;
+        PreSignature { inputs, output, contract }
     } else {
         if ctx.non_creusot_crate(def_id.krate) {
             assert!(contract.is_empty());
@@ -566,8 +569,11 @@ pub fn inputs_and_output<'tcx>(
                 typing_env,
                 tcx.fn_sig(def_id).instantiate_identity().skip_normalization(),
             );
-            let inputs = tcx
-                .fn_arg_idents(def_id)
+            let idents = match tcx.def_kind(def_id) {
+                DefKind::Ctor(..) => &vec![None; sig.inputs().len()],
+                _ => tcx.fn_arg_idents(def_id),
+            };
+            let inputs = idents
                 .iter()
                 .cloned()
                 .zip(sig.inputs().iter().cloned())

--- a/tests/should_succeed/lang/ctor_closure.coma
+++ b/tests/should_succeed/lang/ctor_closure.coma
@@ -1,0 +1,170 @@
+module M_g
+  use creusot.prelude.Any
+  use map.Map
+  
+  type t_A
+  
+  type t_Option_A = None | Some t_A
+  
+  predicate inv_A (_1: t_A)
+  
+  predicate inv_Option_A (_1: t_Option_A)
+  
+  axiom inv_axiom [@rewrite]: forall x: t_Option_A [inv_Option_A x]. inv_Option_A x
+      = match x with
+        | None -> true
+        | Some f0 -> inv_A f0
+        end
+  
+  let c_Some [@coma:extspec] (_1: t_A) (return (x: t_Option_A)) = {[@expl:Some type invariant] inv_Option_A (Some _1)}
+    return {Some _1}
+  
+  type t_Option_Option_A = None'0 | Some'0 t_Option_A
+  
+  predicate precondition_Some (self: ()) (args: t_A) = let _1 = args in c_Some'pre _1
+  
+  meta "rewrite_def" predicate precondition_Some
+  
+  predicate inv_Option_Option_A (_1: t_Option_Option_A)
+  
+  axiom inv_axiom'0 [@rewrite]: forall x: t_Option_Option_A [inv_Option_Option_A x]. inv_Option_Option_A x
+      = match x with
+        | None'0 -> true
+        | Some'0 f0 -> inv_Option_A f0
+        end
+  
+  predicate resolve_Some [@inline:trivial] (_1: ()) = true
+  
+  meta "rewrite_def" predicate resolve_Some
+  
+  predicate postcondition_Some (self: ()) (args: t_A) (result: t_Option_A) =
+    let _1 = args in c_Some'post'return _1 result
+  
+  meta "rewrite_def" predicate postcondition_Some
+  
+  predicate postcondition_once_Some (self: ()) (args: t_A) (result: t_Option_A) = postcondition_Some self args result
+  
+  meta "rewrite_def" predicate postcondition_once_Some
+  
+  let map_A (self_: t_Option_A) (f: ()) (return (x: t_Option_Option_A)) =
+  {[@stop_split] [@expl:map_A requires] ([@stop_split] [@expl:map 'self_' type invariant] inv_Option_A self_)
+    /\ ([@stop_split] [@expl:map requires] match self_ with
+      | None -> true
+      | Some t -> precondition_Some f t
+      end)}
+    any
+    [ return (result: t_Option_Option_A) ->
+    {[@stop_split] [@expl:map_A ensures] ([@stop_split] [@expl:map result type invariant] inv_Option_Option_A result)
+      /\ ([@stop_split] [@expl:map ensures] match self_ with
+        | None -> resolve_Some f /\ result = None'0
+        | Some t -> exists r: t_Option_A. result = Some'0 r /\ postcondition_once_Some f t r
+        end)}
+      (! return {result}) ]
+  
+  function map_Option_A (self: t_Option_A) (f: Map.map t_A t_Option_A) : t_Option_Option_A = match self with
+      | None -> None'0
+      | Some x -> Some'0 (Map.get f x)
+      end
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let g_A (o: t_Option_A) (return (x: t_Option_Option_A)) = {[@stop_split] [@expl:g 'o' type invariant] inv_Option_A o}
+    (! bb0
+    [ bb0 = s0 [ s0 = map_A {o} {()} (fun (_x: t_Option_Option_A) -> [ &_ret <- _x ] s1) | s1 = return {_ret} ] ]
+    [ & _ret: t_Option_Option_A = Any.any_l () | & o: t_Option_A = o ])
+    [ return (result: t_Option_Option_A) ->
+    {[@stop_split] [@expl:g_A ensures] ([@stop_split] [@expl:g result type invariant] inv_Option_Option_A result)
+      /\ ([@stop_split] [@expl:g ensures] result = map_Option_A o (fun (x: t_A) -> Some x))}
+      (! return {result}) ]
+end
+module M_h
+  use creusot.prelude.Any
+  
+  let c_T0 [@coma:extspec] (return (x: ())) = return {()}
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let h (return (x: ())) = (! bb0
+    [ bb0 = s0 [ s0 = [ &t <- () ] s1 | s1 = c_T0 (fun (_x: ()) -> [ &_ret <- _x ] s2) | s2 = return {_ret} ] ]
+    [ & _ret: () = Any.any_l () | & t: () = Any.any_l () ]) [ return (result: ()) -> (! return {result}) ]
+end
+module M_i
+  use creusot.prelude.Any
+  
+  type t_A
+  
+  type t_B
+  
+  type t_T2_A_B = { f0: t_A; f1: t_B }
+  
+  predicate invariant_T2_A_B (self: t_T2_A_B)
+  
+  predicate inv_A (_1: t_A)
+  
+  predicate inv_B (_1: t_B)
+  
+  predicate inv_T2_A_B (_1: t_T2_A_B)
+  
+  axiom inv_axiom [@rewrite]: forall x: t_T2_A_B [inv_T2_A_B x]. inv_T2_A_B x
+      = (invariant_T2_A_B x /\ inv_A x.f0 /\ inv_B x.f1)
+  
+  let c_T2 [@coma:extspec] (_1: t_A) (_2: t_B) (return (x: t_T2_A_B)) = {[@expl:T2 type invariant] inv_T2_A_B { f0 = _1;
+                                                                                                                f1 = _2 }}
+    return {{ f0 = _1; f1 = _2 }}
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  let i_A (x: t_A) (y: t_B) (return (x'0: t_T2_A_B)) =
+  {[@stop_split] [@expl:i_A requires] ([@stop_split] [@expl:i 'x' type invariant] inv_A x)
+    /\ ([@stop_split] [@expl:i 'y' type invariant] inv_B y)
+    /\ ([@stop_split] [@expl:i requires] inv_T2_A_B { f0 = x; f1 = y })}
+    (! bb0
+    [ bb0 = s0
+      [ s0 = [ &t <- () ] s1 | s1 = c_T2 {x} {y} (fun (_x: t_T2_A_B) -> [ &_ret <- _x ] s2) | s2 = return {_ret} ] ]
+    [ & _ret: t_T2_A_B = Any.any_l () | & x: t_A = x | & y: t_B = y | & t: () = Any.any_l () ])
+    [ return (result: t_T2_A_B) ->
+    {[@stop_split] [@expl:i_A ensures] ([@stop_split] [@expl:i result type invariant] inv_T2_A_B result)
+      /\ ([@stop_split] [@expl:i ensures] result = { f0 = x; f1 = y })}
+      (! return {result}) ]
+end
+module M_some_post
+  type t_A
+  
+  type tup2_A_A = { f0: t_A; f1: t_A }
+  
+  type t_T2_A_A = { f0'0: t_A; f1'0: t_A }
+  
+  predicate invariant_T2_A_A (self: t_T2_A_A)
+  
+  predicate inv_A (_1: t_A)
+  
+  predicate inv_T2_A_A (_1: t_T2_A_A)
+  
+  axiom inv_axiom [@rewrite]: forall x: t_T2_A_A [inv_T2_A_A x]. inv_T2_A_A x
+      = (invariant_T2_A_A x /\ inv_A x.f0'0 /\ inv_A x.f1'0)
+  
+  let c_T2 [@coma:extspec] (_1: t_A) (_2: t_A) (return (x: t_T2_A_A)) =
+  {[@expl:T2 type invariant] inv_T2_A_A { f0'0 = _1; f1'0 = _2 }}
+    return {{ f0'0 = _1; f1'0 = _2 }}
+  
+  predicate precondition_T2 (self: ()) (args: tup2_A_A) = let {f0 = _1; f1 = _2} = args in c_T2'pre _1 _2
+  
+  meta "rewrite_def" predicate precondition_T2
+  
+  meta "compute_max_steps" 1000000
+  
+  meta "select_lsinst" "all"
+  
+  constant x : t_A
+  
+  function some_post_A (x: t_A) : ()
+  
+  goal vc_some_post_A: [@stop_split] [@expl:some_post ensures] precondition_T2 () { f0 = x; f1 = x }
+    = inv_T2_A_A { f0'0 = x; f1'0 = x }
+end

--- a/tests/should_succeed/lang/ctor_closure.rs
+++ b/tests/should_succeed/lang/ctor_closure.rs
@@ -1,0 +1,35 @@
+extern crate creusot_std;
+use creusot_std::prelude::*;
+
+#[ensures(result == o.map_logic(|x| Some(x)))]
+pub fn g<A>(o: Option<A>) -> Option<Option<A>> {
+    o.map(Some)
+}
+
+pub struct T0();
+
+pub fn h() -> T0 {
+    let t = T0;
+    t()
+}
+
+#[allow(dead_code)]
+pub struct T2<A, B>(A, B);
+
+impl<A, B> Invariant for T2<A, B> {
+    #[logic(opaque)]
+    fn invariant(self) -> bool {
+        dead
+    }
+}
+
+#[requires(inv(T2(x, y)))]
+#[ensures(result == T2(x, y))]
+pub fn i<A, B>(x: A, y: B) -> T2<A, B> {
+    let t = T2;
+    t(x, y)
+}
+
+#[logic]
+#[ensures(T2.precondition((x, x)) == inv(T2(x, x)))]
+pub fn some_post<A>(x: A) {}

--- a/tests/should_succeed/lang/ctor_closure/proof.json
+++ b/tests/should_succeed/lang/ctor_closure/proof.json
@@ -1,0 +1,22 @@
+{
+  "profile": [],
+  "proofs": {
+    "M_g": {
+      "vc_c_Some": { "prover": "alt-ergo", "time": 0.03 },
+      "vc_g_A": { "prover": "alt-ergo", "time": 0.086 },
+      "vc_map_A": { "prover": "alt-ergo", "time": 0.049 }
+    },
+    "M_h": {
+      "vc_c_T0": { "prover": "alt-ergo", "time": 0.032 },
+      "vc_h": { "prover": "alt-ergo", "time": 0.02 }
+    },
+    "M_i": {
+      "vc_c_T2": { "prover": "alt-ergo", "time": 0.025 },
+      "vc_i_A": { "prover": "alt-ergo", "time": 0.0 }
+    },
+    "M_some_post": {
+      "vc_c_T2": { "prover": "alt-ergo", "time": 0.011 },
+      "vc_some_post_A": { "prover": "alt-ergo", "time": 0.009 }
+    }
+  }
+}


### PR DESCRIPTION
Close #2223

Generate a simplified body of the closure (directly call the continuation after asserting the expected invariant):

```
let c_Some [@coma:extspec] (x: a) (return (x: option_a) = {inv (Some x)} return {Some x}
```

Then reuse the pre- and post-conditions inferred by Coma (`c_Some'pre`, `c_Some'post'return`).